### PR TITLE
Fix detection streaming and X/Z error swap

### DIFF
--- a/src/circuit/circuit.test.cc
+++ b/src/circuit/circuit.test.cc
@@ -442,6 +442,40 @@ TEST(circuit, count_detectors_and_observables) {
     )CIRCUIT")
             .count_detectors_and_observables(),
         1000000000000ULL);
+
+    ASSERT_EQ(
+        Circuit::from_text(R"CIRCUIT(
+        M 0 1
+        REPEAT 999999 {
+         REPEAT 999999 {
+          REPEAT 999999 {
+           REPEAT 999999 {
+            REPEAT 999999 {
+             REPEAT 999999 {
+              REPEAT 999999 {
+               REPEAT 999999 {
+                REPEAT 999999 {
+                 REPEAT 999999 {
+                  REPEAT 999999 {
+                   REPEAT 999999 {
+                    REPEAT 999999 {
+                        DETECTOR rec[-1]
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+          }
+         }
+        }
+    )CIRCUIT")
+            .count_detectors_and_observables(),
+        UINT64_MAX);
 }
 
 TEST(circuit, max_lookback) {
@@ -517,6 +551,30 @@ TEST(circuit, count_measurements) {
     )CIRCUIT")
             .count_measurements(),
         999999ULL * 999999ULL * 999999ULL);
+    ASSERT_EQ(
+        Circuit::from_text(R"CIRCUIT(
+        REPEAT 999999 {
+         REPEAT 999999 {
+          REPEAT 999999 {
+           REPEAT 999999 {
+            REPEAT 999999 {
+             REPEAT 999999 {
+              REPEAT 999999 {
+               REPEAT 999999 {
+                REPEAT 999999 {
+                    M 0
+                }
+               }
+              }
+             }
+            }
+           }
+          }
+         }
+        }
+    )CIRCUIT")
+            .count_measurements(),
+        UINT64_MAX);
 }
 
 TEST(circuit, preserves_repetition_blocks) {

--- a/src/simulators/detection_simulator.test.cc
+++ b/src/simulators/detection_simulator.test.cc
@@ -12,11 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "frame_simulator.h"
 #include "detection_simulator.h"
 
 #include <gtest/gtest.h>
 
 #include "../test_util.test.h"
+
+static std::string rewind_read_all(FILE *f) {
+    rewind(f);
+    std::string result;
+    while (true) {
+        int c = getc(f);
+        if (c == EOF) {
+            return result;
+        }
+        result.push_back((char)c);
+    }
+    fclose(f);
+}
 
 TEST(DetectionSimulator, detector_samples) {
     auto circuit = Circuit::from_text(
@@ -73,5 +87,113 @@ TEST(DetectionSimulator, detector_samples_out) {
     rewind(tmp);
     for (char c : "1,6\n1,6\n") {
         ASSERT_EQ(getc(tmp), c == '\0' ? EOF : c);
+    }
+}
+
+TEST(DetectionSimulator, block_results_single_shot) {
+    auto circuit = Circuit::from_text(R"circuit(
+        REPEAT 10000 {
+            M 0
+            X_ERROR(1) 0
+            M 0
+            R 0
+            DETECTOR rec[-1] rec[-2]
+            M 0
+            DETECTOR rec[-1]
+            DETECTOR rec[-1]
+        }
+    )circuit");
+    FILE *tmp = tmpfile();
+    detector_samples_out(circuit, 1, false, true, tmp, SAMPLE_FORMAT_01, SHARED_TEST_RNG());
+
+    auto result = rewind_read_all(tmp);
+    for (size_t k = 0; k < 30000; k += 3) {
+        ASSERT_EQ(result[k], '1') << k;
+        ASSERT_EQ(result[k + 1], '0') << (k + 1);
+        ASSERT_EQ(result[k + 2], '0') << (k + 2);
+    }
+    ASSERT_EQ(result[30000], '\n');
+}
+
+TEST(DetectionSimulator, block_results_triple_shot) {
+    auto circuit = Circuit::from_text(R"circuit(
+        REPEAT 10000 {
+            M 0
+            X_ERROR(1) 0
+            M 0
+            R 0
+            DETECTOR rec[-1] rec[-2]
+            M 0
+            DETECTOR rec[-1]
+            DETECTOR rec[-1]
+        }
+    )circuit");
+    FILE *tmp = tmpfile();
+    detector_samples_out(circuit, 3, false, true, tmp, SAMPLE_FORMAT_01, SHARED_TEST_RNG());
+
+    auto result = rewind_read_all(tmp);
+    for (size_t rep = 0; rep < 3; rep++) {
+        size_t s = rep * 30001;
+        for (size_t k = 0; k < 30000; k += 3) {
+            ASSERT_EQ(result[s + k], '1') << (s + k);
+            ASSERT_EQ(result[s + k + 1], '0') << (s + k + 1);
+            ASSERT_EQ(result[s + k + 2], '0') << (s + k + 2);
+        }
+        ASSERT_EQ(result[s + 30000], '\n');
+    }
+}
+
+TEST(DetectionSimulator, stream_results) {
+    DebugForceResultStreamingRaii force_streaming;
+    auto circuit = Circuit::from_text(R"circuit(
+        REPEAT 10000 {
+            M 0
+            X_ERROR(1) 0
+            M 0
+            R 0
+            DETECTOR rec[-1] rec[-2]
+            M 0
+            DETECTOR rec[-1]
+            DETECTOR rec[-1]
+        }
+    )circuit");
+    FILE *tmp = tmpfile();
+    detector_samples_out(circuit, 1, false, true, tmp, SAMPLE_FORMAT_01, SHARED_TEST_RNG());
+
+    auto result = rewind_read_all(tmp);
+    for (size_t k = 0; k < 30000; k += 3) {
+        ASSERT_EQ(result[k], '1') << k;
+        ASSERT_EQ(result[k + 1], '0') << (k + 1);
+        ASSERT_EQ(result[k + 2], '0') << (k + 2);
+    }
+    ASSERT_EQ(result[30000], '\n');
+}
+
+TEST(DetectionSimulator, stream_results_triple_shot) {
+    DebugForceResultStreamingRaii force_streaming;
+    auto circuit = Circuit::from_text(R"circuit(
+        REPEAT 10000 {
+            M 0
+            X_ERROR(1) 0
+            M 0
+            R 0
+            DETECTOR rec[-1] rec[-2]
+            M 0
+            DETECTOR rec[-1]
+            DETECTOR rec[-1]
+        }
+    )circuit");
+    FILE *tmp = tmpfile();
+    detector_samples_out(circuit, 3, false, true, tmp, SAMPLE_FORMAT_01, SHARED_TEST_RNG());
+
+    auto result = rewind_read_all(tmp);
+    for (size_t rep = 0; rep < 3; rep++) {
+        size_t s = rep * 30001;
+        for (size_t k = 0; k < 30000; k += 3) {
+            ASSERT_EQ(result[s + k], '1') << (s + k);
+            ASSERT_EQ(result[s + k + 1], '0') << (s + k + 1);
+            ASSERT_EQ(result[s + k + 2], '0') << (s + k + 2);
+        }
+        ASSERT_EQ(result[s + 30000], '\n');
     }
 }

--- a/src/simulators/frame_simulator.h
+++ b/src/simulators/frame_simulator.h
@@ -17,8 +17,6 @@
 #ifndef SIM_FRAME_H
 #define SIM_FRAME_H
 
-#define SWITCH_TO_STREAMING_MEASUREMENT_THRESHOLD 100000000
-
 #include <random>
 
 #include "../circuit/circuit.h"
@@ -89,6 +87,12 @@ struct FrameSimulator {
     simd_bits_range_ref measurement_record_ref(uint32_t encoded_target);
     void single_cx(uint32_t c, uint32_t t);
     void single_cy(uint32_t c, uint32_t t);
+};
+
+bool should_use_streaming_instead_of_memory(uint64_t result_count);
+struct DebugForceResultStreamingRaii {
+    DebugForceResultStreamingRaii();
+    ~DebugForceResultStreamingRaii();
 };
 
 #endif

--- a/src/simulators/tableau_simulator.cc
+++ b/src/simulators/tableau_simulator.cc
@@ -316,7 +316,7 @@ void TableauSimulator::DEPOLARIZE2(const OperationData &target_data) {
 
 void TableauSimulator::X_ERROR(const OperationData &target_data) {
     RareErrorIterator::for_samples(target_data.arg, target_data.targets, rng, [&](size_t q) {
-        inv_state.xs.signs[q] ^= true;
+        inv_state.zs.signs[q] ^= true;
     });
 }
 
@@ -329,7 +329,7 @@ void TableauSimulator::Y_ERROR(const OperationData &target_data) {
 
 void TableauSimulator::Z_ERROR(const OperationData &target_data) {
     RareErrorIterator::for_samples(target_data.arg, target_data.targets, rng, [&](size_t q) {
-        inv_state.zs.signs[q] ^= true;
+        inv_state.xs.signs[q] ^= true;
     });
 }
 

--- a/src/simulators/tableau_simulator.test.cc
+++ b/src/simulators/tableau_simulator.test.cc
@@ -299,6 +299,32 @@ TEST(TableauSimulator, unitary_gates_consistent_with_tableau_data) {
     }
 }
 
+TEST(TableauSimulator, certain_errors_consistent_with_gates) {
+    TableauSimulator sim1(2, SHARED_TEST_RNG());
+    TableauSimulator sim2(2, SHARED_TEST_RNG());
+    uint32_t targets[] {0};
+    OperationData d0{0, {targets, targets + 1}};
+    OperationData d1{1.0, {targets, targets + 1}};
+
+    sim1.X_ERROR(d1);
+    sim2.X(d0);
+    ASSERT_EQ(sim1.inv_state, sim2.inv_state);
+    sim1.X_ERROR(d0);
+    ASSERT_EQ(sim1.inv_state, sim2.inv_state);
+
+    sim1.Y_ERROR(d1);
+    sim2.Y(d0);
+    ASSERT_EQ(sim1.inv_state, sim2.inv_state);
+    sim1.Y_ERROR(d0);
+    ASSERT_EQ(sim1.inv_state, sim2.inv_state);
+
+    sim1.Z_ERROR(d1);
+    sim2.Z(d0);
+    ASSERT_EQ(sim1.inv_state, sim2.inv_state);
+    sim1.Z_ERROR(d0);
+    ASSERT_EQ(sim1.inv_state, sim2.inv_state);
+}
+
 TEST(TableauSimulator, simulate) {
     auto results = TableauSimulator::sample_circuit(
         Circuit::from_text("H 0\n"


### PR DESCRIPTION
- TableauSimulator had X_ERROR and Z_ERROR implementations reversed
- Added unit tests comparing black box stats of all noisy tableau simulator methods to known-good stats from cirq
- Switched to saturating arithmetic when computing circuit counts, so that absurd rep counts don't avoid streaming optimizations [they just never finish since they have more than 2^64 results]
- Fix detection streaming not clearing the buffer that results were being written to, producing garbage data
- Add DebugForceResultStreamingRaii class for forcing streaming for smaller cases
- Add unit tests exercising streaming cases for frame simulator and detector simulator