### PR TITLE
Add (and fix bugs revealed by) stim.TableauSimulator.canonical_stabilizers

### DIFF
--- a/src/simulators/tableau_simulator.h
+++ b/src/simulators/tableau_simulator.h
@@ -88,6 +88,8 @@ struct TableauSimulator {
     /// Determines if a qubit's Z observable commutes (vs anti-commutes) with the current stabilizer generators.
     bool is_deterministic(size_t target) const;
 
+    std::vector<PauliString> canonical_stabilizers() const;
+
     /// === SPECIALIZED VECTORIZED OPERATION IMPLEMENTATIONS ===
     void I(const OperationData &target_data);
     void H_XZ(const OperationData &target_data);

--- a/src/simulators/tableau_simulator_pybind_test.py
+++ b/src/simulators/tableau_simulator_pybind_test.py
@@ -224,9 +224,9 @@ def test_measure_kickback_random_branches():
     assert isinstance(kick, stim.PauliString) and len(kick) == 8
     if result:
         s.do(kick)
-    assert s.current_inverse_tableau() == post_false.current_inverse_tableau()
+    assert s.canonical_stabilizers() == post_false.canonical_stabilizers()
     s.do(kick)
-    assert s.current_inverse_tableau() == post_true.current_inverse_tableau()
+    assert s.canonical_stabilizers() == post_true.canonical_stabilizers()
 
 
 def test_set_num_qubits():
@@ -245,3 +245,23 @@ def test_set_num_qubits():
     s.cnot(0, 4)
     s.set_num_qubits(4)
     assert s.peek_bloch(0) in [stim.PauliString("+Z"), stim.PauliString("-Z")]
+
+
+def test_canonical_stabilizers():
+    s = stim.TableauSimulator()
+    s.h(0)
+    s.h(1)
+    s.h(2)
+    s.cz(0, 1)
+    s.cz(1, 2)
+    assert s.canonical_stabilizers() == [
+        stim.PauliString("+X_X"),
+        stim.PauliString("+ZXZ"),
+        stim.PauliString("+_ZX"),
+    ]
+    s.s(1)
+    assert s.canonical_stabilizers() == [
+        stim.PauliString("+X_X"),
+        stim.PauliString("-ZXY"),
+        stim.PauliString("+_ZX"),
+    ]

--- a/src/stabilizers/tableau.test.cc
+++ b/src/stabilizers/tableau.test.cc
@@ -524,6 +524,15 @@ TEST(tableau, specialized_operations) {
         }));
 
     EXPECT_TRUE(are_tableau_mutations_equivalent(
+        1,
+        [](Tableau &t, const std::vector<size_t> &targets) {
+            t.inplace_scatter_append(GATE_DATA.at("S").tableau(), targets);
+        },
+        [](Tableau &t, const std::vector<size_t> &targets) {
+            TableauTransposedRaii(t).append_S(targets[0]);
+        }));
+
+    EXPECT_TRUE(are_tableau_mutations_equivalent(
         2,
         [](Tableau &t, const std::vector<size_t> &targets) {
             t.inplace_scatter_append(GATE_DATA.at("ZCX").tableau(), targets);

--- a/src/stabilizers/tableau_transposed_raii.cc
+++ b/src/stabilizers/tableau_transposed_raii.cc
@@ -108,6 +108,13 @@ void TableauTransposedRaii::append_H_YZ(size_t target) {
     });
 }
 
+void TableauTransposedRaii::append_S(size_t target) {
+    for_each_trans_obs(*this, target, [](simd_word &x, simd_word &z, simd_word &s) {
+        s ^= x & z;
+        z ^= x;
+    });
+}
+
 void TableauTransposedRaii::append_H_XZ(size_t q) {
     for_each_trans_obs(*this, q, [](simd_word &x, simd_word &z, simd_word &s) {
         std::swap(x, z);

--- a/src/stabilizers/tableau_transposed_raii.h
+++ b/src/stabilizers/tableau_transposed_raii.h
@@ -45,6 +45,7 @@ struct TableauTransposedRaii {
     void append_H_XZ(size_t q);
     void append_H_XY(size_t q);
     void append_H_YZ(size_t q);
+    void append_S(size_t q);
     void append_ZCX(size_t control, size_t target);
     void append_ZCY(size_t control, size_t target);
     void append_ZCZ(size_t control, size_t target);


### PR DESCRIPTION
- Fix `TableauSimulator::collapse_isolate_qubit` using H_XY instead of S (H_XY is unsafe here because not a no-op on the zero state).
    - Add several tests that would have detected this bug
    - Add `TableauSimulator::append_S`
- Improve `stim.TableauSimulator.measure_kickback` so it isolates qubits so their Z term is not spuriously added to later kickbacks
- Add `stim.TableauSimulator.canonical_stabilizers`