### PR TITLE
Add several query methods to Tableau

### DIFF
--- a/glue/javascript/pauli_string.js.cc
+++ b/glue/javascript/pauli_string.js.cc
@@ -58,7 +58,7 @@ uint8_t ExposedPauliString::pauli(size_t index) const {
     }
     uint8_t x = pauli_string.xs[index];
     uint8_t z = pauli_string.zs[index];
-    return (x ^ z) + z * 2;
+    return pauli_xz_to_xyz(x, z);
 }
 
 size_t ExposedPauliString::getLength() const {

--- a/src/stabilizers/pauli_string.h
+++ b/src/stabilizers/pauli_string.h
@@ -25,6 +25,10 @@
 
 namespace stim_internal {
 
+inline uint8_t pauli_xz_to_xyz(bool x, bool z) {
+    return (uint8_t)(x ^ z) | ((uint8_t)z << 1);
+}
+
 /// A Pauli string is a product of Pauli operations (I, X, Y, Z) to apply to various qubits.
 ///
 /// In most cases, methods will take a PauliStringRef instead of a PauliString. This is because PauliStringRef can

--- a/src/stabilizers/pauli_string.pybind.h
+++ b/src/stabilizers/pauli_string.pybind.h
@@ -36,11 +36,13 @@ struct PyPauliString {
     PyPauliString operator*(size_t power) const;
     PyPauliString operator*(std::complex<float> scale) const;
     PyPauliString operator*(const PyPauliString &rhs) const;
+    PyPauliString operator/(const std::complex<float> &divisor) const;
 
     PyPauliString &operator*=(pybind11::object rhs);
     PyPauliString &operator*=(size_t power);
     PyPauliString &operator*=(std::complex<float> scale);
     PyPauliString &operator*=(const PyPauliString &rhs);
+    PyPauliString &operator/=(const std::complex<float> &divisor);
 
     bool operator==(const PyPauliString &other) const;
     bool operator!=(const PyPauliString &other) const;

--- a/src/stabilizers/pauli_string.test.cc
+++ b/src/stabilizers/pauli_string.test.cc
@@ -310,3 +310,10 @@ TEST(PauliString, ensure_num_qubits) {
     p2.zs[3] = true;
     ASSERT_EQ(p, p2);
 }
+
+TEST(PauliString, pauli_xz_to_xyz) {
+    ASSERT_EQ(pauli_xz_to_xyz(false, false), 0);
+    ASSERT_EQ(pauli_xz_to_xyz(true, false), 1);
+    ASSERT_EQ(pauli_xz_to_xyz(true, true), 2);
+    ASSERT_EQ(pauli_xz_to_xyz(false, true), 3);
+}

--- a/src/stabilizers/pauli_string_pybind_test.py
+++ b/src/stabilizers/pauli_string_pybind_test.py
@@ -359,6 +359,27 @@ def test_mul_different_sizes():
     assert alias is p
 
 
+def test_div():
+    assert stim.PauliString("+XYZ") / +1 == stim.PauliString("+XYZ")
+    assert stim.PauliString("+XYZ") / -1 == stim.PauliString("-XYZ")
+    assert stim.PauliString("+XYZ") / 1j == stim.PauliString("-iXYZ")
+    assert stim.PauliString("+XYZ") / -1j == stim.PauliString("iXYZ")
+    assert stim.PauliString("iXYZ") / 1j == stim.PauliString("XYZ")
+    p = stim.PauliString("__")
+    alias = p
+    assert alias == stim.PauliString("__")
+    p /= -1
+    assert alias == stim.PauliString("-__")
+    p /= 1j
+    assert alias == stim.PauliString("i__")
+    p /= 1j
+    assert alias == stim.PauliString("__")
+    p /= -1j
+    assert alias == stim.PauliString("i__")
+    p /= 1
+    assert alias == stim.PauliString("i__")
+
+
 def test_mul_repeat():
     ps = stim.PauliString
     assert ps("") * 100 == ps("")

--- a/src/stabilizers/tableau.h
+++ b/src/stabilizers/tableau.h
@@ -63,7 +63,10 @@ struct Tableau {
     /// Creates a Tableau representing a randomly sampled Clifford operation from a uniform distribution.
     static Tableau random(size_t num_qubits, std::mt19937_64 &rng);
     /// Returns the inverse Tableau.
-    Tableau inverse() const;
+    ///
+    /// Args:
+    ///     skip_signs: Instead of computing the signs, just set them all to positive.
+    Tableau inverse(bool skip_signs = false) const;
     /// Returns the Tableau raised to an integer power (using repeated squaring).
     Tableau raised_to(int64_t exponent) const;
 
@@ -166,6 +169,16 @@ struct Tableau {
     void prepend_YCY(size_t control, size_t target);
     void prepend_YCZ(size_t control, size_t target);
     void prepend(const PauliStringRef &op);
+
+    uint8_t x_output_pauli_xyz(size_t input_index, size_t output_index) const;
+    uint8_t y_output_pauli_xyz(size_t input_index, size_t output_index) const;
+    uint8_t z_output_pauli_xyz(size_t input_index, size_t output_index) const;
+    uint8_t inverse_x_output_pauli_xyz(size_t input_index, size_t output_index) const;
+    uint8_t inverse_y_output_pauli_xyz(size_t input_index, size_t output_index) const;
+    uint8_t inverse_z_output_pauli_xyz(size_t input_index, size_t output_index) const;
+    PauliString inverse_x_output(size_t input_index, bool skip_sign = false) const;
+    PauliString inverse_y_output(size_t input_index, bool skip_sign = false) const;
+    PauliString inverse_z_output(size_t input_index, bool skip_sign = false) const;
 };
 
 }

--- a/src/stabilizers/tableau.test.cc
+++ b/src/stabilizers/tableau.test.cc
@@ -161,6 +161,14 @@ TEST(tableau, str) {
         "| _X __ XZ __\n"
         "| __ _X __ XZ");
     ASSERT_EQ(
+        t.inverse(true).str(),
+        "+-xz-xz-xz-xz-\n"
+        "| ++ ++ ++ ++\n"
+        "| Z_ ZY _Z _Z\n"
+        "| ZX _X _Z __\n"
+        "| _X __ XZ __\n"
+        "| __ _X __ XZ");
+    ASSERT_EQ(
         t.str(),
         "+-xz-xz-xz-xz-\n"
         "| -+ ++ ++ ++\n"
@@ -783,4 +791,103 @@ TEST(tableau, direct_sum) {
     for (size_t k = 0; k < 270; k++) {
         ASSERT_EQ(p3[260 + k], p2[k]);
     }
+}
+
+TEST(tableau, pauli_acces_methods) {
+    auto t = Tableau::random(3, SHARED_TEST_RNG());
+    auto t_inv = t.inverse();
+    for (size_t i = 0; i < 3; i++) {
+        auto x = t.xs[i];
+        auto y = t.eval_y_obs(i);
+        auto z = t.zs[i];
+        for (size_t j = 0; j < 3; j++) {
+            ASSERT_EQ(t.x_output_pauli_xyz(i, j), pauli_xz_to_xyz(x.xs[j], x.zs[j]));
+            ASSERT_EQ(t.y_output_pauli_xyz(i, j), pauli_xz_to_xyz(y.xs[j], y.zs[j]));
+            ASSERT_EQ(t.z_output_pauli_xyz(i, j), pauli_xz_to_xyz(z.xs[j], z.zs[j]));
+            ASSERT_EQ(t_inv.inverse_x_output_pauli_xyz(i, j), pauli_xz_to_xyz(x.xs[j], x.zs[j]));
+            ASSERT_EQ(t_inv.inverse_y_output_pauli_xyz(i, j), pauli_xz_to_xyz(y.xs[j], y.zs[j]));
+            ASSERT_EQ(t_inv.inverse_z_output_pauli_xyz(i, j), pauli_xz_to_xyz(z.xs[j], z.zs[j]));
+        }
+    }
+
+    t = Tableau(3);
+    t.xs[0] = PauliString::from_str("+XXX");
+    t.xs[1] = PauliString::from_str("-XZY");
+    t.xs[2] = PauliString::from_str("+Z_Z");
+    t.zs[0] = PauliString::from_str("-_XZ");
+    t.zs[1] = PauliString::from_str("-_X_");
+    t.zs[2] = PauliString::from_str("-X__");
+
+    ASSERT_EQ(t.x_output_pauli_xyz(0, 0), 1);
+    ASSERT_EQ(t.x_output_pauli_xyz(0, 1), 1);
+    ASSERT_EQ(t.x_output_pauli_xyz(0, 2), 1);
+    ASSERT_EQ(t.x_output_pauli_xyz(1, 0), 1);
+    ASSERT_EQ(t.x_output_pauli_xyz(1, 1), 3);
+    ASSERT_EQ(t.x_output_pauli_xyz(1, 2), 2);
+    ASSERT_EQ(t.x_output_pauli_xyz(2, 0), 3);
+    ASSERT_EQ(t.x_output_pauli_xyz(2, 1), 0);
+    ASSERT_EQ(t.x_output_pauli_xyz(2, 2), 3);
+
+    ASSERT_EQ(t.z_output_pauli_xyz(0, 0), 0);
+    ASSERT_EQ(t.z_output_pauli_xyz(0, 1), 1);
+    ASSERT_EQ(t.z_output_pauli_xyz(0, 2), 3);
+    ASSERT_EQ(t.z_output_pauli_xyz(1, 0), 0);
+    ASSERT_EQ(t.z_output_pauli_xyz(1, 1), 1);
+    ASSERT_EQ(t.z_output_pauli_xyz(1, 2), 0);
+    ASSERT_EQ(t.z_output_pauli_xyz(2, 0), 1);
+    ASSERT_EQ(t.z_output_pauli_xyz(2, 1), 0);
+    ASSERT_EQ(t.z_output_pauli_xyz(2, 2), 0);
+
+    t = t.inverse();
+    ASSERT_EQ(t.inverse_x_output_pauli_xyz(0, 0), 1);
+    ASSERT_EQ(t.inverse_x_output_pauli_xyz(0, 1), 1);
+    ASSERT_EQ(t.inverse_x_output_pauli_xyz(0, 2), 1);
+    ASSERT_EQ(t.inverse_x_output_pauli_xyz(1, 0), 1);
+    ASSERT_EQ(t.inverse_x_output_pauli_xyz(1, 1), 3);
+    ASSERT_EQ(t.inverse_x_output_pauli_xyz(1, 2), 2);
+    ASSERT_EQ(t.inverse_x_output_pauli_xyz(2, 0), 3);
+    ASSERT_EQ(t.inverse_x_output_pauli_xyz(2, 1), 0);
+    ASSERT_EQ(t.inverse_x_output_pauli_xyz(2, 2), 3);
+
+    ASSERT_EQ(t.inverse_z_output_pauli_xyz(0, 0), 0);
+    ASSERT_EQ(t.inverse_z_output_pauli_xyz(0, 1), 1);
+    ASSERT_EQ(t.inverse_z_output_pauli_xyz(0, 2), 3);
+    ASSERT_EQ(t.inverse_z_output_pauli_xyz(1, 0), 0);
+    ASSERT_EQ(t.inverse_z_output_pauli_xyz(1, 1), 1);
+    ASSERT_EQ(t.inverse_z_output_pauli_xyz(1, 2), 0);
+    ASSERT_EQ(t.inverse_z_output_pauli_xyz(2, 0), 1);
+    ASSERT_EQ(t.inverse_z_output_pauli_xyz(2, 1), 0);
+    ASSERT_EQ(t.inverse_z_output_pauli_xyz(2, 2), 0);
+}
+
+TEST(tableau, inverse_pauli_string_acces_methods) {
+    auto t = Tableau::random(5, SHARED_TEST_RNG());
+    auto t_inv = t.inverse();
+    auto y0 = t_inv.eval_y_obs(0);
+    auto y1 = t_inv.eval_y_obs(1);
+    auto y2 = t_inv.eval_y_obs(2);
+    ASSERT_EQ(t.inverse_x_output(0), t_inv.xs[0]);
+    ASSERT_EQ(t.inverse_x_output(1), t_inv.xs[1]);
+    ASSERT_EQ(t.inverse_x_output(2), t_inv.xs[2]);
+    ASSERT_EQ(t.inverse_y_output(0), y0);
+    ASSERT_EQ(t.inverse_y_output(1), y1);
+    ASSERT_EQ(t.inverse_y_output(2), y2);
+    ASSERT_EQ(t.inverse_z_output(0), t_inv.zs[0]);
+    ASSERT_EQ(t.inverse_z_output(1), t_inv.zs[1]);
+    ASSERT_EQ(t.inverse_z_output(2), t_inv.zs[2]);
+
+    t_inv.xs.signs.clear();
+    t_inv.zs.signs.clear();
+    y0.sign = false;
+    y1.sign = false;
+    y2.sign = false;
+    ASSERT_EQ(t.inverse_x_output(0, true), t_inv.xs[0]);
+    ASSERT_EQ(t.inverse_x_output(1, true), t_inv.xs[1]);
+    ASSERT_EQ(t.inverse_x_output(2, true), t_inv.xs[2]);
+    ASSERT_EQ(t.inverse_y_output(0, true), y0);
+    ASSERT_EQ(t.inverse_y_output(1, true), y1);
+    ASSERT_EQ(t.inverse_y_output(2, true), y2);
+    ASSERT_EQ(t.inverse_z_output(0, true), t_inv.zs[0]);
+    ASSERT_EQ(t.inverse_z_output(1, true), t_inv.zs[1]);
+    ASSERT_EQ(t.inverse_z_output(2, true), t_inv.zs[2]);
 }

--- a/src/stabilizers/tableau_pybind_test.py
+++ b/src/stabilizers/tableau_pybind_test.py
@@ -451,3 +451,226 @@ def test_add():
 | XZ __
 | __ XZ
     """.strip()
+
+
+def test_xyz_output_pauli():
+    t = stim.Tableau.from_conjugated_generators(
+        xs=[
+            stim.PauliString("-__Z"),
+            stim.PauliString("+XZ_"),
+            stim.PauliString("+_ZZ"),
+        ],
+        zs=[
+            stim.PauliString("-YYY"),
+            stim.PauliString("+Z_Z"),
+            stim.PauliString("-ZYZ"),
+        ],
+    )
+
+    assert t.x_output_pauli(0, 0) == 0
+    assert t.x_output_pauli(0, 1) == 0
+    assert t.x_output_pauli(0, 2) == 3
+    assert t.x_output_pauli(1, 0) == 1
+    assert t.x_output_pauli(1, 1) == 3
+    assert t.x_output_pauli(1, 2) == 0
+    assert t.x_output_pauli(2, 0) == 0
+    assert t.x_output_pauli(2, 1) == 3
+    assert t.x_output_pauli(2, 2) == 3
+
+    assert t.y_output_pauli(0, 0) == 2
+    assert t.y_output_pauli(0, 1) == 2
+    assert t.y_output_pauli(0, 2) == 1
+    assert t.y_output_pauli(1, 0) == 2
+    assert t.y_output_pauli(1, 1) == 3
+    assert t.y_output_pauli(1, 2) == 3
+    assert t.y_output_pauli(2, 0) == 3
+    assert t.y_output_pauli(2, 1) == 1
+    assert t.y_output_pauli(2, 2) == 0
+
+    assert t.z_output_pauli(0, 0) == 2
+    assert t.z_output_pauli(0, 1) == 2
+    assert t.z_output_pauli(0, 2) == 2
+    assert t.z_output_pauli(1, 0) == 3
+    assert t.z_output_pauli(1, 1) == 0
+    assert t.z_output_pauli(1, 2) == 3
+    assert t.z_output_pauli(2, 0) == 3
+    assert t.z_output_pauli(2, 1) == 2
+    assert t.z_output_pauli(2, 2) == 3
+
+    with pytest.raises(TypeError):
+        t.x_output_pauli(-1, 0)
+    with pytest.raises(ValueError):
+        t.x_output_pauli(3, 0)
+    with pytest.raises(TypeError):
+        t.x_output_pauli(0, -1)
+    with pytest.raises(ValueError):
+        t.x_output_pauli(0, 3)
+
+    with pytest.raises(TypeError):
+        t.y_output_pauli(-1, 0)
+    with pytest.raises(ValueError):
+        t.y_output_pauli(3, 0)
+    with pytest.raises(TypeError):
+        t.y_output_pauli(0, -1)
+    with pytest.raises(ValueError):
+        t.y_output_pauli(0, 3)
+
+    with pytest.raises(TypeError):
+        t.z_output_pauli(-1, 0)
+    with pytest.raises(ValueError):
+        t.z_output_pauli(3, 0)
+    with pytest.raises(TypeError):
+        t.z_output_pauli(0, -1)
+    with pytest.raises(ValueError):
+        t.z_output_pauli(0, 3)
+
+
+def test_inverse_xyz_output_pauli():
+    t = stim.Tableau.from_conjugated_generators(
+        xs=[
+            stim.PauliString("-__Z"),
+            stim.PauliString("+XZ_"),
+            stim.PauliString("+_ZZ"),
+        ],
+        zs=[
+            stim.PauliString("-YYY"),
+            stim.PauliString("+Z_Z"),
+            stim.PauliString("-ZYZ"),
+        ],
+    ).inverse()
+
+    assert t.inverse_x_output_pauli(0, 0) == 0
+    assert t.inverse_x_output_pauli(0, 1) == 0
+    assert t.inverse_x_output_pauli(0, 2) == 3
+    assert t.inverse_x_output_pauli(1, 0) == 1
+    assert t.inverse_x_output_pauli(1, 1) == 3
+    assert t.inverse_x_output_pauli(1, 2) == 0
+    assert t.inverse_x_output_pauli(2, 0) == 0
+    assert t.inverse_x_output_pauli(2, 1) == 3
+    assert t.inverse_x_output_pauli(2, 2) == 3
+
+    assert t.inverse_y_output_pauli(0, 0) == 2
+    assert t.inverse_y_output_pauli(0, 1) == 2
+    assert t.inverse_y_output_pauli(0, 2) == 1
+    assert t.inverse_y_output_pauli(1, 0) == 2
+    assert t.inverse_y_output_pauli(1, 1) == 3
+    assert t.inverse_y_output_pauli(1, 2) == 3
+    assert t.inverse_y_output_pauli(2, 0) == 3
+    assert t.inverse_y_output_pauli(2, 1) == 1
+    assert t.inverse_y_output_pauli(2, 2) == 0
+
+    assert t.inverse_z_output_pauli(0, 0) == 2
+    assert t.inverse_z_output_pauli(0, 1) == 2
+    assert t.inverse_z_output_pauli(0, 2) == 2
+    assert t.inverse_z_output_pauli(1, 0) == 3
+    assert t.inverse_z_output_pauli(1, 1) == 0
+    assert t.inverse_z_output_pauli(1, 2) == 3
+    assert t.inverse_z_output_pauli(2, 0) == 3
+    assert t.inverse_z_output_pauli(2, 1) == 2
+    assert t.inverse_z_output_pauli(2, 2) == 3
+
+    with pytest.raises(TypeError):
+        t.inverse_x_output_pauli(-1, 0)
+    with pytest.raises(ValueError):
+        t.inverse_x_output_pauli(3, 0)
+    with pytest.raises(TypeError):
+        t.inverse_x_output_pauli(0, -1)
+    with pytest.raises(ValueError):
+        t.inverse_x_output_pauli(0, 3)
+
+    with pytest.raises(TypeError):
+        t.inverse_y_output_pauli(-1, 0)
+    with pytest.raises(ValueError):
+        t.inverse_y_output_pauli(3, 0)
+    with pytest.raises(TypeError):
+        t.inverse_y_output_pauli(0, -1)
+    with pytest.raises(ValueError):
+        t.inverse_y_output_pauli(0, 3)
+
+    with pytest.raises(TypeError):
+        t.inverse_z_output_pauli(-1, 0)
+    with pytest.raises(ValueError):
+        t.inverse_z_output_pauli(3, 0)
+    with pytest.raises(TypeError):
+        t.inverse_z_output_pauli(0, -1)
+    with pytest.raises(ValueError):
+        t.inverse_z_output_pauli(0, 3)
+
+
+def test_inverse_xyz_output():
+    t = stim.Tableau.from_conjugated_generators(
+        xs=[
+            stim.PauliString("-__Z"),
+            stim.PauliString("+XZ_"),
+            stim.PauliString("+_ZZ"),
+        ],
+        zs=[
+            stim.PauliString("-YYY"),
+            stim.PauliString("+Z_Z"),
+            stim.PauliString("-ZYZ"),
+        ],
+    )
+    t_inv = t.inverse()
+
+    for k in range(3):
+        assert t_inv.inverse_x_output(k) == t.x_output(k)
+        assert t_inv.inverse_y_output(k) == t.y_output(k)
+        assert t_inv.inverse_z_output(k) == t.z_output(k)
+        assert t_inv.inverse_x_output(k, unsigned=True) == t.x_output(k) / t.x_output(k).sign
+        assert t_inv.inverse_y_output(k, unsigned=True) == t.y_output(k) / t.y_output(k).sign
+        assert t_inv.inverse_z_output(k, unsigned=True) == t.z_output(k) / t.z_output(k).sign
+
+    with pytest.raises(TypeError):
+        t.inverse_x_output(-1)
+    with pytest.raises(ValueError):
+        t.inverse_x_output(3)
+
+    with pytest.raises(TypeError):
+        t.inverse_y_output(-1)
+    with pytest.raises(ValueError):
+        t.inverse_y_output(3)
+
+    with pytest.raises(TypeError):
+        t.inverse_z_output(-1)
+    with pytest.raises(ValueError):
+        t.inverse_z_output(3)
+
+
+def test_inverse():
+    t = stim.Tableau.from_conjugated_generators(
+        xs=[
+            stim.PauliString("+XXX"),
+            stim.PauliString("-XZY"),
+            stim.PauliString("+Z_Z"),
+        ],
+        zs=[
+            stim.PauliString("-_XZ"),
+            stim.PauliString("-_X_"),
+            stim.PauliString("-X__"),
+        ],
+    )
+    assert t.inverse() == t.inverse(unsigned=False) == stim.Tableau.from_conjugated_generators(
+        xs=[
+            stim.PauliString("-__Z"),
+            stim.PauliString("-_Z_"),
+            stim.PauliString("+XZZ"),
+        ],
+        zs=[
+            stim.PauliString("+ZZX"),
+            stim.PauliString("+YX_"),
+            stim.PauliString("+ZZ_"),
+        ],
+    )
+
+    assert t.inverse(unsigned=True) == stim.Tableau.from_conjugated_generators(
+        xs=[
+            stim.PauliString("+__Z"),
+            stim.PauliString("+_Z_"),
+            stim.PauliString("+XZZ"),
+        ],
+        zs=[
+            stim.PauliString("+ZZX"),
+            stim.PauliString("+YX_"),
+            stim.PauliString("+ZZ_"),
+        ],
+    )


### PR DESCRIPTION
- Add `stim.Tableau.inverse(*, unsigned=False)`
- Add `stim.Tableau.{x,y,z}_output_pauli(input_index, output_index)`
- Add `stim.Tableau.inverse_{x,y,z}_output_pauli(input_index, output_index)`
- Add `stim.Tableau.inverse_{x,y,z}_output(input_index, *, unsigned=False)`
- Add `stim.PauliString.__{i,}truediv__`
- Add `stim_internal::pauli_xz_to_xyz` helper method

Fixes https://github.com/quantumlib/Stim/issues/50