### PR TITLE
Add various utility methods motivated by supporting ZX graph translation

### DIFF
--- a/src/circuit/circuit.pybind.cc
+++ b/src/circuit/circuit.pybind.cc
@@ -419,4 +419,25 @@ void pybind_circuit(pybind11::module &m) {
 
     c.def("__str__", &Circuit::str);
     c.def("__repr__", &circuit_repr);
+
+    c.def(
+        "copy",
+        [](Circuit &self) {
+            Circuit copy = self;
+            return copy;
+        },
+        clean_doc_string(u8R"DOC(
+            Returns a copy of the circuit. An independent circuit with the same contents.
+
+            Examples:
+                >>> import stim
+
+                >>> c1 = stim.Circuit("H 0")
+                >>> c2 = c1.copy()
+                >>> c2 is c1
+                False
+                >>> c2 == c1
+                True
+        )DOC").data()
+    );
 }

--- a/src/circuit/circuit_pybind_test.py
+++ b/src/circuit/circuit_pybind_test.py
@@ -286,6 +286,13 @@ def test_circuit_flattened_operations():
     ]
 
 
+def test_copy():
+    c = stim.Circuit("H 0")
+    c2 = c.copy()
+    assert c == c2
+    assert c is not c2
+
+
 def test_hash():
     # stim.Circuit is mutable. It must not also be value-hashable.
     # Defining __hash__ requires defining a FrozenCircuit variant instead.

--- a/src/simd/simd_bits.cc
+++ b/src/simd/simd_bits.cc
@@ -113,6 +113,10 @@ void simd_bits::randomize(size_t num_bits, std::mt19937_64 &rng) {
     simd_bits_range_ref(*this).randomize(num_bits, rng);
 }
 
+void simd_bits::truncated_overwrite_from(simd_bits_range_ref other, size_t num_bits) {
+    simd_bits_range_ref(*this).truncated_overwrite_from(other, num_bits);
+}
+
 bit_ref simd_bits::operator[](size_t k) {
     return bit_ref(u64, k);
 }

--- a/src/simd/simd_bits.h
+++ b/src/simd/simd_bits.h
@@ -97,6 +97,10 @@ struct simd_bits {
     /// Padding bits beyond the minimum number of bits are not randomized.
     static simd_bits random(size_t min_bits, std::mt19937_64 &rng);
 
+    /// Writes bits from another location.
+    /// Bits not part of the write are unchanged.
+    void truncated_overwrite_from(simd_bits_range_ref other, size_t num_bits);
+
     /// Returns a description of the contents of the simd_bits.
     std::string str() const;
 

--- a/src/simd/simd_bits.test.cc
+++ b/src/simd/simd_bits.test.cc
@@ -263,3 +263,15 @@ TEST(simd_bits, mask_assignment_or) {
     expected[3] = true;
     ASSERT_EQ(b, expected);
 }
+
+TEST(simd_bits, truncated_overwrite_from) {
+    simd_bits dat = simd_bits::random(1024, SHARED_TEST_RNG());
+    simd_bits mut = simd_bits::random(1024, SHARED_TEST_RNG());
+    simd_bits old = mut;
+
+    mut.truncated_overwrite_from(dat, 455);
+
+    for (size_t k = 0; k < 1024; k++) {
+        ASSERT_EQ(mut[k], k < 455 ? dat[k] : old[k]) << k;
+    }
+}

--- a/src/simd/simd_bits_range_ref.cc
+++ b/src/simd/simd_bits_range_ref.cc
@@ -107,3 +107,13 @@ void simd_bits_range_ref::randomize(size_t num_bits, std::mt19937_64 &rng) {
         u64[n] |= rng() & mask;
     }
 }
+
+void simd_bits_range_ref::truncated_overwrite_from(simd_bits_range_ref other, size_t num_bits) {
+    size_t n8 = num_bits >> 3;
+    memcpy(u8, other.u8, n8);
+    if (num_bits & 7) {
+        uint8_t m8 = uint8_t{0xFF} >> (8 - (num_bits & 7));
+        u8[n8] &= ~m8;
+        u8[n8] |= other.u8[n8] & m8;
+    }
+}

--- a/src/simd/simd_bits_range_ref.h
+++ b/src/simd/simd_bits_range_ref.h
@@ -84,6 +84,10 @@ struct simd_bits_range_ref {
     /// Randomizes the bits in the referenced range, up to the given bit count. Leaves further bits unchanged.
     void randomize(size_t num_bits, std::mt19937_64 &rng);
 
+    /// Writes bits from another location.
+    /// Bits not part of the write are unchanged.
+    void truncated_overwrite_from(simd_bits_range_ref other, size_t num_bits);
+
     /// Returns a description of the contents of the range.
     std::string str() const;
 

--- a/src/simd/simd_bits_range_ref.test.cc
+++ b/src/simd/simd_bits_range_ref.test.cc
@@ -222,3 +222,15 @@ TEST(simd_bits_range_ref, for_each_set_bit) {
     });
     ASSERT_EQ(hits, (std::vector<size_t>{5, 101}));
 }
+
+TEST(simd_bits_range_ref, truncated_overwrite_from) {
+    simd_bits dat = simd_bits::random(1024, SHARED_TEST_RNG());
+    simd_bits mut = simd_bits::random(1024, SHARED_TEST_RNG());
+    simd_bits old = mut;
+
+    simd_bits_range_ref(mut).truncated_overwrite_from(dat, 455);
+
+    for (size_t k = 0; k < 1024; k++) {
+        ASSERT_EQ(mut[k], k < 455 ? dat[k] : old[k]) << k;
+    }
+}

--- a/src/stabilizers/pauli_string_pybind_test.py
+++ b/src/stabilizers/pauli_string_pybind_test.py
@@ -97,6 +97,12 @@ def test_random():
     p2 = stim.PauliString.random(100)
     assert p1 != p2
 
+    seen_signs = {stim.PauliString.random(1).sign for _ in range(200)}
+    assert seen_signs == {1, -1}
+
+    seen_signs = {stim.PauliString.random(1, allow_imaginary=True).sign for _ in range(200)}
+    assert seen_signs == {1, -1, 1j, -1j}
+
 
 def test_str():
     assert str(stim.PauliString(3)) == "+___"
@@ -294,6 +300,13 @@ def test_get_slice():
     assert p[5:3:-1] == stim.PauliString("__")
     assert p[4:2:-1] == stim.PauliString("_X")
     assert p[2:0:-1] == stim.PauliString("XX")
+
+
+def test_copy():
+    p = stim.PauliString(3)
+    p2 = p.copy()
+    assert p == p2
+    assert p is not p2
 
 
 def test_hash():

--- a/src/stabilizers/tableau.pybind.cc
+++ b/src/stabilizers/tableau.pybind.cc
@@ -399,6 +399,26 @@ void pybind_tableau(pybind11::module &m) {
     );
 
     c.def(
+        "copy",
+        [](Tableau &self) {
+            Tableau copy = self;
+            return copy;
+        },
+        clean_doc_string(u8R"DOC(
+            Returns a copy of the tableau. An independent tableau with the same contents.
+
+            Examples:
+                >>> import stim
+                >>> t1 = stim.Tableau.random(2)
+                >>> t2 = t1.copy()
+                >>> t2 is t1
+                False
+                >>> t2 == t1
+                True
+        )DOC").data()
+    );
+
+    c.def(
         "z_output",
         [](Tableau &self, size_t target) {
             if (target >= self.num_qubits) {

--- a/src/stabilizers/tableau.test.cc
+++ b/src/stabilizers/tableau.test.cc
@@ -737,3 +737,20 @@ TEST(tableau, raised_to) {
     ASSERT_EQ(p15.raised_to(15 * 47321 + 1), p15);
     ASSERT_EQ(p15.raised_to(15 * -47321 + 1), p15);
 }
+
+TEST(tableau, transposed_xz_input) {
+    Tableau t = Tableau::random(4, SHARED_TEST_RNG());
+    PauliString x0(0);
+    PauliString x1(0);
+    {
+        TableauTransposedRaii tmp(t);
+        x0 = tmp.unsigned_x_input(0);
+        x1 = tmp.unsigned_x_input(1);
+    }
+    auto tx0 = t(x0);
+    auto tx1 = t(x1);
+    tx0.sign = false;
+    tx1.sign = false;
+    ASSERT_EQ(tx0, PauliString::from_str("X___"));
+    ASSERT_EQ(tx1, PauliString::from_str("_X__"));
+}

--- a/src/stabilizers/tableau_pybind_test.py
+++ b/src/stabilizers/tableau_pybind_test.py
@@ -374,6 +374,13 @@ def test_composition():
         _ = stim.Tableau(3).then(stim.Tableau(4))
 
 
+def test_copy():
+    t = stim.Tableau(3)
+    t2 = t.copy()
+    assert t == t2
+    assert t is not t2
+
+
 def test_hash():
     # stim.Tableau is mutable. It must not also be value-hashable.
     # Defining __hash__ requires defining a FrozenTableau variant instead.

--- a/src/stabilizers/tableau_transposed_raii.cc
+++ b/src/stabilizers/tableau_transposed_raii.cc
@@ -31,6 +31,14 @@ TableauTransposedRaii::~TableauTransposedRaii() {
     tableau.do_transpose_quadrants();
 }
 
+/// Iterates over the Paulis in a row of the tableau.
+///
+/// Args:
+///     trans: The transposed tableau (where rows are contiguous in memory and so operations can be done efficiently).
+///     q: The row to iterate over.
+///     body: A function taking X, Z, and SIGN words.
+///         The X and Z words are chunks of xz-encoded Paulis from the row.
+///         The SIGN word is the corresponding chunk of sign bits from the sign row.
 template <typename FUNC>
 inline void for_each_trans_obs(TableauTransposedRaii &trans, size_t q, FUNC body) {
     for (size_t k = 0; k < 2; k++) {
@@ -111,4 +119,11 @@ void TableauTransposedRaii::append_X(size_t target) {
     for_each_trans_obs(*this, target, [](simd_word &x, simd_word &z, simd_word &s) {
         s ^= z;
     });
+}
+
+PauliString TableauTransposedRaii::unsigned_x_input(size_t q) const {
+    PauliString result(tableau.num_qubits);
+    result.xs = tableau.zs[q].zs;
+    result.zs = tableau.xs[q].zs;
+    return result;
 }

--- a/src/stabilizers/tableau_transposed_raii.h
+++ b/src/stabilizers/tableau_transposed_raii.h
@@ -40,6 +40,8 @@ struct TableauTransposedRaii {
     TableauTransposedRaii(const TableauTransposedRaii &) = delete;
     TableauTransposedRaii(TableauTransposedRaii &&) = delete;
 
+    PauliString unsigned_x_input(size_t q) const;
+
     void append_H_XZ(size_t q);
     void append_H_XY(size_t q);
     void append_H_YZ(size_t q);


### PR DESCRIPTION
Translating ZX graphs into circuits requires the ability to translate post-selection into measurement. The new method `measure_kickback` allows this to be done by returning a kickback operation that can be used to cleanly invert random measurements. Testing this functionality from the python side then required increased ability to edit the simulator state.

- Add stim.TableauSimulator.do(stim.PauliString)
    - Add TableauSimulator::paulis(PauliString)
- Add stim.TableauSimulator.set_num_qubits
    - Add TableauSimulator::collapse_isolate_qubit
    - Add TableauSimulator::set_num_qubits
    - Add simd_bits::truncated_overwrite_from
    - Refactor TableauSimulator::collapse to take ConstPointerRange<uint32_t>
- Add stim.TableauSimulator.measure_kickback
    - Refactor TableauSimulator::collapse_qubit to return the used pivot index
    - Add TableauSimulator::measure_kickback
- Add stim.TableauSimulator.set_inverse_tableau
- Add stim.{Circuit,Tableau,PauliString,TableauSimulator}.copy
- Add allow_imaginary=False argument to stim.PauliString.random