### PR TITLE
Add --help gate support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ set(SOURCE_FILES_NO_MAIN
         src/arg_parse.cc
         src/circuit/circuit.cc
         src/circuit/gate_data.cc
+        src/gate_help.cc
         src/gen/circuit_gen_main.cc
         src/gen/circuit_gen_params.cc
         src/gen/gen_color_code.cc
@@ -116,7 +117,7 @@ if(NOT(MSVC))
     target_compile_options(stim PRIVATE -O3 -Wall -Wpedantic ${MACHINE_FLAG})
     target_link_options(stim PRIVATE -pthread -O3)
 else()
-    target_compile_options(stim PRIVATE -DSIMD_WIDTH=${SIMD_WIDTH})
+    target_compile_options(stim PRIVATE ${MACHINE_FLAG})
 endif()
 
 add_executable(stim_benchmark ${SOURCE_FILES_NO_MAIN} ${BENCHMARK_FILES})

--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ error(0.003344519141621982161) D1
 - **`--help`**:
     Print usage examples and exit.
 
+    `--help gates` lists all available gates.
+
+    `--help [gatename]` prints information about a gate.
+
 - **`--repl`**:
     **Interactive mode**.
     Print measurement results interactively as a circuit is typed into stdin.
@@ -483,189 +487,1473 @@ error(0.003344519141621982161) D1
     For example, `CNOT 0 1 2 3` will apply `CNOT 0 1` and then `CNOT 2 3`.
     Broadcasting is always evaluated in left-to-right order.
 
-### Single qubit gates
+## Index
 
-- **`Z`**: Pauli Z gate. Phase flip.
-- **`Y`**: Pauli Y gate.
-- **`X`**: Pauli X gate. Bit flip.
-- **`H`** (alternate name **`H_XZ`**): Hadamard gate. Swaps the X and Z axes. Unitary equals (X + Z) / sqrt(2).
-- **`H_XY`**: Variant of the Hadamard gate that swaps the X and Y axes (instead of X and Z). Unitary equals (X + Y) / sqrt(2).
-- **`H_YZ`**: Variant of the Hadamard gate that swaps the Y and Z axes (instead of X and Z). Unitary equals (Y + Z) / sqrt(2).
-- **`S`** (alternate name **`SQRT_Z`**): Principle square root of Z gate. Equal to `diag(1, i)`.
-- **`S_DAG`** (alternate name **`SQRT_Z_DAG`**): Adjoint square root of Z gate. Equal to `diag(1, -i)`.
-- **`SQRT_Y`**: Principle square root of Y gate. Equal to `H_YZ*S*H_YZ`.
-- **`SQRT_Y_DAG`**: Adjoint square root of Y gate. Equal to `H_YZ*S_DAG*H_YZ`.
-- **`SQRT_X`**: Principle square root of X gate. Equal to `H*S*H`.
-- **`SQRT_X_DAG`**: Adjoint square root of X gate. Equal to `H*S_DAG*H`.
-- **`C_XYZ`**: Right handed period 3 axis cycling gate. Sends X -> Y -> Z -> X. Rotates +120 degrees around X+Y+Z.
-- **`C_ZYX`**: Left handed period 3 axis cycling gate. Sends Z -> Y -> X -> Z. Rotates -120 degrees around X+Y+Z. Inverse of `C_XYZ`.
-- **`I`**: Identity gate. Does nothing. Why is this even here? Probably out of a misguided desire for closure.
+- [CNOT](#CNOT)
+- [CORRELATED_ERROR](#CORRELATED_ERROR)
+- [CX](#CX)
+- [CY](#CY)
+- [CZ](#CZ)
+- [C_XYZ](#C_XYZ)
+- [C_ZYX](#C_ZYX)
+- [DEPOLARIZE1](#DEPOLARIZE1)
+- [DEPOLARIZE2](#DEPOLARIZE2)
+- [DETECTOR](#DETECTOR)
+- [E](#E)
+- [ELSE_CORRELATED_ERROR](#ELSE_CORRELATED_ERROR)
+- [H](#H)
+- [H_XY](#H_XY)
+- [H_XZ](#H_XZ)
+- [H_YZ](#H_YZ)
+- [I](#I)
+- [ISWAP](#ISWAP)
+- [ISWAP_DAG](#ISWAP_DAG)
+- [M](#M)
+- [MR](#MR)
+- [MRX](#MRX)
+- [MRY](#MRY)
+- [MRZ](#MRZ)
+- [MX](#MX)
+- [MY](#MY)
+- [MZ](#MZ)
+- [OBSERVABLE_INCLUDE](#OBSERVABLE_INCLUDE)
+- [R](#R)
+- [REPEAT](#REPEAT)
+- [RX](#RX)
+- [RY](#RY)
+- [RZ](#RZ)
+- [S](#S)
+- [SQRT_X](#SQRT_X)
+- [SQRT_X_DAG](#SQRT_X_DAG)
+- [SQRT_Y](#SQRT_Y)
+- [SQRT_Y_DAG](#SQRT_Y_DAG)
+- [SQRT_Z](#SQRT_Z)
+- [SQRT_Z_DAG](#SQRT_Z_DAG)
+- [SWAP](#SWAP)
+- [S_DAG](#S_DAG)
+- [TICK](#TICK)
+- [X](#X)
+- [XCX](#XCX)
+- [XCY](#XCY)
+- [XCZ](#XCZ)
+- [X_ERROR](#X_ERROR)
+- [Y](#Y)
+- [YCX](#YCX)
+- [YCY](#YCY)
+- [YCZ](#YCZ)
+- [Y_ERROR](#Y_ERROR)
+- [Z](#Z)
+- [ZCX](#ZCX)
+- [ZCY](#ZCY)
+- [ZCZ](#ZCZ)
+- [Z_ERROR](#Z_ERROR)
 
-### Two qubit gates
+## Pauli Gates
 
-- **`SWAP`**: Swaps two qubits.
-- **`ISWAP`**: Swaps two qubits while phasing the ZZ observable by i. Equal to `SWAP * CZ * (S tensor S)`.
-- **`ISWAP_DAG`**: Swaps two qubits while phasing the ZZ observable by -i. Equal to `SWAP * CZ * (S_DAG tensor S_DAG)`.
-- **`CNOT`** (alternate names **`CX`**, **`ZCX`**):
-    Controlled NOT operation.
-    Qubit pairs are in name order (first qubit is the control, second is the target).
-    This gate can be controlled by on the measurement record.
-    Examples: unitary `CNOT 1 2`, feedback `CNOT rec[-1] 4`.
-- **`CY`** (alternate name **`ZCY`**):
-    Controlled Y operation.
-    Qubit pairs are in name order (first qubit is the control, second is the target).
-    This gate can be controlled by on the measurement record.
-    Examples: unitary `CY 1 2`, feedback `CY rec[-1] 4`.
-- **`CZ`** (alternate name **`ZCZ`**):
-    Controlled Z operation.
-    This gate can be controlled by on the measurement record.
-    Examples: unitary `CZ 1 2`, feedback `CZ rec[-1] 4` or `CZ 4 rec[-1]`.
-- **`YCZ`**:
-    Y-basis-controlled Z operation (i.e. the reversed-argument-order controlled-Y).
-    Qubit pairs are in name order.
-    This gate can be controlled by on the measurement record.
-    Examples: unitary `YCZ 1 2`, feedback `YCZ 4 rec[-1]`.
-- **`YCY`**: Y-basis-controlled Y operation.
-- **`YCX`**: Y-basis-controlled X operation. Qubit pairs are in name order.
-- **`XCZ`**:
-    X-basis-controlled Z operation (i.e. the reversed-argument-order controlled-not).
-    Qubit pairs are in name order.
-    This gate can be controlled by on the measurement record.
-    Examples: unitary `XCZ 1 2`, feedback `XCZ 4 rec[-1]`.
-- **`XCY`**: X-basis-controlled Y operation. Qubit pairs are in name order.
-- **`XCX`**: X-basis-controlled X operation.
+- <a name="I"></a>**`I`**
+    
+    Identity gate.
+    Does nothing to the target qubits.
+    
+    - Example:
+    
+        ```
+        I 5
+        I 42
+        I 5 42
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X -> +X
+        Z -> +Z
+        ```
+        
+    - Bloch Rotation:
+    
+        ```
+        Axis: 
+        Angle: 0 degrees
+        ```
+        
+    - Unitary Matrix:
+    
+        ```
+        [+1  ,     ]
+        [    , +1  ]
+        ```
+        
+    
+- <a name="X"></a>**`X`**
+    
+    Pauli X gate.
+    The bit flip gate.
+    
+    - Example:
+    
+        ```
+        X 5
+        X 42
+        X 5 42
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X -> +X
+        Z -> -Z
+        ```
+        
+    - Bloch Rotation:
+    
+        ```
+        Axis: +X
+        Angle: 180 degrees
+        ```
+        
+    - Unitary Matrix:
+    
+        ```
+        [    , +1  ]
+        [+1  ,     ]
+        ```
+        
+    
+- <a name="Y"></a>**`Y`**
+    
+    Pauli Y gate.
+    
+    - Example:
+    
+        ```
+        Y 5
+        Y 42
+        Y 5 42
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X -> -X
+        Z -> -Z
+        ```
+        
+    - Bloch Rotation:
+    
+        ```
+        Axis: +Y
+        Angle: 180 degrees
+        ```
+        
+    - Unitary Matrix:
+    
+        ```
+        [    ,   -i]
+        [  +i,     ]
+        ```
+        
+    
+- <a name="Z"></a>**`Z`**
+    
+    Pauli Z gate.
+    The phase flip gate.
+    
+    - Example:
+    
+        ```
+        Z 5
+        Z 42
+        Z 5 42
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X -> -X
+        Z -> +Z
+        ```
+        
+    - Bloch Rotation:
+    
+        ```
+        Axis: +Z
+        Angle: 180 degrees
+        ```
+        
+    - Unitary Matrix:
+    
+        ```
+        [+1  ,     ]
+        [    , -1  ]
+        ```
+        
+    
+## Single Qubit Clifford Gates
 
-### Collapsing gates
+- <a name="C_XYZ"></a>**`C_XYZ`**
+    
+    Right handed period 3 axis cycling gate, sending X -> Y -> Z -> X.
+    
+    - Example:
+    
+        ```
+        C_XYZ 5
+        C_XYZ 42
+        C_XYZ 5 42
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X -> +Y
+        Z -> +X
+        ```
+        
+    - Bloch Rotation:
+    
+        ```
+        Axis: +X+Y+Z
+        Angle: 120 degrees
+        ```
+        
+    - Unitary Matrix:
+    
+        ```
+        [+1-i, -1-i]
+        [+1-i, +1+i] / 2
+        ```
+        
+    
+- <a name="C_ZYX"></a>**`C_ZYX`**
+    
+    Left handed period 3 axis cycling gate, sending Z -> Y -> X -> Z.
+    
+    - Example:
+    
+        ```
+        C_ZYX 5
+        C_ZYX 42
+        C_ZYX 5 42
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X -> +Z
+        Z -> +Y
+        ```
+        
+    - Bloch Rotation:
+    
+        ```
+        Axis: +X+Y+Z
+        Angle: -120 degrees
+        ```
+        
+    - Unitary Matrix:
+    
+        ```
+        [+1+i, +1+i]
+        [-1+i, +1-i] / 2
+        ```
+        
+    
+- <a name="H"></a>**`H`**
+    
+    Alternate name: <a name="H_XZ"></a>`H_XZ`
+    
+    The Hadamard gate.
+    Swaps the X and Z axes.
+    A 180 degree rotation around the X+Z axis.
+    
+    - Example:
+    
+        ```
+        H 5
+        H 42
+        H 5 42
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X -> +Z
+        Z -> +X
+        ```
+        
+    - Bloch Rotation:
+    
+        ```
+        Axis: +X+Z
+        Angle: 180 degrees
+        ```
+        
+    - Unitary Matrix:
+    
+        ```
+        [+1  , +1  ]
+        [+1  , -1  ] / sqrt(2)
+        ```
+        
+    
+- <a name="H_XY"></a>**`H_XY`**
+    
+    A variant of the Hadamard gate that swaps the X and Y axes (instead of X and Z).
+    A 180 degree rotation around the X+Y axis.
+    
+    - Example:
+    
+        ```
+        H_XY 5
+        H_XY 42
+        H_XY 5 42
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X -> +Y
+        Z -> -Z
+        ```
+        
+    - Bloch Rotation:
+    
+        ```
+        Axis: +X+Y
+        Angle: 180 degrees
+        ```
+        
+    - Unitary Matrix:
+    
+        ```
+        [    , +1-i]
+        [+1+i,     ] / sqrt(2)
+        ```
+        
+    
+- <a name="H_YZ"></a>**`H_YZ`**
+    
+    A variant of the Hadamard gate that swaps the Y and Z axes (instead of X and Z).
+    A 180 degree rotation around the Y+Z axis.
+    
+    - Example:
+    
+        ```
+        H_YZ 5
+        H_YZ 42
+        H_YZ 5 42
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X -> -X
+        Z -> +Y
+        ```
+        
+    - Bloch Rotation:
+    
+        ```
+        Axis: +Y+Z
+        Angle: 180 degrees
+        ```
+        
+    - Unitary Matrix:
+    
+        ```
+        [+1  ,   -i]
+        [  +i, -1  ] / sqrt(2)
+        ```
+        
+    
+- <a name="S"></a>**`S`**
+    
+    Alternate name: <a name="SQRT_Z"></a>`SQRT_Z`
+    
+    Principle square root of Z gate.
+    Phases the amplitude of |1> by i.
+    
+    - Example:
+    
+        ```
+        S 5
+        S 42
+        S 5 42
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X -> +Y
+        Z -> +Z
+        ```
+        
+    - Bloch Rotation:
+    
+        ```
+        Axis: +Z
+        Angle: 90 degrees
+        ```
+        
+    - Unitary Matrix:
+    
+        ```
+        [+1  ,     ]
+        [    ,   +i]
+        ```
+        
+    
+- <a name="SQRT_X"></a>**`SQRT_X`**
+    
+    Principle square root of X gate.
+    Phases the amplitude of |-> by i.
+    Equivalent to `H` then `S` then `H`.
+    
+    - Example:
+    
+        ```
+        SQRT_X 5
+        SQRT_X 42
+        SQRT_X 5 42
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X -> +X
+        Z -> -Y
+        ```
+        
+    - Bloch Rotation:
+    
+        ```
+        Axis: +X
+        Angle: 90 degrees
+        ```
+        
+    - Unitary Matrix:
+    
+        ```
+        [+1+i, +1-i]
+        [+1-i, +1+i] / 2
+        ```
+        
+    
+- <a name="SQRT_X_DAG"></a>**`SQRT_X_DAG`**
+    
+    Adjoint square root of X gate.
+    Phases the amplitude of |-> by -i.
+    Equivalent to `H` then `S_DAG` then `H`.
+    
+    - Example:
+    
+        ```
+        SQRT_X_DAG 5
+        SQRT_X_DAG 42
+        SQRT_X_DAG 5 42
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X -> +X
+        Z -> +Y
+        ```
+        
+    - Bloch Rotation:
+    
+        ```
+        Axis: +X
+        Angle: -90 degrees
+        ```
+        
+    - Unitary Matrix:
+    
+        ```
+        [+1-i, +1+i]
+        [+1+i, +1-i] / 2
+        ```
+        
+    
+- <a name="SQRT_Y"></a>**`SQRT_Y`**
+    
+    Principle square root of Y gate.
+    Phases the amplitude of |-i> by i.
+    Equivalent to `S` then `H` then `S` then `H` then `S_DAG`.
+    
+    - Example:
+    
+        ```
+        SQRT_Y 5
+        SQRT_Y 42
+        SQRT_Y 5 42
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X -> -Z
+        Z -> +X
+        ```
+        
+    - Bloch Rotation:
+    
+        ```
+        Axis: +Y
+        Angle: 90 degrees
+        ```
+        
+    - Unitary Matrix:
+    
+        ```
+        [+1+i, -1-i]
+        [+1+i, +1+i] / 2
+        ```
+        
+    
+- <a name="SQRT_Y_DAG"></a>**`SQRT_Y_DAG`**
+    
+    Principle square root of Y gate.
+    Phases the amplitude of |-i> by -i.
+    Equivalent to `S` then `H` then `S_DAG` then `H` then `S_DAG`.
+    
+    - Example:
+    
+        ```
+        SQRT_Y_DAG 5
+        SQRT_Y_DAG 42
+        SQRT_Y_DAG 5 42
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X -> +Z
+        Z -> -X
+        ```
+        
+    - Bloch Rotation:
+    
+        ```
+        Axis: +Y
+        Angle: -90 degrees
+        ```
+        
+    - Unitary Matrix:
+    
+        ```
+        [+1-i, +1-i]
+        [-1+i, +1-i] / 2
+        ```
+        
+    
+- <a name="S_DAG"></a>**`S_DAG`**
+    
+    Alternate name: <a name="SQRT_Z_DAG"></a>`SQRT_Z_DAG`
+    
+    Principle square root of Z gate.
+    Phases the amplitude of |1> by -i.
+    
+    - Example:
+    
+        ```
+        S_DAG 5
+        S_DAG 42
+        S_DAG 5 42
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X -> -Y
+        Z -> +Z
+        ```
+        
+    - Bloch Rotation:
+    
+        ```
+        Axis: +Z
+        Angle: -90 degrees
+        ```
+        
+    - Unitary Matrix:
+    
+        ```
+        [+1  ,     ]
+        [    ,   -i]
+        ```
+        
+    
+## Two Qubit Clifford Gates
 
-- **`M`** (alternate name **`MZ`**):
-    Z-basis measurement.
-    Examples: `M 0`, `M 2 !3 5`.
-    Projects the target qubits into `|0>` or `|1>`and reports their values (false=`|0>`, true=`|1>`).
-    Prefixing a target with a `!` indicates that the measurement result should be inverted when reported.
-- **`MX`**:
-    X-basis measurement.
-    Examples: `MX 0`, `MX 2 !3 5`.
-    Projects the target qubits into `|+>` or `|->`and reports their values (false=`|+>`, true=`|->`).
-    Prefixing a target with a `!` indicates that the measurement result should be inverted when reported.
-- **`MY`**:
-    Y-basis measurement.
-    Examples: `MY 0`, `MY 2 !3 5`.
-    Projects the target qubits into `|i>` or `|-i>`and reports their values (false=`|i>`, true=`|-i>`).
-    Prefixing a target with a `!` indicates that the measurement result should be inverted when reported.
-- **`R`** (alternate name **`RZ`**):
-    Reset to `|0>`.
-    Examples: `R 0`, `R 2 1`, `R 0 3 1 2`.
-    Silently measures the target qubits in the Z basis and applies an `X` to the ones found to be in the `|1>` state.
-- **`RX`**:
-    Reset to `|+>`.
-    Examples: `RX 0`, `RX 2 5 3`.
-    Silently measures the target qubits in the X basis and applies a `Z` to the ones found to be in the `|->` state.
-- **`RY`**:
-    Reset to `|i>`.
-    Examples: `RY 0`, `RY 2 5 3`.
-    Silently measures the target qubits in the Y basis and applies an `X` to the ones found to be in the `|-i>` state.
-- **`MR`** (alternate name **`MRZ`**):
-    Z-basis demolition measurement.
-    A measurement combined with a reset.
-    Examples: `MR 0`, `MR 2 !5 3`.
-    Note that `MR 0 0` is equivalent to `M 0` then `R 0` then `M 0` then `R 0`, not to `M 0 0` then `R 0 0`.
-    Prefixing a target with a `!` indicates that the measurement result should be inverted when reported
-    (it does not change that the qubit is reset to `|0>`).
-- **`MRX`**:
-    X-basis demolition measurement.
-    A measurement combined with a reset.
-    Examples: `MRX 0`, `MRX 2 !5 3`.
-    Note that `MRX 0 0` is equivalent to `MX 0` then `RX 0` then `MX 0` then `RX 0`, not to `MX 0 0` then `RX 0 0`.
-    Prefixing a target with a `!` indicates that the measurement result should be inverted when reported
-    (it does not change that the qubit is reset to `|+>`).
-- **`MRY`**:
-    Y-basis demolition measurement.
-    A measurement combined with a reset.
-    Examples: `MRY 0`, `MRY 2 !5 3`.
-    Note that `MRY 0 0` is equivalent to `MY 0` then `RY 0` then `MY 0` then `RY 0`, not to `MY 0 0` then `RY 0 0`.
-    Prefixing a target with a `!` indicates that the measurement result should be inverted when reported
-    (it does not change that the qubit is reset to `|i>`).
+- <a name="CX"></a>**`CX`**
+    
+    Alternate name: <a name="ZCX"></a>`ZCX`
+    
+    Alternate name: <a name="CNOT"></a>`CNOT`
+    
+    The Z-controlled X gate.
+    First qubit is the control, second qubit is the target.
+    The first qubit can be replaced by a measurement record.
+    
+    Applies an X gate to the target if the control is in the |1> state.
+    
+    Negates the amplitude of the |1>|-> state.
+    
+    - Example:
+    
+        ```
+        CX 5 6
+        CX 42 43
+        CX 5 6 42 43
+        CX rec[-1] 111
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X_ -> +XX
+        Z_ -> +Z_
+        _X -> +_X
+        _Z -> +ZZ
+        ```
+        
+    - Unitary Matrix:
+    
+        ```
+        [+1  ,     ,     ,     ]
+        [    ,     ,     , +1  ]
+        [    ,     , +1  ,     ]
+        [    , +1  ,     ,     ]
+        ```
+        
+    
+- <a name="CY"></a>**`CY`**
+    
+    Alternate name: <a name="ZCY"></a>`ZCY`
+    
+    The Z-controlled Y gate.
+    First qubit is the control, second qubit is the target.
+    The first qubit can be replaced by a measurement record.
+    
+    Applies a Y gate to the target if the control is in the |1> state.
+    
+    Negates the amplitude of the |1>|-i> state.
+    
+    - Example:
+    
+        ```
+        CY 5 6
+        CY 42 43
+        CY 5 6 42 43
+        CY rec[-1] 111
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X_ -> +XY
+        Z_ -> +Z_
+        _X -> +ZX
+        _Z -> +ZZ
+        ```
+        
+    - Unitary Matrix:
+    
+        ```
+        [+1  ,     ,     ,     ]
+        [    ,     ,     ,   -i]
+        [    ,     , +1  ,     ]
+        [    ,   +i,     ,     ]
+        ```
+        
+    
+- <a name="CZ"></a>**`CZ`**
+    
+    Alternate name: <a name="ZCZ"></a>`ZCZ`
+    
+    The Z-controlled Z gate.
+    First qubit is the control, second qubit is the target.
+    Either qubit can be replaced by a measurement record.
+    
+    Applies a Z gate to the target if the control is in the |1> state.
+    
+    Negates the amplitude of the |1>|1> state.
+    
+    - Example:
+    
+        ```
+        CZ 5 6
+        CZ 42 43
+        CZ 5 6 42 43
+        CZ rec[-1] 111
+        CZ 111 rec[-1]
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X_ -> +XZ
+        Z_ -> +Z_
+        _X -> +ZX
+        _Z -> +_Z
+        ```
+        
+    - Unitary Matrix:
+    
+        ```
+        [+1  ,     ,     ,     ]
+        [    , +1  ,     ,     ]
+        [    ,     , +1  ,     ]
+        [    ,     ,     , -1  ]
+        ```
+        
+    
+- <a name="ISWAP"></a>**`ISWAP`**
+    
+    Swaps two qubits and phases the -1 eigenspace of the ZZ observable by i.
+    Equivalent to `SWAP` then `CZ` then `S` on both targets.
+    
+    - Example:
+    
+        ```
+        ISWAP 5 6
+        ISWAP 42 43
+        ISWAP 5 6 42 43
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X_ -> +ZY
+        Z_ -> +_Z
+        _X -> +YZ
+        _Z -> +Z_
+        ```
+        
+    - Unitary Matrix:
+    
+        ```
+        [+1  ,     ,     ,     ]
+        [    ,     ,   +i,     ]
+        [    ,   +i,     ,     ]
+        [    ,     ,     , +1  ]
+        ```
+        
+    
+- <a name="ISWAP_DAG"></a>**`ISWAP_DAG`**
+    
+    Swaps two qubits and phases the -1 eigenspace of the ZZ observable by -i.
+    Equivalent to `SWAP` then `CZ` then `S_DAG` on both targets.
+    
+    - Example:
+    
+        ```
+        ISWAP_DAG 5 6
+        ISWAP_DAG 42 43
+        ISWAP_DAG 5 6 42 43
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X_ -> -ZY
+        Z_ -> +_Z
+        _X -> -YZ
+        _Z -> +Z_
+        ```
+        
+    - Unitary Matrix:
+    
+        ```
+        [+1  ,     ,     ,     ]
+        [    ,     ,   -i,     ]
+        [    ,   -i,     ,     ]
+        [    ,     ,     , +1  ]
+        ```
+        
+    
+- <a name="SWAP"></a>**`SWAP`**
+    
+    Swaps two qubits.
+    
+    - Example:
+    
+        ```
+        SWAP 5 6
+        SWAP 42 43
+        SWAP 5 6 42 43
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X_ -> +_X
+        Z_ -> +_Z
+        _X -> +X_
+        _Z -> +Z_
+        ```
+        
+    - Unitary Matrix:
+    
+        ```
+        [+1  ,     ,     ,     ]
+        [    ,     , +1  ,     ]
+        [    , +1  ,     ,     ]
+        [    ,     ,     , +1  ]
+        ```
+        
+    
+- <a name="XCX"></a>**`XCX`**
+    
+    The X-controlled X gate.
+    First qubit is the control, second qubit is the target.
+    
+    Applies an X gate to the target if the control is in the |-> state.
+    
+    Negates the amplitude of the |->|-> state.
+    
+    - Example:
+    
+        ```
+        XCX 5 6
+        XCX 42 43
+        XCX 5 6 42 43
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X_ -> +X_
+        Z_ -> +ZX
+        _X -> +_X
+        _Z -> +XZ
+        ```
+        
+    - Unitary Matrix:
+    
+        ```
+        [+1  , +1  , +1  , -1  ]
+        [+1  , +1  , -1  , +1  ]
+        [+1  , -1  , +1  , +1  ]
+        [-1  , +1  , +1  , +1  ] / 2
+        ```
+        
+    
+- <a name="XCY"></a>**`XCY`**
+    
+    The X-controlled Y gate.
+    First qubit is the control, second qubit is the target.
+    
+    Applies a Y gate to the target if the control is in the |-> state.
+    
+    Negates the amplitude of the |->|-i> state.
+    
+    - Example:
+    
+        ```
+        XCY 5 6
+        XCY 42 43
+        XCY 5 6 42 43
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X_ -> +X_
+        Z_ -> +ZY
+        _X -> +XX
+        _Z -> +XZ
+        ```
+        
+    - Unitary Matrix:
+    
+        ```
+        [+1  , +1  ,   -i,   +i]
+        [+1  , +1  ,   +i,   -i]
+        [  +i,   -i, +1  , +1  ]
+        [  -i,   +i, +1  , +1  ] / 2
+        ```
+        
+    
+- <a name="XCZ"></a>**`XCZ`**
+    
+    The X-controlled Z gate.
+    First qubit is the control, second qubit is the target.
+    The second qubit can be replaced by a measurement record.
+    
+    Applies a Z gate to the target if the control is in the |-> state.
+    
+    Negates the amplitude of the |->|1> state.
+    
+    - Example:
+    
+        ```
+        XCZ 5 6
+        XCZ 42 43
+        XCZ 5 6 42 43
+        XCZ 111 rec[-1]
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X_ -> +X_
+        Z_ -> +ZZ
+        _X -> +XX
+        _Z -> +_Z
+        ```
+        
+    - Unitary Matrix:
+    
+        ```
+        [+1  ,     ,     ,     ]
+        [    , +1  ,     ,     ]
+        [    ,     ,     , +1  ]
+        [    ,     , +1  ,     ]
+        ```
+        
+    
+- <a name="YCX"></a>**`YCX`**
+    
+    The Y-controlled X gate.
+    First qubit is the control, second qubit is the target.
+    
+    Applies an X gate to the target if the control is in the |-i> state.
+    
+    Negates the amplitude of the |-i>|-> state.
+    
+    - Example:
+    
+        ```
+        YCX 5 6
+        YCX 42 43
+        YCX 5 6 42 43
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X_ -> +XX
+        Z_ -> +ZX
+        _X -> +_X
+        _Z -> +YZ
+        ```
+        
+    - Unitary Matrix:
+    
+        ```
+        [+1  ,   -i, +1  ,   +i]
+        [  +i, +1  ,   -i, +1  ]
+        [+1  ,   +i, +1  ,   -i]
+        [  -i, +1  ,   +i, +1  ] / 2
+        ```
+        
+    
+- <a name="YCY"></a>**`YCY`**
+    
+    The Y-controlled Y gate.
+    First qubit is the control, second qubit is the target.
+    
+    Applies a Y gate to the target if the control is in the |-i> state.
+    
+    Negates the amplitude of the |-i>|-i> state.
+    
+    - Example:
+    
+        ```
+        YCY 5 6
+        YCY 42 43
+        YCY 5 6 42 43
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X_ -> +XY
+        Z_ -> +ZY
+        _X -> +YX
+        _Z -> +YZ
+        ```
+        
+    - Unitary Matrix:
+    
+        ```
+        [+1  ,   -i,   -i, +1  ]
+        [  +i, +1  , -1  ,   -i]
+        [  +i, -1  , +1  ,   -i]
+        [+1  ,   +i,   +i, +1  ] / 2
+        ```
+        
+    
+- <a name="YCZ"></a>**`YCZ`**
+    
+    The Y-controlled Z gate.
+    First qubit is the control, second qubit is the target.
+    The second qubit can be replaced by a measurement record.
+    
+    Applies a Z gate to the target if the control is in the |-i> state.
+    
+    Negates the amplitude of the |-i>|1> state.
+    
+    - Example:
+    
+        ```
+        YCZ 5 6
+        YCZ 42 43
+        YCZ 5 6 42 43
+        YCZ 111 rec[-1]
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X_ -> +XZ
+        Z_ -> +ZZ
+        _X -> +YX
+        _Z -> +_Z
+        ```
+        
+    - Unitary Matrix:
+    
+        ```
+        [+1  ,     ,     ,     ]
+        [    , +1  ,     ,     ]
+        [    ,     ,     ,   -i]
+        [    ,     ,   +i,     ]
+        ```
+        
+    
+## Noise Channels
 
-### Noise Gates
-
-- **`DEPOLARIZE1(p)`**:
-    Single qubit depolarizing error.
-    Examples: `DEPOLARIZE1(0.001) 1`, `DEPOLARIZE1(0.0003) 0 2 4 6`.
-    With probability `p`, applies independent single-qubit depolarizing kicks to the given qubits.
-    A single-qubit depolarizing kick is `X`, `Y`, or `Z` chosen uniformly at random.
-- **`DEPOLARIZE2(p)`**:
-    Two qubit depolarizing error.
-    Examples: `DEPOLARIZE2(0.001) 0 1`, `DEPOLARIZE2(0.0003) 0 2 4 6`.
-    With probability `p`, applies independent two-qubit depolarizing kicks to the given qubit pairs.
-    A two-qubit depolarizing kick is
-    `IX`, `IY`, `IZ`, `XI`, `XX`, `XY`, `XZ`, `YI`, `YX`, `YY`, `YZ`, `ZI`, `ZX`, `ZY`, `ZZ`
-    chosen uniformly at random.
-- **`X_ERROR(p)`**:
-    Single-qubit probabilistic X error.
-    Examples: `X_ERROR(0.001) 0 1`.
-    For each target qubit, independently applies an X gate With probability `p`.
-- **`Y_ERROR(p)`**:
-    Single-qubit probabilistic Y error.
-    Examples: `Y_ERROR(0.001) 0 1`.
-    For each target qubit, independently applies a Y gate With probability `p`.
-- **`Z_ERROR(p)`**:
-    Single-qubit probabilistic Z error.
-    Examples: `Z_ERROR(0.001) 0 1`.
-    For each target qubit, independently applies a Z gate With probability `p`.
-- **`CORRELATED_ERROR(p)`** (alternate name **`E`**)
-    See `ELSE_CORRELATED_ERROR`.
-    `CORRELATED_ERROR` is equivalent to `ELSE_CORRELATED_ERROR` except that
-    `CORRELATED_ERROR` starts by clearing the "correlated error occurred" flag.
-- **`ELSE_CORRELATED_ERROR(p)`**:
-    Pauli product error cases.
-    Probabilistically applies a Pauli product error with probability `p`,
-    unless the "correlated error occurred" flag is already set.
-    Sets the "correlated error occurred" flag if the error is applied.
-    Example:
-
+- <a name="DEPOLARIZE1"></a>**`DEPOLARIZE1`**
+    
+    The single qubit depolarizing channel.
+    
+    Applies a randomly chosen Pauli with a given probability.
+    
+    - Pauli Mixture:
+    
+        ```
+        1-p: I
+        p/3: X
+        p/3: Y
+        p/3: Z
+        ```
+    
+    - Example:
+    
+        ```
+        DEPOLARIZE1(0.001) 5
+        DEPOLARIZE1(0.001) 42
+        DEPOLARIZE1(0.001) 5 42
+        ```
+        
+    
+- <a name="DEPOLARIZE2"></a>**`DEPOLARIZE2`**
+    
+    The two qubit depolarizing channel.
+    
+    Applies a randomly chosen two-qubit Pauli product with a given probability.
+    
+    - Pauli Mixture:
+    
+        ```
+         1-p: II
+        p/15: IX
+        p/15: IY
+        p/15: IZ
+        p/15: XI
+        p/15: XX
+        p/15: XY
+        p/15: XZ
+        p/15: YI
+        p/15: YX
+        p/15: YY
+        p/15: YZ
+        p/15: ZI
+        p/15: ZX
+        p/15: ZY
+        p/15: ZZ
+        ```
+    
+    - Example:
+    
+        ```
+        DEPOLARIZE2(0.001) 5 6
+        DEPOLARIZE2(0.001) 42 43
+        DEPOLARIZE2(0.001) 5 6 42 43
+        ```
+        
+    
+- <a name="E"></a>**`E`**
+    
+    Alternate name: <a name="CORRELATED_ERROR"></a>`CORRELATED_ERROR`
+    
+    Probabilistically applies a Pauli product error with a given probability.
+    Sets the "correlated error occurred flag" to true if the error occurred.
+    Otherwise sets the flag to false.
+    
+    See also: `ELSE_CORRELATED_ERROR`.
+    
+    - Example:
+    
+        ```
         # With 40% probability, uniformly pick X1*Y2 or Z2*Z3 or X1*Y2*Z3.
         CORRELATED_ERROR(0.2) X1 Y2
         ELSE_CORRELATED_ERROR(0.25) Z2 Z3
         ELSE_CORRELATED_ERROR(0.33333333333) X1 Y2 Z3
-
-### Annotations
-
-- **`DETECTOR`**:
-    Asserts that a set of measurements have a deterministic result,
-    and that this result changing can be used to detect errors.
-    Ignored in measurement sampling mode.
-    In detection sampling mode, a detector produces a sample indicating if it was inverted by  noise or not.
-    Example: `DETECTOR rec[-1] rec[-2]`.
-- **`OBSERVABLE_INCLUDE(k)`**:
-    Adds measurement results to a logical observable.
-    A logical observable's measurement result is the parity of all physical measurement results added to it.
-    Behaves similarly to a Detector, except observables can be built up incrementally over the entire circuit.
-    Ignored in measurement sampling mode.
-    In detection sampling mode, a logical observable can produce a sample indicating if it was inverted by  noise or not.
-    These samples are dropped or put before or after detector samples, depending on command line flags.
-    Examples: `OBSERVABLE_INCLUDE(0) rec[-1] rec[-2]`, `OBSERVABLE_INCLUDE(3) rec[-7]`.
-
-### Other
-
-- **`TICK`**:
-    Indicates the end of a layer of gates, or that time is advancing.
-    Used by `stimcirq` to preserve the "moment structure" of cirq circuits converted to/from stim circuits.
-    Examples: `TICK`, `TICK`, and of course `TICK`.
+        ```
     
-- **`REPEAT N { ... }`**:
+- <a name="ELSE_CORRELATED_ERROR"></a>**`ELSE_CORRELATED_ERROR`**
+    
+    Probabilistically applies a Pauli product error with a given probability, unless the "correlated error occurred flag" is set.
+    If the error occurs, sets the "correlated error occurred flag" to true.
+    Otherwise leaves the flag alone.
+    
+    See also: `CORRELATED_ERROR`.
+    
+    - Example:
+    
+        ```
+        # With 40% probability, uniformly pick X1*Y2 or Z2*Z3 or X1*Y2*Z3.
+        CORRELATED_ERROR(0.2) X1 Y2
+        ELSE_CORRELATED_ERROR(0.25) Z2 Z3
+        ELSE_CORRELATED_ERROR(0.33333333333) X1 Y2 Z3
+        ```
+    
+- <a name="X_ERROR"></a>**`X_ERROR`**
+    
+    Applies a Pauli X with a given probability.
+    
+    - Pauli Mixture:
+    
+        ```
+        1-p: I
+         p : X
+        ```
+    
+    - Example:
+    
+        ```
+        X_ERROR(0.001) 5
+        X_ERROR(0.001) 42
+        X_ERROR(0.001) 5 42
+        ```
+        
+    
+- <a name="Y_ERROR"></a>**`Y_ERROR`**
+    
+    Applies a Pauli Y with a given probability.
+    
+    - Pauli Mixture:
+    
+        ```
+        1-p: I
+         p : Y
+        ```
+    
+    - Example:
+    
+        ```
+        Y_ERROR(0.001) 5
+        Y_ERROR(0.001) 42
+        Y_ERROR(0.001) 5 42
+        ```
+        
+    
+- <a name="Z_ERROR"></a>**`Z_ERROR`**
+    
+    Applies a Pauli Z with a given probability.
+    
+    - Pauli Mixture:
+    
+        ```
+        1-p: I
+         p : Z
+        ```
+    
+    - Example:
+    
+        ```
+        Z_ERROR(0.001) 5
+        Z_ERROR(0.001) 42
+        Z_ERROR(0.001) 5 42
+        ```
+        
+    
+## Collapsing Gates
+
+- <a name="M"></a>**`M`**
+    
+    Alternate name: <a name="MZ"></a>`MZ`
+    
+    Z-basis measurement.
+    Projects each target qubit into `|0>` or `|1>` and reports its value (false=`|0>`, true=`|1>`).
+    Prefixing a target with ! inverts its recorded measurement result.
+    
+    - Example:
+    
+        ```
+        M 5
+        M !42
+        M 5 !42
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        Z -> mZ
+        ```
+        
+    
+- <a name="MR"></a>**`MR`**
+    
+    Alternate name: <a name="MRZ"></a>`MRZ`
+    
+    Z-basis demolition measurement.
+    Projects each target qubit into `|0>` or `|1>`, reports its value (false=`|0>`, true=`|1>`), then resets to `|0>`.
+    Prefixing a target with ! inverts its recorded measurement result.
+    
+    - Example:
+    
+        ```
+        MR 5
+        MR !42
+        MR 5 !42
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        Z -> m
+        1 -> +Z
+        ```
+        
+    
+- <a name="MRX"></a>**`MRX`**
+    
+    X-basis demolition measurement.
+    Projects each target qubit into `|+>` or `|->`, reports its value (false=`|+>`, true=`|->`), then resets to `|+>`.
+    Prefixing a target with ! inverts its recorded measurement result.
+    
+    - Example:
+    
+        ```
+        MRX 5
+        MRX !42
+        MRX 5 !42
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X -> m
+        1 -> +X
+        ```
+        
+    
+- <a name="MRY"></a>**`MRY`**
+    
+    Y-basis demolition measurement.
+    Projects each target qubit into `|i>` or `|-i>`, reports its value (false=`|i>`, true=`|-i>`), then resets to `|i>`.
+    Prefixing a target with ! inverts its recorded measurement result.
+    
+    - Example:
+    
+        ```
+        MRY 5
+        MRY !42
+        MRY 5 !42
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        Y -> m
+        1 -> +Y
+        ```
+        
+    
+- <a name="MX"></a>**`MX`**
+    
+    X-basis measurement.
+    Projects each target qubit into `|+>` or `|->` and reports its value (false=`|+>`, true=`|->`).
+    Prefixing a target with ! inverts its recorded measurement result.
+    
+    - Example:
+    
+        ```
+        MX 5
+        MX !42
+        MX 5 !42
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        X -> mX
+        ```
+        
+    
+- <a name="MY"></a>**`MY`**
+    
+    Y-basis measurement.
+    Projects each target qubit into `|i>` or `|-i>` and reports its value (false=`|i>`, true=`|-i>`).
+    Prefixing a target with ! inverts its recorded measurement result.
+    
+    - Example:
+    
+        ```
+        MY 5
+        MY !42
+        MY 5 !42
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        Y -> mY
+        ```
+        
+    
+- <a name="R"></a>**`R`**
+    
+    Alternate name: <a name="RZ"></a>`RZ`
+    
+    Z-basis reset.
+    Forces each target qubit into the `|0>` state by silently measuring it in the Z basis and applying an `X` gate if it ended up in the `|1>` state.
+    
+    - Example:
+    
+        ```
+        R 5
+        R 42
+        R 5 42
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        1 -> +Z
+        ```
+        
+    
+- <a name="RX"></a>**`RX`**
+    
+    X-basis reset.
+    Forces each target qubit into the `|+>` state by silently measuring it in the X basis and applying a `Z` gate if it ended up in the `|->` state.
+    
+    - Example:
+    
+        ```
+        RX 5
+        RX 42
+        RX 5 42
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        1 -> +X
+        ```
+        
+    
+- <a name="RY"></a>**`RY`**
+    
+    Y-basis reset.
+    Forces each target qubit into the `|i>` state by silently measuring it in the Y basis and applying an `X` gate if it ended up in the `|-i>` state.
+    
+    - Example:
+    
+        ```
+        RY 5
+        RY 42
+        RY 5 42
+        ```
+        
+    - Stabilizer Generators:
+    
+        ```
+        1 -> +Y
+        ```
+        
+    
+## Control Flow
+
+- <a name="REPEAT"></a>**`REPEAT`**
+    
     Repeats the instructions in its body N times.
     The implementation-defined maximum value of N is 9223372036854775807.
-    Example:
-    ```
-    REPEAT 2 {
+    
+    - Example:
+    
+        ```
+        REPEAT 2 {
+            CNOT 0 1
+            CNOT 2 1
+            M 1
+        }
+        REPEAT 10000000 {
+            CNOT 0 1
+            CNOT 2 1
+            M 1
+            DETECTOR rec[-1] rec[-3]
+        }
+        ```
+    
+## Annotations
+
+- <a name="DETECTOR"></a>**`DETECTOR`**
+    
+    Annotates that a set of measurements have a deterministic result, which can be used to detect errors.
+    
+    Detectors are ignored in measurement sampling mode.
+    In detector sampling mode, detectors produce results (false=expected parity, true=incorrect parity detected).
+    
+    - Example:
+    
+        ```
+        H 0
         CNOT 0 1
-        CNOT 2 1
-        M 1
-    }
-    REPEAT 10000000 {
+        M 0 1
+        DETECTOR rec[-1] rec[-2]
+        ```
+    
+- <a name="OBSERVABLE_INCLUDE"></a>**`OBSERVABLE_INCLUDE`**
+    
+    Adds measurement results to a given logical observable index.
+    
+    A logical observable's measurement result is the parity of all physical measurement results added to it.
+    
+    A logical observable is similar to a Detector, except the measurements making up an observable can be built up
+    incrementally over the entire circuit.
+    
+    Logical observables are ignored in measurement sampling mode.
+    In detector sampling mode, observables produce results (false=expected parity, true=incorrect parity detected).
+    These results are optionally appended to the detector results, depending on simulator arguments / command line flags.
+    
+    - Example:
+    
+        ```
+        H 0
         CNOT 0 1
-        CNOT 2 1
-        M 1
-        DETECTOR rec[-1] rec[-3]
-    }
-    ```
+        M 0 1
+        OBSERVABLE_INCLUDE(5) rec[-1] rec[-2]
+        ```
+    
+- <a name="TICK"></a>**`TICK`**
+    
+    Indicates the end of a layer of gates, or that time is advancing.
+    For example, used by `stimcirq` to preserve the moment structure of cirq circuits converted to/from stim circuits.
+    
+    - Example:
+    
+        ```
+        TICK
+        TICK
+        # Oh, and of course:
+        TICK
+        ```
+    

--- a/src/circuit/circuit.cc
+++ b/src/circuit/circuit.cc
@@ -366,6 +366,11 @@ inline void read_result_targets_into(int &c, SOURCE read_char, const Gate &gate,
             c = read_char();
         }
         uint32_t q = read_uint24_t(c, read_char);
+        if (flipped_flag && !(gate.flags & GATE_PRODUCES_RESULTS)) {
+            throw std::invalid_argument(
+                "Gate '" + std::string(gate.name) +
+                "' doesn't take inverted targets like '!" + std::to_string(q) + "'.");
+        }
         circuit.jag_targets.append_tail(q ^ flipped_flag);
     }
 }

--- a/src/circuit/gate_data.cc
+++ b/src/circuit/gate_data.cc
@@ -34,8 +34,17 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::measure_x,
             &ErrorFuser::MX,
             GATE_PRODUCES_RESULTS,
-            {},
-            {},
+            []() -> ExtraGateData {
+                return {
+                    "L_Collapsing Gates",
+                    R"MARKDOWN(
+X-basis measurement.
+Projects each target qubit into `|+>` or `|->` and reports its value (false=`|+>`, true=`|->`).
+)MARKDOWN",
+                    {},
+                    {"X -> mX"},
+                };
+            },
         },
         {
             "MY",
@@ -43,8 +52,17 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::measure_y,
             &ErrorFuser::MY,
             GATE_PRODUCES_RESULTS,
-            {},
-            {},
+            []() -> ExtraGateData {
+                return {
+                    "L_Collapsing Gates",
+                    R"MARKDOWN(
+Y-basis measurement.
+Projects each target qubit into `|i>` or `|-i>` and reports its value (false=`|i>`, true=`|-i>`).
+)MARKDOWN",
+                    {},
+                    {"Y -> mY"},
+                };
+            },
         },
         {
             "M",
@@ -52,8 +70,17 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::measure_z,
             &ErrorFuser::MZ,
             GATE_PRODUCES_RESULTS,
-            {},
-            {},
+            []() -> ExtraGateData {
+                return {
+                    "L_Collapsing Gates",
+                    R"MARKDOWN(
+Z-basis measurement.
+Projects each target qubit into `|0>` or `|1>` and reports its value (false=`|0>`, true=`|1>`).
+)MARKDOWN",
+                    {},
+                    {"Z -> mZ"},
+                };
+            },
         },
         {
             "MRX",
@@ -61,8 +88,17 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::measure_reset_x,
             &ErrorFuser::MRX,
             GATE_PRODUCES_RESULTS,
-            {},
-            {},
+            []() -> ExtraGateData {
+                return {
+                    "L_Collapsing Gates",
+                    R"MARKDOWN(
+X-basis demolition measurement.
+Projects each target qubit into `|+>` or `|->`, reports its value (false=`|+>`, true=`|->`), then resets to `|+>`.
+)MARKDOWN",
+                    {},
+                    {"X -> m", "1 -> +X"},
+                };
+            },
         },
         {
             "MRY",
@@ -70,8 +106,17 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::measure_reset_y,
             &ErrorFuser::MRY,
             GATE_PRODUCES_RESULTS,
-            {},
-            {},
+            []() -> ExtraGateData {
+                return {
+                    "L_Collapsing Gates",
+                    R"MARKDOWN(
+Y-basis demolition measurement.
+Projects each target qubit into `|i>` or `|-i>`, reports its value (false=`|i>`, true=`|-i>`), then resets to `|i>`.
+)MARKDOWN",
+                    {},
+                    {"Y -> m", "1 -> +Y"},
+                };
+            },
         },
         {
             "MR",
@@ -79,8 +124,17 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::measure_reset_z,
             &ErrorFuser::MRZ,
             GATE_PRODUCES_RESULTS,
-            {},
-            {},
+            []() -> ExtraGateData {
+                return {
+                    "L_Collapsing Gates",
+                    R"MARKDOWN(
+Z-basis demolition measurement.
+Projects each target qubit into `|0>` or `|1>`, reports its value (false=`|0>`, true=`|1>`), then resets to `|0>`.
+)MARKDOWN",
+                    {},
+                    {"Z -> m", "1 -> +Z"},
+                };
+            },
         },
         {
             "RX",
@@ -88,8 +142,17 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::reset_x,
             &ErrorFuser::RX,
             GATE_NO_FLAGS,
-            {},
-            {},
+            []() -> ExtraGateData {
+                return {
+                    "L_Collapsing Gates",
+                    R"MARKDOWN(
+X-basis reset.
+Forces each target qubit into the `|+>` state by silently measuring it in the X basis and applying a `Z` gate if it ended up in the `|->` state.
+)MARKDOWN",
+                    {},
+                    {"1 -> +X"},
+                };
+            },
         },
         {
             "RY",
@@ -97,8 +160,17 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::reset_y,
             &ErrorFuser::RY,
             GATE_NO_FLAGS,
-            {},
-            {},
+            []() -> ExtraGateData {
+                return {
+                    "L_Collapsing Gates",
+                    R"MARKDOWN(
+Y-basis reset.
+Forces each target qubit into the `|i>` state by silently measuring it in the Y basis and applying an `X` gate if it ended up in the `|-i>` state.
+)MARKDOWN",
+                    {},
+                    {"1 -> +Y"},
+                };
+            },
         },
         {
             "R",
@@ -106,8 +178,17 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::reset_z,
             &ErrorFuser::RZ,
             GATE_NO_FLAGS,
-            {},
-            {},
+            []() -> ExtraGateData {
+                return {
+                    "L_Collapsing Gates",
+                    R"MARKDOWN(
+Z-basis reset.
+Forces each target qubit into the `|0>` state by silently measuring it in the Z basis and applying an `X` gate if it ended up in the `|1>` state.
+)MARKDOWN",
+                    {},
+                    {"1 -> +Z"},
+                };
+            },
         },
 
         // Pauli gates.
@@ -117,8 +198,17 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::I,
             &ErrorFuser::I,
             GATE_IS_UNITARY,
-            {{1, 0}, {0, 1}},
-            {"+X", "+Z"},
+            []() -> ExtraGateData {
+                return {
+                    "A_Pauli Gates",
+                    R"MARKDOWN(
+Identity gate.
+Does nothing to the target qubits.
+)MARKDOWN",
+                    {{1, 0}, {0, 1}},
+                    {"+X", "+Z"},
+                };
+            },
         },
         {
             "X",
@@ -126,8 +216,17 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::I,
             &ErrorFuser::I,
             GATE_IS_UNITARY,
-            {{0, 1}, {1, 0}},
-            {"+X", "-Z"},
+            []() -> ExtraGateData {
+                return {
+                    "A_Pauli Gates",
+                    R"MARKDOWN(
+Pauli X gate.
+The bit flip gate.
+)MARKDOWN",
+                    {{0, 1}, {1, 0}},
+                    {"+X", "-Z"},
+                };
+            },
         },
         {
             "Y",
@@ -135,8 +234,16 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::I,
             &ErrorFuser::I,
             GATE_IS_UNITARY,
-            {{0, -i}, {i, 0}},
-            {"-X", "-Z"},
+            []() -> ExtraGateData {
+                return {
+                    "A_Pauli Gates",
+                    R"MARKDOWN(
+Pauli Y gate.
+)MARKDOWN",
+                    {{0, -i}, {i, 0}},
+                    {"-X", "-Z"},
+                };
+            },
         },
         {
             "Z",
@@ -144,8 +251,17 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::I,
             &ErrorFuser::I,
             GATE_IS_UNITARY,
-            {{1, 0}, {0, -1}},
-            {"-X", "+Z"},
+            []() -> ExtraGateData {
+                return {
+                    "A_Pauli Gates",
+                    R"MARKDOWN(
+Pauli Z gate.
+The phase flip gate.
+)MARKDOWN",
+                    {{1, 0}, {0, -1}},
+                    {"-X", "+Z"},
+                };
+            },
         },
 
         // Axis exchange gates.
@@ -155,8 +271,17 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::H_XY,
             &ErrorFuser::H_XY,
             GATE_IS_UNITARY,
-            {{0, s - i *s}, {s + i * s, 0}},
-            {"+Y", "-Z"},
+            []() -> ExtraGateData {
+                return {
+                    "B_Single Qubit Clifford Gates",
+                    R"MARKDOWN(
+A variant of the Hadamard gate that swaps the X and Y axes (instead of X and Z).
+A 180 degree rotation around the X+Y axis.
+)MARKDOWN",
+                    {{0, s - i *s}, {s + i * s, 0}},
+                    {"+Y", "-Z"},
+                };
+            },
         },
         {
             "H",
@@ -164,8 +289,18 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::H_XZ,
             &ErrorFuser::H_XZ,
             GATE_IS_UNITARY,
-            {{s, s}, {s, -s}},
-            {"+Z", "+X"},
+            []() -> ExtraGateData {
+                return {
+                    "B_Single Qubit Clifford Gates",
+                    R"MARKDOWN(
+The Hadamard gate.
+Swaps the X and Z axes.
+A 180 degree rotation around the X+Z axis.
+)MARKDOWN",
+                    {{s, s}, {s, -s}},
+                    {"+Z", "+X"},
+                };
+            },
         },
         {
             "H_YZ",
@@ -173,8 +308,17 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::H_YZ,
             &ErrorFuser::H_YZ,
             GATE_IS_UNITARY,
-            {{s, -i * s}, {i * s, -s}},
-            {"-X", "+Y"},
+            []() -> ExtraGateData {
+                return {
+                    "B_Single Qubit Clifford Gates",
+                    R"MARKDOWN(
+A variant of the Hadamard gate that swaps the Y and Z axes (instead of X and Z).
+A 180 degree rotation around the Y+Z axis.
+)MARKDOWN",
+                    {{s, -i * s}, {i * s, -s}},
+                    {"-X", "+Y"},
+                };
+            },
         },
 
         // Period 3 gates.
@@ -184,8 +328,16 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::C_XYZ,
             &ErrorFuser::C_XYZ,
             GATE_IS_UNITARY,
-            {{0.5f - i * 0.5f, -0.5f - 0.5f*i}, {0.5f - 0.5f * i, 0.5f + 0.5f * i}},
-            {"Y", "X"},
+            []() -> ExtraGateData {
+                return {
+                    "B_Single Qubit Clifford Gates",
+                    R"MARKDOWN(
+Right handed period 3 axis cycling gate, sending X -> Y -> Z -> X.
+)MARKDOWN",
+                    {{0.5f - i * 0.5f, -0.5f - 0.5f*i}, {0.5f - 0.5f * i, 0.5f + 0.5f * i}},
+                    {"Y", "X"},
+                };
+            },
         },
         {
             "C_ZYX",
@@ -193,8 +345,16 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::C_ZYX,
             &ErrorFuser::C_ZYX,
             GATE_IS_UNITARY,
-            {{0.5f + i * 0.5f, 0.5f + 0.5f*i}, {-0.5f + 0.5f * i, 0.5f - 0.5f * i}},
-            {"Z", "Y"},
+            []() -> ExtraGateData {
+                return {
+                    "B_Single Qubit Clifford Gates",
+                    R"MARKDOWN(
+Left handed period 3 axis cycling gate, sending Z -> Y -> X -> Z.
+)MARKDOWN",
+                    {{0.5f + i * 0.5f, 0.5f + 0.5f*i}, {-0.5f + 0.5f * i, 0.5f - 0.5f * i}},
+                    {"Z", "Y"},
+                };
+            },
         },
 
         // 90 degree rotation gates.
@@ -204,8 +364,18 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::H_YZ,
             &ErrorFuser::H_YZ,
             GATE_IS_UNITARY,
-            {{0.5f + 0.5f * i, 0.5f - 0.5f * i}, {0.5f - 0.5f * i, 0.5f + 0.5f * i}},
-            {"+X", "-Y"},
+            []() -> ExtraGateData {
+                return {
+                    "B_Single Qubit Clifford Gates",
+                    R"MARKDOWN(
+Principle square root of X gate.
+Phases the amplitude of |-> by i.
+Equivalent to `H` then `S` then `H`.
+)MARKDOWN",
+                    {{0.5f + 0.5f * i, 0.5f - 0.5f * i}, {0.5f - 0.5f * i, 0.5f + 0.5f * i}},
+                    {"+X", "-Y"},
+                };
+            },
         },
         {
             "SQRT_X_DAG",
@@ -213,8 +383,18 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::H_YZ,
             &ErrorFuser::H_YZ,
             GATE_IS_UNITARY,
-            {{0.5f - 0.5f * i, 0.5f + 0.5f * i}, {0.5f + 0.5f * i, 0.5f - 0.5f * i}},
-            {"+X", "+Y"},
+            []() -> ExtraGateData {
+                return {
+                    "B_Single Qubit Clifford Gates",
+                    R"MARKDOWN(
+Adjoint square root of X gate.
+Phases the amplitude of |-> by -i.
+Equivalent to `H` then `S_DAG` then `H`.
+)MARKDOWN",
+                    {{0.5f - 0.5f * i, 0.5f + 0.5f * i}, {0.5f + 0.5f * i, 0.5f - 0.5f * i}},
+                    {"+X", "+Y"},
+                };
+            },
         },
         {
             "SQRT_Y",
@@ -222,8 +402,18 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::H_XZ,
             &ErrorFuser::H_XZ,
             GATE_IS_UNITARY,
-            {{0.5f + 0.5f * i, -0.5f - 0.5f * i}, {0.5f + 0.5f * i, 0.5f + 0.5f * i}},
-            {"-Z", "+X"},
+            []() -> ExtraGateData {
+                return {
+                    "B_Single Qubit Clifford Gates",
+                    R"MARKDOWN(
+Principle square root of Y gate.
+Phases the amplitude of |-i> by i.
+Equivalent to `S` then `H` then `S` then `H` then `S_DAG`.
+)MARKDOWN",
+                    {{0.5f + 0.5f * i, -0.5f - 0.5f * i}, {0.5f + 0.5f * i, 0.5f + 0.5f * i}},
+                    {"-Z", "+X"},
+                };
+            },
         },
         {
             "SQRT_Y_DAG",
@@ -231,8 +421,18 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::H_XZ,
             &ErrorFuser::H_XZ,
             GATE_IS_UNITARY,
-            {{0.5f - 0.5f * i, 0.5f - 0.5f * i}, {-0.5f + 0.5f * i, 0.5f - 0.5f * i}},
-            {"+Z", "-X"},
+            []() -> ExtraGateData {
+                return {
+                    "B_Single Qubit Clifford Gates",
+                    R"MARKDOWN(
+Principle square root of Y gate.
+Phases the amplitude of |-i> by -i.
+Equivalent to `S` then `H` then `S_DAG` then `H` then `S_DAG`.
+)MARKDOWN",
+                    {{0.5f - 0.5f * i, 0.5f - 0.5f * i}, {-0.5f + 0.5f * i, 0.5f - 0.5f * i}},
+                    {"+Z", "-X"},
+                };
+            },
         },
         {
             "S",
@@ -240,8 +440,17 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::H_XY,
             &ErrorFuser::H_XY,
             GATE_IS_UNITARY,
-            {{1, 0}, {0, i}},
-            {"+Y", "+Z"},
+            []() -> ExtraGateData {
+                return {
+                    "B_Single Qubit Clifford Gates",
+                    R"MARKDOWN(
+Principle square root of Z gate.
+Phases the amplitude of |1> by i.
+)MARKDOWN",
+                    {{1, 0}, {0, i}},
+                    {"+Y", "+Z"},
+                };
+            },
         },
         {
             "S_DAG",
@@ -249,8 +458,17 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::H_XY,
             &ErrorFuser::H_XY,
             GATE_IS_UNITARY,
-            {{1, 0}, {0, -i}},
-            {"-Y", "+Z"},
+            []() -> ExtraGateData {
+                return {
+                    "B_Single Qubit Clifford Gates",
+                    R"MARKDOWN(
+Principle square root of Z gate.
+Phases the amplitude of |1> by -i.
+)MARKDOWN",
+                    {{1, 0}, {0, -i}},
+                    {"-Y", "+Z"},
+                };
+            },
         },
 
         // Swap gates.
@@ -260,8 +478,16 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::SWAP,
             &ErrorFuser::SWAP,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS),
-            {{1, 0, 0, 0}, {0, 0, 1, 0}, {0, 1, 0, 0}, {0, 0, 0, 1}},
-            {"+IX", "+IZ", "+XI", "+ZI"},
+            []() -> ExtraGateData {
+                return {
+                    "C_Two Qubit Clifford Gates",
+                    R"MARKDOWN(
+Swaps two qubits.
+)MARKDOWN",
+                    {{1, 0, 0, 0}, {0, 0, 1, 0}, {0, 1, 0, 0}, {0, 0, 0, 1}},
+                    {"+IX", "+IZ", "+XI", "+ZI"},
+                };
+            },
         },
         {
             "ISWAP",
@@ -269,8 +495,17 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::ISWAP,
             &ErrorFuser::ISWAP,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS),
-            {{1, 0, 0, 0}, {0, 0, i, 0}, {0, i, 0, 0}, {0, 0, 0, 1}},
-            {"+ZY", "+IZ", "+YZ", "+ZI"},
+            []() -> ExtraGateData {
+                return {
+                    "C_Two Qubit Clifford Gates",
+                    R"MARKDOWN(
+Swaps two qubits and phases the -1 eigenspace of the ZZ observable by i.
+Equivalent to `SWAP` then `CZ` then `S` on both targets.
+)MARKDOWN",
+                    {{1, 0, 0, 0}, {0, 0, i, 0}, {0, i, 0, 0}, {0, 0, 0, 1}},
+                    {"+ZY", "+IZ", "+YZ", "+ZI"},
+                };
+            },
         },
         {
             "ISWAP_DAG",
@@ -278,8 +513,17 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::ISWAP,
             &ErrorFuser::ISWAP,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS),
-            {{1, 0, 0, 0}, {0, 0, -i, 0}, {0, -i, 0, 0}, {0, 0, 0, 1}},
-            {"-ZY", "+IZ", "-YZ", "+ZI"},
+            []() -> ExtraGateData {
+                return {
+                    "C_Two Qubit Clifford Gates",
+                    R"MARKDOWN(
+Swaps two qubits and phases the -1 eigenspace of the ZZ observable by -i.
+Equivalent to `SWAP` then `CZ` then `S_DAG` on both targets.
+)MARKDOWN",
+                    {{1, 0, 0, 0}, {0, 0, -i, 0}, {0, -i, 0, 0}, {0, 0, 0, 1}},
+                    {"-ZY", "+IZ", "-YZ", "+ZI"},
+                };
+            },
         },
 
         // Axis interaction gates.
@@ -289,11 +533,24 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::XCX,
             &ErrorFuser::XCX,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS),
-            {{0.5f, 0.5f, 0.5f, -0.5f},
-             {0.5f, 0.5f, -0.5f, 0.5f},
-             {0.5f, -0.5f, 0.5f, 0.5f},
-             {-0.5f, 0.5f, 0.5f, 0.5f}},
-            {"+XI", "+ZX", "+IX", "+XZ"},
+            []() -> ExtraGateData {
+                return {
+                    "C_Two Qubit Clifford Gates",
+                    R"MARKDOWN(
+The X-controlled X gate.
+First qubit is the control, second qubit is the target.
+
+Applies an X gate to the target if the control is in the |-> state.
+
+Negates the amplitude of the |->|-> state.
+)MARKDOWN",
+                    {{0.5f, 0.5f, 0.5f, -0.5f},
+                     {0.5f, 0.5f, -0.5f, 0.5f},
+                     {0.5f, -0.5f, 0.5f, 0.5f},
+                     {-0.5f, 0.5f, 0.5f, 0.5f}},
+                    {"+XI", "+ZX", "+IX", "+XZ"},
+                };
+            },
         },
         {
             "XCY",
@@ -301,11 +558,24 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::XCY,
             &ErrorFuser::XCY,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS),
-            {{0.5f, 0.5f, -0.5f * i, 0.5f * i},
-             {0.5f, 0.5f, 0.5f * i, -0.5f * i},
-             {0.5f * i, -0.5f * i, 0.5f, 0.5f},
-             {-0.5f * i, 0.5f * i, 0.5f, 0.5f}},
-            {"+XI", "+ZY", "+XX", "+XZ"},
+            []() -> ExtraGateData {
+                return {
+                    "C_Two Qubit Clifford Gates",
+                    R"MARKDOWN(
+The X-controlled Y gate.
+First qubit is the control, second qubit is the target.
+
+Applies a Y gate to the target if the control is in the |-> state.
+
+Negates the amplitude of the |->|-i> state.
+)MARKDOWN",
+                    {{0.5f, 0.5f, -0.5f * i, 0.5f * i},
+                     {0.5f, 0.5f, 0.5f * i, -0.5f * i},
+                     {0.5f * i, -0.5f * i, 0.5f, 0.5f},
+                     {-0.5f * i, 0.5f * i, 0.5f, 0.5f}},
+                    {"+XI", "+ZY", "+XX", "+XZ"},
+                };
+            },
         },
         {
             "XCZ",
@@ -313,8 +583,22 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::XCZ,
             &ErrorFuser::XCZ,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS | GATE_CAN_TARGET_MEASUREMENT_RECORD),
-            {{1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 0, 1}, {0, 0, 1, 0}},
-            {"+XI", "+ZZ", "+XX", "+IZ"},
+            []() -> ExtraGateData {
+                return {
+                    "C_Two Qubit Clifford Gates",
+                    R"MARKDOWN(
+The X-controlled Z gate.
+First qubit is the control, second qubit is the target.
+The second qubit can be replaced by a measurement record.
+
+Applies a Z gate to the target if the control is in the |-> state.
+
+Negates the amplitude of the |->|1> state.
+)MARKDOWN",
+                    {{1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 0, 1}, {0, 0, 1, 0}},
+                    {"+XI", "+ZZ", "+XX", "+IZ"},
+                };
+            },
         },
         {
             "YCX",
@@ -322,11 +606,24 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::YCX,
             &ErrorFuser::YCX,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS),
-            {{0.5f, -i * 0.5f, 0.5f, i * 0.5f},
-             {i * 0.5f, 0.5f, -i * 0.5f, 0.5f},
-             {0.5f, i * 0.5f, 0.5f, -i * 0.5f},
-             {-i * 0.5f, 0.5f, i * 0.5f, 0.5f}},
-            {"+XX", "+ZX", "+IX", "+YZ"},
+            []() -> ExtraGateData {
+                return {
+                    "C_Two Qubit Clifford Gates",
+                    R"MARKDOWN(
+The Y-controlled X gate.
+First qubit is the control, second qubit is the target.
+
+Applies an X gate to the target if the control is in the |-i> state.
+
+Negates the amplitude of the |-i>|-> state.
+)MARKDOWN",
+                    {{0.5f, -i * 0.5f, 0.5f, i * 0.5f},
+                     {i * 0.5f, 0.5f, -i * 0.5f, 0.5f},
+                     {0.5f, i * 0.5f, 0.5f, -i * 0.5f},
+                     {-i * 0.5f, 0.5f, i * 0.5f, 0.5f}},
+                    {"+XX", "+ZX", "+IX", "+YZ"},
+                };
+            },
         },
         {
             "YCY",
@@ -334,11 +631,24 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::YCY,
             &ErrorFuser::YCY,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS),
-            {{0.5f, -i * 0.5f, -i * 0.5f, 0.5f},
-             {i * 0.5f, 0.5f, -0.5f, -i * 0.5f},
-             {i * 0.5f, -0.5f, 0.5f, -i * 0.5f},
-             {0.5f, i * 0.5f, i * 0.5f, 0.5f}},
-            {"+XY", "+ZY", "+YX", "+YZ"},
+            []() -> ExtraGateData {
+                return {
+                    "C_Two Qubit Clifford Gates",
+                    R"MARKDOWN(
+The Y-controlled Y gate.
+First qubit is the control, second qubit is the target.
+
+Applies a Y gate to the target if the control is in the |-i> state.
+
+Negates the amplitude of the |-i>|-i> state.
+)MARKDOWN",
+                    {{0.5f, -i * 0.5f, -i * 0.5f, 0.5f},
+                     {i * 0.5f, 0.5f, -0.5f, -i * 0.5f},
+                     {i * 0.5f, -0.5f, 0.5f, -i * 0.5f},
+                     {0.5f, i * 0.5f, i * 0.5f, 0.5f}},
+                    {"+XY", "+ZY", "+YX", "+YZ"},
+                };
+            },
         },
         {
             "YCZ",
@@ -346,8 +656,22 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::YCZ,
             &ErrorFuser::YCZ,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS | GATE_CAN_TARGET_MEASUREMENT_RECORD),
-            {{1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 0, -i}, {0, 0, i, 0}},
-            {"+XZ", "+ZZ", "+YX", "+IZ"},
+            []() -> ExtraGateData {
+                return {
+                    "C_Two Qubit Clifford Gates",
+                    R"MARKDOWN(
+The Y-controlled Z gate.
+First qubit is the control, second qubit is the target.
+The second qubit can be replaced by a measurement record.
+
+Applies a Z gate to the target if the control is in the |-i> state.
+
+Negates the amplitude of the |-i>|1> state.
+)MARKDOWN",
+                    {{1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 0, -i}, {0, 0, i, 0}},
+                    {"+XZ", "+ZZ", "+YX", "+IZ"},
+                };
+            },
         },
         {
             "CX",
@@ -355,8 +679,22 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::ZCX,
             &ErrorFuser::ZCX,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS | GATE_CAN_TARGET_MEASUREMENT_RECORD),
-            {{1, 0, 0, 0}, {0, 0, 0, 1}, {0, 0, 1, 0}, {0, 1, 0, 0}},
-            {"+XX", "+ZI", "+IX", "+ZZ"},
+            []() -> ExtraGateData {
+                return {
+                    "C_Two Qubit Clifford Gates",
+                    R"MARKDOWN(
+The Z-controlled X gate.
+First qubit is the control, second qubit is the target.
+The first qubit can be replaced by a measurement record.
+
+Applies an X gate to the target if the control is in the |1> state.
+
+Negates the amplitude of the |1>|-> state.
+)MARKDOWN",
+                    {{1, 0, 0, 0}, {0, 0, 0, 1}, {0, 0, 1, 0}, {0, 1, 0, 0}},
+                    {"+XX", "+ZI", "+IX", "+ZZ"},
+                };
+            },
         },
         {
             "CY",
@@ -364,8 +702,22 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::ZCY,
             &ErrorFuser::ZCY,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS | GATE_CAN_TARGET_MEASUREMENT_RECORD),
-            {{1, 0, 0, 0}, {0, 0, 0, -i}, {0, 0, 1, 0}, {0, i, 0, 0}},
-            {"+XY", "+ZI", "+ZX", "+ZZ"},
+            []() -> ExtraGateData {
+                return {
+                    "C_Two Qubit Clifford Gates",
+                    R"MARKDOWN(
+The Z-controlled Y gate.
+First qubit is the control, second qubit is the target.
+The first qubit can be replaced by a measurement record.
+
+Applies a Y gate to the target if the control is in the |1> state.
+
+Negates the amplitude of the |1>|-i> state.
+)MARKDOWN",
+                    {{1, 0, 0, 0}, {0, 0, 0, -i}, {0, 0, 1, 0}, {0, i, 0, 0}},
+                    {"+XY", "+ZI", "+ZX", "+ZZ"},
+                };
+            },
         },
         {
             "CZ",
@@ -373,8 +725,22 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::ZCZ,
             &ErrorFuser::ZCZ,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS | GATE_CAN_TARGET_MEASUREMENT_RECORD),
-            {{1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, -1}},
-            {"+XZ", "+ZI", "+ZX", "+IZ"},
+            []() -> ExtraGateData {
+                return {
+                    "C_Two Qubit Clifford Gates",
+                    R"MARKDOWN(
+The Z-controlled Z gate.
+First qubit is the control, second qubit is the target.
+Either qubit can be replaced by a measurement record.
+
+Applies a Z gate to the target if the control is in the |1> state.
+
+Negates the amplitude of the |1>|1> state.
+)MARKDOWN",
+                    {{1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, -1}},
+                    {"+XZ", "+ZI", "+ZX", "+IZ"},
+                };
+            },
         },
 
         // Noise gates.
@@ -384,8 +750,27 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::DEPOLARIZE1,
             &ErrorFuser::DEPOLARIZE1,
             (GateFlags)(GATE_IS_NOISE | GATE_TAKES_PARENS_ARGUMENT),
-            {},
-            {},
+            []() -> ExtraGateData {
+                return {
+                    "F_Noise Channels",
+                    R"MARKDOWN(
+The single qubit depolarizing channel.
+
+Applies a randomly chosen Pauli with a given probability.
+
+- Pauli Mixture:
+
+    ```
+    1-p: I
+    p/3: X
+    p/3: Y
+    p/3: Z
+    ```
+)MARKDOWN",
+                    {},
+                    {},
+                };
+            },
         },
         {
             "DEPOLARIZE2",
@@ -393,8 +778,39 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::DEPOLARIZE2,
             &ErrorFuser::DEPOLARIZE2,
             (GateFlags)(GATE_IS_NOISE | GATE_TAKES_PARENS_ARGUMENT | GATE_TARGETS_PAIRS),
-            {},
-            {},
+            []() -> ExtraGateData {
+                return {
+                    "F_Noise Channels",
+                    R"MARKDOWN(
+The two qubit depolarizing channel.
+
+Applies a randomly chosen two-qubit Pauli product with a given probability.
+
+- Pauli Mixture:
+
+    ```
+     1-p: II
+    p/15: IX
+    p/15: IY
+    p/15: IZ
+    p/15: XI
+    p/15: XX
+    p/15: XY
+    p/15: XZ
+    p/15: YI
+    p/15: YX
+    p/15: YY
+    p/15: YZ
+    p/15: ZI
+    p/15: ZX
+    p/15: ZY
+    p/15: ZZ
+    ```
+)MARKDOWN",
+                    {},
+                    {},
+                };
+            },
         },
         {
             "X_ERROR",
@@ -402,8 +818,23 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::X_ERROR,
             &ErrorFuser::X_ERROR,
             (GateFlags)(GATE_IS_NOISE | GATE_TAKES_PARENS_ARGUMENT),
-            {},
-            {},
+            []() -> ExtraGateData {
+                return {
+                    "F_Noise Channels",
+                    R"MARKDOWN(
+Applies a Pauli X with a given probability.
+
+- Pauli Mixture:
+
+    ```
+    1-p: I
+     p : X
+    ```
+)MARKDOWN",
+                    {},
+                    {},
+                };
+            },
         },
         {
             "Y_ERROR",
@@ -411,8 +842,23 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::Y_ERROR,
             &ErrorFuser::Y_ERROR,
             (GateFlags)(GATE_IS_NOISE | GATE_TAKES_PARENS_ARGUMENT),
-            {},
-            {},
+            []() -> ExtraGateData {
+                return {
+                    "F_Noise Channels",
+                    R"MARKDOWN(
+Applies a Pauli Y with a given probability.
+
+- Pauli Mixture:
+
+    ```
+    1-p: I
+     p : Y
+    ```
+)MARKDOWN",
+                    {},
+                    {},
+                };
+            },
         },
         {
             "Z_ERROR",
@@ -420,8 +866,23 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::Z_ERROR,
             &ErrorFuser::Z_ERROR,
             (GateFlags)(GATE_IS_NOISE | GATE_TAKES_PARENS_ARGUMENT),
-            {},
-            {},
+            []() -> ExtraGateData {
+                return {
+                    "F_Noise Channels",
+                    R"MARKDOWN(
+Applies a Pauli Z with a given probability.
+
+- Pauli Mixture:
+
+    ```
+    1-p: I
+     p : Z
+    ```
+)MARKDOWN",
+                    {},
+                    {},
+                };
+            },
         },
 
         // Annotation gates.
@@ -431,8 +892,28 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::I,
             &ErrorFuser::DETECTOR,
             (GateFlags)(GATE_ONLY_TARGETS_MEASUREMENT_RECORD | GATE_IS_NOT_FUSABLE),
-            {},
-            {},
+            []() -> ExtraGateData {
+                return {
+                    "Z_Annotations",
+                    R"MARKDOWN(
+Annotates that a set of measurements have a deterministic result, which can be used to detect errors.
+
+Detectors are ignored in measurement sampling mode.
+In detector sampling mode, detectors produce results (false=expected parity, true=incorrect parity detected).
+
+- Example:
+
+    ```
+    H 0
+    CNOT 0 1
+    M 0 1
+    DETECTOR rec[-1] rec[-2]
+    ```
+)MARKDOWN",
+                    {},
+                    {},
+                };
+            },
         },
         {
             "OBSERVABLE_INCLUDE",
@@ -440,8 +921,34 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::I,
             &ErrorFuser::OBSERVABLE_INCLUDE,
             (GateFlags)(GATE_ONLY_TARGETS_MEASUREMENT_RECORD | GATE_TAKES_PARENS_ARGUMENT | GATE_IS_NOT_FUSABLE),
-            {},
-            {},
+            []() -> ExtraGateData {
+                return {
+                    "Z_Annotations",
+                    R"MARKDOWN(
+Adds measurement results to a given logical observable index.
+
+A logical observable's measurement result is the parity of all physical measurement results added to it.
+
+A logical observable is similar to a Detector, except the measurements making up an observable can be built up
+incrementally over the entire circuit.
+
+Logical observables are ignored in measurement sampling mode.
+In detector sampling mode, observables produce results (false=expected parity, true=incorrect parity detected).
+These results are optionally appended to the detector results, depending on simulator arguments / command line flags.
+
+- Example:
+
+    ```
+    H 0
+    CNOT 0 1
+    M 0 1
+    OBSERVABLE_INCLUDE(5) rec[-1] rec[-2]
+    ```
+)MARKDOWN",
+                    {},
+                    {},
+                };
+            },
         },
         {
             "TICK",
@@ -449,8 +956,26 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::I,
             &ErrorFuser::I,
             GATE_IS_NOT_FUSABLE,
-            {},
-            {},
+            []() -> ExtraGateData {
+                return {
+                    "Z_Annotations",
+                    R"MARKDOWN(
+Indicates the end of a layer of gates, or that time is advancing.
+For example, used by `stimcirq` to preserve the moment structure of cirq circuits converted to/from stim circuits.
+
+- Example:
+
+    ```
+    TICK
+    TICK
+    # Oh, and of course:
+    TICK
+    ```
+)MARKDOWN",
+                    {},
+                    {},
+                };
+            },
         },
         {
             "REPEAT",
@@ -458,8 +983,33 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::I,
             &ErrorFuser::I,
             (GateFlags)(GATE_IS_BLOCK | GATE_IS_NOT_FUSABLE),
-            {},
-            {},
+            []() -> ExtraGateData {
+                return {
+                    "Y_Control Flow",
+                    R"MARKDOWN(
+Repeats the instructions in its body N times.
+The implementation-defined maximum value of N is 9223372036854775807.
+
+- Example:
+
+    ```
+    REPEAT 2 {
+        CNOT 0 1
+        CNOT 2 1
+        M 1
+    }
+    REPEAT 10000000 {
+        CNOT 0 1
+        CNOT 2 1
+        M 1
+        DETECTOR rec[-1] rec[-3]
+    }
+    ```
+)MARKDOWN",
+                    {},
+                    {},
+                };
+            },
         },
         {
             "E",
@@ -467,8 +1017,29 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::CORRELATED_ERROR,
             &ErrorFuser::CORRELATED_ERROR,
             (GateFlags)(GATE_IS_NOISE | GATE_TAKES_PARENS_ARGUMENT | GATE_TARGETS_PAULI_STRING | GATE_IS_NOT_FUSABLE),
-            {},
-            {},
+            []() -> ExtraGateData {
+                return {
+                    "F_Noise Channels",
+                    R"MARKDOWN(
+Probabilistically applies a Pauli product error with a given probability.
+Sets the "correlated error occurred flag" to true if the error occurred.
+Otherwise sets the flag to false.
+
+See also: `ELSE_CORRELATED_ERROR`.
+
+- Example:
+
+    ```
+    # With 40% probability, uniformly pick X1*Y2 or Z2*Z3 or X1*Y2*Z3.
+    CORRELATED_ERROR(0.2) X1 Y2
+    ELSE_CORRELATED_ERROR(0.25) Z2 Z3
+    ELSE_CORRELATED_ERROR(0.33333333333) X1 Y2 Z3
+    ```
+)MARKDOWN",
+                    {},
+                    {},
+                };
+            },
         },
         {
             "ELSE_CORRELATED_ERROR",
@@ -476,8 +1047,29 @@ extern const GateDataMap stim_internal::GATE_DATA(
             &FrameSimulator::ELSE_CORRELATED_ERROR,
             &ErrorFuser::ELSE_CORRELATED_ERROR,
             (GateFlags)(GATE_IS_NOISE | GATE_TAKES_PARENS_ARGUMENT | GATE_TARGETS_PAULI_STRING | GATE_IS_NOT_FUSABLE),
-            {},
-            {},
+            []() -> ExtraGateData {
+                return {
+                    "F_Noise Channels",
+                    R"MARKDOWN(
+Probabilistically applies a Pauli product error with a given probability, unless the "correlated error occurred flag" is set.
+If the error occurs, sets the "correlated error occurred flag" to true.
+Otherwise leaves the flag alone.
+
+See also: `CORRELATED_ERROR`.
+
+- Example:
+
+    ```
+    # With 40% probability, uniformly pick X1*Y2 or Z2*Z3 or X1*Y2*Z3.
+    CORRELATED_ERROR(0.2) X1 Y2
+    ELSE_CORRELATED_ERROR(0.25) Z2 Z3
+    ELSE_CORRELATED_ERROR(0.33333333333) X1 Y2 Z3
+    ```
+)MARKDOWN",
+                    {},
+                    {},
+                };
+            },
         },
     },
     {
@@ -495,7 +1087,8 @@ extern const GateDataMap stim_internal::GATE_DATA(
     });
 
 Tableau Gate::tableau() const {
-    const auto &d = tableau_data.data;
+    const auto &tableau_data = extra_data_func().tableau_data;
+    const auto &d = tableau_data;
     if (tableau_data.size() == 2) {
         return Tableau::gate1(d[0], d[1]);
     }
@@ -506,15 +1099,16 @@ Tableau Gate::tableau() const {
 }
 
 std::vector<std::vector<std::complex<float>>> Gate::unitary() const {
+    const auto &unitary_data = extra_data_func().unitary_data;
     if (unitary_data.size() != 2 && unitary_data.size() != 4) {
         throw std::out_of_range(std::string(name) + " doesn't have 1q or 2q unitary data.");
     }
     std::vector<std::vector<std::complex<float>>> result;
     for (size_t k = 0; k < unitary_data.size(); k++) {
-        const auto &d = unitary_data.data[k];
+        const auto &d = unitary_data[k];
         result.emplace_back();
         for (size_t j = 0; j < d.size(); j++) {
-            result.back().push_back(d.data[j]);
+            result.back().push_back(d[j]);
         }
     }
     return result;
@@ -547,16 +1141,14 @@ Gate::Gate(
     const char *name, void (TableauSimulator::*tableau_simulator_function)(const OperationData &),
     void (FrameSimulator::*frame_simulator_function)(const OperationData &),
     void (ErrorFuser::*hit_simulator_function)(const OperationData &), GateFlags flags,
-    TruncatedArray<TruncatedArray<std::complex<float>, 4>, 4> unitary_data,
-    TruncatedArray<const char *, 4> tableau_data)
+    ExtraGateData (*extra_data_func)(void))
     : name(name),
       name_len(strlen(name)),
       tableau_simulator_function(tableau_simulator_function),
       frame_simulator_function(frame_simulator_function),
       reverse_error_fuser_function(hit_simulator_function),
       flags(flags),
-      unitary_data(unitary_data),
-      tableau_data(tableau_data),
+      extra_data_func(extra_data_func),
       id(gate_name_to_id(name)) {
 }
 

--- a/src/gate_help.cc
+++ b/src/gate_help.cc
@@ -17,8 +17,7 @@
 
 #include <algorithm>
 #include <iostream>
-#include <cstdio>
-#include <cstdlib>
+#include <cmath>
 #include <cstring>
 #include <map>
 #include <set>

--- a/src/gate_help.cc
+++ b/src/gate_help.cc
@@ -1,0 +1,336 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gate_help.h"
+#include "stabilizers/tableau.h"
+
+#include <algorithm>
+#include <iostream>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <set>
+
+using namespace stim_internal;
+
+struct Acc {
+    std::string settled;
+    std::stringstream working;
+    int indent{};
+
+    void flush() {
+        auto s = working.str();
+        for (char c : s) {
+            settled.push_back(c);
+            if (c == '\n') {
+                for (int k = 0; k < indent; k++) {
+                    settled.push_back(' ');
+                }
+            }
+        }
+        working.str("");
+    }
+
+    void change_indent(int t) {
+        flush();
+        if (indent + t < 0) {
+            throw std::out_of_range("negative indent");
+        }
+        indent += t;
+        working << '\n';
+    }
+
+    template <typename T>
+    Acc &operator<<(const T& other) {
+        working << other;
+        return *this;
+    }
+};
+
+void print_fixed_width_float(Acc &out, float f, char u) {
+    if (f == 0) {
+        out << "  ";
+    } else if (fabs(f - 1) < 0.0001) {
+        out << "+" << u;
+    } else if (fabs(f + 1) < 0.0001) {
+        out << "-" << u;
+    } else {
+        if (f > 0) {
+            out << "+";
+        }
+        out << f;
+    }
+}
+
+void print_example(Acc &out, const char *name, const Gate &gate) {
+    out << "\n- Example:\n";
+    out.change_indent(+4);
+    out << "```\n";
+    for (size_t k = 0; k < 3; k++) {
+        out << name;
+        if (gate.flags & GATE_IS_NOISE) {
+            out << "(" << 0.001 << ")";
+        }
+        if (k != 1) {
+            out << " " << 5;
+            if (gate.flags & GATE_TARGETS_PAIRS) {
+                out << " " << 6;
+            }
+        }
+        if (k != 0) {
+            out << " ";
+            if (gate.flags & GATE_PRODUCES_RESULTS) {
+                out << "!";
+            }
+            out << 42;
+            if (gate.flags & GATE_TARGETS_PAIRS) {
+                out << " " << 43;
+            }
+        }
+        out << "\n";
+    }
+    if (gate.flags & GATE_CAN_TARGET_MEASUREMENT_RECORD) {
+        if (gate.name[0] == 'C' || gate.name[0] == 'Z') {
+            out << gate.name << " rec[-1] 111\n";
+        }
+        if (gate.name[gate.name_len - 1] == 'Z') {
+            out << gate.name << " 111 rec[-1]\n";
+        }
+    }
+    out << "```\n";
+    out.change_indent(-4);
+}
+
+void print_stabilizer_generators(Acc &out, const char *name, const Gate &gate) {
+    if (gate.flags & GATE_IS_UNITARY) {
+        out << "- Stabilizer Generators:\n";
+        out.change_indent(+4);
+        out << "```\n";
+        auto tableau = gate.tableau();
+        if (gate.flags & GATE_TARGETS_PAIRS) {
+            out << "X_ -> " << tableau.xs[0] << "\n";
+            out << "Z_ -> " << tableau.zs[0] << "\n";
+            out << "_X -> " << tableau.xs[1] << "\n";
+            out << "_Z -> " << tableau.zs[1] << "\n";
+        } else {
+            out << "X -> " << tableau.xs[0] << "\n";
+            out << "Z -> " << tableau.zs[0] << "\n";
+        }
+        out << "```\n";
+        out.change_indent(-4);
+    } else {
+        auto data = gate.extra_data_func();
+        if (data.tableau_data.size()) {
+            out << "- Stabilizer Generators:\n";
+            out.change_indent(+4);
+            out << "```\n";
+            for (const auto &e : data.tableau_data) {
+                out << e << "\n";
+            }
+            out << "```\n";
+            out.change_indent(-4);
+        }
+    }
+}
+
+void print_bloch_vector(Acc &out, const char *name, const Gate &gate) {
+    if (!(gate.flags & GATE_IS_UNITARY) || (gate.flags & GATE_TARGETS_PAIRS)) {
+        return;
+    }
+
+    out << "- Bloch Rotation:\n";
+    out.change_indent(+4);
+    out << "```\n";
+    auto matrix = gate.unitary();
+    auto a = matrix[0][0];
+    auto b = matrix[0][1];
+    auto c = matrix[1][0];
+    auto d = matrix[1][1];
+    auto i = std::complex<float>{0, 1};
+    auto x = b + c;
+    auto y = b * i + c * -i;
+    auto z = a - d;
+    auto s = a + d;
+    s *= -i;
+    std::complex<double> p = 1;
+    if (s.imag() != 0) {
+        p = s;
+    }
+    if (x.imag() != 0) {
+        p = x;
+    }
+    if (y.imag() != 0) {
+        p = y;
+    }
+    if (z.imag() != 0) {
+        p = z;
+    }
+    p /= sqrt(p.imag() * p.imag() + p.real() * p.real());
+    p *= 2;
+    x /= p;
+    y /= p;
+    z /= p;
+    s /= p;
+    assert(x.imag() == 0);
+    assert(y.imag() == 0);
+    assert(z.imag() == 0);
+    assert(s.imag() == 0);
+    auto rx = x.real();
+    auto ry = y.real();
+    auto rz = z.real();
+    auto rs = s.real();
+    auto angle = (int)round(acosf(rs) * 360 / M_PI);
+    if (angle > 180) {
+        angle -= 360;
+    }
+    out << "Axis: ";
+    if (rx != 0) {
+        out << "+-"[rx < 0] << 'X';
+    }
+    if (ry != 0) {
+        out << "+-"[rx < 0] << 'Y';
+    }
+    if (rz != 0) {
+        out << "+-"[rx < 0] << 'Z';
+    }
+    out << "\n";
+    out << "Angle: " << angle << " degrees\n";
+    out << "```\n";
+    out.change_indent(-4);
+}
+
+void print_unitary_matrix(Acc &out, const char *name, const Gate &gate) {
+    if (!(gate.flags & GATE_IS_UNITARY)) {
+        return;
+    }
+    auto matrix = gate.unitary();
+    out << "- Unitary Matrix:\n";
+    out.change_indent(+4);
+    bool all_halves = true;
+    bool all_sqrt_halves = true;
+    double s = sqrt(0.5);
+    for (const auto &row : matrix) {
+        for (const auto &cell : row) {
+            all_halves &= cell.real() == 0.5 || cell.real() == 0 || cell.real() == -0.5;
+            all_halves &= cell.imag() == 0.5 || cell.imag() == 0 || cell.imag() == -0.5;
+            all_sqrt_halves &= fabs(fabs(cell.real()) - s) < 0.001 || cell.real() == 0;
+            all_sqrt_halves &= fabs(fabs(cell.imag()) - s) < 0.001 || cell.imag() == 0;
+        }
+    }
+    out << "```\n";
+    float factor = all_halves ? 2 : all_sqrt_halves ?  1 / s : 1;
+    bool first_row = true;
+    for (const auto &row : matrix) {
+        if (first_row) {
+            first_row = false;
+        } else {
+            out << "\n";
+        }
+        out << "[";
+        bool first = true;
+        for (const auto &cell : row) {
+            if (first) {
+                first = false;
+            } else {
+                out << ", ";
+            }
+            print_fixed_width_float(out, cell.real() * factor, '1');
+            print_fixed_width_float(out, cell.imag() * factor, 'i');
+        }
+        out << "]";
+    }
+    if (all_halves) {
+        out << " / 2";
+    }
+    if (all_sqrt_halves) {
+        out << " / sqrt(2)";
+    }
+    out << "\n```\n";
+    out.change_indent(-4);
+}
+
+std::string generate_per_gate_help_markdown(const Gate &alt_gate, int indent, bool anchor) {
+    Acc out;
+    out.indent = indent;
+    const Gate &gate = GATE_DATA.at(alt_gate.name);
+    if (anchor) {
+        out << "<a name=\"" << alt_gate.name << "\"></a>";
+    }
+    out << "**`" << alt_gate.name << "`**\n";
+    for (const auto &other : GATE_DATA.gates()) {
+        if (other.id == alt_gate.id && other.name != alt_gate.name) {
+            out << "\nAlternate name: ";
+            if (anchor) {
+                out << "<a name=\"" << other.name << "\"></a>";
+            }
+            out << "`" << other.name << "`\n";
+        }
+    }
+    auto data = gate.extra_data_func();
+    out << data.description;
+    if (gate.flags & GATE_PRODUCES_RESULTS) {
+        out << "Prefixing a target with ! inverts its recorded measurement result.\n";
+    }
+
+    if (std::string(data.description).find("xample:\n") == std::string::npos) {
+        print_example(out, alt_gate.name, gate);
+    }
+    print_stabilizer_generators(out, alt_gate.name, gate);
+    print_bloch_vector(out, alt_gate.name, gate);
+    print_unitary_matrix(out, alt_gate.name, gate);
+    out.flush();
+    return out.settled;
+}
+
+std::map<std::string, std::string> stim_internal::generate_gate_help_markdown() {
+    std::map<std::string, std::string> result;
+    for (const auto &g : GATE_DATA.gates()) {
+        result[g.name] = generate_per_gate_help_markdown(g, 0, false);
+    }
+
+    std::map<std::string, std::vector<std::string>> categories;
+    std::set<std::string> gate_names;
+    for (const auto &g : GATE_DATA.gates()) {
+        if (g.name == GATE_DATA.at(g.name).name) {
+            categories[std::string(g.extra_data_func().category)].push_back(g.name);
+        }
+        gate_names.insert(g.name);
+    }
+
+    std::stringstream all;
+    all << "Gates supported by Stim\n";
+    all << "=======================\n";
+    for (const auto &name : gate_names) {
+        all << name << "\n";
+    }
+    result[std::string("gates")] = all.str();
+
+    all.str("");
+    all << "## Index\n\n";
+    for (const auto &name : gate_names) {
+        all << "- [" << name << "](#" << name << ")\n";
+    }
+    all << "\n";
+    for (auto &category : categories) {
+        all << "## " << category.first.substr(2) << "\n\n";
+        std::sort(category.second.begin(), category.second.end());
+        for (const auto &name : category.second) {
+            all << "- " << generate_per_gate_help_markdown(GATE_DATA.at(name), 4, true) << "\n";
+        }
+    }
+    result[std::string("gates_markdown")] = all.str();
+
+    return result;
+}

--- a/src/gate_help.cc
+++ b/src/gate_help.cc
@@ -17,7 +17,6 @@
 
 #include <algorithm>
 #include <iostream>
-#include <cmath>
 #include <cstring>
 #include <map>
 #include <set>
@@ -112,7 +111,7 @@ void print_example(Acc &out, const char *name, const Gate &gate) {
     out.change_indent(-4);
 }
 
-void print_stabilizer_generators(Acc &out, const char *name, const Gate &gate) {
+void print_stabilizer_generators(Acc &out, const Gate &gate) {
     if (gate.flags & GATE_IS_UNITARY) {
         out << "- Stabilizer Generators:\n";
         out.change_indent(+4);
@@ -144,7 +143,7 @@ void print_stabilizer_generators(Acc &out, const char *name, const Gate &gate) {
     }
 }
 
-void print_bloch_vector(Acc &out, const char *name, const Gate &gate) {
+void print_bloch_vector(Acc &out, const Gate &gate) {
     if (!(gate.flags & GATE_IS_UNITARY) || (gate.flags & GATE_TARGETS_PAIRS)) {
         return;
     }
@@ -190,7 +189,7 @@ void print_bloch_vector(Acc &out, const char *name, const Gate &gate) {
     auto ry = y.real();
     auto rz = z.real();
     auto rs = s.real();
-    auto angle = (int)round(acosf(rs) * 360 / M_PI);
+    auto angle = (int)round(acosf(rs) * 360 / 3.14159265359);
     if (angle > 180) {
         angle -= 360;
     }
@@ -210,7 +209,7 @@ void print_bloch_vector(Acc &out, const char *name, const Gate &gate) {
     out.change_indent(-4);
 }
 
-void print_unitary_matrix(Acc &out, const char *name, const Gate &gate) {
+void print_unitary_matrix(Acc &out, const Gate &gate) {
     if (!(gate.flags & GATE_IS_UNITARY)) {
         return;
     }
@@ -229,7 +228,7 @@ void print_unitary_matrix(Acc &out, const char *name, const Gate &gate) {
         }
     }
     out << "```\n";
-    float factor = all_halves ? 2 : all_sqrt_halves ?  1 / s : 1;
+    double factor = all_halves ? 2 : all_sqrt_halves ?  1 / s : 1;
     bool first_row = true;
     for (const auto &row : matrix) {
         if (first_row) {
@@ -286,9 +285,9 @@ std::string generate_per_gate_help_markdown(const Gate &alt_gate, int indent, bo
     if (std::string(data.description).find("xample:\n") == std::string::npos) {
         print_example(out, alt_gate.name, gate);
     }
-    print_stabilizer_generators(out, alt_gate.name, gate);
-    print_bloch_vector(out, alt_gate.name, gate);
-    print_unitary_matrix(out, alt_gate.name, gate);
+    print_stabilizer_generators(out, gate);
+    print_bloch_vector(out, gate);
+    print_unitary_matrix(out, gate);
     out.flush();
     return out.settled;
 }

--- a/src/gate_help.h
+++ b/src/gate_help.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GATE_HELP_H
+#define GATE_HELP_H
+
+#include "circuit/gate_data.h"
+
+#include <map>
+#include <string>
+
+namespace stim_internal {
+
+std::map<std::string, std::string> generate_gate_help_markdown();
+
+}
+
+#endif

--- a/src/main_helper.cc
+++ b/src/main_helper.cc
@@ -16,6 +16,7 @@
 
 #include "arg_parse.h"
 #include "gen/circuit_gen_main.h"
+#include "gate_help.h"
 #include "probability_util.h"
 #include "simulators/detection_simulator.h"
 #include "simulators/error_fuser.h"
@@ -56,9 +57,23 @@ struct RaiiFiles {
 };
 
 int stim_internal::main_helper(int argc, const char **argv) {
-    if (find_argument("--help", argc, argv) != nullptr) {
+    const char *help = find_argument("--help", argc, argv);
+    if (help != nullptr) {
+        auto m = generate_gate_help_markdown();
+        auto p = m.find(std::string(help));
+        if (p != m.end()) {
+            std::cerr << p->second;
+            return EXIT_SUCCESS;
+        } else if (help[0] != '\0') {
+            std::cerr << "Unrecognized help topic '" << help << "'.\n";
+            return EXIT_FAILURE;
+        }
         std::cerr << R"HELP(BASIC USAGE
 ===========
+Gate reference:
+    stim --help gates
+    stim --help [gate_name]
+
 Interactive measurement sampling mode:
     stim --repl
 

--- a/src/simulators/error_fuser.h
+++ b/src/simulators/error_fuser.h
@@ -172,7 +172,12 @@ struct ErrorFuser {
                 if (is_encoded_detector_id(id)) {
                     auto r = involved_detectors.find(id);
                     if (r == involved_detectors.end()) {
-                        involved_detectors.push_back(id);
+                        try {
+                            involved_detectors.push_back(id);
+                        } catch (const std::out_of_range &ex) {
+                            throw std::out_of_range(
+                                "An error involves too many detectors (>15) to find reducible errors.");
+                        }
                     }
                     detector_masks[1 << k] ^= 1 << (r - involved_detectors.begin());
                 }

--- a/src/simulators/error_fuser.h
+++ b/src/simulators/error_fuser.h
@@ -164,7 +164,7 @@ struct ErrorFuser {
     template <size_t s>
     void add_error_combinations(double p, std::array<ConstPointerRange<uint64_t>, s> basis_errors) {
         // Determine involved detectors while creating basis masks and storing added data.
-        FixedCapVector<uint64_t, 8> involved_detectors{};
+        FixedCapVector<uint64_t, 16> involved_detectors{};
         std::array<uint64_t, 1 << s> detector_masks{};
         std::array<ConstPointerRange<uint64_t>, 1 << s> stored_ids;
         for (size_t k = 0; k < s; k++) {

--- a/src/simulators/error_fuser.test.cc
+++ b/src/simulators/error_fuser.test.cc
@@ -869,3 +869,38 @@ error\(0.00026\d+\) D8
 reducible_error\(0.00026\d+\) D8 \^ D5
 )graph"));
 }
+
+TEST(ErrorFuser, reduce_error_detector_dependence_error_message) {
+    ASSERT_THROW({
+        try {
+            convert(
+                R"CIRCUIT(
+                    R 0
+                    DEPOLARIZE1(0.01) 0
+                    M 0
+                    DETECTOR rec[-1]
+                    DETECTOR rec[-1]
+                    DETECTOR rec[-1]
+                    DETECTOR rec[-1]
+                    DETECTOR rec[-1]
+                    DETECTOR rec[-1]
+                    DETECTOR rec[-1]
+                    DETECTOR rec[-1]
+                    DETECTOR rec[-1]
+                    DETECTOR rec[-1]
+                    DETECTOR rec[-1]
+                    DETECTOR rec[-1]
+                    DETECTOR rec[-1]
+                    DETECTOR rec[-1]
+                    DETECTOR rec[-1]
+                    DETECTOR rec[-1]
+                    DETECTOR rec[-1]
+                    DETECTOR rec[-1]
+                )CIRCUIT",
+                true, false);
+        } catch (const std::out_of_range &e) {
+            EXPECT_EQ("", check_matches(e.what(), ".*error involves too many detectors.*"));
+            throw;
+        }
+    }, std::out_of_range);
+}


### PR DESCRIPTION
- `--help` can now be given `gates` (lists all gates) or a gate name (describes the gate)
- Added code to autogenerate the supported gates content in the README, using the --help output
- Fix circuit parsing inverted targets for gates that don't support them
- Modify Gate to have an ExtraGateData function for doc and test data
- Remove TruncatedArray (use FixedCapVector instead)
- Increase max error components to 16 in add_error_combinations (so error analysis on generated color code succeeds)
- Better error message for too-complex errors