### PR TITLE
Fix some performance gotchas

### DIFF
--- a/src/circuit/circuit.h
+++ b/src/circuit/circuit.h
@@ -116,6 +116,7 @@ struct Circuit {
     size_t num_qubits;
     /// The total number of measurement results the circuit (so far) will produce.
     size_t num_measurements;
+    size_t min_safe_fusion_index = 0;
 
     /// Constructs an empty circuit.
     Circuit();
@@ -171,10 +172,10 @@ struct Circuit {
     void append_operation(const Operation &operation);
     /// Safely adds an operation at the end of the circuit, copying its data into the circuit's jagged data as needed.
     void append_op(
-        const std::string &gate_name, const std::vector<uint32_t> &vec, double arg = 0, bool allow_fusing = false);
+        const std::string &gate_name, const std::vector<uint32_t> &vec, double arg = 0);
     /// Safely adds an operation at the end of the circuit, copying its data into the circuit's jagged data as needed.
     void append_operation(
-        const Gate &gate, const uint32_t *targets_start, size_t num_targets, double arg, bool allow_fusing = false);
+        const Gate &gate, const uint32_t *targets_start, size_t num_targets, double arg);
 
     /// Resets the circuit back to an empty circuit.
     void clear();
@@ -190,6 +191,8 @@ struct Circuit {
 
     /// Updates metadata (e.g. num_qubits) to account for an operation appended via non-standard means.
     void update_metadata_for_manually_appended_operation();
+
+    void fusion_barrier();
 };
 
 /// Lists sets of measurements that have deterministic parity under noiseless execution from a circuit.

--- a/src/circuit/circuit.test.cc
+++ b/src/circuit/circuit.test.cc
@@ -133,6 +133,7 @@ TEST(circuit, from_text) {
     expected.clear();
     expected.append_op("X", {0});
     expected.append_op("Y", {1, 2});
+    expected.fusion_barrier();
     expected.append_op("Y", {1, 2});
     ASSERT_EQ(
         f("X 0\n"
@@ -151,10 +152,15 @@ TEST(circuit, from_text) {
 
     expected.clear();
     expected.append_op("M", {0});
+    expected.fusion_barrier();
     expected.append_op("M", {1, 2, 3});
+    expected.fusion_barrier();
     expected.append_op("M", {1, 2, 3});
+    expected.fusion_barrier();
     expected.append_op("M", {1, 2, 3});
+    expected.fusion_barrier();
     expected.append_op("M", {1, 2, 3});
+    expected.fusion_barrier();
     expected.append_op("M", {1, 2, 3});
     ASSERT_EQ(
         f("M 0\n"
@@ -188,6 +194,7 @@ TEST(circuit, append_circuit) {
     Circuit expected;
     expected.append_op("X", {0, 1});
     expected.append_op("M", {0, 1, 2, 4});
+    expected.fusion_barrier();
     expected.append_op("M", {7});
 
     Circuit actual = c1;
@@ -198,6 +205,7 @@ TEST(circuit, append_circuit) {
     for (size_t k = 0; k < 3; k++) {
         expected.append_op("X", {0, 1});
         expected.append_op("M", {0, 1, 2, 4});
+        expected.fusion_barrier();
         expected.append_op("M", {7});
     }
     ASSERT_EQ(actual, expected);
@@ -209,22 +217,22 @@ TEST(circuit, append_op_fuse) {
     Circuit expected;
     Circuit actual;
     expected.append_op("H", {1, 2, 3});
-    actual.append_op("H", {1}, 0, true);
-    actual.append_op("H", {2, 3}, 0, true);
+    actual.append_op("H", {1}, 0);
+    actual.append_op("H", {2, 3}, 0);
     ASSERT_EQ(actual, expected);
 
-    actual.append_op("R", {0}, 0, true);
+    actual.append_op("R", {0}, 0);
     expected.append_op("R", {0});
     ASSERT_EQ(actual, expected);
 
-    actual.append_op("DETECTOR", {0, 0}, 0, true);
-    actual.append_op("DETECTOR", {1, 1}, 0, true);
+    actual.append_op("DETECTOR", {0, 0}, 0);
+    actual.append_op("DETECTOR", {1, 1}, 0);
     expected.append_op("DETECTOR", {0, 0});
     expected.append_op("DETECTOR", {1, 1});
     ASSERT_EQ(actual, expected);
 
-    actual.append_op("M", {0, 1}, 0, true);
-    actual.append_op("M", {2, 3}, 0, true);
+    actual.append_op("M", {0, 1}, 0);
+    actual.append_op("M", {2, 3}, 0);
     expected.append_op("M", {0, 1, 2, 3});
     ASSERT_EQ(actual, expected);
 
@@ -251,8 +259,7 @@ TEST(circuit, str) {
         0.25);
     ASSERT_EQ(c.str(), R"circuit(# Circuit [num_qubits=30, num_measurements=3]
 TICK
-ZCX 2 3
-ZCX rec[-5] 3
+ZCX 2 3 rec[-5] 3
 M 1 3 2
 DETECTOR rec[-7]
 OBSERVABLE_INCLUDE(17) rec[-11] rec[-1]

--- a/src/main_helper.test.cc
+++ b/src/main_helper.test.cc
@@ -565,3 +565,16 @@ OBSERVABLE_INCLUDE(0) rec[-2]
 0001
             )output"));
 }
+
+TEST(main_helper, detector_error_sets) {
+    ASSERT_EQ(
+        trim(execute({"--detector_error_sets"}, R"input(
+X_ERROR(0.25) 0
+M 0
+DETECTOR rec[-1]
+            )input")),
+        trim(R"output(
+E(0.250000) X0
+M 0
+            )output"));
+}

--- a/src/py/stim.pybind.cc
+++ b/src/py/stim.pybind.cc
@@ -321,7 +321,7 @@ PYBIND11_MODULE(stim, m) {
          )DOC")
         .def(
             "compile_sampler",
-            [](Circuit &self) {
+            [](const Circuit &self) {
                 return CompiledMeasurementSampler(self);
             },
             R"DOC(
@@ -358,12 +358,8 @@ PYBIND11_MODULE(stim, m) {
                 name: The name of the operation's gate (e.g. "H" or "M" or "CNOT").
                 targets: The gate targets. Gates implicitly broadcast over their targets.
                 arg: A modifier for the gate, e.g. the probability of an error. Defaults to 0.
-                fuse: Defaults to true. If the gate being added is compatible with the last gate in the circuit, the
-                    new targets will be appended to the last gate instead of adding a new one. This is particularly
-                    important for measurement operations, because batched measurements are significantly more efficient
-                    in some cases. Set to false if you don't want this to occur.
          )DOC",
-            pybind11::arg("name"), pybind11::arg("targets"), pybind11::arg("arg") = 0.0, pybind11::arg("fuse") = true)
+            pybind11::arg("name"), pybind11::arg("targets"), pybind11::arg("arg") = 0.0)
         .def(
             "append_from_stim_program_text", &Circuit::append_from_text, R"DOC(
             Appends operations described by a STIM format program into the circuit.

--- a/src/simulators/error_fuser.cc
+++ b/src/simulators/error_fuser.cc
@@ -390,7 +390,7 @@ void ErrorFuser::convert_circuit_out(const Circuit &circuit, FILE *out, bool pre
     for (const auto &kv : fuser.error_class_probabilities) {
         fprintf(out, "E(%f)", kv.second);
         for (auto e : kv.first) {
-            fprintf(out, " X%lld", (long long)e);
+            fprintf(out, " X%lld", (long long)(e & TARGET_VALUE_MASK));
         }
         fprintf(out, "\n");
     }

--- a/src/simulators/tableau_simulator.test.cc
+++ b/src/simulators/tableau_simulator.test.cc
@@ -20,7 +20,7 @@
 #include "../circuit/gate_data.h"
 #include "../test_util.test.h"
 
-TEST(SimTableau, identity) {
+TEST(TableauSimulator, identity) {
     auto s = TableauSimulator(1, SHARED_TEST_RNG());
     ASSERT_EQ(s.measurement_record, (std::vector<bool>{}));
     s.measure(OpDat(0));
@@ -29,7 +29,7 @@ TEST(SimTableau, identity) {
     ASSERT_EQ(s.measurement_record, (std::vector<bool>{false, true}));
 }
 
-TEST(SimTableau, bit_flip) {
+TEST(TableauSimulator, bit_flip) {
     auto s = TableauSimulator(1, SHARED_TEST_RNG());
     s.H_XZ(OpDat(0));
     s.SQRT_Z(OpDat(0));
@@ -41,7 +41,7 @@ TEST(SimTableau, bit_flip) {
     ASSERT_EQ(s.measurement_record, (std::vector<bool>{true, false}));
 }
 
-TEST(SimTableau, identity2) {
+TEST(TableauSimulator, identity2) {
     auto s = TableauSimulator(2, SHARED_TEST_RNG());
     s.measure(OpDat(0));
     ASSERT_EQ(s.measurement_record, (std::vector<bool>{false}));
@@ -49,7 +49,7 @@ TEST(SimTableau, identity2) {
     ASSERT_EQ(s.measurement_record, (std::vector<bool>{false, false}));
 }
 
-TEST(SimTableau, bit_flip_2) {
+TEST(TableauSimulator, bit_flip_2) {
     auto s = TableauSimulator(2, SHARED_TEST_RNG());
     s.H_XZ(OpDat(0));
     s.SQRT_Z(OpDat(0));
@@ -61,7 +61,7 @@ TEST(SimTableau, bit_flip_2) {
     ASSERT_EQ(s.measurement_record, (std::vector<bool>{true, false}));
 }
 
-TEST(SimTableau, epr) {
+TEST(TableauSimulator, epr) {
     auto s = TableauSimulator(2, SHARED_TEST_RNG());
     s.H_XZ(OpDat(0));
     s.ZCX(OpDat({0, 1}));
@@ -74,7 +74,7 @@ TEST(SimTableau, epr) {
     ASSERT_EQ(s.measurement_record[0], s.measurement_record[1]);
 }
 
-TEST(SimTableau, big_determinism) {
+TEST(TableauSimulator, big_determinism) {
     auto s = TableauSimulator(1000, SHARED_TEST_RNG());
     s.H_XZ(OpDat(0));
     ASSERT_FALSE(s.is_deterministic(0));
@@ -83,7 +83,7 @@ TEST(SimTableau, big_determinism) {
     }
 }
 
-TEST(SimTableau, phase_kickback_consume_s_state) {
+TEST(TableauSimulator, phase_kickback_consume_s_state) {
     for (size_t k = 0; k < 8; k++) {
         auto s = TableauSimulator(2, SHARED_TEST_RNG());
         s.H_XZ(OpDat(1));
@@ -105,7 +105,7 @@ TEST(SimTableau, phase_kickback_consume_s_state) {
     }
 }
 
-TEST(SimTableau, phase_kickback_preserve_s_state) {
+TEST(TableauSimulator, phase_kickback_preserve_s_state) {
     auto s = TableauSimulator(2, SHARED_TEST_RNG());
 
     // Prepare S state.
@@ -134,7 +134,7 @@ TEST(SimTableau, phase_kickback_preserve_s_state) {
     ASSERT_EQ(s.measurement_record.back(), true);
 }
 
-TEST(SimTableau, kickback_vs_stabilizer) {
+TEST(TableauSimulator, kickback_vs_stabilizer) {
     auto sim = TableauSimulator(3, SHARED_TEST_RNG());
     sim.H_XZ(OpDat(2));
     sim.ZCX(OpDat({2, 0}));
@@ -153,7 +153,7 @@ TEST(SimTableau, kickback_vs_stabilizer) {
         "| XX XX XZ");
 }
 
-TEST(SimTableau, s_state_distillation_low_depth) {
+TEST(TableauSimulator, s_state_distillation_low_depth) {
     for (size_t reps = 0; reps < 10; reps++) {
         auto sim = TableauSimulator(9, SHARED_TEST_RNG());
 
@@ -224,7 +224,7 @@ TEST(SimTableau, s_state_distillation_low_depth) {
     }
 }
 
-TEST(SimTableau, s_state_distillation_low_space) {
+TEST(TableauSimulator, s_state_distillation_low_space) {
     for (size_t rep = 0; rep < 10; rep++) {
         auto sim = TableauSimulator(5, SHARED_TEST_RNG());
 
@@ -277,7 +277,7 @@ TEST(SimTableau, s_state_distillation_low_space) {
     }
 }
 
-TEST(SimTableau, unitary_gates_consistent_with_tableau_data) {
+TEST(TableauSimulator, unitary_gates_consistent_with_tableau_data) {
     auto t = Tableau::random(10, SHARED_TEST_RNG());
     TableauSimulator sim(10, SHARED_TEST_RNG());
     sim.inv_state = t;
@@ -299,7 +299,7 @@ TEST(SimTableau, unitary_gates_consistent_with_tableau_data) {
     }
 }
 
-TEST(SimTableau, simulate) {
+TEST(TableauSimulator, simulate) {
     auto results = TableauSimulator::sample_circuit(
         Circuit::from_text("H 0\n"
                            "CNOT 0 1\n"
@@ -311,7 +311,7 @@ TEST(SimTableau, simulate) {
     ASSERT_EQ(results[2], false);
 }
 
-TEST(SimTableau, simulate_reset) {
+TEST(TableauSimulator, simulate_reset) {
     auto results = TableauSimulator::sample_circuit(
         Circuit::from_text("X 0\n"
                            "M 0\n"
@@ -325,7 +325,7 @@ TEST(SimTableau, simulate_reset) {
     ASSERT_EQ(results[2], false);
 }
 
-TEST(SimTableau, to_vector_sim) {
+TEST(TableauSimulator, to_vector_sim) {
     TableauSimulator sim_tab(2, SHARED_TEST_RNG());
     VectorSimulator sim_vec(2);
     ASSERT_TRUE(sim_tab.to_vector_sim().approximate_equals(sim_vec, true));
@@ -374,7 +374,7 @@ bool vec_sim_corroborates_measurement_process(
     return true;
 }
 
-TEST(SimTableau, measurement_vs_vector_sim) {
+TEST(TableauSimulator, measurement_vs_vector_sim) {
     for (size_t k = 0; k < 10; k++) {
         TableauSimulator sim_tab(2, SHARED_TEST_RNG());
         sim_tab.inv_state = Tableau::random(2, SHARED_TEST_RNG());
@@ -681,4 +681,11 @@ TEST(TableauSimulator, classical_control_cases) {
     )circuit"),
             SHARED_TEST_RNG()),
         expected);
+}
+
+TEST(TableauSimulator, mr_repeated_target) {
+    simd_bits expected(2);
+    expected[0] = true;
+    auto r = TableauSimulator::sample_circuit(Circuit::from_text("X 0\nMR 0 0"), SHARED_TEST_RNG());
+    ASSERT_EQ(r, expected);
 }


### PR DESCRIPTION
- Increased circuit gate fusion aggressiveness to increase difficulty of getting bad performance from ungrouped measurements
- Added Circuit::fusion_barrier to avoid fusing across repeat loop bodies
- Added --detector_error_sets main_helper test