### PR TITLE
Fix stim.TableauSimulator.measure not resizing if needed for target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_SKIP: "cp27-* pp27-* cp35-*"  # skip Python 2.7 and 3.5 wheels
+          CIBW_TEST_COMMAND: echo TESTING && false
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_SKIP: "cp27-* pp27-* cp35-*"  # skip Python 2.7 and 3.5 wheels
+          CIBW_SKIP: "cp27-* cp35-* pp*"
           CIBW_TEST_REQUIRES: stimcirq pytest
           CIBW_TEST_COMMAND: pytest {project}/src {project}/glue/cirq
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           CIBW_SKIP: "cp27-* pp27-* cp35-*"  # skip Python 2.7 and 3.5 wheels
           CIBW_TEST_REQUIRES: stimcirq pytest
-          CIBW_TEST_COMMAND: ls && cd stim && pytest src glue/cirq
+          CIBW_TEST_COMMAND: pytest {project}/src {project}/glue/cirq
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           CIBW_SKIP: "cp27-* pp27-* cp35-*"  # skip Python 2.7 and 3.5 wheels
           CIBW_TEST_REQUIRES: stimcirq pytest
-          CIBW_TEST_COMMAND: pytest src glue/cirq
+          CIBW_TEST_COMMAND: ls && cd stim && pytest src glue/cirq
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,8 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_SKIP: "cp27-* pp27-* cp35-*"  # skip Python 2.7 and 3.5 wheels
-          CIBW_TEST_COMMAND: echo TESTING && false
+          CIBW_TEST_REQUIRES: stimcirq pytest
+          CIBW_TEST_COMMAND: pytest src glue/cirq
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/src/simulators/tableau_simulator.pybind.cc
+++ b/src/simulators/tableau_simulator.pybind.cc
@@ -481,6 +481,7 @@ void pybind_tableau_simulator(pybind11::module &m) {
         .def(
             "measure",
             [](TableauSimulator &self, uint32_t target) {
+                self.ensure_large_enough_for_qubits(target + 1);
                 self.measure(TempViewableData({target}));
                 return (bool)self.measurement_record.storage.back();
             },


### PR DESCRIPTION
- Add test command to cibuildwheel configuration
- Fix unescaped unspecified encoding unicode characters in a docstring
- Drop pypy wheels from cibuildwheel tests