### PR TITLE
Add `stimcirq.stim_circuit_to_cirq_circuit ` and polish bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ MANIFEST
 **/__pycache__/**
 pip-wheel-metadata/*
 wheelhouse/*
+*.pyd

--- a/dev/README.md
+++ b/dev/README.md
@@ -122,7 +122,7 @@ make stim_test
 ```
 
 To force AVX vectorization, SSE vectorization, or no vectorization
-pass `-DSIMD_WIDTH=256` or `-DSIMD_WIDTH=128` or -DSIMD_WIDTH=64` to the `cmake` command.
+pass `-DSIMD_WIDTH=256` or `-DSIMD_WIDTH=128` or `-DSIMD_WIDTH=64` to the `cmake` command.
 
 Run tests with optimizations without sanitization:
 

--- a/glue/cirq/setup.py
+++ b/glue/cirq/setup.py
@@ -19,7 +19,7 @@ with open('README.md') as f:
 
 setup(
     name='stimcirq',
-    version='1.2.dev',
+    version='1.3.0dev',
     author='Craig Gidney',
     author_email='craig.gidney@gmail.com',
     url='https://github.com/quantumlib/stim',

--- a/glue/cirq/stimcirq/__init__.py
+++ b/glue/cirq/stimcirq/__init__.py
@@ -1,2 +1,9 @@
 from ._stim_sampler import StimSampler, cirq_circuit_to_stim_circuit
 from ._circuit_conversion import stim_circuit_to_cirq_circuit
+
+# Workaround for doctest not searching imported objects.
+__test__ = {
+    "StimSampler": StimSampler,
+    "cirq_circuit_to_stim_circuit": cirq_circuit_to_stim_circuit,
+    "stim_circuit_to_cirq_circuit": stim_circuit_to_cirq_circuit,
+}

--- a/glue/cirq/stimcirq/__init__.py
+++ b/glue/cirq/stimcirq/__init__.py
@@ -1,1 +1,2 @@
 from ._stim_sampler import StimSampler, cirq_circuit_to_stim_circuit
+from ._circuit_conversion import stim_circuit_to_cirq_circuit

--- a/glue/cirq/stimcirq/_circuit_conversion.py
+++ b/glue/cirq/stimcirq/_circuit_conversion.py
@@ -114,15 +114,15 @@ def stim_circuit_to_cirq_circuit(circuit: stim.Circuit) -> cirq.Circuit:
 
         >>> import stimcirq
         >>> import stim
-        >>> stimcirq.stim_circuit_to_cirq_circuit(stim.Circuit('''
+        >>> print(stimcirq.stim_circuit_to_cirq_circuit(stim.Circuit('''
         ...     H 0
         ...     CNOT 0 1
         ...     X_ERROR(0.25) 0
         ...     M !1 0
-        ... ''')).to_text_diagram(use_unicode_characters=False)
-        0: ---H---@---X[prob=0.25]---M('1')---
-                  |
-        1: -------X---!M('0')-----------------
+        ... ''')))
+        0: ───H───@───X[prob=0.25]───M('1')───
+                  │
+        1: ───────X───!M('0')─────────────────
     """
     _next_measure_id = 0
     def get_next_measure_id() -> int:

--- a/glue/cirq/stimcirq/_circuit_conversion.py
+++ b/glue/cirq/stimcirq/_circuit_conversion.py
@@ -1,0 +1,136 @@
+from typing import Callable, cast, Dict, Iterable, List, Optional, Sequence, Tuple, Type, Union, Iterator
+
+import functools
+import itertools
+import math
+
+import cirq
+import stim
+
+
+STIM_TO_CIRQ_GATE_TABLE: Dict[str, Union[Tuple, cirq.Gate, Callable[[float], cirq.Gate]]] = {
+    "R": cirq.ResetChannel(),
+    "I": cirq.I,
+    "X": cirq.X,
+    "Y": cirq.Y,
+    "Z": cirq.Z,
+    "H_XY": cirq.SingleQubitCliffordGate.from_xz_map(x_to=(cirq.Y, False), z_to=(cirq.Z, True)),
+    "H": cirq.H,
+    "H_YZ": cirq.SingleQubitCliffordGate.from_xz_map(x_to=(cirq.X, True), z_to=(cirq.Y, False)),
+    "SQRT_X": cirq.X**0.5,
+    "SQRT_X_DAG": cirq.X**-0.5,
+    "SQRT_Y": cirq.Y**0.5,
+    "SQRT_Y_DAG": cirq.Y**-0.5,
+    "S": cirq.S,
+    "S_DAG": cirq.S**-1,
+    "SWAP": cirq.SWAP,
+    "ISWAP": cirq.ISWAP,
+    "ISWAP_DAG": cirq.ISWAP**-1,
+    "XCX": cirq.PauliInteractionGate(cirq.X, False, cirq.X, False),
+    "XCY": cirq.PauliInteractionGate(cirq.X, False, cirq.Y, False),
+    "XCZ": cirq.PauliInteractionGate(cirq.X, False, cirq.Z, False),
+    "YCX": cirq.PauliInteractionGate(cirq.Y, False, cirq.X, False),
+    "YCY": cirq.PauliInteractionGate(cirq.Y, False, cirq.Y, False),
+    "YCZ": cirq.PauliInteractionGate(cirq.Y, False, cirq.Z, False),
+    "CX": cirq.CNOT,
+    "CY": cirq.Y.controlled(1),
+    "CZ": cirq.CZ,
+    "DEPOLARIZE1": lambda arg: cirq.DepolarizingChannel(arg, 1),
+    "DEPOLARIZE2": lambda arg: cirq.DepolarizingChannel(arg, 2),
+    "X_ERROR": lambda arg: cirq.X.with_probability(arg),
+    "Y_ERROR": lambda arg: cirq.Y.with_probability(arg),
+    "Z_ERROR": lambda arg: cirq.Z.with_probability(arg),
+    "DETECTOR": (),
+    "OBSERVABLE_INCLUDE": (),
+    "TICK": (),
+}
+
+def _translate_flattened_operation(
+        op: Tuple[str, List, float],
+        get_next_measure_id: Callable[[], int]) -> Iterator[cirq.Operation]:
+    name, targets, arg = op
+
+    handler = STIM_TO_CIRQ_GATE_TABLE.get(name)
+    if handler is not None:
+        if isinstance(handler, cirq.Gate):
+            gate = handler
+        elif handler == ():
+            return
+        else:
+            gate = handler(arg)
+        for q in targets:
+            if isinstance(q, tuple) and q[0] == "rec":
+                raise NotImplementedError("Measurement record.")
+        m = gate.num_qubits()
+        for k in range(0, len(targets), m):
+            yield gate(*[cirq.LineQubit(q) for q in targets[k:k+m]])
+        return
+
+    if name == "M" or name == "MR":
+        for t in targets:
+            if isinstance(t, int):
+                q = t
+                inv = False
+            elif t[0] == "inv":
+                q = t[1]
+                inv = True
+            else:
+                raise NotImplementedError("Unrecognized measurement target.")
+            q = cirq.LineQubit(q)
+            yield cirq.measure(q, key=str(get_next_measure_id()), invert_mask=(True,) if inv else ())
+            if name == "MR":
+                yield cirq.ResetChannel().on(q)
+        return
+
+    if name == "E":
+        yield cirq.PauliString({cirq.LineQubit(q): k for k, q in targets}).with_probability(arg)
+        return
+
+    raise NotImplementedError(f"Unsupported gate: {name}")
+
+
+def stim_circuit_to_cirq_circuit(circuit: stim.Circuit) -> cirq.Circuit:
+    """Converts a stim circuit into an equivalent cirq circuit.
+
+    Qubit indices are turned into cirq.LineQubit instances. Measurements are
+    keyed by their ordering (e.g. the first measurement is keyed "0", the second
+    is keyed "1", etc).
+
+    Not all circuits can be converted:
+        - ELSE_CORRELATED_ERROR instructions are not supported.
+
+    Not all circuits can be converted with perfect 1:1 fidelity:
+        - DETECTOR annotations are discarded.
+        - OBSERVABLE_INCLUDE annotations are discarded.
+        - MR ops decompose into separate measurement and reset ops.
+
+    Args:
+        circuit: The stim circuit to convert into a cirq circuit.
+
+    Returns:
+        The converted circuit.
+
+    Examples:
+
+        >>> import stimcirq
+        >>> import stim
+        >>> stimcirq.stim_circuit_to_cirq_circuit(stim.Circuit('''
+        ...     H 0
+        ...     CNOT 0 1
+        ...     X_ERROR(0.25) 0
+        ...     M !1 0
+        ... ''')).to_text_diagram(use_unicode_characters=False)
+        0: ---H---@---X[prob=0.25]---M('1')---
+                  |
+        1: -------X---!M('0')-----------------
+    """
+    _next_measure_id = 0
+    def get_next_measure_id() -> int:
+        nonlocal _next_measure_id
+        _next_measure_id += 1
+        return _next_measure_id - 1
+
+    return cirq.Circuit(
+        _translate_flattened_operation(op, get_next_measure_id)
+        for op in circuit.flattened_operations()
+    )

--- a/glue/cirq/stimcirq/_circuit_conversion_test.py
+++ b/glue/cirq/stimcirq/_circuit_conversion_test.py
@@ -1,0 +1,52 @@
+from typing import Dict, Tuple, Sequence, List, Union, Callable
+
+import cirq
+import numpy as np
+import pytest
+import stim
+
+import stimcirq
+from ._circuit_conversion import STIM_TO_CIRQ_GATE_TABLE
+
+
+def test_stim_circuit_to_cirq_circuit():
+    circuit = stimcirq.stim_circuit_to_cirq_circuit(stim.Circuit("""
+        X 0
+        CNOT 0 1
+        X_ERROR(0.125) 0 1
+        CORRELATED_ERROR(0.25) X0 Y1 Z2
+        M 1
+        M !1
+        MR 0 !1
+    """))
+    a, b, c = cirq.LineQubit.range(3)
+    assert circuit == cirq.Circuit(
+        cirq.X(a),
+        cirq.CNOT(a, b),
+        cirq.X.with_probability(0.125).on(a),
+        cirq.X.with_probability(0.125).on(b),
+        cirq.PauliString({a: cirq.X, b: cirq.Y, c: cirq.Z}).with_probability(0.25),
+        cirq.measure(b, key="0"),
+        cirq.measure(b, key="1", invert_mask=(True,)),
+        cirq.measure(a, key="2"),
+        cirq.ResetChannel().on(a),
+        cirq.measure(b, key="3", invert_mask=(True,)),
+        cirq.ResetChannel().on(b),
+    )
+
+
+@pytest.mark.parametrize("handler", STIM_TO_CIRQ_GATE_TABLE.values())
+def test_exact_gate_round_trips(handler: Union[cirq.Gate, Callable[[float], cirq.Gate], Tuple]):
+    if handler == ():
+        return
+    if isinstance(handler, cirq.Gate):
+        gate = handler
+    else:
+        gate = handler(0.125)
+
+    n = gate.num_qubits()
+    qs = cirq.LineQubit.range(n)
+    original = cirq.Circuit(gate.on(*qs))
+    converted = stimcirq.cirq_circuit_to_stim_circuit(original)
+    restored = stimcirq.stim_circuit_to_cirq_circuit(converted)
+    assert original == restored

--- a/glue/cirq/stimcirq/_stim_sampler.py
+++ b/glue/cirq/stimcirq/_stim_sampler.py
@@ -70,7 +70,7 @@ def cirq_circuit_to_stim_circuit(circuit: cirq.Circuit) -> stim.Circuit:
         The converted circuit.
 
     Examples:
-        >>> import stimcirq
+        >>> import cirq, stimcirq
         >>> assert False
         >>> assert False
         >>> assert False

--- a/glue/cirq/stimcirq/_stim_sampler.py
+++ b/glue/cirq/stimcirq/_stim_sampler.py
@@ -45,6 +45,96 @@ class StimSampler(cirq.Sampler):
 
 
 def cirq_circuit_to_stim_circuit(circuit: cirq.Circuit) -> stim.Circuit:
+    """Converts a cirq circuit into an equivalent stim circuit.
+
+    Qubits are indexed in sorted order.
+
+    Not all circuits can be converted. In order for a circuit to be convertable,
+    all of its operations must be convertable.
+
+    An operation is convertable if:
+        - It is a stabilizer gate or probabilistic Pauli gate from cirq
+            - cirq.H
+            - cirq.S
+            - cirq.X
+            - cirq.X**0.5
+            - cirq.CNOT
+            - cirq.ResetChannel()
+            - cirq.X.with_probability(p)
+            - cirq.DepolarizingChannel(p, n_qubits=1 or 2)
+            - etc
+        - Or it has a _decompose_ method that yields convertable operations.
+        - Or it has a correctly implemented _stim_conversion_ method.
+
+    Returns:
+        The converted circuit.
+
+    Examples:
+        >>> import stimcirq
+        >>> assert False
+        >>> assert False
+        >>> assert False
+        >>> assert False
+        >>> assert False
+        >>> assert False
+        >>> assert False
+        >>> assert False
+        >>> assert False
+        >>> assert False
+        >>> assert False
+        >>> assert False
+        >>> assert False
+        >>> assert False
+        >>> assert False
+        >>> assert False
+        >>> assert False
+        >>> assert False
+        >>> assert False
+        >>> assert False
+        >>> assert False
+        >>> assert False
+        >>> assert False
+        >>> assert False
+        >>> assert False
+        >>> assert False
+        >>> a = cirq.NamedQubit("one")
+        >>> b = cirq.NamedQubit("two")
+        >>> stimcirq.cirq_circuit_to_stim_circuit(cirq.Circuit(
+        ...     cirq.H(a),
+        ...     cirq.CNOT(a, b),
+        ...     cirq.X(a).with_probability(0.25),
+        ...     cirq.DepolarizingChannel(0.125, n_qubits=2).on(b, a),
+        ...     cirq.measure(a, b),
+        ... ))
+        stim.Circuit('''
+        H 0
+        CX 0 1
+        X_ERROR(0.25) 0
+        DEPOLARIZE2(0.125) 1 0
+        M 0 1
+        ''')
+
+    Here is an example of a _stim_conversion_ method:
+
+        def _stim_conversion_(
+                self,
+
+                # The stim circuit being built. Add onto it.
+                edit_circuit: stim.Circuit,
+
+                # Metadata about measurement groupings needed by stimcirq.StimSampler.
+                # If your gate contains a measurement, it has to append how many qubits
+                # that measurement measures (and its key) into this list.
+                edit_measurement_key_lengths: List[Tuple[str, int]],
+
+                # The indices of qubits the gate should target.
+                targets: List[int],
+
+                # Forward compatibility with future arguments.
+                **kwargs):
+
+            edit_circuit.append_operation("H", targets)
+    """
     return cirq_circuit_to_stim_data(circuit)[0]
 
 
@@ -105,7 +195,7 @@ def gate_to_stim_append_func() -> Dict[cirq.Gate, Callable[[stim.Circuit, List[i
     return {
         cirq.ResetChannel(): use("R"),
         # Identities.
-        cirq.I: do_nothing,
+        cirq.I: use("I"),
         cirq.H ** 0: do_nothing,
         cirq.X ** 0: do_nothing,
         cirq.Y ** 0: do_nothing,

--- a/glue/cirq/stimcirq/_stim_sampler.py
+++ b/glue/cirq/stimcirq/_stim_sampler.py
@@ -71,32 +71,6 @@ def cirq_circuit_to_stim_circuit(circuit: cirq.Circuit) -> stim.Circuit:
 
     Examples:
         >>> import cirq, stimcirq
-        >>> assert False
-        >>> assert False
-        >>> assert False
-        >>> assert False
-        >>> assert False
-        >>> assert False
-        >>> assert False
-        >>> assert False
-        >>> assert False
-        >>> assert False
-        >>> assert False
-        >>> assert False
-        >>> assert False
-        >>> assert False
-        >>> assert False
-        >>> assert False
-        >>> assert False
-        >>> assert False
-        >>> assert False
-        >>> assert False
-        >>> assert False
-        >>> assert False
-        >>> assert False
-        >>> assert False
-        >>> assert False
-        >>> assert False
         >>> a = cirq.NamedQubit("one")
         >>> b = cirq.NamedQubit("two")
         >>> stimcirq.cirq_circuit_to_stim_circuit(cirq.Circuit(

--- a/glue/python/generate_api_reference.py
+++ b/glue/python/generate_api_reference.py
@@ -29,6 +29,7 @@ keep = {
     "__pow__",
     "__repr__",
     "__rmul__",
+    "__hash__",
 }
 skip = {
     "__class__",
@@ -38,7 +39,6 @@ skip = {
     "__file__",
     "__format__",
     "__getattribute__",
-    "__hash__",
     "__init_subclass__",
     "__loader__",
     "__module__",

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ TEST_HEADERS = glob.glob("src/**/*.test.h", recursive=True)
 PERF_HEADERS = glob.glob("src/**/*.perf.h", recursive=True)
 RELEVANT_HEADERS = sorted(set(ALL_HEADERS) - set(TEST_HEADERS + PERF_HEADERS))
 
-version = '1.2.dev'
+version = '1.3.0dev'
 
 extension_module = Extension(
     'stim',

--- a/src/circuit/circuit.pybind.cc
+++ b/src/circuit/circuit.pybind.cc
@@ -26,9 +26,10 @@ std::string circuit_repr(const Circuit &self) {
 }
 
 void pybind_circuit(pybind11::module &m) {
-    pybind11::class_<Circuit>(
-        m, "Circuit",
-        R"DOC(
+    auto &&c = pybind11::class_<Circuit>(
+        m,
+        "Circuit",
+        clean_doc_string(u8R"DOC(
             A mutable stabilizer circuit.
 
             Examples:
@@ -47,15 +48,17 @@ void pybind_circuit(pybind11::module &m) {
                 ... ''').compile_detector_sampler().sample(shots=1)
                 array([[0]], dtype=uint8)
 
-        )DOC")
-        .def(
-            pybind11::init([](const char *stim_program_text) {
-                Circuit self;
-                self.append_from_text(stim_program_text);
-                return self;
-            }),
-            pybind11::arg("stim_program_text") = "",
-            R"DOC(
+        )DOC").data()
+    );
+
+    c.def(
+        pybind11::init([](const char *stim_program_text) {
+            Circuit self;
+            self.append_from_text(stim_program_text);
+            return self;
+        }),
+        pybind11::arg("stim_program_text") = "",
+        clean_doc_string(u8R"DOC(
             Creates a stim.Circuit.
 
             Args:
@@ -69,8 +72,13 @@ void pybind_circuit(pybind11::module &m) {
                 ...    CNOT 0 1
                 ...    M 1
                 ... ''')
-         )DOC")
-        .def_property_readonly("num_measurements", &Circuit::count_measurements, R"DOC(
+        )DOC").data()
+    );
+
+    c.def_property_readonly(
+        "num_measurements",
+        &Circuit::count_measurements,
+        clean_doc_string(u8R"DOC(
             Counts the number of measurement bits produced when sampling from the circuit.
 
             Examples:
@@ -81,8 +89,13 @@ void pybind_circuit(pybind11::module &m) {
                 ... ''')
                 >>> c.num_measurements
                 3
-         )DOC")
-        .def_property_readonly("num_qubits", &Circuit::count_qubits, R"DOC(
+        )DOC").data()
+    );
+
+    c.def_property_readonly(
+        "num_qubits",
+        &Circuit::count_qubits,
+        clean_doc_string(u8R"DOC(
             Counts the number of qubits used when simulating the circuit.
 
             Examples:
@@ -98,46 +111,55 @@ void pybind_circuit(pybind11::module &m) {
                 ... ''')
                 >>> c.num_qubits
                 101
-         )DOC")
-        .def(
-            "compile_sampler",
-            [](const Circuit &self) {
-                return CompiledMeasurementSampler(self);
-            },
-            R"DOC(
-                Returns a CompiledMeasurementSampler, which can quickly batch sample measurements, for the circuit.
+        )DOC").data()
+    );
 
-                Examples:
-                    >>> import stim
-                    >>> c = stim.Circuit('''
-                    ...    X 2
-                    ...    M 0 1 2
-                    ... ''')
-                    >>> s = c.compile_sampler()
-                    >>> s.sample(shots=1)
-                    array([[0, 0, 1]], dtype=uint8)
-            )DOC")
-        .def(
-            "compile_detector_sampler",
-            [](Circuit &self) {
-                return CompiledDetectorSampler(self);
-            },
-            R"DOC(
-                Returns a CompiledDetectorSampler, which can quickly batch sample detection events, for the circuit.
+    c.def(
+        "compile_sampler",
+        [](const Circuit &self) {
+            return CompiledMeasurementSampler(self);
+        },
+        clean_doc_string(u8R"DOC(
+            Returns a CompiledMeasurementSampler, which can quickly batch sample measurements, for the circuit.
 
-                Examples:
-                    >>> import stim
-                    >>> c = stim.Circuit('''
-                    ...    H 0
-                    ...    CNOT 0 1
-                    ...    M 0 1
-                    ...    DETECTOR rec[-1] rec[-2]
-                    ... ''')
-                    >>> s = c.compile_detector_sampler()
-                    >>> s.sample(shots=1)
-                    array([[0]], dtype=uint8)
-            )DOC")
-        .def("clear", &Circuit::clear, R"DOC(
+            Examples:
+                >>> import stim
+                >>> c = stim.Circuit('''
+                ...    X 2
+                ...    M 0 1 2
+                ... ''')
+                >>> s = c.compile_sampler()
+                >>> s.sample(shots=1)
+                array([[0, 0, 1]], dtype=uint8)
+        )DOC").data()
+    );
+
+    c.def(
+        "compile_detector_sampler",
+        [](Circuit &self) {
+            return CompiledDetectorSampler(self);
+        },
+        clean_doc_string(u8R"DOC(
+            Returns a CompiledDetectorSampler, which can quickly batch sample detection events, for the circuit.
+
+            Examples:
+                >>> import stim
+                >>> c = stim.Circuit('''
+                ...    H 0
+                ...    CNOT 0 1
+                ...    M 0 1
+                ...    DETECTOR rec[-1] rec[-2]
+                ... ''')
+                >>> s = c.compile_detector_sampler()
+                >>> s.sample(shots=1)
+                array([[0]], dtype=uint8)
+        )DOC").data()
+    );
+
+    c.def(
+        "clear",
+        &Circuit::clear,
+        clean_doc_string(u8R"DOC(
             Clears the contents of the circuit.
 
             Examples:
@@ -149,8 +171,14 @@ void pybind_circuit(pybind11::module &m) {
                 >>> c.clear()
                 >>> c
                 stim.Circuit()
-         )DOC")
-        .def("__iadd__", &Circuit::operator+=, pybind11::arg("second"), R"DOC(
+        )DOC").data()
+    );
+
+    c.def(
+        "__iadd__",
+        &Circuit::operator+=,
+        pybind11::arg("second"),
+        clean_doc_string(u8R"DOC(
             Appends a circuit into the receiving circuit (mutating it).
 
             Examples:
@@ -167,79 +195,83 @@ void pybind_circuit(pybind11::module &m) {
                 X 0
                 Y 1 2
                 M 0 1 2
-         )DOC")
-        .def("flattened_operations",
-            [](Circuit &self){
-                pybind11::list result;
-                self.for_each_operation([&](const Operation &op){
-                    pybind11::list targets;
-                    for (auto t : op.target_data.targets) {
-                        auto v = t & TARGET_VALUE_MASK;
-                        if (t & TARGET_INVERTED_BIT) {
-                            targets.append(pybind11::make_tuple("inv", v));
-                        } else if (t & (TARGET_PAULI_X_BIT | TARGET_PAULI_Z_BIT)) {
-                            if (!(t & TARGET_PAULI_Z_BIT)) {
-                                targets.append(pybind11::make_tuple("X", v));
-                            } else if (!(t & TARGET_PAULI_X_BIT)) {
-                                targets.append(pybind11::make_tuple("Z", v));
-                            } else {
-                                targets.append(pybind11::make_tuple("Y", v));
-                            }
-                        } else if (t & TARGET_RECORD_BIT) {
-                            targets.append(pybind11::make_tuple("rec", -(long long)v));
+        )DOC").data()
+    );
+
+    c.def(
+        "flattened_operations",
+        [](Circuit &self){
+            pybind11::list result;
+            self.for_each_operation([&](const Operation &op){
+                pybind11::list targets;
+                for (auto t : op.target_data.targets) {
+                    auto v = t & TARGET_VALUE_MASK;
+                    if (t & TARGET_INVERTED_BIT) {
+                        targets.append(pybind11::make_tuple("inv", v));
+                    } else if (t & (TARGET_PAULI_X_BIT | TARGET_PAULI_Z_BIT)) {
+                        if (!(t & TARGET_PAULI_Z_BIT)) {
+                            targets.append(pybind11::make_tuple("X", v));
+                        } else if (!(t & TARGET_PAULI_X_BIT)) {
+                            targets.append(pybind11::make_tuple("Z", v));
                         } else {
-                            targets.append(pybind11::int_(v));
+                            targets.append(pybind11::make_tuple("Y", v));
                         }
+                    } else if (t & TARGET_RECORD_BIT) {
+                        targets.append(pybind11::make_tuple("rec", -(long long)v));
+                    } else {
+                        targets.append(pybind11::int_(v));
                     }
-                    result.append(pybind11::make_tuple(op.gate->name, targets, op.target_data.arg));
-                });
-                return result;
-            },
-            R"DOC(
-                Flattens the circuit's operations into a list.
+                }
+                result.append(pybind11::make_tuple(op.gate->name, targets, op.target_data.arg));
+            });
+            return result;
+        },
+        clean_doc_string(u8R"DOC(
+            Flattens the circuit's operations into a list.
 
-                The operations within repeat blocks are actually repeated in the output.
+            The operations within repeat blocks are actually repeated in the output.
 
-                Returns:
-                    A List[Tuple[name, targets, arg]] of the operations in the circuit.
-                        name: A string with the gate's name.
-                        targets: A list of things acted on by the gate. Each thing can be:
-                            int: The index of a qubit.
-                            Tuple["inv", int]: The index of a qubit to measure with an inverted result.
-                            Tuple["rec", int]: A measurement record target like `rec[-1]`.
-                            Tuple["X", int]: A Pauli X operation to apply during a correlated error.
-                            Tuple["Y", int]: A Pauli Y operation to apply during a correlated error.
-                            Tuple["Z", int]: A Pauli Z operation to apply during a correlated error.
-                        arg: The gate's numeric argument. For most gates this is just 0. For noisy
-                            gates this is the probability of the noise being applied.
+            Returns:
+                A List[Tuple[name, targets, arg]] of the operations in the circuit.
+                    name: A string with the gate's name.
+                    targets: A list of things acted on by the gate. Each thing can be:
+                        int: The index of a qubit.
+                        Tuple["inv", int]: The index of a qubit to measure with an inverted result.
+                        Tuple["rec", int]: A measurement record target like `rec[-1]`.
+                        Tuple["X", int]: A Pauli X operation to apply during a correlated error.
+                        Tuple["Y", int]: A Pauli Y operation to apply during a correlated error.
+                        Tuple["Z", int]: A Pauli Z operation to apply during a correlated error.
+                    arg: The gate's numeric argument. For most gates this is just 0. For noisy
+                        gates this is the probability of the noise being applied.
 
-                Examples:
-                    >>> import stim
-                    >>> stim.Circuit('''
-                    ...    H 0
-                    ...    X_ERROR(0.125) 1
-                    ...    M 0 !1
-                    ... ''').flattened_operations()
-                    [('H', [0], 0.0), ('X_ERROR', [1], 0.125), ('M', [0, ('inv', 1)], 0.0)]
+            Examples:
+                >>> import stim
+                >>> stim.Circuit('''
+                ...    H 0
+                ...    X_ERROR(0.125) 1
+                ...    M 0 !1
+                ... ''').flattened_operations()
+                [('H', [0], 0.0), ('X_ERROR', [1], 0.125), ('M', [0, ('inv', 1)], 0.0)]
 
-                    >>> stim.Circuit('''
-                    ...    REPEAT 2 {
-                    ...        H 6
-                    ...    }
-                    ... ''').flattened_operations()
-                    [('H', [6], 0.0), ('H', [6], 0.0)]
-            )DOC")
-        .def(
-            "__eq__",
-            [](const Circuit &self, const Circuit &other) {
-                return self == other;
-            })
-        .def(
-            "__ne__",
-            [](const Circuit &self, const Circuit &other) {
-                return self != other;
-            })
-        .def("__add__", &Circuit::operator+, pybind11::arg("second"), R"DOC(
+                >>> stim.Circuit('''
+                ...    REPEAT 2 {
+                ...        H 6
+                ...    }
+                ... ''').flattened_operations()
+                [('H', [6], 0.0), ('H', [6], 0.0)]
+        )DOC").data()
+    );
+
+    c.def(pybind11::self == pybind11::self,
+        "Determines if two circuits have identical contents.");
+    c.def(pybind11::self != pybind11::self,
+        "Determines if two circuits have non-identical contents.");
+
+    c.def(
+        "__add__",
+        &Circuit::operator+,
+        pybind11::arg("second"),
+        clean_doc_string(u8R"DOC(
             Creates a circuit by appending two circuits.
 
             Examples:
@@ -255,8 +287,14 @@ void pybind_circuit(pybind11::module &m) {
                 X 0
                 Y 1 2
                 M 0 1 2
-         )DOC")
-        .def("__imul__", &Circuit::operator*=, pybind11::arg("repetitions"), R"DOC(
+        )DOC").data()
+    );
+
+    c.def(
+        "__imul__",
+        &Circuit::operator*=,
+        pybind11::arg("repetitions"),
+        clean_doc_string(u8R"DOC(
             Mutates the circuit into multiple copies of itself.
 
             Examples:
@@ -271,8 +309,14 @@ void pybind_circuit(pybind11::module &m) {
                     X 0
                     Y 1 2
                 }
-         )DOC")
-        .def("__mul__", &Circuit::operator*, pybind11::arg("repetitions"), R"DOC(
+        )DOC").data()
+    );
+
+    c.def(
+        "__mul__",
+        &Circuit::operator*,
+        pybind11::arg("repetitions"),
+        clean_doc_string(u8R"DOC(
             Creates a circuit by repeating a circuit multiple times.
 
             Examples:
@@ -286,79 +330,93 @@ void pybind_circuit(pybind11::module &m) {
                     X 0
                     Y 1 2
                 }
-         )DOC")
-        .def(
-            "__rmul__", &Circuit::operator*, pybind11::arg("repetitions"),
-            R"DOC(
-                 Creates a circuit by repeating a circuit multiple times.
+        )DOC").data()
+    );
 
-                 Examples:
-                     >>> import stim
-                     >>> c = stim.Circuit('''
-                     ...    X 0
-                     ...    Y 1 2
-                     ... ''')
-                     >>> print(3 * c)
-                     REPEAT 3 {
-                         X 0
-                         Y 1 2
-                     }
-            )DOC")
-        .def(
-            "append_operation", &Circuit::append_op, R"DOC(
-                Appends an operation into the circuit.
+    c.def(
+        "__rmul__",
+        &Circuit::operator*,
+        pybind11::arg("repetitions"),
+        clean_doc_string(u8R"DOC(
+            Creates a circuit by repeating a circuit multiple times.
 
-                Examples:
-                    >>> import stim
-                    >>> c = stim.Circuit()
-                    >>> c.append_operation("X", [0])
-                    >>> c.append_operation("H", [0, 1])
-                    >>> c.append_operation("M", [0, stim.target_inv(1)])
-                    >>> c.append_operation("CNOT", [stim.target_rec(-1), 0])
-                    >>> c.append_operation("X_ERROR", [0], 0.125)
-                    >>> c.append_operation("CORRELATED_ERROR", [stim.target_x(0), stim.target_y(2)], 0.25)
-                    >>> print(c)
+            Examples:
+                >>> import stim
+                >>> c = stim.Circuit('''
+                ...    X 0
+                ...    Y 1 2
+                ... ''')
+                >>> print(3 * c)
+                REPEAT 3 {
                     X 0
-                    H 0 1
-                    M 0 !1
-                    CX rec[-1] 0
-                    X_ERROR(0.125) 0
-                    E(0.25) X0 Y2
+                    Y 1 2
+                }
+        )DOC").data()
+    );
 
-                Args:
-                    name: The name of the operation's gate (e.g. "H" or "M" or "CNOT").
-                    targets: The gate targets. Gates implicitly broadcast over their targets.
-                    arg: A modifier for the gate, e.g. the probability of an error. Defaults to 0.
-            )DOC",
-            pybind11::arg("name"), pybind11::arg("targets"), pybind11::arg("arg") = 0.0)
-        .def(
-            "append_from_stim_program_text",
-            [](Circuit &self, const char *text) {
-                self.append_from_text(text);
-            },
-            R"DOC(
-                Appends operations described by a STIM format program into the circuit.
+    c.def(
+        "append_operation",
+        &Circuit::append_op,
+        pybind11::arg("name"),
+        pybind11::arg("targets"),
+        pybind11::arg("arg") = 0.0,
+        clean_doc_string(u8R"DOC(
+            Appends an operation into the circuit.
 
-                Examples:
-                    >>> import stim
-                    >>> c = stim.Circuit()
-                    >>> c.append_from_stim_program_text('''
-                    ...    H 0  # comment
-                    ...    CNOT 0 2
-                    ...
-                    ...    M 2
-                    ...    CNOT rec[-1] 1
-                    ... ''')
-                    >>> print(c)
-                    H 0
-                    CX 0 2
-                    M 2
-                    CX rec[-1] 1
+            Examples:
+                >>> import stim
+                >>> c = stim.Circuit()
+                >>> c.append_operation("X", [0])
+                >>> c.append_operation("H", [0, 1])
+                >>> c.append_operation("M", [0, stim.target_inv(1)])
+                >>> c.append_operation("CNOT", [stim.target_rec(-1), 0])
+                >>> c.append_operation("X_ERROR", [0], 0.125)
+                >>> c.append_operation("CORRELATED_ERROR", [stim.target_x(0), stim.target_y(2)], 0.25)
+                >>> print(c)
+                X 0
+                H 0 1
+                M 0 !1
+                CX rec[-1] 0
+                X_ERROR(0.125) 0
+                E(0.25) X0 Y2
 
-                Args:
-                    text: The STIM program text containing the circuit operations to append.
-            )DOC",
-            pybind11::arg("stim_program_text"))
-        .def("__str__", &Circuit::str)
-        .def("__repr__", &circuit_repr);
+            Args:
+                name: The name of the operation's gate (e.g. "H" or "M" or "CNOT").
+                targets: The gate targets. Gates implicitly broadcast over their targets.
+                arg: A modifier for the gate, e.g. the probability of an error. Defaults to 0.
+        )DOC").data()
+    );
+
+    c.def(
+        "append_from_stim_program_text",
+        [](Circuit &self, const char *text) {
+            self.append_from_text(text);
+        },
+        pybind11::arg("stim_program_text"),
+        clean_doc_string(u8R"DOC(
+            Appends operations described by a STIM format program into the circuit.
+
+            Examples:
+                >>> import stim
+                >>> c = stim.Circuit()
+                >>> c.append_from_stim_program_text('''
+                ...    H 0  # comment
+                ...    CNOT 0 2
+                ...
+                ...    M 2
+                ...    CNOT rec[-1] 1
+                ... ''')
+                >>> print(c)
+                H 0
+                CX 0 2
+                M 2
+                CX rec[-1] 1
+
+            Args:
+                text: The STIM program text containing the circuit operations to append.
+        )DOC").data()
+    );
+
+    c.def("__str__", &Circuit::str);
+    c.def("__repr__", &circuit_repr);
 }

--- a/src/circuit/circuit_pybind_test.py
+++ b/src/circuit/circuit_pybind_test.py
@@ -248,3 +248,33 @@ DETECTOR rec[-1]
 
     # Check that expression can be evaluated.
     _ = eval(r, {"stim": stim})
+
+
+def test_circuit_flattened_operations():
+    for e in stim.Circuit('''
+        H 0
+        REPEAT 3 {
+            X_ERROR(0.125) 1
+        }
+        CORRELATED_ERROR(0.25) X3 Y4 Z5
+        M 0 !1
+        DETECTOR rec[-1]
+    ''').flattened_operations():
+        print(e)
+    assert stim.Circuit('''
+        H 0
+        REPEAT 3 {
+            X_ERROR(0.125) 1
+        }
+        CORRELATED_ERROR(0.25) X3 Y4 Z5
+        M 0 !1
+        DETECTOR rec[-1]
+    ''').flattened_operations() == [
+        ("H", [0], 0),
+        ("X_ERROR", [1], 0.125),
+        ("X_ERROR", [1], 0.125),
+        ("X_ERROR", [1], 0.125),
+        ("E", [("X", 3), ("Y", 4), ("Z", 5)], 0.25),
+        ("M", [0, ("inv", 1)], 0),
+        ("DETECTOR", [("rec", -1)], 0),
+    ]

--- a/src/circuit/circuit_pybind_test.py
+++ b/src/circuit/circuit_pybind_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
 import stim
 import pytest
 
@@ -192,6 +191,13 @@ def test_circuit_eq():
     assert stim.Circuit(b) == stim.Circuit(b)
     assert stim.Circuit(a) != stim.Circuit(b)
 
+    assert stim.Circuit() != None
+    assert stim.Circuit != object()
+    assert stim.Circuit != "another type"
+    assert not (stim.Circuit == None)
+    assert not (stim.Circuit == object())
+    assert not (stim.Circuit == "another type")
+
 
 def test_circuit_clear():
     c = stim.Circuit("""
@@ -278,3 +284,10 @@ def test_circuit_flattened_operations():
         ("M", [0, ("inv", 1)], 0),
         ("DETECTOR", [("rec", -1)], 0),
     ]
+
+
+def test_hash():
+    # stim.Circuit is mutable. It must not also be value-hashable.
+    # Defining __hash__ requires defining a FrozenCircuit variant instead.
+    with pytest.raises(TypeError, match="unhashable"):
+        _ = hash(stim.Circuit())

--- a/src/circuit/circuit_pybind_test.py
+++ b/src/circuit/circuit_pybind_test.py
@@ -82,11 +82,13 @@ OBSERVABLE_INCLUDE(5) rec[-1] rec[-2]
 
 def test_circuit_iadd():
     c = stim.Circuit()
+    alias = c
     c.append_operation("X", [1, 2])
     c2 = stim.Circuit()
     c2.append_operation("Y", [3])
     c2.append_operation("M", [4])
     c += c2
+    assert c is alias
     assert str(c).strip() == """
 X 1 2
 Y 3
@@ -102,6 +104,7 @@ X 1 2
 Y 3
 M 4
     """.strip()
+    assert c is alias
 
 
 def test_circuit_add():
@@ -147,12 +150,16 @@ REPEAT 3 {
 }
     """.strip()
     assert str(c * 3) == str(3 * c) == expected
+    alias = c
     c *= 3
+    assert alias is c
     assert str(c) == expected
     c *= 1
     assert str(c) == expected
+    assert alias is c
     c *= 0
     assert str(c) == ""
+    assert alias is c
 
 
 def test_circuit_repr():

--- a/src/py/base.pybind.cc
+++ b/src/py/base.pybind.cc
@@ -26,3 +26,33 @@ std::mt19937_64 &PYBIND_SHARED_RNG() {
     }
     return shared_rng;
 }
+
+std::string clean_doc_string(const char *c) {
+    // Skip leading empty lines.
+    while (*c == '\n') {
+        c++;
+    }
+
+    // Determine indentation using first non-empty line.
+    size_t indent = 0;
+    while (*c == ' ') {
+        indent++;
+        c++;
+    }
+
+    std::string result;
+    while (*c != '\0') {
+        // Skip indentation.
+        for (size_t j = 0; j < indent && *c == ' '; j++) {
+            c++;
+        }
+
+        // Copy rest of line.
+        do {
+            result.push_back(*c);
+            c++;
+        } while (*c != '\n' && *c != '\0');
+    }
+
+    return result;
+}

--- a/src/py/base.pybind.h
+++ b/src/py/base.pybind.h
@@ -22,5 +22,6 @@
 #include <random>
 
 std::mt19937_64 &PYBIND_SHARED_RNG();
+std::string clean_doc_string(const char *c);
 
 #endif

--- a/src/py/base.pybind.h
+++ b/src/py/base.pybind.h
@@ -16,6 +16,7 @@
 #define STIM_BASE_PYBIND_H
 
 #include <pybind11/numpy.h>
+#include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <random>

--- a/src/py/compiled_detector_sampler.pybind.cc
+++ b/src/py/compiled_detector_sampler.pybind.cc
@@ -76,11 +76,22 @@ std::string CompiledDetectorSampler::repr() const {
 }
 
 void pybind_compiled_detector_sampler(pybind11::module &m) {
-    pybind11::class_<CompiledDetectorSampler>(
-        m, "CompiledDetectorSampler", "An analyzed stabilizer circuit whose detection events can be sampled quickly.")
-        .def(pybind11::init<Circuit>())
-        .def(
-            "sample", &CompiledDetectorSampler::sample, R"DOC(
+    auto &&c = pybind11::class_<CompiledDetectorSampler>(
+        m,
+        "CompiledDetectorSampler",
+        "An analyzed stabilizer circuit whose detection events can be sampled quickly."
+    );
+
+    c.def(pybind11::init<Circuit>());
+
+    c.def(
+        "sample",
+        &CompiledDetectorSampler::sample,
+        pybind11::arg("shots"),
+        pybind11::kw_only(),
+        pybind11::arg("prepend_observables") = false,
+        pybind11::arg("append_observables") = false,
+        clean_doc_string(u8R"DOC(
             Returns a numpy array containing a batch of detector samples from the circuit.
 
             The circuit must define the detectors using DETECTOR instructions. Observables defined by OBSERVABLE_INCLUDE
@@ -97,11 +108,17 @@ void pybind_compiled_detector_sampler(pybind11::module &m) {
                 A numpy array with `dtype=uint8` and `shape=(shots, n)` where
                 `n = num_detectors + num_observables*(append_observables + prepend_observables)`.
                 The bit for detection event `m` in shot `s` is at `result[s, m]`.
-            )DOC",
-            pybind11::arg("shots"), pybind11::kw_only(), pybind11::arg("prepend_observables") = false,
-            pybind11::arg("append_observables") = false)
-        .def(
-            "sample_bit_packed", &CompiledDetectorSampler::sample_bit_packed, R"DOC(
+        )DOC").data()
+    );
+
+    c.def(
+        "sample_bit_packed",
+        &CompiledDetectorSampler::sample_bit_packed,
+        pybind11::arg("shots"),
+        pybind11::kw_only(),
+        pybind11::arg("prepend_observables") = false,
+        pybind11::arg("append_observables") = false,
+        clean_doc_string(u8R"DOC(
             Returns a numpy array containing bit packed batch of detector samples from the circuit.
 
             The circuit must define the detectors using DETECTOR instructions. Observables defined by OBSERVABLE_INCLUDE
@@ -118,8 +135,11 @@ void pybind_compiled_detector_sampler(pybind11::module &m) {
                 A numpy array with `dtype=uint8` and `shape=(shots, n)` where
                 `n = num_detectors + num_observables*(append_observables + prepend_observables)`.
                 The bit for detection event `m` in shot `s` is at `result[s, (m // 8)] & 2**(m % 8)`.
-            )DOC",
-            pybind11::arg("shots"), pybind11::kw_only(), pybind11::arg("prepend_observables") = false,
-            pybind11::arg("append_observables") = false)
-        .def("__repr__", &CompiledDetectorSampler::repr);
+        )DOC").data()
+    );
+
+    c.def(
+        "__repr__",
+        &CompiledDetectorSampler::repr
+    );
 }

--- a/src/py/compiled_measurement_sampler.pybind.cc
+++ b/src/py/compiled_measurement_sampler.pybind.cc
@@ -68,11 +68,19 @@ std::string CompiledMeasurementSampler::repr() const {
 }
 
 void pybind_compiled_measurement_sampler(pybind11::module &m) {
-    pybind11::class_<CompiledMeasurementSampler>(
-        m, "CompiledMeasurementSampler", "An analyzed stabilizer circuit whose measurements can be sampled quickly.")
-        .def(pybind11::init<Circuit>())
-        .def(
-            "sample", &CompiledMeasurementSampler::sample, R"DOC(
+    auto &&c = pybind11::class_<CompiledMeasurementSampler>(
+        m,
+        "CompiledMeasurementSampler",
+        "An analyzed stabilizer circuit whose measurements can be sampled quickly."
+    );
+
+    c.def(pybind11::init<Circuit>());
+
+    c.def(
+        "sample",
+        &CompiledMeasurementSampler::sample,
+        pybind11::arg("shots"),
+        clean_doc_string(u8R"DOC(
             Returns a numpy array containing a batch of measurement samples from the circuit.
 
             Examples:
@@ -91,10 +99,14 @@ void pybind_compiled_measurement_sampler(pybind11::module &m) {
             Returns:
                 A numpy array with `dtype=uint8` and `shape=(shots, num_measurements)`.
                 The bit for measurement `m` in shot `s` is at `result[s, m]`.
-        )DOC",
-            pybind11::arg("shots"))
-        .def(
-            "sample_bit_packed", &CompiledMeasurementSampler::sample_bit_packed, R"DOC(
+        )DOC").data()
+    );
+
+    c.def(
+        "sample_bit_packed",
+        &CompiledMeasurementSampler::sample_bit_packed,
+        pybind11::arg("shots"),
+        clean_doc_string(u8R"DOC(
             Returns a numpy array containing a bit packed batch of measurement samples from the circuit.
 
             Examples:
@@ -113,7 +125,12 @@ void pybind_compiled_measurement_sampler(pybind11::module &m) {
             Returns:
                 A numpy array with `dtype=uint8` and `shape=(shots, (num_measurements + 7) // 8)`.
                 The bit for measurement `m` in shot `s` is at `result[s, (m // 8)] & 2**(m % 8)`.
-        )DOC",
-            pybind11::arg("shots"))
-        .def("__repr__", &CompiledMeasurementSampler::repr);
+        )DOC").data()
+    );
+
+    c.def(
+        "__repr__",
+        &CompiledMeasurementSampler::repr,
+        "Returns an eval-able text description."
+    );
 }

--- a/src/py/stim.pybind.cc
+++ b/src/py/stim.pybind.cc
@@ -16,6 +16,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include "base.pybind.h"
 #include "../circuit/circuit.pybind.h"
 #include "../simulators/tableau_simulator.pybind.h"
 #include "../stabilizers/pauli_string.pybind.h"
@@ -56,36 +57,55 @@ PYBIND11_MODULE(stim, m) {
     )pbdoc";
 
     m.def(
-        "target_rec", &target_rec, R"DOC(
-        Returns a record target that can be passed into Circuit.append_operation.
-        For example, the 'rec[-2]' in 'DETECTOR rec[-2]' is a record target.
-    )DOC",
-        pybind11::arg("lookback_index"));
+        "target_rec",
+        &target_rec,
+        pybind11::arg("lookback_index"),
+        clean_doc_string(u8R"DOC(
+            Returns a record target that can be passed into Circuit.append_operation.
+            For example, the 'rec[-2]' in 'DETECTOR rec[-2]' is a record target.
+        )DOC").data()
+    );
+
     m.def(
-        "target_inv", &target_inv, R"DOC(
-        Returns a target flagged as inverted that can be passed into Circuit.append_operation
-        For example, the '!1' in 'M 0 !1 2' is qubit 1 flagged as inverted,
-        meaning the measurement result from qubit 1 should be inverted when reported.
-    )DOC",
-        pybind11::arg("qubit_index"));
+        "target_inv",
+        &target_inv,
+        pybind11::arg("qubit_index"),
+        clean_doc_string(u8R"DOC(
+            Returns a target flagged as inverted that can be passed into Circuit.append_operation
+            For example, the '!1' in 'M 0 !1 2' is qubit 1 flagged as inverted,
+            meaning the measurement result from qubit 1 should be inverted when reported.
+        )DOC").data()
+    );
+
     m.def(
-        "target_x", &target_x, R"DOC(
-        Returns a target flagged as Pauli X that can be passed into Circuit.append_operation
-        For example, the 'X1' in 'CORRELATED_ERROR(0.1) X1 Y2 Z3' is qubit 1 flagged as Pauli X.
-    )DOC",
-        pybind11::arg("qubit_index"));
+        "target_x",
+        &target_x,
+        pybind11::arg("qubit_index"),
+        clean_doc_string(u8R"DOC(
+            Returns a target flagged as Pauli X that can be passed into Circuit.append_operation
+            For example, the 'X1' in 'CORRELATED_ERROR(0.1) X1 Y2 Z3' is qubit 1 flagged as Pauli X.
+        )DOC").data()
+    );
+
     m.def(
-        "target_y", &target_y, R"DOC(
-        Returns a target flagged as Pauli Y that can be passed into Circuit.append_operation
-        For example, the 'Y2' in 'CORRELATED_ERROR(0.1) X1 Y2 Z3' is qubit 2 flagged as Pauli Y.
-    )DOC",
-        pybind11::arg("qubit_index"));
+        "target_y",
+        &target_y,
+        pybind11::arg("qubit_index"),
+        clean_doc_string(u8R"DOC(
+            Returns a target flagged as Pauli Y that can be passed into Circuit.append_operation
+            For example, the 'Y2' in 'CORRELATED_ERROR(0.1) X1 Y2 Z3' is qubit 2 flagged as Pauli Y.
+        )DOC").data()
+    );
+
     m.def(
-        "target_z", &target_z, R"DOC(
-        Returns a target flagged as Pauli Z that can be passed into Circuit.append_operation
-        For example, the 'Z3' in 'CORRELATED_ERROR(0.1) X1 Y2 Z3' is qubit 3 flagged as Pauli Z.
-    )DOC",
-        pybind11::arg("qubit_index"));
+        "target_z",
+        &target_z,
+        pybind11::arg("qubit_index"),
+        clean_doc_string(u8R"DOC(
+            Returns a target flagged as Pauli Z that can be passed into Circuit.append_operation
+            For example, the 'Z3' in 'CORRELATED_ERROR(0.1) X1 Y2 Z3' is qubit 3 flagged as Pauli Z.
+        )DOC").data()
+    );
 
     pybind_circuit(m);
     pybind_compiled_detector_sampler(m);

--- a/src/simulators/tableau_simulator.pybind.cc
+++ b/src/simulators/tableau_simulator.pybind.cc
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "../simulators/tableau_simulator.h"
+#include "tableau_simulator.pybind.h"
 
+#include "../simulators/tableau_simulator.h"
+#include "../stabilizers/pauli_string.pybind.h"
 #include "../py/base.pybind.h"
 #include "../stabilizers/tableau.h"
-#include "tableau_simulator.pybind.h"
 
 struct TempViewableData {
     std::vector<uint32_t> targets;
@@ -482,7 +483,7 @@ void pybind_tableau_simulator(pybind11::module &m) {
             "peek_bloch",
             [](TableauSimulator &self, size_t target) {
                 self.ensure_large_enough_for_qubits(target + 1);
-                return self.peek_bloch(target);
+                return PyPauliString(self.peek_bloch(target));
             },
             pybind11::arg("target"),
             R"DOC(

--- a/src/stabilizers/pauli_string.pybind.h
+++ b/src/stabilizers/pauli_string.pybind.h
@@ -15,7 +15,25 @@
 #ifndef PAULI_STRING_PYBIND_H
 #define PAULI_STRING_PYBIND_H
 
+#include <complex>
 #include <pybind11/pybind11.h>
+
+#include "pauli_string.h"
+
+struct PyPauliString {
+    PauliString value;
+    bool imag;
+
+    PyPauliString(const PauliStringRef val, bool imag = false);
+    PyPauliString(PauliString&& val, bool imag = false);
+
+    std::complex<float> get_phase() const;
+    PyPauliString operator*(std::complex<float> scale) const;
+    PyPauliString &operator*=(std::complex<float> scale);
+    PyPauliString operator*(const PyPauliString &rhs) const;
+    PyPauliString &operator*=(const PyPauliString &rhs);
+    std::string str() const;
+};
 
 void pybind_pauli_string(pybind11::module &m);
 

--- a/src/stabilizers/pauli_string.pybind.h
+++ b/src/stabilizers/pauli_string.pybind.h
@@ -32,6 +32,8 @@ struct PyPauliString {
     PyPauliString &operator*=(std::complex<float> scale);
     PyPauliString operator*(const PyPauliString &rhs) const;
     PyPauliString &operator*=(const PyPauliString &rhs);
+    bool operator==(const PyPauliString &other) const;
+    bool operator!=(const PyPauliString &other) const;
     std::string str() const;
 };
 

--- a/src/stabilizers/pauli_string_pybind_test.py
+++ b/src/stabilizers/pauli_string_pybind_test.py
@@ -40,6 +40,31 @@ def test_from_str():
     assert len(p) == 0
     assert p.sign == +1
 
+    p = stim.PauliString("X")
+    assert len(p) == 1
+    assert p[0] == 1
+    assert p.sign == +1
+
+    p = stim.PauliString("+X")
+    assert len(p) == 1
+    assert p[0] == 1
+    assert p.sign == +1
+
+    p = stim.PauliString("iX")
+    assert len(p) == 1
+    assert p[0] == 1
+    assert p.sign == 1j
+
+    p = stim.PauliString("+iX")
+    assert len(p) == 1
+    assert p[0] == 1
+    assert p.sign == 1j
+
+    p = stim.PauliString("-iX")
+    assert len(p) == 1
+    assert p[0] == 1
+    assert p.sign == -1j
+
 
 def test_equality():
     assert stim.PauliString(4) == stim.PauliString(4)
@@ -51,6 +76,8 @@ def test_equality():
     assert stim.PauliString("+X") != stim.PauliString("-X")
     assert stim.PauliString("+X") != stim.PauliString("+Y")
     assert stim.PauliString("+X") != stim.PauliString("-Y")
+    assert stim.PauliString("+X") != stim.PauliString("+iX")
+    assert stim.PauliString("+X") != stim.PauliString("-iX")
 
     assert stim.PauliString("__") != stim.PauliString("_X")
     assert stim.PauliString("__") != stim.PauliString("X_")
@@ -68,18 +95,52 @@ def test_str():
     assert str(stim.PauliString(3)) == "+___"
     assert str(stim.PauliString("XYZ")) == "+XYZ"
     assert str(stim.PauliString("-XYZ")) == "-XYZ"
+    assert str(stim.PauliString("iXYZ")) == "+iXYZ"
+    assert str(stim.PauliString("-iXYZ")) == "-iXYZ"
 
 
 def test_repr():
     assert repr(stim.PauliString(3)) == 'stim.PauliString("+___")'
-    v = stim.PauliString("-XYZ")
-    r = repr(v)
-    assert r == 'stim.PauliString("-XYZ")'
-    assert eval(r, {'stim': stim}) == v
+    assert repr(stim.PauliString("-XYZ")) == 'stim.PauliString("-XYZ")'
+    vs = [
+        stim.PauliString(""),
+        stim.PauliString("ZXYZZ"),
+        stim.PauliString("-XYZ"),
+        stim.PauliString("I"),
+        stim.PauliString("iIXYZ"),
+        stim.PauliString("-iIXYZ"),
+    ]
+    for v in vs:
+        r = repr(v)
+        assert eval(r, {'stim': stim}) == v
+
+
+def test_commutes():
+    def c(a: stim.PauliString, b: stim.PauliString) -> bool:
+        return stim.PauliString(a).commutes(stim.PauliString(b))
+
+    with pytest.raises(ValueError, match="len"):
+        c("", "X")
+    assert c("", "")
+    assert c("X", "_")
+    assert c("X", "X")
+    assert not c("X", "Y")
+    assert not c("X", "Z")
+
+    assert c("XXXX", "YYYY")
+    assert c("XXXX", "YYYZ")
+    assert not c("XXXX", "XXXZ")
+    assert not c("XXXX", "___Z")
+    assert not c("XXXX", "Z___")
+    assert c("XXXX", "Z_Z_")
 
 
 def test_product():
     assert stim.PauliString("") * stim.PauliString("") == stim.PauliString("")
+    assert stim.PauliString("i") * stim.PauliString("i") == stim.PauliString("-")
+    assert stim.PauliString("i") * stim.PauliString("-i") == stim.PauliString("+")
+    assert stim.PauliString("-i") * stim.PauliString("-i") == stim.PauliString("-")
+    assert stim.PauliString("i") * stim.PauliString("-") == stim.PauliString("-i")
 
     x = stim.PauliString("X")
     y = stim.PauliString("Y")
@@ -96,11 +157,14 @@ def test_product():
     with pytest.raises(ValueError, match="!= len"):
         _ = stim.PauliString(10).extended_product(stim.PauliString(11))
 
-    with pytest.raises(ValueError, match="non-commut"):
-        _ = x * z
+    assert x * z == stim.PauliString("-iY")
     assert x * x == stim.PauliString(1)
-    assert x.extended_product(y) == (1j, z)
-    assert y.extended_product(x) == (1j, -z)
+    assert x * y == stim.PauliString("iZ")
+    assert y * x == stim.PauliString("-iZ")
+    assert x * y == 1j * z
+    assert y * x == z * -1j
+    assert x.extended_product(y) == (1, 1j * z)
+    assert y.extended_product(x) == (1, -1j * z)
     assert x.extended_product(x) == (1, stim.PauliString(1))
 
     xx = stim.PauliString("+XX")
@@ -108,6 +172,65 @@ def test_product():
     zz = stim.PauliString("+ZZ")
     assert xx * zz == -yy
     assert xx.extended_product(zz) == (1, -yy)
+
+
+def test_inplace_product():
+    p = stim.PauliString("X")
+    alias = p
+
+    p *= 1j
+    assert alias == stim.PauliString("iX")
+    assert alias is p
+    p *= 1j
+    assert alias == stim.PauliString("-X")
+    p *= 1j
+    assert alias == stim.PauliString("-iX")
+    p *= 1j
+    assert alias == stim.PauliString("+X")
+
+    p *= stim.PauliString("Z")
+    assert alias == stim.PauliString("-iY")
+
+    p *= -1j
+    assert alias == stim.PauliString("-Y")
+    p *= -1j
+    assert alias == stim.PauliString("iY")
+    p *= -1j
+    assert alias == stim.PauliString("+Y")
+    p *= -1j
+    assert alias == stim.PauliString("-iY")
+
+    p *= stim.PauliString("i_")
+    assert alias == stim.PauliString("+Y")
+    p *= stim.PauliString("i_")
+    assert alias == stim.PauliString("iY")
+    p *= stim.PauliString("i_")
+    assert alias == stim.PauliString("-Y")
+    p *= stim.PauliString("i_")
+    assert alias == stim.PauliString("-iY")
+
+    p *= stim.PauliString("-i_")
+    assert alias == stim.PauliString("-Y")
+    p *= stim.PauliString("-i_")
+    assert alias == stim.PauliString("iY")
+    p *= stim.PauliString("-i_")
+    assert alias == stim.PauliString("+Y")
+    p *= stim.PauliString("-i_")
+    assert alias == stim.PauliString("-iY")
+
+    assert alias is p
+
+
+def test_imaginary_phase():
+    p = stim.PauliString("IXYZ")
+    ip = stim.PauliString("iIXYZ")
+    assert 1j * p == p * 1j == ip == -stim.PauliString("-iIXYZ")
+    assert p.sign == 1
+    assert (-p).sign == -1
+    assert ip.sign == 1j
+    assert (-ip).sign == -1j
+    assert stim.PauliString("X") * stim.PauliString("Y") == 1j * stim.PauliString("Z")
+    assert stim.PauliString("Y") * stim.PauliString("X") == -1j * stim.PauliString("Z")
 
 
 def test_get_set_sign():
@@ -121,6 +244,14 @@ def test_get_set_sign():
     assert p.sign == +1
     with pytest.raises(ValueError, match="new_sign"):
         p.sign = 5
+
+    p.sign = 1j
+    assert str(p) == "+i__"
+    assert p.sign == 1j
+
+    p.sign = -1j
+    assert str(p) == "-i__"
+    assert p.sign == -1j
 
 
 def test_get_set_item():

--- a/src/stabilizers/pauli_string_pybind_test.py
+++ b/src/stabilizers/pauli_string_pybind_test.py
@@ -67,6 +67,13 @@ def test_from_str():
 
 
 def test_equality():
+    assert not (stim.PauliString(4) == None)
+    assert not (stim.PauliString(4) == "other object")
+    assert not (stim.PauliString(4) == object())
+    assert stim.PauliString(4) != None
+    assert stim.PauliString(4) != "other object"
+    assert stim.PauliString(4) != object()
+
     assert stim.PauliString(4) == stim.PauliString(4)
     assert stim.PauliString(3) != stim.PauliString(4)
     assert not (stim.PauliString(4) != stim.PauliString(4))
@@ -287,3 +294,10 @@ def test_get_slice():
     assert p[5:3:-1] == stim.PauliString("__")
     assert p[4:2:-1] == stim.PauliString("_X")
     assert p[2:0:-1] == stim.PauliString("XX")
+
+
+def test_hash():
+    # stim.PauliString is mutable. It must not also be value-hashable.
+    # Defining __hash__ requires defining a FrozenPauliString variant instead.
+    with pytest.raises(TypeError, match="unhashable"):
+        _ = hash(stim.PauliString(1))

--- a/src/stabilizers/tableau.pybind.cc
+++ b/src/stabilizers/tableau.pybind.cc
@@ -21,9 +21,10 @@
 #include "../stabilizers/tableau.h"
 
 void pybind_tableau(pybind11::module &m) {
-    pybind11::class_<Tableau>(
-        m, "Tableau",
-        R"DOC(
+    auto &&c = pybind11::class_<Tableau>(
+        m,
+        "Tableau",
+        clean_doc_string(u8R"DOC(
             A stabilizer tableau.
 
             Represents a Clifford operation by explicitly storing how that operation conjugates a list of Pauli
@@ -55,461 +56,498 @@ void pybind_tableau(pybind11::module &m) {
                 >>> x2z3 = t.x_output(2) * t.z_output(3)
                 >>> t_inv(x2z3)
                 stim.PauliString("+__XZ_")
-        )DOC")
-        .def(
-            pybind11::init<size_t>(), pybind11::arg("num_qubits"),
-            R"DOC(
-                Creates an identity tableau over the given number of qubits.
+        )DOC").data()
+    );
 
-                Examples:
-                    >>> import stim
-                    >>> t = stim.Tableau(3)
-                    >>> print(t)
-                    +-xz-xz-xz-
-                    | ++ ++ ++
-                    | XZ __ __
-                    | __ XZ __
-                    | __ __ XZ
+    c.def(
+        pybind11::init<size_t>(),
+        pybind11::arg("num_qubits"),
+        clean_doc_string(u8R"DOC(
+            Creates an identity tableau over the given number of qubits.
 
-                Args:
-                    num_qubits: The number of qubits the tableau's operation acts on.
-             )DOC")
-        .def_static(
-            "random",
-            [](size_t num_qubits) {
-                return Tableau::random(num_qubits, PYBIND_SHARED_RNG());
-            },
-            pybind11::arg("num_qubits"),
-            R"DOC(
-                Samples a uniformly random Clifford operation over the given number of qubits and returns its tableau.
+            Examples:
+                >>> import stim
+                >>> t = stim.Tableau(3)
+                >>> print(t)
+                +-xz-xz-xz-
+                | ++ ++ ++
+                | XZ __ __
+                | __ XZ __
+                | __ __ XZ
 
-                Args:
-                    num_qubits: The number of qubits the tableau should act on.
+            Args:
+                num_qubits: The number of qubits the tableau's operation acts on.
+        )DOC").data()
+    );
 
-                Returns:
-                    The sampled tableau.
+    c.def_static(
+        "random",
+        [](size_t num_qubits) {
+            return Tableau::random(num_qubits, PYBIND_SHARED_RNG());
+        },
+        pybind11::arg("num_qubits"),
+        clean_doc_string(u8R"DOC(
+            Samples a uniformly random Clifford operation over the given number of qubits and returns its tableau.
 
-                Examples:
-                    >>> import stim
-                    >>> t = stim.Tableau.random(42)
+            Args:
+                num_qubits: The number of qubits the tableau should act on.
 
-                References:
-                    "Hadamard-free circuits expose the structure of the Clifford group"
-                    Sergey Bravyi, Dmitri Maslov
-                    https://arxiv.org/abs/2003.09412
-            )DOC")
-        .def_static(
-            "from_named_gate",
-            [](const char *name) {
-                const Gate &gate = GATE_DATA.at(name);
-                if (!(gate.flags & GATE_IS_UNITARY)) {
-                    throw std::out_of_range("Recognized name, but not unitary: " + std::string(name));
-                }
-                return gate.tableau();
-            },
-            pybind11::arg("name"),
-            R"DOC(
-                Returns the tableau of a named Clifford gate.
+            Returns:
+                The sampled tableau.
 
-                Args:
-                    name: The name of the Clifford gate.
+            Examples:
+                >>> import stim
+                >>> t = stim.Tableau.random(42)
 
-                Returns:
-                    The gate's tableau.
+            References:
+                "Hadamard-free circuits expose the structure of the Clifford group"
+                Sergey Bravyi, Dmitri Maslov
+                https://arxiv.org/abs/2003.09412
+        )DOC").data()
+    );
 
-                Examples:
-                    >>> import stim
-                    >>> print(stim.Tableau.from_named_gate("H"))
-                    +-xz-
-                    | ++
-                    | ZX
-                    >>> print(stim.Tableau.from_named_gate("CNOT"))
-                    +-xz-xz-
-                    | ++ ++
-                    | XZ _Z
-                    | X_ XZ
-                    >>> print(stim.Tableau.from_named_gate("S"))
-                    +-xz-
-                    | ++
-                    | YZ
-            )DOC")
-        .def(
-            "__len__",
-            [](const Tableau &self) {
-                return self.num_qubits;
-            })
-        .def("__str__", &Tableau::str)
-        .def(
-            "__eq__",
-            [](const Tableau &self, const Tableau &other) {
-                return self == other;
-            })
-        .def(
-            "__ne__",
-            [](const Tableau &self, const Tableau &other) {
-                return self != other;
-            })
-        .def(
-            "__pow__", &Tableau::raised_to, pybind11::arg("exponent"),
-            R"DOC(
-                Raises the tableau to an integer power using inversion and repeated squaring.
+    c.def_static(
+        "from_named_gate",
+        [](const char *name) {
+            const Gate &gate = GATE_DATA.at(name);
+            if (!(gate.flags & GATE_IS_UNITARY)) {
+                throw std::out_of_range("Recognized name, but not unitary: " + std::string(name));
+            }
+            return gate.tableau();
+        },
+        pybind11::arg("name"),
+        clean_doc_string(u8R"DOC(
+            Returns the tableau of a named Clifford gate.
 
-                Args:
-                    exponent: The power to raise to. Can be negative, zero, or positive.
+            Args:
+                name: The name of the Clifford gate.
 
-                Examples:
-                    >>> import stim
-                    >>> s = stim.Tableau.from_named_gate("S")
-                    >>> s**0 == stim.Tableau(1)
-                    True
-                    >>> s**1 == s
-                    True
-                    >>> s**2 == stim.Tableau.from_named_gate("Z")
-                    True
-                    >>> s**-1 == s**3 == stim.Tableau.from_named_gate("S_DAG")
-                    True
-                    >>> s**5 == s
-                    True
-                    >>> s**(400000000 + 1) == s
-                    True
-                    >>> s**(-400000000 + 1) == s
-                    True
-            )DOC")
-        .def(
-            "append",
-            [](Tableau &self, const Tableau &gate, const std::vector<size_t> targets) {
-                std::vector<bool> use(self.num_qubits, false);
-                if (targets.size() != gate.num_qubits) {
-                    throw std::invalid_argument("len(targets) != len(gate)");
-                }
-                for (size_t k : targets) {
-                    if (k >= self.num_qubits) {
-                        throw std::invalid_argument("target >= len(tableau)");
-                    }
-                    if (use[k]) {
-                        throw std::invalid_argument("target collision on qubit " + std::to_string(k));
-                    }
-                    use[k] = true;
-                }
-                self.inplace_scatter_append(gate, targets);
-            },
-            pybind11::arg("gate"), pybind11::arg("targets"),
-            R"DOC(
-                Appends an operation's effect into this tableau, mutating this tableau.
+            Returns:
+                The gate's tableau.
 
-                Time cost is O(n*m*m) where n=len(self) and m=len(gate).
+            Examples:
+                >>> import stim
+                >>> print(stim.Tableau.from_named_gate("H"))
+                +-xz-
+                | ++
+                | ZX
+                >>> print(stim.Tableau.from_named_gate("CNOT"))
+                +-xz-xz-
+                | ++ ++
+                | XZ _Z
+                | X_ XZ
+                >>> print(stim.Tableau.from_named_gate("S"))
+                +-xz-
+                | ++
+                | YZ
+        )DOC").data()
+    );
 
-                Args:
-                    gate: The tableau of the operation being appended into this tableau.
-                    targets: The qubits being targeted by the gate.
+    c.def(
+        "__len__",
+        [](const Tableau &self) {
+            return self.num_qubits;
+        },
+        "Returns the number of qubits operated on by the tableau."
+    );
 
-                Examples:
-                    >>> import stim
-                    >>> cnot = stim.Tableau.from_named_gate("CNOT")
-                    >>> t = stim.Tableau(2)
-                    >>> t.append(cnot, [0, 1])
-                    >>> t.append(cnot, [1, 0])
-                    >>> t.append(cnot, [0, 1])
-                    >>> t == stim.Tableau.from_named_gate("SWAP")
-                    True
-            )DOC")
-        .def(
-            "then",
-            [](const Tableau &self, const Tableau &second) {
-                if (self.num_qubits != second.num_qubits) {
-                    throw std::invalid_argument("len(self) != len(second)");
-                }
-                return self.then(second);
-            },
-            pybind11::arg("second"),
-            R"DOC(
-                Returns the result of composing two tableaus.
+    c.def(
+        "__str__",
+        &Tableau::str,
+        "Returns a text description."
+    );
 
-                If the tableau T1 represents the Clifford operation with unitary C1,
-                and the tableau T2 represents the Clifford operation with unitary C2,
-                then the tableau T1.then(T2) represents the Clifford operation with unitary C2*C1.
+    c.def(pybind11::self == pybind11::self,
+        "Determines if two tableaus have identical contents.");
+    c.def(pybind11::self != pybind11::self,
+        "Determines if two tableaus have non-identical contents.");
 
-                Args:
-                    second: The result is equivalent to applying the second tableau after
-                        the receiving tableau.
+    c.def(
+        "__pow__", &Tableau::raised_to, pybind11::arg("exponent"),
+        clean_doc_string(u8R"DOC(
+            Raises the tableau to an integer power.
 
-                Examples:
-                    >>> import stim
-                    >>> t1 = stim.Tableau.random(4)
-                    >>> t2 = stim.Tableau.random(4)
-                    >>> t3 = t1.then(t2)
-                    >>> p = stim.PauliString.random(4)
-                    >>> t3(p) == t2(t1(p))
-                    True
-            )DOC")
-        .def(
-            "__mul__",
-            [](const Tableau &self, const Tableau &rhs) {
-                if (self.num_qubits != rhs.num_qubits) {
-                    throw std::invalid_argument("len(lhs) != len(rhs)");
-                }
-                return rhs.then(self);
-            },
-            pybind11::arg("rhs"),
-            R"DOC(
-                Returns the product of two tableaus.
+            Large powers are reached efficiently using repeated squaring.
+            Negative powers are reached by inverting the tableau.
 
-                If the tableau T1 represents the Clifford operation with unitary C1,
-                and the tableau T2 represents the Clifford operation with unitary C2,
-                then the tableau T1*T2 represents the Clifford operation with unitary C1*C2.
+            Args:
+                exponent: The power to raise to. Can be negative, zero, or positive.
 
-                Args:
-                    rhs: The tableau  on the right hand side of the multiplication.
+            Examples:
+                >>> import stim
+                >>> s = stim.Tableau.from_named_gate("S")
+                >>> s**0 == stim.Tableau(1)
+                True
+                >>> s**1 == s
+                True
+                >>> s**2 == stim.Tableau.from_named_gate("Z")
+                True
+                >>> s**-1 == s**3 == stim.Tableau.from_named_gate("S_DAG")
+                True
+                >>> s**5 == s
+                True
+                >>> s**(400000000 + 1) == s
+                True
+                >>> s**(-400000000 + 1) == s
+                True
+        )DOC").data()
+    );
 
-                Examples:
-                    >>> import stim
-                    >>> t1 = stim.Tableau.random(4)
-                    >>> t2 = stim.Tableau.random(4)
-                    >>> t3 = t2 * t1
-                    >>> p = stim.PauliString.random(4)
-                    >>> t3(p) == t2(t1(p))
-                    True
-            )DOC")
-        .def(
-            "prepend",
-            [](Tableau &self, const Tableau &gate, const std::vector<size_t> targets) {
-                std::vector<bool> use(self.num_qubits, false);
-                if (targets.size() != gate.num_qubits) {
-                    throw std::invalid_argument("len(targets) != len(gate)");
-                }
-                for (size_t k : targets) {
-                    if (k >= self.num_qubits) {
-                        throw std::invalid_argument("target >= len(tableau)");
-                    }
-                    if (use[k]) {
-                        throw std::invalid_argument("target collision on qubit " + std::to_string(k));
-                    }
-                    use[k] = true;
-                }
-                self.inplace_scatter_prepend(gate, targets);
-            },
-            pybind11::arg("gate"), pybind11::arg("targets"),
-            R"DOC(
-                Prepends an operation's effect into this tableau, mutating this tableau.
-
-                Time cost is O(n*m*m) where n=len(self) and m=len(gate).
-
-                Args:
-                    gate: The tableau of the operation being prepended into this tableau.
-                    targets: The qubits being targeted by the gate.
-
-                Examples:
-                    >>> import stim
-                    >>> h = stim.Tableau.from_named_gate("H")
-                    >>> cnot = stim.Tableau.from_named_gate("CNOT")
-                    >>> t = stim.Tableau.from_named_gate("H")
-                    >>> t.prepend(stim.Tableau.from_named_gate("X"), [0])
-                    >>> t == stim.Tableau.from_named_gate("SQRT_Y_DAG")
-                    True
-            )DOC")
-        .def(
-            "x_output",
-            [](Tableau &self, size_t target) {
-                if (target >= self.num_qubits) {
+    c.def(
+        "append",
+        [](Tableau &self, const Tableau &gate, const std::vector<size_t> targets) {
+            std::vector<bool> use(self.num_qubits, false);
+            if (targets.size() != gate.num_qubits) {
+                throw std::invalid_argument("len(targets) != len(gate)");
+            }
+            for (size_t k : targets) {
+                if (k >= self.num_qubits) {
                     throw std::invalid_argument("target >= len(tableau)");
                 }
-                return PyPauliString(self.xs[target]);
-            },
-            pybind11::arg("target"),
-            R"DOC(
-                Returns the result of conjugating a Pauli X by the tableau's Clifford operation.
+                if (use[k]) {
+                    throw std::invalid_argument("target collision on qubit " + std::to_string(k));
+                }
+                use[k] = true;
+            }
+            self.inplace_scatter_append(gate, targets);
+        },
+        pybind11::arg("gate"), pybind11::arg("targets"),
+        clean_doc_string(u8R"DOC(
+            Appends an operation's effect into this tableau, mutating this tableau.
 
-                Args:
-                    target: The qubit targeted by the Pauli X operation.
+            Time cost is O(n*m*m) where n=len(self) and m=len(gate).
 
-                Examples:
-                    >>> import stim
-                    >>> h = stim.Tableau.from_named_gate("H")
-                    >>> h.x_output(0)
-                    stim.PauliString("+Z")
+            Args:
+                gate: The tableau of the operation being appended into this tableau.
+                targets: The qubits being targeted by the gate.
 
-                    >>> cnot = stim.Tableau.from_named_gate("CNOT")
-                    >>> cnot.x_output(0)
-                    stim.PauliString("+XX")
-                    >>> cnot.x_output(1)
-                    stim.PauliString("+_X")
-            )DOC")
-        .def(
-            "y_output",
-            [](Tableau &self, size_t target) {
-                if (target >= self.num_qubits) {
+            Examples:
+                >>> import stim
+                >>> cnot = stim.Tableau.from_named_gate("CNOT")
+                >>> t = stim.Tableau(2)
+                >>> t.append(cnot, [0, 1])
+                >>> t.append(cnot, [1, 0])
+                >>> t.append(cnot, [0, 1])
+                >>> t == stim.Tableau.from_named_gate("SWAP")
+                True
+        )DOC").data()
+    );
+
+    c.def(
+        "then",
+        [](const Tableau &self, const Tableau &second) {
+            if (self.num_qubits != second.num_qubits) {
+                throw std::invalid_argument("len(self) != len(second)");
+            }
+            return self.then(second);
+        },
+        pybind11::arg("second"),
+        clean_doc_string(u8R"DOC(
+            Returns the result of composing two tableaus.
+
+            If the tableau T1 represents the Clifford operation with unitary C1,
+            and the tableau T2 represents the Clifford operation with unitary C2,
+            then the tableau T1.then(T2) represents the Clifford operation with unitary C2*C1.
+
+            Args:
+                second: The result is equivalent to applying the second tableau after
+                    the receiving tableau.
+
+            Examples:
+                >>> import stim
+                >>> t1 = stim.Tableau.random(4)
+                >>> t2 = stim.Tableau.random(4)
+                >>> t3 = t1.then(t2)
+                >>> p = stim.PauliString.random(4)
+                >>> t3(p) == t2(t1(p))
+                True
+        )DOC").data()
+    );
+
+    c.def(
+        "__mul__",
+        [](const Tableau &self, const Tableau &rhs) {
+            if (self.num_qubits != rhs.num_qubits) {
+                throw std::invalid_argument("len(lhs) != len(rhs)");
+            }
+            return rhs.then(self);
+        },
+        pybind11::arg("rhs"),
+        clean_doc_string(u8R"DOC(
+            Returns the product of two tableaus.
+
+            If the tableau T1 represents the Clifford operation with unitary C1,
+            and the tableau T2 represents the Clifford operation with unitary C2,
+            then the tableau T1*T2 represents the Clifford operation with unitary C1*C2.
+
+            Args:
+                rhs: The tableau  on the right hand side of the multiplication.
+
+            Examples:
+                >>> import stim
+                >>> t1 = stim.Tableau.random(4)
+                >>> t2 = stim.Tableau.random(4)
+                >>> t3 = t2 * t1
+                >>> p = stim.PauliString.random(4)
+                >>> t3(p) == t2(t1(p))
+                True
+        )DOC").data()
+    );
+
+    c.def(
+        "prepend",
+        [](Tableau &self, const Tableau &gate, const std::vector<size_t> targets) {
+            std::vector<bool> use(self.num_qubits, false);
+            if (targets.size() != gate.num_qubits) {
+                throw std::invalid_argument("len(targets) != len(gate)");
+            }
+            for (size_t k : targets) {
+                if (k >= self.num_qubits) {
                     throw std::invalid_argument("target >= len(tableau)");
                 }
-
-                // Compute Y using Y = i*X*Z.
-                uint8_t log_i = 1;
-                PauliString copy = self.xs[target];
-                log_i += copy.ref().inplace_right_mul_returning_log_i_scalar(self.zs[target]);
-                assert((log_i & 1) == 0);
-                copy.sign ^= (log_i & 2) != 0;
-                return PyPauliString(std::move(copy));
-            },
-            pybind11::arg("target"),
-            R"DOC(
-                Returns the result of conjugating a Pauli Y by the tableau's Clifford operation.
-
-                Args:
-                    target: The qubit targeted by the Pauli Y operation.
-
-                Examples:
-                    >>> import stim
-                    >>> h = stim.Tableau.from_named_gate("H")
-                    >>> h.y_output(0)
-                    stim.PauliString("-Y")
-
-                    >>> cnot = stim.Tableau.from_named_gate("CNOT")
-                    >>> cnot.y_output(0)
-                    stim.PauliString("+YX")
-                    >>> cnot.y_output(1)
-                    stim.PauliString("+ZY")
-            )DOC")
-        .def(
-            "z_output",
-            [](Tableau &self, size_t target) {
-                if (target >= self.num_qubits) {
-                    throw std::invalid_argument("target >= len(tableau)");
+                if (use[k]) {
+                    throw std::invalid_argument("target collision on qubit " + std::to_string(k));
                 }
-                return PyPauliString(self.zs[target]);
-            },
-            pybind11::arg("target"),
-            R"DOC(
-                Returns the result of conjugating a Pauli Z by the tableau's Clifford operation.
+                use[k] = true;
+            }
+            self.inplace_scatter_prepend(gate, targets);
+        },
+        pybind11::arg("gate"), pybind11::arg("targets"),
+        clean_doc_string(u8R"DOC(
+            Prepends an operation's effect into this tableau, mutating this tableau.
 
-                Args:
-                    target: The qubit targeted by the Pauli Z operation.
+            Time cost is O(n*m*m) where n=len(self) and m=len(gate).
 
-                Examples:
-                    >>> import stim
-                    >>> h = stim.Tableau.from_named_gate("H")
-                    >>> h.z_output(0)
-                    stim.PauliString("+X")
+            Args:
+                gate: The tableau of the operation being prepended into this tableau.
+                targets: The qubits being targeted by the gate.
 
-                    >>> cnot = stim.Tableau.from_named_gate("CNOT")
-                    >>> cnot.z_output(0)
-                    stim.PauliString("+Z_")
-                    >>> cnot.z_output(1)
-                    stim.PauliString("+ZZ")
-            )DOC")
-        .def_static(
-            "from_conjugated_generators",
-            [](const std::vector<PyPauliString> &xs, const std::vector<PyPauliString> &zs) {
-                size_t n = xs.size();
-                if (n != zs.size()) {
-                    throw std::invalid_argument("len(xs) != len(zs)");
+            Examples:
+                >>> import stim
+                >>> h = stim.Tableau.from_named_gate("H")
+                >>> cnot = stim.Tableau.from_named_gate("CNOT")
+                >>> t = stim.Tableau.from_named_gate("H")
+                >>> t.prepend(stim.Tableau.from_named_gate("X"), [0])
+                >>> t == stim.Tableau.from_named_gate("SQRT_Y_DAG")
+                True
+        )DOC").data()
+    );
+
+    c.def(
+        "x_output",
+        [](Tableau &self, size_t target) {
+            if (target >= self.num_qubits) {
+                throw std::invalid_argument("target >= len(tableau)");
+            }
+            return PyPauliString(self.xs[target]);
+        },
+        pybind11::arg("target"),
+        clean_doc_string(u8R"DOC(
+            Returns the result of conjugating a Pauli X by the tableau's Clifford operation.
+
+            Args:
+                target: The qubit targeted by the Pauli X operation.
+
+            Examples:
+                >>> import stim
+                >>> h = stim.Tableau.from_named_gate("H")
+                >>> h.x_output(0)
+                stim.PauliString("+Z")
+
+                >>> cnot = stim.Tableau.from_named_gate("CNOT")
+                >>> cnot.x_output(0)
+                stim.PauliString("+XX")
+                >>> cnot.x_output(1)
+                stim.PauliString("+_X")
+        )DOC").data()
+    );
+
+    c.def(
+        "y_output",
+        [](Tableau &self, size_t target) {
+            if (target >= self.num_qubits) {
+                throw std::invalid_argument("target >= len(tableau)");
+            }
+
+            // Compute Y using Y = i*X*Z.
+            uint8_t log_i = 1;
+            PauliString copy = self.xs[target];
+            log_i += copy.ref().inplace_right_mul_returning_log_i_scalar(self.zs[target]);
+            assert((log_i & 1) == 0);
+            copy.sign ^= (log_i & 2) != 0;
+            return PyPauliString(std::move(copy));
+        },
+        pybind11::arg("target"),
+        clean_doc_string(u8R"DOC(
+            Returns the result of conjugating a Pauli Y by the tableau's Clifford operation.
+
+            Args:
+                target: The qubit targeted by the Pauli Y operation.
+
+            Examples:
+                >>> import stim
+                >>> h = stim.Tableau.from_named_gate("H")
+                >>> h.y_output(0)
+                stim.PauliString("-Y")
+
+                >>> cnot = stim.Tableau.from_named_gate("CNOT")
+                >>> cnot.y_output(0)
+                stim.PauliString("+YX")
+                >>> cnot.y_output(1)
+                stim.PauliString("+ZY")
+        )DOC").data()
+    );
+
+    c.def(
+        "z_output",
+        [](Tableau &self, size_t target) {
+            if (target >= self.num_qubits) {
+                throw std::invalid_argument("target >= len(tableau)");
+            }
+            return PyPauliString(self.zs[target]);
+        },
+        pybind11::arg("target"),
+        clean_doc_string(u8R"DOC(
+            Returns the result of conjugating a Pauli Z by the tableau's Clifford operation.
+
+            Args:
+                target: The qubit targeted by the Pauli Z operation.
+
+            Examples:
+                >>> import stim
+                >>> h = stim.Tableau.from_named_gate("H")
+                >>> h.z_output(0)
+                stim.PauliString("+X")
+
+                >>> cnot = stim.Tableau.from_named_gate("CNOT")
+                >>> cnot.z_output(0)
+                stim.PauliString("+Z_")
+                >>> cnot.z_output(1)
+                stim.PauliString("+ZZ")
+        )DOC").data()
+    );
+
+    c.def_static(
+        "from_conjugated_generators",
+        [](const std::vector<PyPauliString> &xs, const std::vector<PyPauliString> &zs) {
+            size_t n = xs.size();
+            if (n != zs.size()) {
+                throw std::invalid_argument("len(xs) != len(zs)");
+            }
+            for (const auto &p : xs) {
+                if (p.imag) {
+                    throw std::invalid_argument("Conjugated generator can't have imaginary sign.");
                 }
-                for (const auto &p : xs) {
-                    if (p.imag) {
-                        throw std::invalid_argument("Conjugated generator can't have imaginary sign.");
-                    }
-                    if (p.value.num_qubits != n) {
-                        throw std::invalid_argument("not all(len(p) == len(xs) for p in xs)");
-                    }
+                if (p.value.num_qubits != n) {
+                    throw std::invalid_argument("not all(len(p) == len(xs) for p in xs)");
                 }
-                for (const auto &p : zs) {
-                    if (p.imag) {
-                        throw std::invalid_argument("Conjugated generator can't have imaginary sign.");
-                    }
-                    if (p.value.num_qubits != n) {
-                        throw std::invalid_argument("not all(len(p) == len(zs) for p in zs)");
-                    }
+            }
+            for (const auto &p : zs) {
+                if (p.imag) {
+                    throw std::invalid_argument("Conjugated generator can't have imaginary sign.");
                 }
-                Tableau result(n);
-                for (size_t q = 0; q < n; q++) {
-                    result.xs[q] = xs[q].value;
-                    result.zs[q] = zs[q].value;
+                if (p.value.num_qubits != n) {
+                    throw std::invalid_argument("not all(len(p) == len(zs) for p in zs)");
                 }
-                if (!result.satisfies_invariants()) {
-                    throw std::invalid_argument(
-                        "The given generator outputs don't describe a valid Clifford operation.\n"
-                        "They don't preserve commutativity.\n"
-                        "Everything must commute, except for X_k anticommuting with Z_k for each k.");
-                }
-                return result;
-            },
-            pybind11::kw_only(), pybind11::arg("xs"), pybind11::arg("zs"),
-            R"DOC(
-                Creates a tableau from the given outputs for each generator.
+            }
+            Tableau result(n);
+            for (size_t q = 0; q < n; q++) {
+                result.xs[q] = xs[q].value;
+                result.zs[q] = zs[q].value;
+            }
+            if (!result.satisfies_invariants()) {
+                throw std::invalid_argument(
+                    "The given generator outputs don't describe a valid Clifford operation.\n"
+                    "They don't preserve commutativity.\n"
+                    "Everything must commute, except for X_k anticommuting with Z_k for each k.");
+            }
+            return result;
+        },
+        pybind11::kw_only(), pybind11::arg("xs"), pybind11::arg("zs"),
+        clean_doc_string(u8R"DOC(
+            Creates a tableau from the given outputs for each generator.
 
-                Verifies that the tableau is well formed.
+            Verifies that the tableau is well formed.
 
-                Args:
-                    xs: A List[stim.PauliString] with the results of conjugating X0, X1, etc.
-                    zs: A List[stim.PauliString] with the results of conjugating Z0, Z1, etc.
+            Args:
+                xs: A List[stim.PauliString] with the results of conjugating X0, X1, etc.
+                zs: A List[stim.PauliString] with the results of conjugating Z0, Z1, etc.
 
-                Returns:
-                    The created tableau.
+            Returns:
+                The created tableau.
 
-                Raises:
-                    ValueError: The given outputs are malformed. Their lengths are inconsistent,
-                        or they don't satisfy the required commutation relationships.
+            Raises:
+                ValueError: The given outputs are malformed. Their lengths are inconsistent,
+                    or they don't satisfy the required commutation relationships.
 
-                Examples:
-                    >>> import stim
-                    >>> identity3 = stim.Tableau.from_conjugated_generators(
-                    ...     xs=[
-                    ...         stim.PauliString("X__"),
-                    ...         stim.PauliString("_X_"),
-                    ...         stim.PauliString("__X"),
-                    ...     ],
-                    ...     zs=[
-                    ...         stim.PauliString("Z__"),
-                    ...         stim.PauliString("_Z_"),
-                    ...         stim.PauliString("__Z"),
-                    ...     ],
-                    ... )
-                    >>> identity3 == stim.Tableau(3)
-                    True
-            )DOC")
-        .def(
-            "__repr__",
-            [](const Tableau &self) {
-                std::stringstream result;
-                result << "stim.Tableau.from_conjugated_generators(\n    xs=[\n";
-                for (size_t q = 0; q < self.num_qubits; q++) {
-                    result << "        stim.PauliString(\"" << self.xs[q].str() << "\"),\n";
-                }
-                result << "    ],\n    zs=[\n";
-                for (size_t q = 0; q < self.num_qubits; q++) {
-                    result << "        stim.PauliString(\"" << self.zs[q].str() << "\"),\n";
-                }
-                result << "    ],\n)";
-                return result.str();
-            })
-        .def(
-            "__call__",
-            [](const Tableau &self, const PyPauliString &pauli_string) {
-                PyPauliString result{self(pauli_string.value)};
-                if (pauli_string.imag) {
-                    result *= std::complex<float>(0, 1);
-                }
-                return result;
-            },
-            pybind11::arg("pauli_string"),
-            R"DOC(
-                 Returns the result of conjugating the given PauliString by the Tableau's Clifford operation.
+            Examples:
+                >>> import stim
+                >>> identity3 = stim.Tableau.from_conjugated_generators(
+                ...     xs=[
+                ...         stim.PauliString("X__"),
+                ...         stim.PauliString("_X_"),
+                ...         stim.PauliString("__X"),
+                ...     ],
+                ...     zs=[
+                ...         stim.PauliString("Z__"),
+                ...         stim.PauliString("_Z_"),
+                ...         stim.PauliString("__Z"),
+                ...     ],
+                ... )
+                >>> identity3 == stim.Tableau(3)
+                True
+        )DOC").data()
+    );
 
-                 Args:
-                     pauli_string: The pauli string to conjugate.
+    c.def(
+        "__repr__",
+        [](const Tableau &self) {
+            std::stringstream result;
+            result << "stim.Tableau.from_conjugated_generators(\n    xs=[\n";
+            for (size_t q = 0; q < self.num_qubits; q++) {
+                result << "        stim.PauliString(\"" << self.xs[q].str() << "\"),\n";
+            }
+            result << "    ],\n    zs=[\n";
+            for (size_t q = 0; q < self.num_qubits; q++) {
+                result << "        stim.PauliString(\"" << self.zs[q].str() << "\"),\n";
+            }
+            result << "    ],\n)";
+            return result.str();
+        },
+        "Returns an eval-able text description."
+    );
 
-                 Returns:
-                     The new conjugated pauli string.
+    c.def(
+        "__call__",
+        [](const Tableau &self, const PyPauliString &pauli_string) {
+            PyPauliString result{self(pauli_string.value)};
+            if (pauli_string.imag) {
+                result *= std::complex<float>(0, 1);
+            }
+            return result;
+        },
+        pybind11::arg("pauli_string"),
+        clean_doc_string(u8R"DOC(
+             Returns the result of conjugating the given PauliString by the Tableau's Clifford operation.
 
-                 Examples:
-                     >>> import stim
-                     >>> t = stim.Tableau.from_named_gate("CNOT")
-                     >>> p = stim.PauliString("XX")
-                     >>> result = t(p)
-                     >>> print(result)
-                     +X_
+             Args:
+                 pauli_string: The pauli string to conjugate.
 
-                 References:
-                     "Hadamard-free circuits expose the structure of the Clifford group"
-                     Sergey Bravyi, Dmitri Maslov
-                     https://arxiv.org/abs/2003.09412
-             )DOC");
+             Returns:
+                 The new conjugated pauli string.
+
+             Examples:
+                 >>> import stim
+                 >>> t = stim.Tableau.from_named_gate("CNOT")
+                 >>> p = stim.PauliString("XX")
+                 >>> result = t(p)
+                 >>> print(result)
+                 +X_
+
+             References:
+                 "Hadamard-free circuits expose the structure of the Clifford group"
+                 Sergey Bravyi, Dmitri Maslov
+                 https://arxiv.org/abs/2003.09412
+        )DOC").data()
+    );
 }

--- a/src/stabilizers/tableau_pybind_test.py
+++ b/src/stabilizers/tableau_pybind_test.py
@@ -270,6 +270,9 @@ def test_repr():
 def test_call():
     t = stim.Tableau.from_named_gate("CNOT")
     assert t(stim.PauliString("__")) == stim.PauliString("__")
+    assert t(stim.PauliString("-__")) == stim.PauliString("-__")
+    assert t(stim.PauliString("i__")) == stim.PauliString("i__")
+    assert t(stim.PauliString("-i__")) == stim.PauliString("-i__")
     assert t(stim.PauliString("X_")) == stim.PauliString("XX")
     assert t(stim.PauliString("Y_")) == stim.PauliString("YX")
     assert t(stim.PauliString("Z_")) == stim.PauliString("Z_")

--- a/src/stabilizers/tableau_pybind_test.py
+++ b/src/stabilizers/tableau_pybind_test.py
@@ -18,6 +18,13 @@ import pytest
 
 
 def test_init_equality():
+    assert stim.Tableau(3) != None
+    assert stim.Tableau(3) != object()
+    assert stim.Tableau(3) != "another type"
+    assert not (stim.Tableau(3) == None)
+    assert not (stim.Tableau(3) == object())
+    assert not (stim.Tableau(3) == "another type")
+
     assert stim.Tableau(3) == stim.Tableau(3)
     assert not (stim.Tableau(3) != stim.Tableau(3))
     assert stim.Tableau(3) != stim.Tableau(4)
@@ -365,3 +372,10 @@ def test_composition():
         _ = stim.Tableau(3) * stim.Tableau(4)
     with pytest.raises(ValueError, match="!= len"):
         _ = stim.Tableau(3).then(stim.Tableau(4))
+
+
+def test_hash():
+    # stim.Tableau is mutable. It must not also be value-hashable.
+    # Defining __hash__ requires defining a FrozenTableau variant instead.
+    with pytest.raises(TypeError, match="unhashable"):
+        _ = hash(stim.Tableau(1))

--- a/src/stabilizers/tableau_pybind_test.py
+++ b/src/stabilizers/tableau_pybind_test.py
@@ -159,6 +159,24 @@ def test_from_conjugated_generators():
         ],
     )
 
+    assert stim.Tableau.from_named_gate("S") == stim.Tableau.from_conjugated_generators(
+        xs=[
+            stim.PauliString("Y"),
+        ],
+        zs=[
+            stim.PauliString("Z"),
+        ],
+    )
+
+    assert stim.Tableau.from_named_gate("S_DAG") == stim.Tableau.from_conjugated_generators(
+        xs=[
+            stim.PauliString("-Y"),
+        ],
+        zs=[
+            stim.PauliString("Z"),
+        ],
+    )
+
     assert stim.Tableau(2) == stim.Tableau.from_conjugated_generators(
         xs=[
             stim.PauliString("X_"),
@@ -179,6 +197,29 @@ def test_from_conjugated_generators():
             zs=[
                 stim.PauliString("Z_"),
                 stim.PauliString("_Z_"),
+            ],
+        )
+
+    with pytest.raises(ValueError, match="imag"):
+        stim.Tableau.from_conjugated_generators(
+            xs=[
+                stim.PauliString("iX_"),
+                stim.PauliString("_X"),
+            ],
+            zs=[
+                stim.PauliString("Z_"),
+                stim.PauliString("_Z"),
+            ],
+        )
+    with pytest.raises(ValueError, match="imag"):
+        stim.Tableau.from_conjugated_generators(
+            xs=[
+                stim.PauliString("X_"),
+                stim.PauliString("_X"),
+            ],
+            zs=[
+                stim.PauliString("Z_"),
+                stim.PauliString("i_Z"),
             ],
         )
 


### PR DESCRIPTION
- Add `stimcirq.stim_circuit_to_cirq_circuit`
- Add sorta-hacky `stim.Circuit.flattened_operations` to make it possible
- Fix stimcirq doctest not running on imported methods/types
- Fix docstrings generated via pybind11 being over-indented
- Remove hashability of `stim.PauliString` and `stim.Tableau` (because they are mutable), and test that it's not re-added