### PR TITLE
Extend arithmetic operators (tensor products, differing lengths)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,4 +122,4 @@ jobs:
       - run: pip install -e glue/cirq
       - run: pip install pytest
       - run: pytest glue/cirq
-      - run: python -c "import cirq; import stimcirq; import doctest; assert doctest.testmod(stimcirq).failed == 0"
+      - run: python -c "import stimcirq; import doctest; assert doctest.testmod(stimcirq).failed == 0"

--- a/src/stabilizers/pauli_string.cc
+++ b/src/stabilizers/pauli_string.cc
@@ -112,3 +112,21 @@ bool PauliString::operator==(const PauliStringRef &other) const {
 bool PauliString::operator!=(const PauliStringRef &other) const {
     return ref() != other;
 }
+
+void PauliString::ensure_num_qubits(size_t min_num_qubits) {
+    if (min_num_qubits <= num_qubits) {
+        return;
+    }
+    if (xs.num_bits_padded() >= min_num_qubits) {
+        num_qubits = min_num_qubits;
+        return;
+    }
+
+    simd_bits new_xs(min_num_qubits);
+    simd_bits new_zs(min_num_qubits);
+    new_xs.truncated_overwrite_from(xs, num_qubits);
+    new_zs.truncated_overwrite_from(zs, num_qubits);
+    xs = std::move(new_xs);
+    zs = std::move(new_zs);
+    num_qubits = min_num_qubits;
+}

--- a/src/stabilizers/pauli_string.h
+++ b/src/stabilizers/pauli_string.h
@@ -68,6 +68,8 @@ struct PauliString {
 
     /// Returns a string describing the given Pauli string, with one character per qubit.
     std::string str() const;
+
+    void ensure_num_qubits(size_t min_num_qubits);
 };
 
 /// Writes a string describing the given Pauli string to an output stream.

--- a/src/stabilizers/pauli_string.pybind.cc
+++ b/src/stabilizers/pauli_string.pybind.cc
@@ -301,7 +301,7 @@ void pybind_pauli_string(pybind11::module &m) {
 
             Examples:
                 >>> import stim
-                >>> stim.PauliString([0, 1, 2, 3, 0, 3)
+                >>> stim.PauliString([0, 1, 2, 3, 0, 3])
                 stim.PauliString("+_XYZ_Z")
 
             Args:
@@ -501,6 +501,7 @@ void pybind_pauli_string(pybind11::module &m) {
                 >>> p = stim.PauliString("iX")
                 >>> alias = p
                 >>> p *= stim.PauliString("-YY")
+                >>> p
                 stim.PauliString("-iXYY")
                 >>> alias is p
                 True
@@ -630,7 +631,7 @@ void pybind_pauli_string(pybind11::module &m) {
                 >>> p = stim.PauliString("X")
                 >>> p *= 1j
                 >>> p
-                stim.PauliString("iX")
+                stim.PauliString("+iX")
 
                 >>> p = stim.PauliString("iXY_")
                 >>> p *= 3
@@ -645,6 +646,7 @@ void pybind_pauli_string(pybind11::module &m) {
 
                 >>> p = stim.PauliString("X")
                 >>> p *= stim.PauliString("_YY")
+                >>> p
                 stim.PauliString("+XYY")
 
             Returns:

--- a/src/stabilizers/pauli_string.pybind.cc
+++ b/src/stabilizers/pauli_string.pybind.cc
@@ -500,7 +500,7 @@ void pybind_pauli_string(pybind11::module &m) {
 
                 >>> p = stim.PauliString("iX")
                 >>> alias = p
-                >>> p *= stim.PauliString("-YY")
+                >>> p += stim.PauliString("-YY")
                 >>> p
                 stim.PauliString("-iXYY")
                 >>> alias is p

--- a/src/stabilizers/pauli_string.pybind.h
+++ b/src/stabilizers/pauli_string.pybind.h
@@ -28,10 +28,20 @@ struct PyPauliString {
     PyPauliString(PauliString&& val, bool imag = false);
 
     std::complex<float> get_phase() const;
+
+    PyPauliString operator+(const PyPauliString &rhs) const;
+    PyPauliString &operator+=(const PyPauliString &rhs);
+
+    PyPauliString operator*(pybind11::object rhs) const;
+    PyPauliString operator*(size_t power) const;
     PyPauliString operator*(std::complex<float> scale) const;
-    PyPauliString &operator*=(std::complex<float> scale);
     PyPauliString operator*(const PyPauliString &rhs) const;
+
+    PyPauliString &operator*=(pybind11::object rhs);
+    PyPauliString &operator*=(size_t power);
+    PyPauliString &operator*=(std::complex<float> scale);
     PyPauliString &operator*=(const PyPauliString &rhs);
+
     bool operator==(const PyPauliString &other) const;
     bool operator!=(const PyPauliString &other) const;
     std::string str() const;

--- a/src/stabilizers/pauli_string.test.cc
+++ b/src/stabilizers/pauli_string.test.cc
@@ -270,6 +270,10 @@ TEST(pauli_string, commutes) {
     ASSERT_EQ(qb.ref().commutes(qb), true);
     ASSERT_EQ(qa.ref().commutes(qb), false);
     ASSERT_EQ(qb.ref().commutes(qa), false);
+
+    // Differing sizes.
+    ASSERT_EQ(qa.ref().commutes(PauliString(0)), true);
+    ASSERT_EQ(PauliString(0).ref().commutes(qa), true);
 }
 
 TEST(PauliStringPtr, sparse_str) {
@@ -286,4 +290,21 @@ TEST(PauliStringPtr, sparse_str) {
                     .ref()
                     .sparse_str();
     ASSERT_EQ(x501, "+X501");
+}
+
+TEST(PauliString, ensure_num_qubits) {
+    auto p = PauliString::from_str("IXYZ_I");
+    p.ensure_num_qubits(1);
+    ASSERT_EQ(p, PauliString::from_str("IXYZ_I"));
+    p.ensure_num_qubits(6);
+    ASSERT_EQ(p, PauliString::from_str("IXYZ_I"));
+    p.ensure_num_qubits(7);
+    ASSERT_EQ(p, PauliString::from_str("IXYZ_I_"));
+    p.ensure_num_qubits(1000);
+    PauliString p2(1000);
+    p2.xs[1] = true;
+    p2.xs[2] = true;
+    p2.zs[2] = true;
+    p2.zs[3] = true;
+    ASSERT_EQ(p, p2);
 }

--- a/src/stabilizers/pauli_string_ref.cc
+++ b/src/stabilizers/pauli_string_ref.cc
@@ -119,7 +119,9 @@ uint8_t PauliStringRef::inplace_right_mul_returning_log_i_scalar(const PauliStri
 }
 
 bool PauliStringRef::commutes(const PauliStringRef &other) const noexcept {
-    assert(num_qubits == other.num_qubits);
+    if (num_qubits > other.num_qubits) {
+        return other.commutes(*this);
+    }
     simd_word cnt1{};
     xs.for_each_word(zs, other.xs, other.zs, [&cnt1](simd_word &x1, simd_word &z1, simd_word &x2, simd_word &z2) {
         cnt1 ^= (x1 & z2) ^ (x2 & z1);


### PR DESCRIPTION
- Add `PauliString::ensure_num_qubits`
- Add `stim.PauliString.__add__` and `stim.PauliString.__iadd__` for concatenating / tensor product
- Extend `stim.PauliString.__mul__` to handle tensor powers (concatenation)
- Extend `stim.PauliString.__mul__` to allow different sized Paulis
- Extend `stim.PauliString.commutes` to allow different sized Paulis
- Extend `PauliString.__init__` to take Sequence[int]
- Extend `PauliString.__init__` to take stim.PauliString