### PR TITLE
Add support for imaginary phase to stim.PauliString python binding

### DIFF
--- a/glue/cirq/setup.py
+++ b/glue/cirq/setup.py
@@ -19,7 +19,7 @@ with open('README.md') as f:
 
 setup(
     name='stimcirq',
-    version='1.2.dev',
+    version='1.3.0dev',
     author='Craig Gidney',
     author_email='craig.gidney@gmail.com',
     url='https://github.com/quantumlib/stim',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ TEST_HEADERS = glob.glob("src/**/*.test.h", recursive=True)
 PERF_HEADERS = glob.glob("src/**/*.perf.h", recursive=True)
 RELEVANT_HEADERS = sorted(set(ALL_HEADERS) - set(TEST_HEADERS + PERF_HEADERS))
 
-version = '1.2.dev'
+version = '1.3.0dev'
 
 extension_module = Extension(
     'stim',

--- a/src/circuit/circuit_pybind_test.py
+++ b/src/circuit/circuit_pybind_test.py
@@ -82,11 +82,13 @@ OBSERVABLE_INCLUDE(5) rec[-1] rec[-2]
 
 def test_circuit_iadd():
     c = stim.Circuit()
+    alias = c
     c.append_operation("X", [1, 2])
     c2 = stim.Circuit()
     c2.append_operation("Y", [3])
     c2.append_operation("M", [4])
     c += c2
+    assert c is alias
     assert str(c).strip() == """
 X 1 2
 Y 3
@@ -102,6 +104,7 @@ X 1 2
 Y 3
 M 4
     """.strip()
+    assert c is alias
 
 
 def test_circuit_add():
@@ -147,12 +150,16 @@ REPEAT 3 {
 }
     """.strip()
     assert str(c * 3) == str(3 * c) == expected
+    alias = c
     c *= 3
+    assert alias is c
     assert str(c) == expected
     c *= 1
     assert str(c) == expected
+    assert alias is c
     c *= 0
     assert str(c) == ""
+    assert alias is c
 
 
 def test_circuit_repr():

--- a/src/py/base.pybind.h
+++ b/src/py/base.pybind.h
@@ -16,6 +16,7 @@
 #define STIM_BASE_PYBIND_H
 
 #include <pybind11/numpy.h>
+#include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <random>

--- a/src/simulators/tableau_simulator.pybind.cc
+++ b/src/simulators/tableau_simulator.pybind.cc
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "../simulators/tableau_simulator.h"
+#include "tableau_simulator.pybind.h"
 
+#include "../simulators/tableau_simulator.h"
+#include "../stabilizers/pauli_string.pybind.h"
 #include "../py/base.pybind.h"
 #include "../stabilizers/tableau.h"
-#include "tableau_simulator.pybind.h"
 
 struct TempViewableData {
     std::vector<uint32_t> targets;
@@ -482,7 +483,7 @@ void pybind_tableau_simulator(pybind11::module &m) {
             "peek_bloch",
             [](TableauSimulator &self, size_t target) {
                 self.ensure_large_enough_for_qubits(target + 1);
-                return self.peek_bloch(target);
+                return PyPauliString(self.peek_bloch(target));
             },
             pybind11::arg("target"),
             R"DOC(

--- a/src/stabilizers/pauli_string.pybind.h
+++ b/src/stabilizers/pauli_string.pybind.h
@@ -15,7 +15,25 @@
 #ifndef PAULI_STRING_PYBIND_H
 #define PAULI_STRING_PYBIND_H
 
+#include <complex>
 #include <pybind11/pybind11.h>
+
+#include "pauli_string.h"
+
+struct PyPauliString {
+    PauliString value;
+    bool imag;
+
+    PyPauliString(const PauliStringRef val, bool imag = false);
+    PyPauliString(PauliString&& val, bool imag = false);
+
+    std::complex<float> get_phase() const;
+    PyPauliString operator*(std::complex<float> scale) const;
+    PyPauliString &operator*=(std::complex<float> scale);
+    PyPauliString operator*(const PyPauliString &rhs) const;
+    PyPauliString &operator*=(const PyPauliString &rhs);
+    std::string str() const;
+};
 
 void pybind_pauli_string(pybind11::module &m);
 

--- a/src/stabilizers/pauli_string_pybind_test.py
+++ b/src/stabilizers/pauli_string_pybind_test.py
@@ -40,6 +40,31 @@ def test_from_str():
     assert len(p) == 0
     assert p.sign == +1
 
+    p = stim.PauliString("X")
+    assert len(p) == 1
+    assert p[0] == 1
+    assert p.sign == +1
+
+    p = stim.PauliString("+X")
+    assert len(p) == 1
+    assert p[0] == 1
+    assert p.sign == +1
+
+    p = stim.PauliString("iX")
+    assert len(p) == 1
+    assert p[0] == 1
+    assert p.sign == 1j
+
+    p = stim.PauliString("+iX")
+    assert len(p) == 1
+    assert p[0] == 1
+    assert p.sign == 1j
+
+    p = stim.PauliString("-iX")
+    assert len(p) == 1
+    assert p[0] == 1
+    assert p.sign == -1j
+
 
 def test_equality():
     assert stim.PauliString(4) == stim.PauliString(4)
@@ -51,6 +76,8 @@ def test_equality():
     assert stim.PauliString("+X") != stim.PauliString("-X")
     assert stim.PauliString("+X") != stim.PauliString("+Y")
     assert stim.PauliString("+X") != stim.PauliString("-Y")
+    assert stim.PauliString("+X") != stim.PauliString("+iX")
+    assert stim.PauliString("+X") != stim.PauliString("-iX")
 
     assert stim.PauliString("__") != stim.PauliString("_X")
     assert stim.PauliString("__") != stim.PauliString("X_")
@@ -68,18 +95,52 @@ def test_str():
     assert str(stim.PauliString(3)) == "+___"
     assert str(stim.PauliString("XYZ")) == "+XYZ"
     assert str(stim.PauliString("-XYZ")) == "-XYZ"
+    assert str(stim.PauliString("iXYZ")) == "+iXYZ"
+    assert str(stim.PauliString("-iXYZ")) == "-iXYZ"
 
 
 def test_repr():
     assert repr(stim.PauliString(3)) == 'stim.PauliString("+___")'
-    v = stim.PauliString("-XYZ")
-    r = repr(v)
-    assert r == 'stim.PauliString("-XYZ")'
-    assert eval(r, {'stim': stim}) == v
+    assert repr(stim.PauliString("-XYZ")) == 'stim.PauliString("-XYZ")'
+    vs = [
+        stim.PauliString(""),
+        stim.PauliString("ZXYZZ"),
+        stim.PauliString("-XYZ"),
+        stim.PauliString("I"),
+        stim.PauliString("iIXYZ"),
+        stim.PauliString("-iIXYZ"),
+    ]
+    for v in vs:
+        r = repr(v)
+        assert eval(r, {'stim': stim}) == v
+
+
+def test_commutes():
+    def c(a: stim.PauliString, b: stim.PauliString) -> bool:
+        return stim.PauliString(a).commutes(stim.PauliString(b))
+
+    with pytest.raises(ValueError, match="len"):
+        c("", "X")
+    assert c("", "")
+    assert c("X", "_")
+    assert c("X", "X")
+    assert not c("X", "Y")
+    assert not c("X", "Z")
+
+    assert c("XXXX", "YYYY")
+    assert c("XXXX", "YYYZ")
+    assert not c("XXXX", "XXXZ")
+    assert not c("XXXX", "___Z")
+    assert not c("XXXX", "Z___")
+    assert c("XXXX", "Z_Z_")
 
 
 def test_product():
     assert stim.PauliString("") * stim.PauliString("") == stim.PauliString("")
+    assert stim.PauliString("i") * stim.PauliString("i") == stim.PauliString("-")
+    assert stim.PauliString("i") * stim.PauliString("-i") == stim.PauliString("+")
+    assert stim.PauliString("-i") * stim.PauliString("-i") == stim.PauliString("-")
+    assert stim.PauliString("i") * stim.PauliString("-") == stim.PauliString("-i")
 
     x = stim.PauliString("X")
     y = stim.PauliString("Y")
@@ -96,11 +157,14 @@ def test_product():
     with pytest.raises(ValueError, match="!= len"):
         _ = stim.PauliString(10).extended_product(stim.PauliString(11))
 
-    with pytest.raises(ValueError, match="non-commut"):
-        _ = x * z
+    assert x * z == stim.PauliString("-iY")
     assert x * x == stim.PauliString(1)
-    assert x.extended_product(y) == (1j, z)
-    assert y.extended_product(x) == (1j, -z)
+    assert x * y == stim.PauliString("iZ")
+    assert y * x == stim.PauliString("-iZ")
+    assert x * y == 1j * z
+    assert y * x == z * -1j
+    assert x.extended_product(y) == (1, 1j * z)
+    assert y.extended_product(x) == (1, -1j * z)
     assert x.extended_product(x) == (1, stim.PauliString(1))
 
     xx = stim.PauliString("+XX")
@@ -108,6 +172,65 @@ def test_product():
     zz = stim.PauliString("+ZZ")
     assert xx * zz == -yy
     assert xx.extended_product(zz) == (1, -yy)
+
+
+def test_inplace_product():
+    p = stim.PauliString("X")
+    alias = p
+
+    p *= 1j
+    assert alias == stim.PauliString("iX")
+    assert alias is p
+    p *= 1j
+    assert alias == stim.PauliString("-X")
+    p *= 1j
+    assert alias == stim.PauliString("-iX")
+    p *= 1j
+    assert alias == stim.PauliString("+X")
+
+    p *= stim.PauliString("Z")
+    assert alias == stim.PauliString("-iY")
+
+    p *= -1j
+    assert alias == stim.PauliString("-Y")
+    p *= -1j
+    assert alias == stim.PauliString("iY")
+    p *= -1j
+    assert alias == stim.PauliString("+Y")
+    p *= -1j
+    assert alias == stim.PauliString("-iY")
+
+    p *= stim.PauliString("i_")
+    assert alias == stim.PauliString("+Y")
+    p *= stim.PauliString("i_")
+    assert alias == stim.PauliString("iY")
+    p *= stim.PauliString("i_")
+    assert alias == stim.PauliString("-Y")
+    p *= stim.PauliString("i_")
+    assert alias == stim.PauliString("-iY")
+
+    p *= stim.PauliString("-i_")
+    assert alias == stim.PauliString("-Y")
+    p *= stim.PauliString("-i_")
+    assert alias == stim.PauliString("iY")
+    p *= stim.PauliString("-i_")
+    assert alias == stim.PauliString("+Y")
+    p *= stim.PauliString("-i_")
+    assert alias == stim.PauliString("-iY")
+
+    assert alias is p
+
+
+def test_imaginary_phase():
+    p = stim.PauliString("IXYZ")
+    ip = stim.PauliString("iIXYZ")
+    assert 1j * p == p * 1j == ip == -stim.PauliString("-iIXYZ")
+    assert p.sign == 1
+    assert (-p).sign == -1
+    assert ip.sign == 1j
+    assert (-ip).sign == -1j
+    assert stim.PauliString("X") * stim.PauliString("Y") == 1j * stim.PauliString("Z")
+    assert stim.PauliString("Y") * stim.PauliString("X") == -1j * stim.PauliString("Z")
 
 
 def test_get_set_sign():
@@ -121,6 +244,14 @@ def test_get_set_sign():
     assert p.sign == +1
     with pytest.raises(ValueError, match="new_sign"):
         p.sign = 5
+
+    p.sign = 1j
+    assert str(p) == "+i__"
+    assert p.sign == 1j
+
+    p.sign = -1j
+    assert str(p) == "-i__"
+    assert p.sign == -1j
 
 
 def test_get_set_item():

--- a/src/stabilizers/tableau_pybind_test.py
+++ b/src/stabilizers/tableau_pybind_test.py
@@ -270,6 +270,9 @@ def test_repr():
 def test_call():
     t = stim.Tableau.from_named_gate("CNOT")
     assert t(stim.PauliString("__")) == stim.PauliString("__")
+    assert t(stim.PauliString("-__")) == stim.PauliString("-__")
+    assert t(stim.PauliString("i__")) == stim.PauliString("i__")
+    assert t(stim.PauliString("-i__")) == stim.PauliString("-i__")
     assert t(stim.PauliString("X_")) == stim.PauliString("XX")
     assert t(stim.PauliString("Y_")) == stim.PauliString("YX")
     assert t(stim.PauliString("Z_")) == stim.PauliString("Z_")

--- a/src/stabilizers/tableau_pybind_test.py
+++ b/src/stabilizers/tableau_pybind_test.py
@@ -159,6 +159,24 @@ def test_from_conjugated_generators():
         ],
     )
 
+    assert stim.Tableau.from_named_gate("S") == stim.Tableau.from_conjugated_generators(
+        xs=[
+            stim.PauliString("Y"),
+        ],
+        zs=[
+            stim.PauliString("Z"),
+        ],
+    )
+
+    assert stim.Tableau.from_named_gate("S_DAG") == stim.Tableau.from_conjugated_generators(
+        xs=[
+            stim.PauliString("-Y"),
+        ],
+        zs=[
+            stim.PauliString("Z"),
+        ],
+    )
+
     assert stim.Tableau(2) == stim.Tableau.from_conjugated_generators(
         xs=[
             stim.PauliString("X_"),
@@ -179,6 +197,29 @@ def test_from_conjugated_generators():
             zs=[
                 stim.PauliString("Z_"),
                 stim.PauliString("_Z_"),
+            ],
+        )
+
+    with pytest.raises(ValueError, match="imag"):
+        stim.Tableau.from_conjugated_generators(
+            xs=[
+                stim.PauliString("iX_"),
+                stim.PauliString("_X"),
+            ],
+            zs=[
+                stim.PauliString("Z_"),
+                stim.PauliString("_Z"),
+            ],
+        )
+    with pytest.raises(ValueError, match="imag"):
+        stim.Tableau.from_conjugated_generators(
+            xs=[
+                stim.PauliString("X_"),
+                stim.PauliString("_X"),
+            ],
+            zs=[
+                stim.PauliString("Z_"),
+                stim.PauliString("i_Z"),
             ],
         )
 


### PR DESCRIPTION
- Refactor pauli string pybind code to split class method definitions over multiple statements
- Add support for proper `__imul__`
- Deprecate stim.PauliString.extended_product
- Refactor stim.PauliString.sign to return a complex value