### PR TITLE
Use a namespace

### DIFF
--- a/glue/javascript/circuit.js.cc
+++ b/glue/javascript/circuit.js.cc
@@ -2,6 +2,8 @@
 #include <emscripten/val.h>
 #include "circuit.js.h"
 
+using namespace stim_internal;
+
 ExposedCircuit::ExposedCircuit() : circuit() {
 }
 

--- a/glue/javascript/circuit.js.h
+++ b/glue/javascript/circuit.js.h
@@ -7,9 +7,9 @@
 #include "../../src/circuit/circuit.h"
 
 struct ExposedCircuit {
-    Circuit circuit;
+    stim_internal::Circuit circuit;
     ExposedCircuit();
-    explicit ExposedCircuit(Circuit circuit);
+    explicit ExposedCircuit(stim_internal::Circuit circuit);
     explicit ExposedCircuit(const std::string &text);
     void append_operation(const std::string &name, const emscripten::val &targets, double arg);
     void append_from_stim_program_text(const std::string &text);

--- a/glue/javascript/common.js.cc
+++ b/glue/javascript/common.js.cc
@@ -1,5 +1,7 @@
 #include "common.js.h"
 
+using namespace stim_internal;
+
 static bool shared_rng_initialized;
 static std::mt19937_64 shared_rng;
 

--- a/glue/javascript/pauli_string.js.cc
+++ b/glue/javascript/pauli_string.js.cc
@@ -2,6 +2,8 @@
 #include "common.js.h"
 #include "pauli_string.js.h"
 
+using namespace stim_internal;
+
 ExposedPauliString::ExposedPauliString(PauliString pauli_string) : pauli_string(pauli_string) {
 }
 

--- a/glue/javascript/pauli_string.js.h
+++ b/glue/javascript/pauli_string.js.h
@@ -7,8 +7,8 @@
 #include "../../src/stabilizers/pauli_string.h"
 
 struct ExposedPauliString {
-    PauliString pauli_string;
-    explicit ExposedPauliString(PauliString pauli_string);
+    stim_internal::PauliString pauli_string;
+    explicit ExposedPauliString(stim_internal::PauliString pauli_string);
     explicit ExposedPauliString(const emscripten::val &arg);
     static ExposedPauliString random(size_t n);
     ExposedPauliString times(const ExposedPauliString &other) const;

--- a/glue/javascript/tableau.js.cc
+++ b/glue/javascript/tableau.js.cc
@@ -3,6 +3,8 @@
 #include "common.js.h"
 #include "tableau.js.h"
 
+using namespace stim_internal;
+
 ExposedTableau::ExposedTableau(Tableau tableau) : tableau(tableau) {
 }
 

--- a/glue/javascript/tableau.js.h
+++ b/glue/javascript/tableau.js.h
@@ -7,8 +7,8 @@
 #include "pauli_string.js.h"
 
 struct ExposedTableau {
-    Tableau tableau;
-    explicit ExposedTableau(Tableau tableau);
+    stim_internal::Tableau tableau;
+    explicit ExposedTableau(stim_internal::Tableau tableau);
     explicit ExposedTableau(int n);
     static ExposedTableau random(int n);
     static ExposedTableau from_named_gate(const std::string &name);

--- a/glue/javascript/tableau_simulator.js.cc
+++ b/glue/javascript/tableau_simulator.js.cc
@@ -3,6 +3,8 @@
 #include "common.js.h"
 #include "tableau_simulator.js.h"
 
+using namespace stim_internal;
+
 struct TempArgData {
     std::vector<uint32_t> targets;
     TempArgData(std::vector<uint32_t> targets) : targets(std::move(targets)) {

--- a/glue/javascript/tableau_simulator.js.h
+++ b/glue/javascript/tableau_simulator.js.h
@@ -10,7 +10,7 @@
 #include "tableau.js.h"
 
 struct ExposedTableauSimulator {
-    TableauSimulator sim;
+    stim_internal::TableauSimulator sim;
     ExposedTableauSimulator();
     ExposedTableauSimulator copy() const;
     bool measure(size_t target);

--- a/src/arg_parse.cc
+++ b/src/arg_parse.cc
@@ -18,7 +18,9 @@
 #include <cstdlib>
 #include <cstring>
 
-const char *require_find_argument(const char *name, int argc, const char **argv) {
+using namespace stim_internal;
+
+const char *stim_internal::require_find_argument(const char *name, int argc, const char **argv) {
     const char *result = find_argument(name, argc, argv);
     if (result == 0) {
         fprintf(stderr, "\033[31mMissing command line argument: '%s'\033[0m\n", name);
@@ -27,7 +29,7 @@ const char *require_find_argument(const char *name, int argc, const char **argv)
     return result;
 }
 
-const char *find_argument(const char *name, int argc, const char **argv) {
+const char *stim_internal::find_argument(const char *name, int argc, const char **argv) {
     // Respect that the "--" argument terminates flags.
     size_t flag_count = 1;
     while (flag_count < (size_t)argc && strcmp(argv[flag_count], "--") != 0) {
@@ -64,7 +66,7 @@ const char *find_argument(const char *name, int argc, const char **argv) {
     return 0;
 }
 
-void check_for_unknown_arguments(
+void stim_internal::check_for_unknown_arguments(
     const std::vector<const char *> &known_arguments, const char *for_mode, int argc, const char **argv) {
     for (int i = 1; i < argc; i++) {
         // Respect that the "--" argument terminates flags.
@@ -105,7 +107,7 @@ void check_for_unknown_arguments(
     }
 }
 
-bool find_bool_argument(const char *name, int argc, const char **argv) {
+bool stim_internal::find_bool_argument(const char *name, int argc, const char **argv) {
     const char *text = find_argument(name, argc, argv);
     if (text == nullptr) {
         return false;
@@ -117,7 +119,7 @@ bool find_bool_argument(const char *name, int argc, const char **argv) {
     exit(EXIT_FAILURE);
 }
 
-int find_int_argument(const char *name, int default_value, int min_value, int max_value, int argc, const char **argv) {
+int stim_internal::find_int_argument(const char *name, int default_value, int min_value, int max_value, int argc, const char **argv) {
     const char *text = find_argument(name, argc, argv);
     if (text == nullptr || text[0] == '\0') {
         if (default_value < min_value || default_value > max_value) {
@@ -151,7 +153,7 @@ int find_int_argument(const char *name, int default_value, int min_value, int ma
     return (int)i;
 }
 
-float find_float_argument(
+float stim_internal::find_float_argument(
     const char *name, float default_value, float min_value, float max_value, int argc, const char **argv) {
     const char *text = find_argument(name, argc, argv);
     if (text == nullptr) {
@@ -186,7 +188,7 @@ float find_float_argument(
     return f;
 }
 
-int find_enum_argument(
+int stim_internal::find_enum_argument(
     const char *name, int default_index, const std::vector<const char *> &known_values, int argc, const char **argv) {
     const char *text = find_argument(name, argc, argv);
     if (text == nullptr) {

--- a/src/arg_parse.h
+++ b/src/arg_parse.h
@@ -20,6 +20,8 @@
 #include <cstddef>
 #include <vector>
 
+namespace stim_internal {
+
 /// Searches through command line flags for a particular flag's argument.
 ///
 /// Args:
@@ -157,5 +159,7 @@ bool find_bool_argument(const char *name, int argc, const char **argv);
 ///         The command line flag is not specified and default_index is negative.
 int find_enum_argument(
     const char *name, int default_index, const std::vector<const char *> &known_values, int argc, const char **argv);
+
+}
 
 #endif

--- a/src/arg_parse.test.cc
+++ b/src/arg_parse.test.cc
@@ -20,6 +20,8 @@
 
 #include "assert.h"
 
+using namespace stim_internal;
+
 TEST(arg_parse, check_for_unknown_arguments_recognize_arguments) {
     std::vector<const char *> known{
         "--mode",

--- a/src/benchmark_main.perf.cc
+++ b/src/benchmark_main.perf.cc
@@ -19,6 +19,8 @@
 #include "arg_parse.h"
 #include "benchmark_util.h"
 
+using namespace stim_internal;
+
 RegisteredBenchmark *running_benchmark = nullptr;
 std::vector<RegisteredBenchmark> all_registered_benchmarks{};
 

--- a/src/circuit/circuit.cc
+++ b/src/circuit/circuit.cc
@@ -22,6 +22,8 @@
 #include "../stabilizers/tableau.h"
 #include "gate_data.h"
 
+using namespace stim_internal;
+
 enum READ_CONDITION {
     READ_AS_LITTLE_AS_POSSIBLE,
     READ_UNTIL_END_OF_BLOCK,

--- a/src/circuit/circuit.h
+++ b/src/circuit/circuit.h
@@ -27,6 +27,8 @@
 #include "../simd/monotonic_buffer.h"
 #include "gate_data.h"
 
+namespace stim_internal {
+
 #define TARGET_VALUE_MASK ((uint32_t{1} << 24) - uint32_t{1})
 #define TARGET_INVERTED_BIT (uint32_t{1} << 31)
 #define TARGET_PAULI_X_BIT (uint32_t{1} << 30)
@@ -232,7 +234,10 @@ struct DetectorsAndObservables {
     DetectorsAndObservables &operator=(const DetectorsAndObservables &other);
 };
 
-std::ostream &operator<<(std::ostream &out, const Circuit &c);
-std::ostream &operator<<(std::ostream &out, const Operation &op);
+}
+
+std::ostream &operator<<(std::ostream &out, const stim_internal::Circuit &c);
+std::ostream &operator<<(std::ostream &out, const stim_internal::Operation &op);
+
 
 #endif

--- a/src/circuit/circuit.perf.cc
+++ b/src/circuit/circuit.perf.cc
@@ -16,6 +16,8 @@
 
 #include "../benchmark_util.h"
 
+using namespace stim_internal;
+
 BENCHMARK(circuit_parse) {
     Circuit c;
     benchmark_go([&]() {

--- a/src/circuit/circuit.pybind.cc
+++ b/src/circuit/circuit.pybind.cc
@@ -18,6 +18,8 @@
 #include "../py/compiled_detector_sampler.pybind.h"
 #include "../py/compiled_measurement_sampler.pybind.h"
 
+using namespace stim_internal;
+
 std::string circuit_repr(const Circuit &self) {
     if (self.operations.empty()) {
         return "stim.Circuit()";

--- a/src/circuit/circuit.pybind.h
+++ b/src/circuit/circuit.pybind.h
@@ -20,6 +20,6 @@
 #include "circuit.h"
 
 void pybind_circuit(pybind11::module &m);
-std::string circuit_repr(const Circuit &self);
+std::string circuit_repr(const stim_internal::Circuit &self);
 
 #endif

--- a/src/circuit/circuit.test.cc
+++ b/src/circuit/circuit.test.cc
@@ -16,6 +16,8 @@
 
 #include <gtest/gtest.h>
 
+using namespace stim_internal;
+
 OpDat::OpDat(uint32_t target) : targets({target}) {
 }
 

--- a/src/circuit/circuit.test.h
+++ b/src/circuit/circuit.test.h
@@ -25,7 +25,7 @@ struct OpDat {
     OpDat(uint32_t target);
     OpDat(std::vector<uint32_t> targets);
     static OpDat flipped(size_t target);
-    operator OperationData();
+    operator stim_internal::OperationData();
 };
 
 #endif

--- a/src/circuit/gate_data.cc
+++ b/src/circuit/gate_data.cc
@@ -20,10 +20,12 @@
 #include "../simulators/frame_simulator.h"
 #include "../simulators/tableau_simulator.h"
 
+using namespace stim_internal;
+
 static constexpr std::complex<float> i = std::complex<float>(0, 1);
 static constexpr std::complex<float> s = 0.7071067811865475244f;
 
-extern const GateDataMap GATE_DATA(
+extern const GateDataMap stim_internal::GATE_DATA(
     {
         // Collapsing gates.
         {

--- a/src/circuit/gate_data.h
+++ b/src/circuit/gate_data.h
@@ -28,6 +28,8 @@
 #include <unordered_set>
 #include <vector>
 
+namespace stim_internal {
+
 struct TableauSimulator;
 struct FrameSimulator;
 struct OperationData;
@@ -261,5 +263,7 @@ struct GateDataMap {
 };
 
 extern const GateDataMap GATE_DATA;
+
+}
 
 #endif

--- a/src/circuit/gate_data.perf.cc
+++ b/src/circuit/gate_data.perf.cc
@@ -18,6 +18,8 @@
 
 #include "../benchmark_util.h"
 
+using namespace stim_internal;
+
 BENCHMARK(gate_data_fast_hash) {
     std::vector<std::string> names;
     for (const auto &gate : GATE_DATA.gates()) {

--- a/src/circuit/gate_data.test.cc
+++ b/src/circuit/gate_data.test.cc
@@ -18,6 +18,8 @@
 
 #include "../test_util.test.h"
 
+using namespace stim_internal;
+
 TEST(gate_data, lookup) {
     ASSERT_TRUE(GATE_DATA.has("H"));
     ASSERT_FALSE(GATE_DATA.has("H2345"));

--- a/src/main.cc
+++ b/src/main.cc
@@ -14,6 +14,8 @@
 
 #include "main_helper.h"
 
+using namespace stim_internal;
+
 int main(int argc, const char **argv) {
     return main_helper(argc, argv);
 }

--- a/src/main.perf.cc
+++ b/src/main.perf.cc
@@ -16,6 +16,8 @@
 #include "main_helper.h"
 #include "simulators/detection_simulator.h"
 
+using namespace stim_internal;
+
 Circuit make_rep_code(uint32_t distance, uint32_t rounds) {
     Circuit round_ops;
     for (uint32_t k = 0; k < distance - 1; k++) {

--- a/src/main_helper.cc
+++ b/src/main_helper.cc
@@ -21,6 +21,8 @@
 #include "simulators/frame_simulator.h"
 #include "simulators/tableau_simulator.h"
 
+using namespace stim_internal;
+
 static std::vector<const char *> known_arguments{
     "--help",
 
@@ -65,7 +67,7 @@ struct RaiiFiles {
     }
 };
 
-int main_helper(int argc, const char **argv) {
+int stim_internal::main_helper(int argc, const char **argv) {
     if (find_argument("--help", argc, argv) != nullptr) {
         std::cerr << R"HELP(BASIC USAGE
 ===========

--- a/src/main_helper.test.cc
+++ b/src/main_helper.test.cc
@@ -16,6 +16,8 @@
 
 #include <gtest/gtest.h>
 
+using namespace stim_internal;
+
 struct RaiiDeleteFile {
     char *c = nullptr;
     ~RaiiDeleteFile() {

--- a/src/probability_util.cc
+++ b/src/probability_util.cc
@@ -14,6 +14,8 @@
 
 #include "probability_util.h"
 
+using namespace stim_internal;
+
 RareErrorIterator::RareErrorIterator(float probability)
     : next_candidate(0), is_one(probability == 1), dist(probability) {
     if (!(probability >= 0 && probability <= 1)) {
@@ -27,7 +29,7 @@ size_t RareErrorIterator::next(std::mt19937_64 &rng) {
     return result;
 }
 
-std::vector<size_t> sample_hit_indices(float probability, size_t attempts, std::mt19937_64 &rng) {
+std::vector<size_t> stim_internal::sample_hit_indices(float probability, size_t attempts, std::mt19937_64 &rng) {
     std::vector<size_t> result;
     RareErrorIterator::for_samples(probability, attempts, rng, [&](size_t s) {
         result.push_back(s);
@@ -35,7 +37,7 @@ std::vector<size_t> sample_hit_indices(float probability, size_t attempts, std::
     return result;
 }
 
-std::mt19937_64 externally_seeded_rng() {
+std::mt19937_64 stim_internal::externally_seeded_rng() {
 #if defined(__linux) && defined(__GLIBCXX__) && __GLIBCXX__ >= 20200128
     // Workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94087
     // See https://github.com/quantumlib/Stim/issues/26
@@ -48,7 +50,7 @@ std::mt19937_64 externally_seeded_rng() {
     return result;
 }
 
-void biased_randomize_bits(float probability, uint64_t *start, uint64_t *end, std::mt19937_64 &rng) {
+void stim_internal::biased_randomize_bits(float probability, uint64_t *start, uint64_t *end, std::mt19937_64 &rng) {
     if (probability > 0.5) {
         // Recurse and invert for probabilities larger than 0.5.
         biased_randomize_bits(1 - probability, start, end, rng);

--- a/src/probability_util.h
+++ b/src/probability_util.h
@@ -23,6 +23,8 @@
 
 #include "circuit/circuit.h"
 
+namespace stim_internal {
+
 /// Yields the indices of hits sampled from a Bernoulli distribution.
 /// Gets more efficient as the hit probability drops.
 struct RareErrorIterator {
@@ -65,5 +67,7 @@ std::vector<size_t> sample_hit_indices(float probability, size_t attempts, std::
 std::mt19937_64 externally_seeded_rng();
 
 void biased_randomize_bits(float probability, uint64_t *start, uint64_t *end, std::mt19937_64 &rng);
+
+}
 
 #endif

--- a/src/probability_util.perf.cc
+++ b/src/probability_util.perf.cc
@@ -17,6 +17,8 @@
 #include "benchmark_util.h"
 #include "simd/simd_bits.h"
 
+using namespace stim_internal;
+
 BENCHMARK(biased_random_1024_0point1percent) {
     std::mt19937_64 rng(0);
     float p = 0.001;

--- a/src/probability_util.test.cc
+++ b/src/probability_util.test.cc
@@ -18,6 +18,8 @@
 
 #include "test_util.test.h"
 
+using namespace stim_internal;
+
 TEST(probability_util, sample_hit_indices_corner_cases) {
     ASSERT_EQ(sample_hit_indices(0, 100000, SHARED_TEST_RNG()), (std::vector<size_t>{}));
     ASSERT_EQ(sample_hit_indices(1, 10, SHARED_TEST_RNG()), (std::vector<size_t>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));

--- a/src/py/base.pybind.cc
+++ b/src/py/base.pybind.cc
@@ -16,6 +16,8 @@
 
 #include "../probability_util.h"
 
+using namespace stim_internal;
+
 static bool shared_rng_initialized;
 static std::mt19937_64 shared_rng;
 

--- a/src/py/compiled_detector_sampler.pybind.cc
+++ b/src/py/compiled_detector_sampler.pybind.cc
@@ -20,6 +20,8 @@
 #include "../simulators/tableau_simulator.h"
 #include "base.pybind.h"
 
+using namespace stim_internal;
+
 CompiledDetectorSampler::CompiledDetectorSampler(Circuit circuit) : dets_obs(circuit), circuit(std::move(circuit)) {
 }
 

--- a/src/py/compiled_detector_sampler.pybind.h
+++ b/src/py/compiled_detector_sampler.pybind.h
@@ -25,9 +25,9 @@
 void pybind_compiled_detector_sampler(pybind11::module &m);
 
 struct CompiledDetectorSampler {
-    const DetectorsAndObservables dets_obs;
-    const Circuit circuit;
-    CompiledDetectorSampler(Circuit circuit);
+    const stim_internal::DetectorsAndObservables dets_obs;
+    const stim_internal::Circuit circuit;
+    CompiledDetectorSampler(stim_internal::Circuit circuit);
     pybind11::array_t<uint8_t> sample(size_t num_shots, bool prepend_observables, bool append_observables);
     pybind11::array_t<uint8_t> sample_bit_packed(size_t num_shots, bool prepend_observables, bool append_observables);
     std::string repr() const;

--- a/src/py/compiled_measurement_sampler.pybind.cc
+++ b/src/py/compiled_measurement_sampler.pybind.cc
@@ -20,6 +20,8 @@
 #include "../simulators/tableau_simulator.h"
 #include "base.pybind.h"
 
+using namespace stim_internal;
+
 CompiledMeasurementSampler::CompiledMeasurementSampler(Circuit circuit)
     : ref(TableauSimulator::reference_sample_circuit(circuit)), circuit(std::move(circuit)) {
 }

--- a/src/py/compiled_measurement_sampler.pybind.h
+++ b/src/py/compiled_measurement_sampler.pybind.h
@@ -25,9 +25,9 @@
 void pybind_compiled_measurement_sampler(pybind11::module &m);
 
 struct CompiledMeasurementSampler {
-    const simd_bits ref;
-    const Circuit circuit;
-    CompiledMeasurementSampler(Circuit circuit);
+    const stim_internal::simd_bits ref;
+    const stim_internal::Circuit circuit;
+    CompiledMeasurementSampler(stim_internal::Circuit circuit);
     pybind11::array_t<uint8_t> sample(size_t num_samples);
     pybind11::array_t<uint8_t> sample_bit_packed(size_t num_samples);
     std::string repr() const;

--- a/src/py/stim.pybind.cc
+++ b/src/py/stim.pybind.cc
@@ -27,6 +27,8 @@
 #define xstr(s) str(s)
 #define str(s) #s
 
+using namespace stim_internal;
+
 uint32_t target_rec(int32_t lookback) {
     if (lookback >= 0 || lookback <= -(1 << 24)) {
         throw std::out_of_range("Need -16777215 <= lookback <= -1");

--- a/src/simd/bit_ref.cc
+++ b/src/simd/bit_ref.cc
@@ -14,6 +14,8 @@
 
 #include "bit_ref.h"
 
+using namespace stim_internal;
+
 bit_ref::bit_ref(void *base, size_t init_offset)
     : byte((uint8_t *)base + (init_offset / 8)), bit_index(init_offset & 7) {
 }

--- a/src/simd/bit_ref.h
+++ b/src/simd/bit_ref.h
@@ -20,6 +20,8 @@
 #include <cstddef>
 #include <cstdint>
 
+namespace stim_internal {
+
 /// A reference to a bit within a byte.
 ///
 /// Conceptually behaves the same as a `bool &`, as opposed to a `bool *`. For example, the `=` operator overwrites the
@@ -73,5 +75,7 @@ struct bit_ref {
         return (*byte >> bit_index) & 1;
     }
 };
+
+}
 
 #endif

--- a/src/simd/bit_ref.test.cc
+++ b/src/simd/bit_ref.test.cc
@@ -16,6 +16,8 @@
 
 #include <gtest/gtest.h>
 
+using namespace stim_internal;
+
 TEST(bit_ref, get) {
     uint64_t word = 0;
     bit_ref b(&word, 5);

--- a/src/simd/monotonic_buffer.h
+++ b/src/simd/monotonic_buffer.h
@@ -27,6 +27,8 @@
 
 #include "pointer_range.h"
 
+namespace stim_internal {
+
 /// A memory resource that can efficiently incrementally accumulate data.
 ///
 /// There are three important types of "region" in play: the tail region, the current region, and old regions.
@@ -160,5 +162,7 @@ struct MonotonicBuffer {
         tail = {cur.ptr_start, cur.ptr_start + tail_size};
     }
 };
+
+}
 
 #endif

--- a/src/simd/monotonic_buffer.test.cc
+++ b/src/simd/monotonic_buffer.test.cc
@@ -16,6 +16,8 @@
 
 #include <gtest/gtest.h>
 
+using namespace stim_internal;
+
 TEST(pointer_range, equality) {
     int data[100]{};
     PointerRange<int> r1{&data[0], &data[10]};

--- a/src/simd/pointer_range.h
+++ b/src/simd/pointer_range.h
@@ -24,6 +24,8 @@
 #include <stdexcept>
 #include <vector>
 
+namespace stim_internal {
+
 /// Delineates mutable memory using an inclusive start pointer and exclusive end pointer.
 template <typename T>
 struct PointerRange {
@@ -156,8 +158,10 @@ struct ConstPointerRange {
     }
 };
 
+}
+
 template <typename T>
-std::ostream &operator<<(std::ostream &out, ConstPointerRange<T> v) {
+std::ostream &operator<<(std::ostream &out, stim_internal::ConstPointerRange<T> v) {
     out << "PointerRange{";
     bool first = true;
     for (auto &e : v) {

--- a/src/simd/simd_bit_table.cc
+++ b/src/simd/simd_bit_table.cc
@@ -21,6 +21,8 @@
 
 #include "simd_util.h"
 
+using namespace stim_internal;
+
 simd_bit_table::simd_bit_table(size_t min_bits_major, size_t min_bits_minor)
     : num_simd_words_major(simd_bits::min_bits_to_num_simd_words(min_bits_major)),
       num_simd_words_minor(simd_bits::min_bits_to_num_simd_words(min_bits_minor)),

--- a/src/simd/simd_bit_table.h
+++ b/src/simd/simd_bit_table.h
@@ -19,6 +19,8 @@
 
 #include "simd_bits.h"
 
+namespace stim_internal {
+
 struct simd_bit_table {
     size_t num_simd_words_major;
     size_t num_simd_words_minor;
@@ -115,6 +117,8 @@ struct simd_bit_table {
 
 constexpr uint8_t lg(size_t k) {
     return k <= 1 ? 0 : lg(k >> 1) + 1;
+}
+
 }
 
 #endif

--- a/src/simd/simd_bit_table.perf.cc
+++ b/src/simd/simd_bit_table.perf.cc
@@ -16,6 +16,8 @@
 
 #include "../benchmark_util.h"
 
+using namespace stim_internal;
+
 BENCHMARK(simd_bit_table_inplace_square_transpose_diam10K) {
     size_t n = 10 * 1000;
     simd_bit_table table(n, n);

--- a/src/simd/simd_bit_table.test.cc
+++ b/src/simd/simd_bit_table.test.cc
@@ -18,6 +18,8 @@
 
 #include "../test_util.test.h"
 
+using namespace stim_internal;
+
 TEST(bit_mat, creation) {
     simd_bit_table a(3, 3);
     ASSERT_EQ(

--- a/src/simd/simd_bits.cc
+++ b/src/simd/simd_bits.cc
@@ -21,6 +21,8 @@
 
 #include "simd_util.h"
 
+using namespace stim_internal;
+
 size_t simd_bits::min_bits_to_num_bits_padded(size_t min_bits) {
     constexpr size_t mask = sizeof(simd_word) * 8 - 1;
     return (min_bits + mask) & ~mask;

--- a/src/simd/simd_bits.h
+++ b/src/simd/simd_bits.h
@@ -23,6 +23,8 @@
 #include "bit_ref.h"
 #include "simd_bits_range_ref.h"
 
+namespace stim_internal {
+
 /// Densely packed bits, allocated with alignment and padding enabling SIMD operations.
 ///
 /// A backing store for a `simd_bits_range_ref`.
@@ -125,5 +127,7 @@ struct simd_bits {
         return num_simd_words * sizeof(simd_word) << 3;
     }
 };
+
+}
 
 #endif

--- a/src/simd/simd_bits.perf.cc
+++ b/src/simd/simd_bits.perf.cc
@@ -18,6 +18,8 @@
 
 #include "../benchmark_util.h"
 
+using namespace stim_internal;
+
 BENCHMARK(simd_bits_randomize_10K) {
     size_t n = 10 * 1000;
     simd_bits data(n);

--- a/src/simd/simd_bits.test.cc
+++ b/src/simd/simd_bits.test.cc
@@ -19,6 +19,8 @@
 #include "../test_util.test.h"
 #include "simd_util.h"
 
+using namespace stim_internal;
+
 TEST(simd_bits, move) {
     simd_bits a(512);
     auto ptr = a.u64;

--- a/src/simd/simd_bits_range_ref.cc
+++ b/src/simd/simd_bits_range_ref.cc
@@ -19,6 +19,8 @@
 
 #include "simd_util.h"
 
+using namespace stim_internal;
+
 simd_bits_range_ref::simd_bits_range_ref(simd_word *ptr_simd_init, size_t num_simd_words)
     : ptr_simd(ptr_simd_init), num_simd_words(num_simd_words) {
 }

--- a/src/simd/simd_bits_range_ref.h
+++ b/src/simd/simd_bits_range_ref.h
@@ -24,6 +24,8 @@
 #include "bit_ref.h"
 #include "simd_compat.h"
 
+namespace stim_internal {
+
 /// A reference to a range of bits that support SIMD operations (e.g. they are aligned and padded correctly).
 ///
 /// Conceptually behaves the same as a reference like `int &`, as opposed to a pointer like `int *`. For example, the
@@ -292,7 +294,9 @@ struct simd_bits_range_ref {
     }
 };
 
+}
+
 /// Writes a description of the contents of the range to `out`.
-std::ostream &operator<<(std::ostream &out, const simd_bits_range_ref m);
+std::ostream &operator<<(std::ostream &out, const stim_internal::simd_bits_range_ref m);
 
 #endif

--- a/src/simd/simd_bits_range_ref.test.cc
+++ b/src/simd/simd_bits_range_ref.test.cc
@@ -18,6 +18,8 @@
 
 #include "../test_util.test.h"
 
+using namespace stim_internal;
+
 TEST(simd_bits_range_ref, construct) {
     alignas(64) uint64_t data[16]{};
     simd_bits_range_ref ref((simd_word *)data, sizeof(data) / sizeof(simd_word));

--- a/src/simd/simd_compat.perf.cc
+++ b/src/simd/simd_compat.perf.cc
@@ -18,6 +18,8 @@
 #include "simd_bits.h"
 #include "simd_compat.h"
 
+using namespace stim_internal;
+
 BENCHMARK(simd_compat_popcnt) {
     simd_bits d(1024 * 256);
     std::mt19937_64 rng(0);

--- a/src/simd/simd_compat.test.cc
+++ b/src/simd/simd_compat.test.cc
@@ -18,6 +18,8 @@
 
 #include "../test_util.test.h"
 
+using namespace stim_internal;
+
 union WordOr64 {
     simd_word w;
     uint64_t p[sizeof(simd_word) / sizeof(uint64_t)];

--- a/src/simd/simd_compat_avx2.h
+++ b/src/simd/simd_compat_avx2.h
@@ -22,6 +22,8 @@
 
 #include "simd_util.h"
 
+namespace stim_internal {
+
 struct simd_word {
     union {
         __m256i val;
@@ -102,7 +104,7 @@ struct simd_word {
     }
 
     inline uint16_t popcount() const {
-        return popcnt64(u64[0]) + popcnt64(u64[1]) + popcnt64(u64[2]) + (uint16_t)popcnt64(u64[3]);
+        return stim_internal::popcnt64(u64[0]) + stim_internal::popcnt64(u64[1]) + stim_internal::popcnt64(u64[2]) + (uint16_t)stim_internal::popcnt64(u64[3]);
     }
 
     /// For each 128 bit word pair between the two registers, the byte order goes from this:
@@ -115,3 +117,5 @@ struct simd_word {
         other.val = t;
     }
 };
+
+}

--- a/src/simd/simd_compat_polyfill.h
+++ b/src/simd/simd_compat_polyfill.h
@@ -20,6 +20,8 @@
 
 #include "simd_util.h"
 
+namespace stim_internal {
+
 struct emu_u128 {
     uint64_t a;
     uint64_t b;
@@ -129,3 +131,5 @@ struct simd_word {
         other.u64[1] = b2 | (d2 << 8);
     }
 };
+
+}

--- a/src/simd/simd_compat_sse2.h
+++ b/src/simd/simd_compat_sse2.h
@@ -21,6 +21,8 @@
 
 #include "simd_util.h"
 
+namespace stim_internal {
+
 struct simd_word {
     union {
         __m128i val;
@@ -114,3 +116,5 @@ struct simd_word {
         other.val = t;
     }
 };
+
+}

--- a/src/simd/simd_util.h
+++ b/src/simd/simd_util.h
@@ -20,6 +20,8 @@
 #include <cstddef>
 #include <cstdint>
 
+namespace stim_internal {
+
 constexpr uint64_t tile64_helper(uint64_t val, size_t shift) {
     return shift >= 64 ? val : tile64_helper(val | (val << shift), shift << 1);
 }
@@ -41,6 +43,8 @@ inline uint8_t popcnt64(uint64_t val) {
     val *= 0x101010101010101ULL;
     val >>= 56;
     return val;
+}
+
 }
 
 #endif

--- a/src/simd/simd_util.test.cc
+++ b/src/simd/simd_util.test.cc
@@ -20,6 +20,8 @@
 #include "simd_bit_table.h"
 #include "simd_bits.h"
 
+using namespace stim_internal;
+
 simd_bits reference_transpose_of(size_t bit_width, const simd_bits &data) {
     assert(!(bit_width & 0xFF));
     auto expected = simd_bits(bit_width * bit_width);

--- a/src/simd/sparse_xor_vec.h
+++ b/src/simd/sparse_xor_vec.h
@@ -26,6 +26,8 @@
 
 #include "monotonic_buffer.h"
 
+namespace stim_internal {
+
 /// Merges the elements of two sorted buffers into an output buffer while cancelling out duplicate items.
 ///
 /// \param sorted_in1: Pointer range covering the first sorted list.
@@ -162,8 +164,10 @@ struct SparseXorVec {
     }
 };
 
+}
+
 template <typename T>
-std::ostream &operator<<(std::ostream &out, const SparseXorVec<T> &v) {
+std::ostream &operator<<(std::ostream &out, const stim_internal::SparseXorVec<T> &v) {
     out << "SparseXorVec{";
     bool first = true;
     for (auto &e : v) {

--- a/src/simd/sparse_xor_vec.perf.cc
+++ b/src/simd/sparse_xor_vec.perf.cc
@@ -18,6 +18,8 @@
 
 #include "../benchmark_util.h"
 
+using namespace stim_internal;
+
 BENCHMARK(SparseXorTable_SmallRowXor_1000) {
     size_t n = 1000;
     std::vector<SparseXorVec<uint32_t>> table(n);

--- a/src/simd/sparse_xor_vec.test.cc
+++ b/src/simd/sparse_xor_vec.test.cc
@@ -20,6 +20,8 @@
 #include "../test_util.test.h"
 #include "simd_util.h"
 
+using namespace stim_internal;
+
 TEST(sparse_xor_table, inplace_xor) {
     SparseXorVec<uint32_t> v1;
     SparseXorVec<uint32_t> v2;

--- a/src/simulators/detection_simulator.cc
+++ b/src/simulators/detection_simulator.cc
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 #include "frame_simulator.h"
+#include "detection_simulator.h"
+
+using namespace stim_internal;
 
 template <typename T>
 void xor_measurement_set_into_result(
@@ -23,7 +26,7 @@ void xor_measurement_set_into_result(
     }
 }
 
-simd_bit_table detector_samples(
+simd_bit_table stim_internal::detector_samples(
     const Circuit &circuit, const DetectorsAndObservables &det_obs, size_t num_shots, bool prepend_observables,
     bool append_observables, std::mt19937_64 &rng) {
     // Start from measurement samples.
@@ -53,7 +56,7 @@ simd_bit_table detector_samples(
     return result;
 }
 
-simd_bit_table detector_samples(
+simd_bit_table stim_internal::detector_samples(
     const Circuit &circuit, size_t num_shots, bool prepend_observables, bool append_observables, std::mt19937_64 &rng) {
     return detector_samples(
         circuit, DetectorsAndObservables(circuit), num_shots, prepend_observables, append_observables, rng);
@@ -152,7 +155,7 @@ void detector_sample_out_helper(
     }
 }
 
-void detector_samples_out(
+void stim_internal::detector_samples_out(
     const Circuit &circuit, size_t num_shots, bool prepend_observables, bool append_observables, FILE *out,
     SampleFormat format, std::mt19937_64 &rng) {
     constexpr size_t GOOD_BLOCK_SIZE = 1024;

--- a/src/simulators/detection_simulator.h
+++ b/src/simulators/detection_simulator.h
@@ -22,6 +22,8 @@
 #include "../circuit/circuit.h"
 #include "../simd/simd_bit_table.h"
 
+namespace stim_internal {
+
 simd_bit_table detector_samples(
     const Circuit &circuit, const DetectorsAndObservables &det_obs, size_t num_shots, bool prepend_observables,
     bool append_observables, std::mt19937_64 &rng);
@@ -32,5 +34,7 @@ simd_bit_table detector_samples(
 void detector_samples_out(
     const Circuit &circuit, size_t num_shots, bool prepend_observables, bool append_observables, FILE *out,
     SampleFormat format, std::mt19937_64 &rng);
+
+}
 
 #endif

--- a/src/simulators/detection_simulator.test.cc
+++ b/src/simulators/detection_simulator.test.cc
@@ -19,17 +19,19 @@
 
 #include "../test_util.test.h"
 
+using namespace stim_internal;
+
 static std::string rewind_read_all(FILE *f) {
     rewind(f);
     std::string result;
     while (true) {
         int c = getc(f);
         if (c == EOF) {
+            fclose(f);
             return result;
         }
         result.push_back((char)c);
     }
-    fclose(f);
 }
 
 TEST(DetectionSimulator, detector_samples) {

--- a/src/simulators/error_fuser.cc
+++ b/src/simulators/error_fuser.cc
@@ -22,6 +22,8 @@
 
 #include "../circuit/circuit.h"
 
+using namespace stim_internal;
+
 void ErrorFuser::R(const OperationData &dat) {
     for (size_t k = dat.targets.size(); k-- > 0;) {
         auto q = dat.targets[k];

--- a/src/simulators/error_fuser.h
+++ b/src/simulators/error_fuser.h
@@ -26,6 +26,8 @@
 #include "../simd/monotonic_buffer.h"
 #include "../simd/sparse_xor_vec.h"
 
+namespace stim_internal {
+
 struct ErrorFuser {
     std::map<uint32_t, std::vector<uint32_t>> measurement_to_detectors;
     uint32_t num_found_detectors = 0;
@@ -91,5 +93,7 @@ struct ErrorFuser {
     void feedback(uint32_t record_control, size_t target, bool x, bool z);
     void run_circuit(const Circuit &circuit);
 };
+
+}
 
 #endif

--- a/src/simulators/error_fuser.test.cc
+++ b/src/simulators/error_fuser.test.cc
@@ -20,6 +20,8 @@
 #include "../test_util.test.h"
 #include "frame_simulator.h"
 
+using namespace stim_internal;
+
 std::string convert(const char *text) {
     FILE *f = tmpfile();
     ErrorFuser::convert_circuit_out(Circuit::from_text(text), f);

--- a/src/simulators/frame_simulator.cc
+++ b/src/simulators/frame_simulator.cc
@@ -22,6 +22,8 @@
 #include "../simd/simd_util.h"
 #include "tableau_simulator.h"
 
+using namespace stim_internal;
+
 static size_t force_stream_count = 0;
 DebugForceResultStreamingRaii::DebugForceResultStreamingRaii() {
     force_stream_count++;
@@ -30,7 +32,7 @@ DebugForceResultStreamingRaii::~DebugForceResultStreamingRaii() {
     force_stream_count--;
 }
 
-bool should_use_streaming_instead_of_memory(uint64_t result_count) {
+bool stim_internal::should_use_streaming_instead_of_memory(uint64_t result_count) {
     return force_stream_count > 0 || result_count > 100000000;
 }
 

--- a/src/simulators/frame_simulator.h
+++ b/src/simulators/frame_simulator.h
@@ -24,6 +24,8 @@
 #include "../stabilizers/pauli_string.h"
 #include "measure_record_batch.h"
 
+namespace stim_internal {
+
 /// A Pauli Frame simulator that computes many samples simultaneously.
 ///
 /// This simulator tracks, for each qubit, whether or not that qubit is bit flipped and/or phase flipped.
@@ -94,5 +96,7 @@ struct DebugForceResultStreamingRaii {
     DebugForceResultStreamingRaii();
     ~DebugForceResultStreamingRaii();
 };
+
+}
 
 #endif

--- a/src/simulators/frame_simulator.perf.cc
+++ b/src/simulators/frame_simulator.perf.cc
@@ -16,6 +16,8 @@
 
 #include "../benchmark_util.h"
 
+using namespace stim_internal;
+
 BENCHMARK(FrameSimulator_depolarize1_100Kqubits_1Ksamples_per1000) {
     size_t num_qubits = 100 * 1000;
     size_t num_samples = 1000;

--- a/src/simulators/frame_simulator.test.cc
+++ b/src/simulators/frame_simulator.test.cc
@@ -21,17 +21,19 @@
 #include "../test_util.test.h"
 #include "tableau_simulator.h"
 
+using namespace stim_internal;
+
 static std::string rewind_read_all(FILE *f) {
     rewind(f);
     std::string result;
     while (true) {
         int c = getc(f);
         if (c == EOF) {
+            fclose(f);
             return result;
         }
         result.push_back((char)c);
     }
-    fclose(f);
 }
 
 TEST(FrameSimulator, get_set_frame) {

--- a/src/simulators/measure_record.cc
+++ b/src/simulators/measure_record.cc
@@ -20,6 +20,8 @@
 
 #include "measure_record_writer.h"
 
+using namespace stim_internal;
+
 MeasureRecord::MeasureRecord(size_t max_lookback) : max_lookback(max_lookback), unwritten(0) {
 }
 

--- a/src/simulators/measure_record.h
+++ b/src/simulators/measure_record.h
@@ -22,6 +22,8 @@
 
 #include "measure_record_writer.h"
 
+namespace stim_internal {
+
 /// Stores a historical record of measurement results that can be looked up and written to the external world.
 ///
 /// Results that have been written and are further back than `max_lookback` may be discarded from memory.
@@ -48,5 +50,7 @@ struct MeasureRecord {
     /// Appends a measurement to the record.
     void record_result(bool result);
 };
+
+}
 
 #endif

--- a/src/simulators/measure_record.test.cc
+++ b/src/simulators/measure_record.test.cc
@@ -20,6 +20,8 @@
 
 #include "../test_util.test.h"
 
+using namespace stim_internal;
+
 TEST(MeasureRecord, basic_usage) {
     MeasureRecord r(20);
     r.record_result(true);

--- a/src/simulators/measure_record_batch.cc
+++ b/src/simulators/measure_record_batch.cc
@@ -20,6 +20,8 @@
 
 #include "measure_record_batch_writer.h"
 
+using namespace stim_internal;
+
 MeasureRecordBatch::MeasureRecordBatch(size_t num_shots, size_t max_lookback)
     : max_lookback(max_lookback), unwritten(0), stored(0), written(0), shot_mask(num_shots), storage(1, num_shots) {
     for (size_t k = 0; k < num_shots; k++) {

--- a/src/simulators/measure_record_batch.h
+++ b/src/simulators/measure_record_batch.h
@@ -19,6 +19,8 @@
 
 #include "measure_record_batch_writer.h"
 
+namespace stim_internal {
+
 /// Stores a record of multiple measurement streams that can be looked up and written to the external world.
 ///
 /// Results that have been written and are further back than `max_lookback` may be discarded from memory.
@@ -63,5 +65,7 @@ struct MeasureRecordBatch {
     /// Resets the record to an empty state.
     void clear();
 };
+
+}
 
 #endif

--- a/src/simulators/measure_record_batch.test.cc
+++ b/src/simulators/measure_record_batch.test.cc
@@ -20,6 +20,8 @@
 
 #include "../test_util.test.h"
 
+using namespace stim_internal;
+
 TEST(MeasureRecordBatch, basic_usage) {
     simd_bits s0(5);
     simd_bits s1(5);

--- a/src/simulators/measure_record_batch_writer.cc
+++ b/src/simulators/measure_record_batch_writer.cc
@@ -20,6 +20,8 @@
 
 #include "measure_record_batch.h"
 
+using namespace stim_internal;
+
 MeasureRecordBatchWriter::MeasureRecordBatchWriter(FILE *out, size_t num_shots, SampleFormat output_format)
     : output_format(output_format), out(out) {
     auto f = output_format;

--- a/src/simulators/measure_record_batch_writer.h
+++ b/src/simulators/measure_record_batch_writer.h
@@ -20,6 +20,8 @@
 #include "../simd/simd_bit_table.h"
 #include "measure_record_writer.h"
 
+namespace stim_internal {
+
 /// Handles buffering and writing multiple measurement data streams that ultimately need to be concatenated.
 struct MeasureRecordBatchWriter {
     SampleFormat output_format;
@@ -56,5 +58,7 @@ struct MeasureRecordBatchWriter {
     /// Tells each writer to finish up, then concatenates all of their data into the `out` stream and cleans up.
     void write_end();
 };
+
+}
 
 #endif

--- a/src/simulators/measure_record_batch_writer.test.cc
+++ b/src/simulators/measure_record_batch_writer.test.cc
@@ -20,6 +20,8 @@
 
 #include "../test_util.test.h"
 
+using namespace stim_internal;
+
 TEST(MeasureRecordBatchWriter, basic_usage) {
     FILE *tmp = tmpfile();
     MeasureRecordBatchWriter w(tmp, 5, SAMPLE_FORMAT_01);

--- a/src/simulators/measure_record_writer.cc
+++ b/src/simulators/measure_record_writer.cc
@@ -18,6 +18,8 @@
 
 #include <algorithm>
 
+using namespace stim_internal;
+
 std::unique_ptr<MeasureRecordWriter> MeasureRecordWriter::make(FILE *out, SampleFormat output_format) {
     switch (output_format) {
         case SAMPLE_FORMAT_01:
@@ -193,7 +195,7 @@ void MeasureRecordFormatDets::write_end() {
     position = 0;
 }
 
-simd_bit_table transposed_vs_ref(
+simd_bit_table stim_internal::transposed_vs_ref(
     size_t num_samples_raw, const simd_bit_table &table, const simd_bits &reference_sample) {
     auto result = table.transposed();
     for (size_t s = 0; s < num_samples_raw; s++) {
@@ -202,7 +204,7 @@ simd_bit_table transposed_vs_ref(
     return result;
 }
 
-void write_table_data(
+void stim_internal::write_table_data(
     FILE *out, size_t num_shots, size_t num_measurements, const simd_bits &reference_sample,
     const simd_bit_table &table, SampleFormat format, char dets_prefix_1, char dets_prefix_2,
     size_t dets_prefix_transition) {

--- a/src/simulators/measure_record_writer.h
+++ b/src/simulators/measure_record_writer.h
@@ -23,6 +23,8 @@
 #include "../simd/pointer_range.h"
 #include "../simd/simd_bit_table.h"
 
+namespace stim_internal {
+
 /// Handles writing measurement data to the outside world.
 ///
 /// Child classes implement the various output formats.
@@ -100,5 +102,7 @@ void write_table_data(
     FILE *out, size_t num_shots, size_t num_measurements, const simd_bits &reference_sample,
     const simd_bit_table &table, SampleFormat format, char dets_prefix_1, char dets_prefix_2,
     size_t dets_prefix_transition);
+
+}
 
 #endif

--- a/src/simulators/measure_record_writer.test.cc
+++ b/src/simulators/measure_record_writer.test.cc
@@ -20,17 +20,19 @@
 
 #include "../test_util.test.h"
 
+using namespace stim_internal;
+
 static std::string rewind_read_all(FILE *f) {
     rewind(f);
     std::string result;
     while (true) {
         int c = getc(f);
         if (c == EOF) {
+            fclose(f);
             return result;
         }
         result.push_back((char)c);
     }
-    fclose(f);
 }
 
 TEST(MeasureRecordWriter, Format01) {
@@ -251,7 +253,7 @@ TEST(MeasureRecordWriter, write_table_data_large) {
     write_table_data(tmp, 2, 100, ref_sample, results, SAMPLE_FORMAT_PTB64, 'M', 'M', 0);
     auto actual = rewind_read_all(tmp);
     ASSERT_EQ(
-        rewind_read_all(tmp), std::string(
+        actual, std::string(
                                   "\0\0\0\0\0\0\0\0"
                                   "\0\0\0\0\0\0\0\0"
                                   "\x03\0\0\0\0\0\0\0"

--- a/src/simulators/tableau_simulator.cc
+++ b/src/simulators/tableau_simulator.cc
@@ -17,6 +17,8 @@
 #include "../circuit/gate_data.h"
 #include "../probability_util.h"
 
+using namespace stim_internal;
+
 TableauSimulator::TableauSimulator(size_t num_qubits, std::mt19937_64 &rng, int8_t sign_bias, MeasureRecord record)
     : inv_state(Tableau::identity(num_qubits)),
       rng(rng),

--- a/src/simulators/tableau_simulator.h
+++ b/src/simulators/tableau_simulator.h
@@ -30,6 +30,8 @@
 #include "measure_record.h"
 #include "vector_simulator.h"
 
+namespace stim_internal {
+
 struct TableauSimulator {
     Tableau inv_state;
     std::mt19937_64 &rng;
@@ -170,5 +172,7 @@ struct TableauSimulator {
     /// qubit.
     void collapse_isolate_qubit(size_t target, TableauTransposedRaii &transposed_raii);
 };
+
+}
 
 #endif

--- a/src/simulators/tableau_simulator.perf.cc
+++ b/src/simulators/tableau_simulator.perf.cc
@@ -16,6 +16,8 @@
 
 #include "../benchmark_util.h"
 
+using namespace stim_internal;
+
 BENCHMARK(TableauSimulator_CX_10Kqubits) {
     size_t num_qubits = 10 * 1000;
     std::mt19937_64 rng(0);  // NOLINT(cert-msc51-cpp)

--- a/src/simulators/tableau_simulator.pybind.cc
+++ b/src/simulators/tableau_simulator.pybind.cc
@@ -19,6 +19,8 @@
 #include "../py/base.pybind.h"
 #include "../stabilizers/tableau.h"
 
+using namespace stim_internal;
+
 struct TempViewableData {
     std::vector<uint32_t> targets;
     TempViewableData(std::vector<uint32_t> targets) : targets(std::move(targets)) {

--- a/src/simulators/tableau_simulator.test.cc
+++ b/src/simulators/tableau_simulator.test.cc
@@ -20,6 +20,8 @@
 #include "../circuit/gate_data.h"
 #include "../test_util.test.h"
 
+using namespace stim_internal;
+
 TEST(TableauSimulator, identity) {
     auto s = TableauSimulator(1, SHARED_TEST_RNG());
     ASSERT_EQ(s.measurement_record.storage, (std::vector<bool>{}));

--- a/src/simulators/vector_simulator.cc
+++ b/src/simulators/vector_simulator.cc
@@ -20,6 +20,8 @@
 #include "../simd/simd_util.h"
 #include "../stabilizers/pauli_string.h"
 
+using namespace stim_internal;
+
 VectorSimulator::VectorSimulator(size_t num_qubits) {
     state.resize(size_t{1} << num_qubits, 0.0f);
     state[0] = 1;

--- a/src/simulators/vector_simulator.h
+++ b/src/simulators/vector_simulator.h
@@ -24,6 +24,8 @@
 
 #include "../stabilizers/pauli_string.h"
 
+namespace stim_internal {
+
 /// A state vector quantum circuit simulator.
 ///
 /// Not intended to be particularly performant. Mostly used as a reference when testing.
@@ -63,7 +65,9 @@ struct VectorSimulator {
     std::string str() const;
 };
 
+}
+
 /// Writes a description of the state vector's state to an output stream.
-std::ostream &operator<<(std::ostream &out, const VectorSimulator &sim);
+std::ostream &operator<<(std::ostream &out, const stim_internal::VectorSimulator &sim);
 
 #endif

--- a/src/simulators/vector_simulator.test.cc
+++ b/src/simulators/vector_simulator.test.cc
@@ -19,6 +19,8 @@
 #include "../circuit/gate_data.h"
 #include "../test_util.test.h"
 
+using namespace stim_internal;
+
 static float complex_distance(std::complex<float> a, std::complex<float> b) {
     auto d = a - b;
     return sqrtf(d.real() * d.real() + d.imag() * d.imag());

--- a/src/stabilizers/pauli_string.cc
+++ b/src/stabilizers/pauli_string.cc
@@ -19,6 +19,8 @@
 
 #include "../simd/simd_util.h"
 
+using namespace stim_internal;
+
 PauliString::operator const PauliStringRef() const {
     return ref();
 }

--- a/src/stabilizers/pauli_string.h
+++ b/src/stabilizers/pauli_string.h
@@ -23,6 +23,8 @@
 #include "../simd/simd_bits.h"
 #include "pauli_string_ref.h"
 
+namespace stim_internal {
+
 /// A Pauli string is a product of Pauli operations (I, X, Y, Z) to apply to various qubits.
 ///
 /// In most cases, methods will take a PauliStringRef instead of a PauliString. This is because PauliStringRef can
@@ -72,7 +74,9 @@ struct PauliString {
     void ensure_num_qubits(size_t min_num_qubits);
 };
 
+}
+
 /// Writes a string describing the given Pauli string to an output stream.
-std::ostream &operator<<(std::ostream &out, const PauliString &ps);
+std::ostream &operator<<(std::ostream &out, const stim_internal::PauliString &ps);
 
 #endif

--- a/src/stabilizers/pauli_string.perf.cc
+++ b/src/stabilizers/pauli_string.perf.cc
@@ -16,6 +16,8 @@
 
 #include "../benchmark_util.h"
 
+using namespace stim_internal;
+
 BENCHMARK(PauliString_multiplication_1M) {
     size_t n = 1000 * 1000;
     PauliString p1(n);

--- a/src/stabilizers/pauli_string.pybind.cc
+++ b/src/stabilizers/pauli_string.pybind.cc
@@ -20,6 +20,8 @@
 #include "../stabilizers/tableau.h"
 #include "tableau.pybind.h"
 
+using namespace stim_internal;
+
 PyPauliString::PyPauliString(const PauliStringRef val, bool imag) : value(val), imag(imag) {
 }
 

--- a/src/stabilizers/pauli_string.pybind.h
+++ b/src/stabilizers/pauli_string.pybind.h
@@ -21,11 +21,11 @@
 #include "pauli_string.h"
 
 struct PyPauliString {
-    PauliString value;
+    stim_internal::PauliString value;
     bool imag;
 
-    PyPauliString(const PauliStringRef val, bool imag = false);
-    PyPauliString(PauliString&& val, bool imag = false);
+    PyPauliString(const stim_internal::PauliStringRef val, bool imag = false);
+    PyPauliString(stim_internal::PauliString&& val, bool imag = false);
 
     std::complex<float> get_phase() const;
 

--- a/src/stabilizers/pauli_string.test.cc
+++ b/src/stabilizers/pauli_string.test.cc
@@ -19,6 +19,8 @@
 #include "../test_util.test.h"
 #include "tableau.h"
 
+using namespace stim_internal;
+
 TEST(pauli_string, str) {
     auto p1 = PauliString::from_str("+IXYZ");
     ASSERT_EQ(p1.str(), "+_XYZ");

--- a/src/stabilizers/pauli_string_ref.cc
+++ b/src/stabilizers/pauli_string_ref.cc
@@ -18,6 +18,8 @@
 #include "../simd/simd_util.h"
 #include "pauli_string.h"
 
+using namespace stim_internal;
+
 PauliStringRef::PauliStringRef(
     size_t init_num_qubits, bit_ref init_sign, simd_bits_range_ref init_xs, simd_bits_range_ref init_zs)
     : num_qubits(init_num_qubits), sign(init_sign), xs(init_xs), zs(init_zs) {

--- a/src/stabilizers/pauli_string_ref.h
+++ b/src/stabilizers/pauli_string_ref.h
@@ -22,6 +22,8 @@
 #include "../simd/bit_ref.h"
 #include "../simd/simd_bits_range_ref.h"
 
+namespace stim_internal {
+
 /// A Pauli string is a product of Pauli operations (I, X, Y, Z) to apply to various qubits.
 ///
 /// A PauliStringRef is a Pauli string whose contents are backed by referenced memory, instead of memory owned by the
@@ -102,7 +104,9 @@ struct PauliStringRef {
     std::string sparse_str() const;
 };
 
+}
+
 /// Writes a string describing the given Pauli string to an output stream.
-std::ostream &operator<<(std::ostream &out, const PauliStringRef &ps);
+std::ostream &operator<<(std::ostream &out, const stim_internal::PauliStringRef &ps);
 
 #endif

--- a/src/stabilizers/tableau.cc
+++ b/src/stabilizers/tableau.cc
@@ -27,6 +27,8 @@
 #include "pauli_string.h"
 #include "tableau_transposed_raii.h"
 
+using namespace stim_internal;
+
 void Tableau::expand(size_t new_num_qubits) {
     // If the new qubits fit inside the padding, just extend into it.
     assert(new_num_qubits >= num_qubits);

--- a/src/stabilizers/tableau.h
+++ b/src/stabilizers/tableau.h
@@ -24,6 +24,8 @@
 #include "../simd/simd_util.h"
 #include "pauli_string.h"
 
+namespace stim_internal {
+
 struct TableauHalf {
     size_t num_qubits;
     simd_bit_table xt;
@@ -164,6 +166,8 @@ struct Tableau {
     void prepend(const PauliStringRef &op);
 };
 
-std::ostream &operator<<(std::ostream &out, const Tableau &ps);
+}
+
+std::ostream &operator<<(std::ostream &out, const stim_internal::Tableau &ps);
 
 #endif

--- a/src/stabilizers/tableau.perf.cc
+++ b/src/stabilizers/tableau.perf.cc
@@ -16,6 +16,8 @@
 
 #include "../benchmark_util.h"
 
+using namespace stim_internal;
+
 BENCHMARK(tableau_random_10) {
     size_t n = 10;
     Tableau t(n);

--- a/src/stabilizers/tableau.pybind.cc
+++ b/src/stabilizers/tableau.pybind.cc
@@ -20,6 +20,8 @@
 #include "../stabilizers/pauli_string.h"
 #include "../stabilizers/tableau.h"
 
+using namespace stim_internal;
+
 void pybind_tableau(pybind11::module &m) {
     auto &&c = pybind11::class_<Tableau>(
         m,

--- a/src/stabilizers/tableau.test.cc
+++ b/src/stabilizers/tableau.test.cc
@@ -22,6 +22,8 @@
 #include "../test_util.test.h"
 #include "tableau_transposed_raii.h"
 
+using namespace stim_internal;
+
 static float complex_distance(std::complex<float> a, std::complex<float> b) {
     auto d = a - b;
     return sqrtf(d.real() * d.real() + d.imag() * d.imag());

--- a/src/stabilizers/tableau_specialized_prepend.cc
+++ b/src/stabilizers/tableau_specialized_prepend.cc
@@ -16,6 +16,8 @@
 
 #include "tableau.h"
 
+using namespace stim_internal;
+
 void Tableau::prepend_X(size_t q) {
     zs[q].sign ^= 1;
 }

--- a/src/stabilizers/tableau_transposed_raii.cc
+++ b/src/stabilizers/tableau_transposed_raii.cc
@@ -23,6 +23,8 @@
 
 #include "pauli_string.h"
 
+using namespace stim_internal;
+
 TableauTransposedRaii::TableauTransposedRaii(Tableau &tableau) : tableau(tableau) {
     tableau.do_transpose_quadrants();
 }

--- a/src/stabilizers/tableau_transposed_raii.h
+++ b/src/stabilizers/tableau_transposed_raii.h
@@ -25,6 +25,8 @@
 #include "pauli_string.h"
 #include "tableau.h"
 
+namespace stim_internal {
+
 /// When this class is constructed, it transposes the tableau given to it.
 /// The transpose is undone on deconstruction.
 ///
@@ -52,5 +54,7 @@ struct TableauTransposedRaii {
     void append_X(size_t q);
     void append_SWAP(size_t q1, size_t q2);
 };
+
+}
 
 #endif

--- a/src/stim.h
+++ b/src/stim.h
@@ -14,18 +14,23 @@
  * limitations under the License.
  */
 
-#ifndef MAIN_HELPER_H
-#define MAIN_HELPER_H
+#ifndef STIM_H
+#define STIM_H
 
-#include "arg_parse.h"
-#include "probability_util.h"
+#include "simulators/tableau_simulator.h"
+#include "stabilizers/tableau.h"
+#include "stabilizers/pauli_string.h"
 #include "simulators/frame_simulator.h"
 #include "simulators/tableau_simulator.h"
+#include "simulators/tableau_simulator.h"
 
-namespace stim_internal {
-
-int main_helper(int argc, const char **argv);
-
+namespace stim {
+    using Tableau = stim_internal::Tableau;
+    using TableauSimulator = stim_internal::TableauSimulator;
+    using FrameSimulator = stim_internal::FrameSimulator;
+    using Circuit = stim_internal::Circuit;
+    using PauliString = stim_internal::PauliString;
+    const auto &GATE_DATA = stim_internal::GATE_DATA;
 }
 
 #endif

--- a/src/test_util.test.cc
+++ b/src/test_util.test.cc
@@ -16,6 +16,8 @@
 
 #include "probability_util.h"
 
+using namespace stim_internal;
+
 static bool shared_test_rng_initialized;
 static std::mt19937_64 shared_test_rng;
 


### PR DESCRIPTION
- Move all exposed names into namespace stim_internal
- Add stim.h with namespace stim re-exporting aliases of some of the internals