### PR TITLE
Fix some system-specific build errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ set(BENCHMARK_FILES
 
 add_executable(stim src/main.cc ${SOURCE_FILES_NO_MAIN})
 if(NOT(MSVC))
-    target_compile_options(stim PRIVATE -O3 -Wall -Wpedantic -Werror ${MACHINE_FLAG})
+    target_compile_options(stim PRIVATE -O3 -Wall -Wpedantic ${MACHINE_FLAG})
     target_link_options(stim PRIVATE -pthread -O3)
 else()
     target_compile_options(stim PRIVATE -DSIMD_WIDTH=${SIMD_WIDTH})
@@ -112,7 +112,7 @@ endif()
 
 add_executable(stim_benchmark ${SOURCE_FILES_NO_MAIN} ${BENCHMARK_FILES})
 if(NOT(MSVC))
-    target_compile_options(stim_benchmark PRIVATE -Wall -Wpedantic -Werror -O3 ${MACHINE_FLAG})
+    target_compile_options(stim_benchmark PRIVATE -Wall -Wpedantic -O3 ${MACHINE_FLAG})
     target_link_options(stim_benchmark PRIVATE -pthread)
 else()
     target_compile_options(stim_benchmark PRIVATE ${MACHINE_FLAG})

--- a/src/simulators/measure_record_writer.h
+++ b/src/simulators/measure_record_writer.h
@@ -29,6 +29,7 @@
 struct MeasureRecordWriter {
     /// Creates a MeasureRecordWriter that writes the given format into the given FILE*.
     static std::unique_ptr<MeasureRecordWriter> make(FILE *out, SampleFormat output_format);
+    virtual ~MeasureRecordWriter() = default;
     /// Writes (or buffers) one measurement result.
     virtual void write_bit(bool b) = 0;
     /// Writes (or buffers) multiple measurement results.

--- a/src/simulators/tableau_simulator.cc
+++ b/src/simulators/tableau_simulator.cc
@@ -599,7 +599,7 @@ void TableauSimulator::set_num_qubits(size_t new_num_qubits) {
     }
 
     Tableau old_state = std::move(inv_state);
-    inv_state = std::move(Tableau(new_num_qubits));
+    inv_state = Tableau(new_num_qubits);
     inv_state.xs.signs.truncated_overwrite_from(old_state.xs.signs, new_num_qubits);
     inv_state.zs.signs.truncated_overwrite_from(old_state.zs.signs, new_num_qubits);
     for (size_t q = 0; q < new_num_qubits; q++) {

--- a/src/stabilizers/tableau.cc
+++ b/src/stabilizers/tableau.cc
@@ -183,8 +183,8 @@ void Tableau::inplace_scatter_prepend(const Tableau &operation, const std::vecto
     new_x.reserve(operation.num_qubits);
     new_z.reserve(operation.num_qubits);
     for (size_t q = 0; q < operation.num_qubits; q++) {
-        new_x.emplace_back(std::move(scatter_eval(operation.xs[q], target_qubits)));
-        new_z.emplace_back(std::move(scatter_eval(operation.zs[q], target_qubits)));
+        new_x.push_back(scatter_eval(operation.xs[q], target_qubits));
+        new_z.push_back(scatter_eval(operation.zs[q], target_qubits));
     }
     for (size_t q = 0; q < operation.num_qubits; q++) {
         xs[target_qubits[q]] = new_x[q];


### PR DESCRIPTION
- Give MeasureRecordWriter a virtual destructor (because it is deleted through std::unique_ptr pointers to its child types)
- Remove some std::move calls preventing possible copy elision
- Remove -Werror because it's brittle across time and space

Fixes https://github.com/quantumlib/Stim/issues/27