### PR TITLE
Add support for gauge detectors to `--analyze_errors` mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ echo "
   M 0 1
   DETECTOR rec[-1] rec[-3]
   DETECTOR rec[-2] rec[-4]
-" | ./stim --detector_hypergraph
+" | ./stim --analyze_errors
 ```
 
 ```
@@ -218,7 +218,7 @@ error(0.003344519141621982161) D1
         built up using `OBSERVABLE_INCLUDE` instructions.
         Put these observables' values into the detection event output as if they were additional detectors at the end of the circuit.
 
-- **`--detector_hypergraph`**:
+- **`--analyze_errors`**:
     **Detector error model creation mode**.
     Determines the detectors and logical observables flipped by error channels in the input circuit.
     Outputs lines like `error(p) D2 D3 L5`, which means that there is an independent error
@@ -291,6 +291,26 @@ error(0.003344519141621982161) D1
     
         This mode currently requires that every case of a compound error channel can be reduced to
         single-detector components accompanied by at most two double-detector components.    
+
+    - **`--allow_gauge_detectors`**:
+        Normally, when a detector anti-commutes with a stabilizer of the circuit (forcing the detector
+        to have random results instead of deterministic results), error analysis throws an exception.
+
+        Specifying `--allow_gauge_detectors` instead allows this behavior and reports it as an `error(0.5)`.
+
+        For example, in the following circuit, the two detectors are gauge detector:
+
+        ```
+        R 0
+        H 0
+        CNOT 0 1
+        M 0 1
+        DETECTOR rec[-1]
+        DETECTOR rec[-2]
+        ```
+
+        Without `--allow_gauge_detectors`, stim will raise an exception when analyzing this circuit.
+        With `--allow_gauge_detectors`, stim will report `error(0.5) D1 D2`.
 
 - **`--gen=surface_code|repetition_code|color_code`**:
     **Circuit generation mode**.

--- a/src/arg_parse.cc
+++ b/src/arg_parse.cc
@@ -232,27 +232,25 @@ float stim_internal::find_float_argument(
     return f;
 }
 
-int stim_internal::find_enum_argument(
-    const char *name, int default_index, const std::vector<const char *> &known_values, int argc, const char **argv) {
-    const char *text = find_argument(name, argc, argv);
-    if (text == nullptr) {
-        if (default_index >= 0) {
-            return default_index;
-        }
-        fprintf(stderr, "\033[31mMust specify a value for enum flag '%s'.\n", name);
-    } else {
-        for (size_t i = 0; i < known_values.size(); i++) {
-            if (!strcmp(text, known_values[i])) {
-                return i;
-            }
-        }
-        fprintf(stderr, "\033[31mUnrecognized value '%s' for enum flag '%s'.\n", text, name);
+FILE *stim_internal::find_open_file_argument(
+    const char *name, FILE *default_file, const char *mode, int argc, const char **argv) {
+  const char *path = find_argument(name, argc, argv);
+  if (path == nullptr) {
+    if (default_file == nullptr) {
+      std::cerr << "\033[31mMissing command line argument: '" << name << "'\033[0m\n";
+      exit(EXIT_FAILURE);
     }
-
-    fprintf(stderr, "Recognized values are:\n");
-    for (size_t i = 0; i < known_values.size(); i++) {
-        fprintf(stderr, "    '%s'%s\n", known_values[i], i == (size_t)default_index ? " (default)" : "");
-    }
-    fprintf(stderr, "\033[0m");
+    return default_file;
+  }
+  if (*path == '\0') {
+    std::cerr << "\033[31mCommand line argument '" << name
+              << "' can't be empty. It's supposed to be a file path.\033[0m\n";
     exit(EXIT_FAILURE);
+  }
+  FILE *file = fopen(path, mode);
+  if (file == nullptr) {
+    std::cerr << "\033[31mFailed to open '" << path << "'\033[0m\n";
+    exit(EXIT_FAILURE);
+  }
+  return file;
 }

--- a/src/circuit/gate_data.cc
+++ b/src/circuit/gate_data.cc
@@ -42,7 +42,7 @@ X-basis measurement.
 Projects each target qubit into `|+>` or `|->` and reports its value (false=`|+>`, true=`|->`).
 )MARKDOWN",
                     {},
-                    {"X -> mX"},
+                    {"X -> m", "X -> +X"},
                 };
             },
         },
@@ -60,7 +60,7 @@ Y-basis measurement.
 Projects each target qubit into `|i>` or `|-i>` and reports its value (false=`|i>`, true=`|-i>`).
 )MARKDOWN",
                     {},
-                    {"Y -> mY"},
+                    {"Y -> m", "Y -> +Y"},
                 };
             },
         },
@@ -78,7 +78,7 @@ Z-basis measurement.
 Projects each target qubit into `|0>` or `|1>` and reports its value (false=`|0>`, true=`|1>`).
 )MARKDOWN",
                     {},
-                    {"Z -> mZ"},
+                    {"Z -> m", "Z -> +Z"},
                 };
             },
         },

--- a/src/gate_help.cc
+++ b/src/gate_help.cc
@@ -313,7 +313,7 @@ std::map<std::string, std::string> stim_internal::generate_gate_help_markdown() 
     for (const auto &name : gate_names) {
         all << name << "\n";
     }
-    result[std::string("gates")] = all.str();
+    result[std::string("GATES")] = all.str();
 
     all.str("");
     all << "## Index\n\n";
@@ -328,7 +328,7 @@ std::map<std::string, std::string> stim_internal::generate_gate_help_markdown() 
             all << "- " << generate_per_gate_help_markdown(GATE_DATA.at(name), 4, true) << "\n";
         }
     }
-    result[std::string("gates_markdown")] = all.str();
+    result[std::string("GATES_MARKDOWN")] = all.str();
 
     return result;
 }

--- a/src/gen/circuit_gen_main.h
+++ b/src/gen/circuit_gen_main.h
@@ -7,7 +7,7 @@
 #include "../circuit/circuit.h"
 
 namespace stim_internal {
-    int main_generate_circuit(int argc, const char **argv, FILE *out);
+    int main_generate_circuit(int argc, const char **argv);
 }
 
 #endif

--- a/src/main_helper.cc
+++ b/src/main_helper.cc
@@ -25,36 +25,114 @@
 
 using namespace stim_internal;
 
-static std::vector<const char *> sample_mode_known_arguments{
-    "--sample", "--frame0", "--out_format", "--out", "--in",
-};
-static std::vector<const char *> detect_mode_known_arguments{
-    "--detect", "--prepend_observables", "--append_observables", "--out_format", "--out", "--in",
-};
-static std::vector<const char *> detector_hypergraph_mode_known_arguments{
-    "--detector_hypergraph",
-    "--find_reducible_errors",
-    "--fold_loops",
-    "--out",
-    "--in",
-};
-static std::vector<const char *> repl_mode_known_arguments{
-    "--repl",
-};
-static std::vector<const char *> format_names{"01", "b8", "ptb64", "hits", "r8", "dets"};
-static std::vector<SampleFormat> format_values{
-    SAMPLE_FORMAT_01, SAMPLE_FORMAT_B8, SAMPLE_FORMAT_PTB64, SAMPLE_FORMAT_HITS, SAMPLE_FORMAT_R8, SAMPLE_FORMAT_DETS,
+static std::map<std::string, SampleFormat> format_name_to_enum_map{
+    {"01", SAMPLE_FORMAT_01},
+    {"b8", SAMPLE_FORMAT_B8},
+    {"ptb64", SAMPLE_FORMAT_PTB64},
+    {"hits", SAMPLE_FORMAT_HITS},
+    {"r8", SAMPLE_FORMAT_R8},
+    {"dets", SAMPLE_FORMAT_DETS},
 };
 
-struct RaiiFiles {
-    std::vector<FILE *> files;
-    ~RaiiFiles() {
-        for (auto *f : files) {
-            fclose(f);
-        }
-        files.clear();
+int main_mode_detect(int argc, const char **argv) {
+    check_for_unknown_arguments(
+        {"--detect", "--prepend_observables", "--append_observables", "--out_format", "--out", "--in"},
+        "--detect",
+        argc,
+        argv);
+    SampleFormat out_format = find_enum_argument("--out_format", "01", format_name_to_enum_map, argc, argv);
+    bool prepend_observables = find_bool_argument("--prepend_observables", argc, argv);
+    bool append_observables = find_bool_argument("--append_observables", argc, argv);
+    uint64_t num_shots = (uint64_t)find_int64_argument("--detect", 1, 0, INT64_MAX, argc, argv);
+    if (num_shots == 0) {
+        return EXIT_SUCCESS;
     }
-};
+    if (out_format == SAMPLE_FORMAT_DETS && !append_observables) {
+        prepend_observables = true;
+    }
+
+    FILE *in = find_open_file_argument("--in", stdin, "r", argc, argv);
+    FILE *out = find_open_file_argument("--out", stdout, "w", argc, argv);
+    auto circuit = Circuit::from_file(in);
+    if (in != stdin) {
+        fclose(in);
+    }
+    auto rng = externally_seeded_rng();
+    detector_samples_out(circuit, num_shots, prepend_observables, append_observables, out, out_format, rng);
+    if (out != stdout) {
+        fclose(out);
+    }
+    return EXIT_SUCCESS;
+}
+
+int main_mode_sample(int argc, const char **argv) {
+    check_for_unknown_arguments(
+        {"--sample", "--frame0", "--out_format", "--out", "--in"},
+        "--sample",
+        argc,
+        argv);
+    SampleFormat out_format = find_enum_argument("--out_format", "01", format_name_to_enum_map, argc, argv);
+    bool frame0 = find_bool_argument("--frame0", argc, argv);
+    uint64_t num_shots = (uint64_t)find_int64_argument("--sample", 1, 0, INT64_MAX, argc, argv);
+    FILE *in = find_open_file_argument("--in", stdin, "r", argc, argv);
+    FILE *out = find_open_file_argument("--out", stdout, "w", argc, argv);
+    auto rng = externally_seeded_rng();
+
+    if (num_shots == 1 && !frame0) {
+        TableauSimulator::sample_stream(in, out, out_format, false, rng);
+    } else if (num_shots > 0) {
+        auto circuit = Circuit::from_file(in);
+        simd_bits ref(0);
+        if (!frame0) {
+            ref = TableauSimulator::reference_sample_circuit(circuit);
+        }
+        FrameSimulator::sample_out(circuit, ref, num_shots, out, out_format, rng);
+    }
+
+    if (in != stdin) {
+        fclose(in);
+    }
+    if (out != stdout) {
+        fclose(out);
+    }
+    return EXIT_SUCCESS;
+}
+
+int main_mode_analyze_errors(int argc, const char **argv) {
+    check_for_unknown_arguments(
+        {
+            "--analyze_errors",
+            "--allow_gauge_detectors",
+            "--detector_hypergraph",
+            "--find_reducible_errors",
+            "--fold_loops",
+            "--out",
+            "--in",
+        },
+        "--analyze_errors",
+        argc,
+        argv);
+    bool find_reducible_errors = find_bool_argument("--find_reducible_errors", argc, argv);
+    bool fold_loops = find_bool_argument("--fold_loops", argc, argv);
+    bool validate_detectors = !find_bool_argument("--allow_gauge_detectors", argc, argv);
+    FILE *in = find_open_file_argument("--in", stdin, "r", argc, argv);
+    FILE *out = find_open_file_argument("--out", stdout, "w", argc, argv);
+    ErrorFuser::convert_circuit_out(Circuit::from_file(in), out, find_reducible_errors, fold_loops, validate_detectors);
+    if (in != stdin) {
+        fclose(in);
+    }
+    if (out != stdout) {
+        fclose(out);
+    }
+    return EXIT_SUCCESS;
+}
+
+int main_mode_repl(int argc, const char **argv) {
+    check_for_unknown_arguments({"--repl"}, "--repl", argc, argv);
+    auto rng = externally_seeded_rng();
+    TableauSimulator::sample_stream(stdin, stdout, SAMPLE_FORMAT_01, true, rng);
+    return EXIT_SUCCESS;
+}
 
 int stim_internal::main_helper(int argc, const char **argv) {
     const char *help = find_argument("--help", argc, argv);
@@ -95,7 +173,7 @@ Detection event sampling mode:
          [--out=file]
 
 Error analysis mode:
-    stim --detector_hypergraph \
+    stim --analyze_errors \
          [--find_reducible_errors] \
          [--in=file] \
          [--out=file]
@@ -121,102 +199,42 @@ M 0 1 2
         return EXIT_SUCCESS;
     }
 
-    bool mode_interactive = find_bool_argument("--repl", argc, argv);
-    bool mode_sampling = find_argument("--sample", argc, argv) != nullptr;
-    bool mode_detecting = find_argument("--detect", argc, argv) != nullptr;
-    bool mode_detector_hypergraph = find_bool_argument("--detector_hypergraph", argc, argv);
+    bool mode_repl = find_bool_argument("--repl", argc, argv);
+    bool mode_sample = find_argument("--sample", argc, argv) != nullptr;
+    bool mode_detect = find_argument("--detect", argc, argv) != nullptr;
+    bool mode_analyze_errors = find_bool_argument("--analyze_errors", argc, argv);
     bool mode_gen = find_argument("--gen", argc, argv) != nullptr;
-    if (mode_interactive + mode_sampling + mode_detecting + mode_detector_hypergraph + mode_gen != 1) {
+    bool old_mode_detector_hypergraph = find_bool_argument("--detector_hypergraph", argc, argv);
+    if (old_mode_detector_hypergraph) {
+        std::cerr << "[DEPRECATION] Use `--analyze_errors` instead of `--detector_hypergraph`\n";
+        mode_analyze_errors = true;
+    }
+    if (mode_repl + mode_sample + mode_detect + mode_analyze_errors + mode_gen != 1) {
         std::cerr << "\033[31m"
                      "Need to pick a mode by giving exactly one of the following command line arguments:\n"
                      "    --repl: Interactive mode. Eagerly sample measurements in input circuit.\n"
                      "    --sample #: Measurement sampling mode. Bulk sample measurement results from input circuit.\n"
                      "    --detect #: Detector sampling mode. Bulk sample detection events from input circuit.\n"
-                     "    --detector_hypergraph: Error analysis mode. Convert circuit into a detector error model.\n"
+                     "    --analyze_errors: Error analysis mode. Convert circuit into a detector error model.\n"
                      "    --gen: Circuit generation mode. Produce common error correction circuits.\n"
                      "\033[0m";
         return EXIT_FAILURE;
     }
 
-    RaiiFiles raii_files;
-
-    FILE *out = stdout;
-    const char *out_path = find_argument("--out", argc, argv);
-    if (out_path != nullptr) {
-        out = fopen(out_path, "w");
-        if (out == nullptr) {
-            std::cerr << "\033[31mFailed to open '" << out_path << "' to write.\033[0m";
-            return EXIT_FAILURE;
-        }
-        raii_files.files.push_back(out);
-    }
-
-    FILE *in = stdin;
-    const char *in_path = find_argument("--in", argc, argv);
-    if (in_path != nullptr) {
-        in = fopen(in_path, "r");
-        if (in == nullptr) {
-            std::cerr << "\033[31mFailed to open '" << in_path << "' to read.\033[0m";
-            return EXIT_FAILURE;
-        }
-        raii_files.files.push_back(in);
-    }
-
-    std::mt19937_64 rng = externally_seeded_rng();
     if (mode_gen) {
-        return main_generate_circuit(argc, argv, out);
+        return main_generate_circuit(argc, argv);
     }
-    if (mode_interactive) {
-        check_for_unknown_arguments(repl_mode_known_arguments, "--repl", argc, argv);
-        TableauSimulator::sample_stream(in, out, SAMPLE_FORMAT_01, mode_interactive, rng);
-        return EXIT_SUCCESS;
+    if (mode_repl) {
+        return main_mode_repl(argc, argv);
     }
-    if (mode_sampling) {
-        check_for_unknown_arguments(sample_mode_known_arguments, "--sample", argc, argv);
-        SampleFormat out_format =
-            format_values[find_enum_argument("--out_format", SAMPLE_FORMAT_01, format_names, argc, argv)];
-        bool frame0 = find_bool_argument("--frame0", argc, argv);
-        uint64_t num_shots = (uint64_t)find_int64_argument("--sample", 1, 0, INT64_MAX, argc, argv);
-        if (num_shots == 0) {
-            return EXIT_SUCCESS;
-        }
-        if (num_shots == 1 && !frame0) {
-            TableauSimulator::sample_stream(in, out, out_format, false, rng);
-            return EXIT_SUCCESS;
-        }
-
-        auto circuit = Circuit::from_file(in);
-        simd_bits ref(0);
-        if (!frame0) {
-            ref = TableauSimulator::reference_sample_circuit(circuit);
-        }
-        FrameSimulator::sample_out(circuit, ref, num_shots, out, out_format, rng);
-        return EXIT_SUCCESS;
+    if (mode_sample) {
+        return main_mode_sample(argc, argv);
     }
-    if (mode_detecting) {
-        check_for_unknown_arguments(detect_mode_known_arguments, "--detect", argc, argv);
-        SampleFormat out_format =
-            format_values[find_enum_argument("--out_format", 0, format_names, argc, argv)];
-        bool prepend_observables = find_bool_argument("--prepend_observables", argc, argv);
-        bool append_observables = find_bool_argument("--append_observables", argc, argv);
-        uint64_t num_shots = (uint64_t)find_int64_argument("--detect", 1, 0, INT64_MAX, argc, argv);
-        if (num_shots == 0) {
-            return EXIT_SUCCESS;
-        }
-        if (out_format == SAMPLE_FORMAT_DETS && !append_observables) {
-            prepend_observables = true;
-        }
-
-        auto circuit = Circuit::from_file(in);
-        detector_samples_out(circuit, num_shots, prepend_observables, append_observables, out, out_format, rng);
-        return EXIT_SUCCESS;
+    if (mode_detect) {
+        return main_mode_detect(argc, argv);
     }
-    if (mode_detector_hypergraph) {
-        check_for_unknown_arguments(detector_hypergraph_mode_known_arguments, "--detector_hypergraph", argc, argv);
-        bool find_reducible_errors = find_bool_argument("--find_reducible_errors", argc, argv);
-        bool fold_loops = find_bool_argument("--fold_loops", argc, argv);
-        ErrorFuser::convert_circuit_out(Circuit::from_file(in), out, find_reducible_errors, fold_loops);
-        return EXIT_SUCCESS;
+    if (mode_analyze_errors) {
+        return main_mode_analyze_errors(argc, argv);
     }
 
     throw std::out_of_range("Mode not handled.");

--- a/src/main_helper.cc
+++ b/src/main_helper.cc
@@ -60,15 +60,19 @@ int stim_internal::main_helper(int argc, const char **argv) {
     const char *help = find_argument("--help", argc, argv);
     if (help != nullptr) {
         auto m = generate_gate_help_markdown();
-        auto p = m.find(std::string(help));
+        auto key = std::string(help);
+        for (auto &c : key) {
+            c = toupper(c);
+        }
+        auto p = m.find(key);
         if (p != m.end()) {
-            std::cerr << p->second;
+            std::cout << p->second;
             return EXIT_SUCCESS;
         } else if (help[0] != '\0') {
             std::cerr << "Unrecognized help topic '" << help << "'.\n";
             return EXIT_FAILURE;
         }
-        std::cerr << R"HELP(BASIC USAGE
+        std::cout << R"HELP(BASIC USAGE
 ===========
 Gate reference:
     stim --help gates

--- a/src/simulators/error_fuser.h
+++ b/src/simulators/error_fuser.h
@@ -71,6 +71,7 @@ struct ErrorFuser {
     bool find_reducible_errors = false;
     bool accumulate_errors = true;
     bool fold_loops = false;
+    bool validate_detectors = false;
     std::vector<FusedError> flushed;
 
     /// The final result. Independent probabilities of flipping various sets of detectors.
@@ -78,9 +79,9 @@ struct ErrorFuser {
     /// Backing datastore for values in error_class_probabilities.
     MonotonicBuffer<uint64_t> mono_buf;
 
-    ErrorFuser(size_t num_qubits, bool find_reducible_errors, bool fold_loops);
+    ErrorFuser(size_t num_qubits, bool find_reducible_errors, bool fold_loops, bool validate_detectors);
 
-    static void convert_circuit_out(const Circuit &circuit, FILE *out, bool find_reducible_errors, bool fold_loops);
+    static void convert_circuit_out(const Circuit &circuit, FILE *out, bool find_reducible_errors, bool fold_loops, bool validate_detectors);
 
     /// Moving is deadly due to the map containing pointers to the jagged data.
     ErrorFuser(const ErrorFuser &fuser) = delete;
@@ -126,6 +127,7 @@ struct ErrorFuser {
     void ISWAP(const OperationData &dat);
 
     void run_circuit(const Circuit &circuit);
+    void post_check_initialization();
 
    private:
     void shift_active_detector_ids(int64_t shift);

--- a/src/simulators/error_fuser.h
+++ b/src/simulators/error_fuser.h
@@ -294,8 +294,6 @@ struct ErrorFuser {
     }
 };
 
-void error_fuser_analyze_loop(const Circuit &behind, uint64_t ahead, ErrorFuser &f);
-
 }
 
 #endif

--- a/src/simulators/error_fuser.perf.cc
+++ b/src/simulators/error_fuser.perf.cc
@@ -26,7 +26,7 @@ BENCHMARK(ErrorFuser_surface_code_rotated_memory_z_d11_r100) {
     params.after_clifford_depolarization = 0.001;
     auto circuit = generate_surface_code_circuit(params).circuit;
     benchmark_go([&]() {
-        ErrorFuser fuser(circuit.count_qubits(), false, false);
+        ErrorFuser fuser(circuit.count_qubits(), false, false, false);
         fuser.run_circuit(circuit);
     }).goal_millis(320);
 }
@@ -38,7 +38,7 @@ BENCHMARK(ErrorFuser_surface_code_rotated_memory_z_d11_r100_find_reducible_error
     params.after_clifford_depolarization = 0.001;
     auto circuit = generate_surface_code_circuit(params).circuit;
     benchmark_go([&]() {
-        ErrorFuser fuser(circuit.count_qubits(), true, false);
+        ErrorFuser fuser(circuit.count_qubits(), true, false, false);
         fuser.run_circuit(circuit);
     }).goal_millis(450);
 }
@@ -50,7 +50,7 @@ BENCHMARK(ErrorFuser_surface_code_rotated_memory_z_d11_r100000000_find_loops) {
     params.after_clifford_depolarization = 0.001;
     auto circuit = generate_surface_code_circuit(params).circuit;
     benchmark_go([&]() {
-        ErrorFuser fuser(circuit.count_qubits(), false, true);
+        ErrorFuser fuser(circuit.count_qubits(), false, true, false);
         fuser.run_circuit(circuit);
     }).goal_millis(15);
 }

--- a/src/test_util.test.cc
+++ b/src/test_util.test.cc
@@ -28,3 +28,19 @@ std::mt19937_64 &SHARED_TEST_RNG() {
     }
     return shared_test_rng;
 }
+
+RaiiTempNamedFile::RaiiTempNamedFile() {
+    char tmp_stdin_filename[] = "/tmp/stim_test_named_file_XXXXXX";
+    descriptor = mkstemp(tmp_stdin_filename);
+    if (descriptor == -1) {
+        throw std::runtime_error("Failed to create temporary file.");
+    }
+    path = tmp_stdin_filename;
+}
+
+RaiiTempNamedFile::~RaiiTempNamedFile() {
+    if (!path.empty()) {
+        remove(path.data());
+        path = "";
+    }
+}

--- a/src/test_util.test.h
+++ b/src/test_util.test.h
@@ -20,3 +20,10 @@
 #include "stabilizers/pauli_string.h"
 
 std::mt19937_64 &SHARED_TEST_RNG();
+
+struct RaiiTempNamedFile {
+    int descriptor;
+    std::string path;
+    RaiiTempNamedFile();
+    ~RaiiTempNamedFile();
+};


### PR DESCRIPTION
- Add `--allow_gauge_detectors` option to `--analyze_errors` mode 
- Deprecate `--detector_hypergraph` for `--analyze_errors`
- Split main helper into several mode helper main methods
- Add `find_open_file_argument`
- Refactor `find_enum_argument` to use a `std::map`
- Adding testing util `RaiiTempNamedFile`
- Make ErrorFuser check for non-Z basis dependence at start of circuit when validating detectors
- Add `validate_detectors` field to ErrorFuser
- When `validate_detectors` is true, add 50% errors instead of raising exceptions for gauge detectors
- Inline a few flag constants
- Fix measurement help only listing 1 stabilizer generator instead of 2
- Fix `--help` going to std::cerr instead of std::cout
- Fix help commands being case sensitive