### PR TITLE
Define classes for storing detector error models

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ set(SOURCE_FILES_NO_MAIN
         src/circuit/gate_data_period_3.cc
         src/circuit/gate_data_period_4.cc
         src/circuit/gate_data_swaps.cc
+        src/dem/detector_error_model.cc
         src/gate_help.cc
         src/gen/circuit_gen_main.cc
         src/gen/circuit_gen_params.cc
@@ -76,6 +77,7 @@ set(TEST_FILES
         src/arg_parse.test.cc
         src/circuit/circuit.test.cc
         src/circuit/gate_data.test.cc
+        src/dem/detector_error_model.test.cc
         src/gen/circuit_gen_main.test.cc
         src/gen/circuit_gen_params.test.cc
         src/gen/gen_color_code.test.cc

--- a/README.md
+++ b/README.md
@@ -785,7 +785,6 @@ error(0.003344519141621982161) D1
     
     The Hadamard gate.
     Swaps the X and Z axes.
-    A 180 degree rotation around the X+Z axis.
     
     - Example:
     
@@ -820,7 +819,6 @@ error(0.003344519141621982161) D1
 - <a name="H_XY"></a>**`H_XY`**
     
     A variant of the Hadamard gate that swaps the X and Y axes (instead of X and Z).
-    A 180 degree rotation around the X+Y axis.
     
     - Example:
     
@@ -855,7 +853,6 @@ error(0.003344519141621982161) D1
 - <a name="H_YZ"></a>**`H_YZ`**
     
     A variant of the Hadamard gate that swaps the Y and Z axes (instead of X and Z).
-    A 180 degree rotation around the Y+Z axis.
     
     - Example:
     
@@ -1724,7 +1721,8 @@ error(0.003344519141621982161) D1
     - Stabilizer Generators:
     
         ```
-        Z -> mZ
+        Z -> m
+        Z -> +Z
         ```
         
     
@@ -1813,7 +1811,8 @@ error(0.003344519141621982161) D1
     - Stabilizer Generators:
     
         ```
-        X -> mX
+        X -> m
+        X -> +X
         ```
         
     
@@ -1834,7 +1833,8 @@ error(0.003344519141621982161) D1
     - Stabilizer Generators:
     
         ```
-        Y -> mY
+        Y -> m
+        Y -> +Y
         ```
         
     

--- a/src/arg_parse.h
+++ b/src/arg_parse.h
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <iostream>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -205,6 +206,34 @@ const T &find_enum_argument(
 ///         No argument specified and default file is nullptr.
 FILE *find_open_file_argument(
     const char *name, FILE *default_file, const char *mode, int argc, const char **argv);
+
+/// Exposes an owned ostream or else falls back to std::cout.
+struct ostream_else_cout {
+   private:
+    std::unique_ptr<std::ostream> held;
+   public:
+    ostream_else_cout(std::unique_ptr<std::ostream> &&held);
+    std::ostream &stream();
+};
+
+/// Returns an opened ostream from a command line argument.
+///
+/// Args:
+///     name: The name of the command line flag that will specify the file path.
+///     default_std_out: If true, defaults to stdout when the command line argument isn't given. Otherwise exits with
+///         failure when the command line argumen tisn't given.
+///     argc: Number of command line arguments.
+///     argv: Array of command line argument strings.
+///
+/// Returns:
+///     The default file pointer or the opened file.
+///
+/// Exits:
+///     EXIT_FAILURE:
+///         Failed to open the filepath.
+///     EXIT_FAILURE:
+///         Command line argument isn't present and default_std_out is false.
+ostream_else_cout find_output_stream_argument(const char *name, bool default_std_out, int argc, const char **argv);
 
 }
 

--- a/src/circuit/gate_data_hada.cc
+++ b/src/circuit/gate_data_hada.cc
@@ -38,7 +38,6 @@ void GateDataMap::add_gate_data_hada(bool &failed) {
                 R"MARKDOWN(
 The Hadamard gate.
 Swaps the X and Z axes.
-A 180 degree rotation around the X+Z axis.
 )MARKDOWN",
                 {{s, s}, {s, -s}},
                 {"+Z", "+X"},
@@ -58,7 +57,6 @@ A 180 degree rotation around the X+Z axis.
                 "B_Single Qubit Clifford Gates",
                 R"MARKDOWN(
 A variant of the Hadamard gate that swaps the X and Y axes (instead of X and Z).
-A 180 degree rotation around the X+Y axis.
 )MARKDOWN",
                 {{0, s - i *s}, {s + i * s, 0}},
                 {"+Y", "-Z"},
@@ -77,7 +75,6 @@ A 180 degree rotation around the X+Y axis.
                 "B_Single Qubit Clifford Gates",
                 R"MARKDOWN(
 A variant of the Hadamard gate that swaps the Y and Z axes (instead of X and Z).
-A 180 degree rotation around the Y+Z axis.
 )MARKDOWN",
                 {{s, -i * s}, {i * s, -s}},
                 {"-X", "+Y"},

--- a/src/dem/detector_error_model.cc
+++ b/src/dem/detector_error_model.cc
@@ -1,0 +1,516 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "detector_error_model.h"
+
+#include <cmath>
+#include <iomanip>
+
+#include "../simulators/error_fuser.h"
+
+using namespace stim_internal;
+
+constexpr uint64_t MASK_REL_BIT = uint64_t{1} << 63;
+constexpr uint64_t UNSPECIFIED_SYGIL = UINT64_MAX - uint64_t{2};
+constexpr uint64_t OBSERVABLE_SYGIL = UINT64_MAX - uint64_t{3};
+constexpr uint64_t SEPARATOR_SYGIL = UINT64_MAX - uint64_t{4};
+
+uint64_t DemRelValue::raw_value() const {
+    if (is_unspecified()) {
+        return 0;
+    }
+    return data & ~MASK_REL_BIT;
+}
+uint64_t DemRelValue::absolute_value(uint64_t t) const {
+    if (is_unspecified()) {
+        return 0;
+    }
+    return raw_value() + is_relative() * t;
+}
+DemRelValue DemRelValue::unspecified() {
+    return {UNSPECIFIED_SYGIL};
+}
+bool DemRelValue::is_relative() const {
+    return data != UNSPECIFIED_SYGIL && (data & MASK_REL_BIT);
+}
+bool DemRelValue::is_absolute() const {
+    return data != UNSPECIFIED_SYGIL && !(data & MASK_REL_BIT);
+}
+bool DemRelValue::is_unspecified() const {
+    return data == UNSPECIFIED_SYGIL;
+}
+DemRelValue DemRelValue::relative(uint64_t v) {
+    if (v & MASK_REL_BIT) {
+        throw std::out_of_range("v & MASK_REL_BIT");
+    }
+    return {v | MASK_REL_BIT};
+}
+DemRelValue DemRelValue::absolute(uint64_t v) {
+    if (v & MASK_REL_BIT) {
+        throw std::out_of_range("v & MASK_REL_BIT");
+    }
+    return {v};
+}
+bool DemRelValue::operator==(const DemRelValue &other) const {
+    return data == other.data;
+}
+bool DemRelValue::operator!=(const DemRelValue &other) const {
+    return data != other.data;
+}
+
+std::string DemRelValue::str() const {
+    std::stringstream s;
+    s << *this;
+    return s.str();
+}
+
+std::ostream &operator<<(std::ostream &out, const DemRelValue &v) {
+    if (v.is_unspecified()) {
+        out << "unspecified";
+    } else {
+        out << v.raw_value();
+        if (v.is_relative()) {
+            out << "+t";
+        }
+    }
+    return out;
+}
+
+DemRelativeSymptom DemRelativeSymptom::observable_id(uint32_t id) {
+    return {{OBSERVABLE_SYGIL}, {0}, DemRelValue::absolute(id)};
+}
+DemRelativeSymptom DemRelativeSymptom::detector_id(DemRelValue x, DemRelValue y, DemRelValue t) {
+    return {x, y, t};
+}
+DemRelativeSymptom DemRelativeSymptom::separator() {
+    return {{SEPARATOR_SYGIL}, {0}, {0}};
+}
+bool DemRelativeSymptom::is_observable_id() const {
+    return x.data == OBSERVABLE_SYGIL;
+}
+bool DemRelativeSymptom::is_separator() const {
+    return x.data == SEPARATOR_SYGIL;
+}
+bool DemRelativeSymptom::is_detector_id() const {
+    return !is_observable_id() && !is_separator();
+}
+
+bool DemRelativeSymptom::operator==(const DemRelativeSymptom &other) const {
+    return t == other.t && y == other.y && x == other.x;
+}
+bool DemRelativeSymptom::operator!=(const DemRelativeSymptom &other) const {
+    return !(*this == other);
+}
+std::ostream &operator<<(std::ostream &out, const DemRelativeSymptom &v) {
+    std::array<DemRelValue, 3> coords{v.x, v.y, v.t};
+    if (v.is_separator()) {
+        out << "^";
+        return out;
+    } else if (v.is_detector_id()) {
+        out << "D";
+        bool first = true;
+        for (const auto &e : coords) {
+            if (!e.is_unspecified()) {
+                if (first) {
+                    first = false;
+                } else {
+                    out << ",";
+                }
+                out << e;
+            }
+        }
+    } else if (v.is_observable_id()) {
+        out << "L" << v.t.raw_value();
+    } else {
+        out << "???";
+    }
+    return out;
+}
+
+std::string DemRelativeSymptom::str() const {
+    std::stringstream s;
+    s << *this;
+    return s.str();
+}
+
+bool DemInstruction::operator==(const DemInstruction &other) const {
+    return approx_equals(other, 0);
+}
+bool DemInstruction::operator!=(const DemInstruction &other) const {
+    return !(*this == other);
+}
+bool DemInstruction::approx_equals(const DemInstruction &other, double atol) const {
+    return fabs(probability - other.probability) <= atol && target_data == other.target_data && type == other.type;
+}
+std::string DemInstruction::str() const {
+    std::stringstream s;
+    s << *this;
+    return s.str();
+}
+std::ostream &operator<<(std::ostream &out, const DemInstruction &op) {
+    switch (op.type) {
+        case DEM_ERROR:
+            out << "error(" << op.probability << ")";
+            for (const auto &e : op.target_data) {
+                out << " " << e;
+            }
+            break;
+        case DEM_REDUCIBLE_ERROR:
+            out << "reducible_error(" << op.probability << ")";
+            for (const auto &e : op.target_data) {
+                out << " " << e;
+            }
+            break;
+        case DEM_TICK:
+            out << "tick " << op.target_data[0].t;
+            break;
+        case DEM_REPEAT_BLOCK:
+            out << "repeat " << op.target_data[0].t << " { ... }";
+            break;
+        default:
+            out << "???";
+    }
+    return out;
+}
+
+void DetectorErrorModel::append_error(double probability, ConstPointerRange<DemRelativeSymptom> data) {
+    for (auto e : data) {
+        if (e.is_separator()) {
+            throw std::invalid_argument("Use append_reducible_error for symptoms containing separators.");
+        }
+    }
+    symptom_buf.append_tail(data);
+    auto stored = symptom_buf.commit_tail();
+    instructions.push_back(DemInstruction{probability, stored, DEM_ERROR});
+}
+
+void DetectorErrorModel::append_reducible_error(double probability, ConstPointerRange<DemRelativeSymptom> data) {
+    symptom_buf.append_tail(data);
+    auto stored = symptom_buf.commit_tail();
+    instructions.push_back(DemInstruction{probability, stored, DEM_REDUCIBLE_ERROR});
+}
+
+void DetectorErrorModel::append_tick(uint64_t tick_count) {
+    symptom_buf.append_tail(DemRelativeSymptom{{0}, {0}, {tick_count}});
+    instructions.push_back({0, symptom_buf.commit_tail(), DEM_TICK});
+}
+
+void DetectorErrorModel::append_repeat_block(uint64_t repeat_count, DetectorErrorModel &&body) {
+    uint64_t block_id = blocks.size();
+    symptom_buf.append_tail(DemRelativeSymptom{{block_id}, {0}, {repeat_count}});
+    blocks.push_back(std::move(body));
+    instructions.push_back({0, symptom_buf.commit_tail(), DEM_REPEAT_BLOCK});
+}
+
+void DetectorErrorModel::append_repeat_block(uint64_t repeat_count, const DetectorErrorModel &body) {
+    uint64_t block_id = blocks.size();
+    symptom_buf.append_tail(DemRelativeSymptom{{block_id}, {0}, {repeat_count}});
+    blocks.push_back(body);
+    instructions.push_back({0, symptom_buf.commit_tail(), DEM_REPEAT_BLOCK});
+}
+
+bool DetectorErrorModel::operator==(const DetectorErrorModel &other) const {
+    return instructions == other.instructions && blocks == other.blocks;
+}
+bool DetectorErrorModel::operator!=(const DetectorErrorModel &other) const {
+    return !(*this == other);
+}
+bool DetectorErrorModel::approx_equals(const DetectorErrorModel &other, double atol) const {
+    if (instructions.size() != other.instructions.size() || blocks.size() != other.blocks.size()) {
+        return false;
+    }
+    for (size_t k = 0; k < instructions.size(); k++) {
+        if (!instructions[k].approx_equals(other.instructions[k], atol)) {
+            return false;
+        }
+    }
+    for (size_t k = 0; k < blocks.size(); k++) {
+        if (!blocks[k].approx_equals(other.blocks[k], atol)) {
+            return false;
+        }
+    }
+    return true;
+
+}
+std::string DetectorErrorModel::str() const {
+    std::stringstream s;
+    s << *this;
+    return s.str();
+}
+
+void stream_out_indent(std::ostream &out, const DetectorErrorModel &v, size_t indent) {
+    for (const auto &e : v.instructions) {
+        for (size_t k = 0; k < indent; k++) {
+            out << " ";
+        }
+        if (e.type == DEM_REPEAT_BLOCK) {
+            out << "repeat " << e.target_data[0].t.data << " {\n";
+            stream_out_indent(out, v.blocks[(size_t)e.target_data[0].x.data], indent + 4);
+            for (size_t k = 0; k < indent; k++) {
+                out << " ";
+            }
+            out << "}";
+        } else {
+            out << e;
+        }
+        out << "\n";
+    }
+}
+
+std::ostream &operator<<(std::ostream &out, const DetectorErrorModel &v) {
+    out << std::setprecision(std::numeric_limits<long double>::digits10 + 1);
+    stream_out_indent(out, v, 0);
+    return out;
+}
+
+DetectorErrorModel::DetectorErrorModel() {
+}
+
+DetectorErrorModel::DetectorErrorModel(const DetectorErrorModel &other)
+    : symptom_buf(other.symptom_buf.total_allocated()), instructions(other.instructions), blocks(other.blocks) {
+    // Keep local copy of operation data.
+    for (auto &e : instructions) {
+        e.target_data = symptom_buf.take_copy(e.target_data);
+    }
+}
+
+DetectorErrorModel::DetectorErrorModel(DetectorErrorModel &&other) noexcept
+    : symptom_buf(std::move(other.symptom_buf)), instructions(std::move(other.instructions)), blocks(std::move(other.blocks)) {
+}
+
+DetectorErrorModel &DetectorErrorModel::operator=(const DetectorErrorModel &other) {
+    if (&other != this) {
+        instructions = other.instructions;
+        blocks = other.blocks;
+
+        // Keep local copy of operation data.
+        symptom_buf = MonotonicBuffer<DemRelativeSymptom>(other.symptom_buf.total_allocated());
+        for (auto &e : instructions) {
+            e.target_data = symptom_buf.take_copy(e.target_data);
+        }
+    }
+    return *this;
+}
+
+DetectorErrorModel &DetectorErrorModel::operator=(DetectorErrorModel &&other) noexcept {
+    if (&other != this) {
+        instructions = std::move(other.instructions);
+        blocks = std::move(other.blocks);
+        symptom_buf = std::move(other.symptom_buf);
+    }
+    return *this;
+}
+
+enum DEM_READ_CONDITION {
+    DEM_READ_AS_LITTLE_AS_POSSIBLE,
+    DEM_READ_UNTIL_END_OF_BLOCK,
+    DEM_READ_UNTIL_END_OF_FILE,
+};
+
+inline bool is_name_char(int c) {
+    return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_';
+}
+
+template <typename SOURCE>
+inline DemInstructionType read_instruction_name(int &c, SOURCE read_char) {
+    char name_buf[32];
+    size_t n = 0;
+    while (is_name_char(c) && n < sizeof(name_buf) - 1) {
+        name_buf[n] = tolower((char)c);
+        c = read_char();
+        n++;
+    }
+    name_buf[n] = 0;
+    if (!strcmp(name_buf, "error")) {
+        return DEM_ERROR;
+    }
+    if (!strcmp(name_buf, "reducible_error")) {
+        return DEM_REDUCIBLE_ERROR;
+    }
+    if (!strcmp(name_buf, "tick")) {
+        return DEM_TICK;
+    }
+    if (!strcmp(name_buf, "repeat")) {
+        return DEM_REPEAT_BLOCK;
+    }
+    throw std::out_of_range("Unrecognized instruction name: " + std::string(name_buf));
+}
+
+template <typename SOURCE>
+uint64_t read_uint60_t(int &c, SOURCE read_char) {
+    if (!(c >= '0' && c <= '9')) {
+        throw std::out_of_range("Expected a digit but got " + std::string(1, c));
+    }
+    uint64_t result = 0;
+    do {
+        result *= 10;
+        result += c - '0';
+        if (result >= uint64_t{1} << 60) {
+            throw std::out_of_range("Number too large.");
+        }
+        c = read_char();
+    } while (c >= '0' && c <= '9');
+    return result;
+}
+
+template <typename SOURCE>
+inline void read_tick(int &c, SOURCE read_char, DetectorErrorModel &model) {
+    read_past_within_line_whitespace(c, read_char);
+    model.append_tick(read_uint60_t(c, read_char));
+}
+
+template <typename SOURCE>
+inline void read_repeat(int &c, SOURCE read_char, DetectorErrorModel &model) {
+    read_past_within_line_whitespace(c, read_char);
+    model.append_repeat_block(read_uint60_t(c, read_char), {});
+    read_until_next_line_arg(c, read_char);
+}
+
+template <typename SOURCE>
+inline DemRelValue read_rel_value(int &c, SOURCE read_char) {
+    uint64_t v = read_uint60_t(c, read_char);
+    if (c == '+') {
+        c = read_char();
+        if (c != 't') {
+            throw std::invalid_argument("'+' not followed by 't' at end of detector id.");
+        }
+        c = read_char();
+        return DemRelValue::relative(v);
+    }
+    return DemRelValue::absolute(v);
+}
+
+template <typename SOURCE>
+inline bool read_symptom(int &c, SOURCE read_char, bool allow_separators, MonotonicBuffer<DemRelativeSymptom> &out) {
+    read_until_next_line_arg(c, read_char);
+    if (c == 'L') {
+        c = read_char();
+        out.append_tail(DemRelativeSymptom::observable_id(read_uint60_t(c, read_char)));
+        return true;
+    }
+    if (c == 'D') {
+        c = read_char();
+        DemRelValue v0 = read_rel_value(c, read_char);
+        if (c == ',') {
+            c = read_char();
+            DemRelValue v1 = read_rel_value(c, read_char);
+            if (c == ',') {
+                c = read_char();
+                DemRelValue v2 = read_rel_value(c, read_char);
+                out.append_tail(DemRelativeSymptom::detector_id(v0, v1, v2));
+            } else {
+                out.append_tail(DemRelativeSymptom::detector_id(v0, DemRelValue::unspecified(), v1));
+            }
+        } else {
+            out.append_tail(DemRelativeSymptom::detector_id(DemRelValue::unspecified(), DemRelValue::unspecified(), v0));
+        }
+        return true;
+    }
+    if (c == '^') {
+        if (!allow_separators) {
+            throw std::invalid_argument("`error` with `^` separators (needs `reducible_error`).");
+        }
+        c = read_char();
+        out.append_tail(DemRelativeSymptom::separator());
+        return true;
+    }
+    return false;
+}
+
+template <typename SOURCE>
+inline void read_error(int &c, SOURCE read_char, DetectorErrorModel &model, bool reducible) {
+    auto p = read_parens_argument(c, reducible ? "reducible_error" : "error", read_char);
+    while (read_symptom(c, read_char, reducible, model.symptom_buf)) {
+    }
+    model.instructions.push_back(
+        DemInstruction{p, model.symptom_buf.commit_tail(), reducible ? DEM_REDUCIBLE_ERROR : DEM_ERROR});
+}
+
+template <typename SOURCE>
+void model_read_single_operation(DetectorErrorModel &model, char lead_char, SOURCE read_char) {
+    int c = (int)lead_char;
+    DemInstructionType type = read_instruction_name(c, read_char);
+    switch (type) {
+        case DEM_ERROR:
+            read_error(c, read_char, model, false);
+            break;
+        case DEM_REDUCIBLE_ERROR:
+            read_error(c, read_char, model, true);
+            break;
+        case DEM_TICK:
+            read_tick(c, read_char, model);
+            break;
+        case DEM_REPEAT_BLOCK:
+            read_repeat(c, read_char, model);
+            break;
+        default:
+            throw std::out_of_range("Instruction type not implemented.");
+    }
+    if (c != '{' && type == DEM_REPEAT_BLOCK) {
+        throw std::out_of_range("Missing '{' at start of repeat block.");
+    }
+    if (c == '{' && type != DEM_REPEAT_BLOCK) {
+        throw std::out_of_range("Unexpected '{' after non-block command.");
+    }
+}
+
+template <typename SOURCE>
+void model_read_operations(DetectorErrorModel &model, SOURCE read_char, DEM_READ_CONDITION read_condition) {
+    auto &ops = model.instructions;
+    do {
+        int c = read_char();
+        read_past_dead_space_between_commands(c, read_char);
+        if (c == EOF) {
+            if (read_condition == DEM_READ_UNTIL_END_OF_BLOCK) {
+                throw std::out_of_range("Unterminated block. Got a '{' without an eventual '}'.");
+            }
+            return;
+        }
+        if (c == '}') {
+            if (read_condition != DEM_READ_UNTIL_END_OF_BLOCK) {
+                throw std::out_of_range("Uninitiated block. Got a '}' without a '{'.");
+            }
+            return;
+        }
+        model_read_single_operation(model, c, read_char);
+        auto &new_op = ops.back();
+
+        if (new_op.type == DEM_REPEAT_BLOCK) {
+            // Recursively read the block contents.
+            auto &block = model.blocks[new_op.target_data[0].x.data];
+            model_read_operations(block, read_char, DEM_READ_UNTIL_END_OF_BLOCK);
+        }
+    } while (read_condition != DEM_READ_AS_LITTLE_AS_POSSIBLE);
+}
+
+void DetectorErrorModel::append_from_text(const char *text) {
+    size_t k = 0;
+    model_read_operations(
+        *this,
+        [&]() {
+            return text[k] != 0 ? text[k++] : EOF;
+        },
+        DEM_READ_UNTIL_END_OF_FILE);
+}
+
+DetectorErrorModel::DetectorErrorModel(const char *text) {
+    append_from_text(text);
+}
+void DetectorErrorModel::clear() {
+    symptom_buf.clear();
+    instructions.clear();
+    blocks.clear();
+}

--- a/src/dem/detector_error_model.h
+++ b/src/dem/detector_error_model.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef STIM_DETECTOR_ERROR_MODEL_H
+#define STIM_DETECTOR_ERROR_MODEL_H
+
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "../circuit/circuit.h"
+#include "../simd/monotonic_buffer.h"
+
+namespace stim_internal {
+
+enum DemInstructionType : uint8_t {
+    DEM_ERROR,
+    DEM_REDUCIBLE_ERROR,
+    DEM_TICK,
+    DEM_REPEAT_BLOCK,
+};
+
+struct DemRelValue {
+    uint64_t data;
+    uint64_t raw_value() const;
+    uint64_t absolute_value(uint64_t t) const;
+    bool is_relative() const;
+    bool is_unspecified() const;
+    bool is_absolute() const;
+    static DemRelValue unspecified();
+    static DemRelValue relative(uint64_t v);
+    static DemRelValue absolute(uint64_t v);
+    bool operator==(const DemRelValue &other) const;
+    bool operator!=(const DemRelValue &other) const;
+    std::string str() const;
+};
+
+struct DemRelativeSymptom {
+    DemRelValue x;
+    DemRelValue y;
+    DemRelValue t;
+
+    static DemRelativeSymptom observable_id(uint32_t id);
+    static DemRelativeSymptom detector_id(DemRelValue x, DemRelValue y, DemRelValue t);
+    static DemRelativeSymptom separator();
+    bool is_observable_id() const;
+    bool is_separator() const;
+    bool is_detector_id() const;
+
+    bool operator==(const DemRelativeSymptom &other) const;
+    bool operator!=(const DemRelativeSymptom &other) const;
+    std::string str() const;
+};
+
+struct DemInstruction {
+    double probability;
+    PointerRange<DemRelativeSymptom> target_data;
+    DemInstructionType type;
+
+    bool operator==(const DemInstruction &other) const;
+    bool operator!=(const DemInstruction &other) const;
+    bool approx_equals(const DemInstruction &other, double atol) const;
+    std::string str() const;
+};
+
+struct DetectorErrorModel {
+    MonotonicBuffer<DemRelativeSymptom> symptom_buf;
+    std::vector<DemInstruction> instructions;
+    std::vector<DetectorErrorModel> blocks;
+
+    /// Constructs an empty detector error model.
+    DetectorErrorModel();
+    /// Parses a detector error model from the given text.
+    DetectorErrorModel(const char *text);
+
+    /// Copy constructor.
+    DetectorErrorModel(const DetectorErrorModel &other);
+    /// Move constructor.
+    DetectorErrorModel(DetectorErrorModel &&other) noexcept;
+    /// Copy assignment.
+    DetectorErrorModel &operator=(const DetectorErrorModel &other);
+    /// Move assignment.
+    DetectorErrorModel &operator=(DetectorErrorModel &&other) noexcept;
+
+    static DetectorErrorModel from_circuit(const Circuit &circuit);
+
+    void append_error(double probability, ConstPointerRange<DemRelativeSymptom> data);
+    void append_reducible_error(double probability, ConstPointerRange<DemRelativeSymptom> data);
+    void append_tick(uint64_t tick_count);
+    void append_repeat_block(uint64_t repeat_count, DetectorErrorModel &&body);
+    void append_repeat_block(uint64_t repeat_count, const DetectorErrorModel &body);
+    void append_from_text(const char *text);
+
+    bool operator==(const DetectorErrorModel &other) const;
+    bool operator!=(const DetectorErrorModel &other) const;
+    bool approx_equals(const DetectorErrorModel &other, double atol) const;
+    std::string str() const;
+
+    void clear();
+};
+
+}
+
+std::ostream &operator<<(std::ostream &out, const stim_internal::DemRelValue &v);
+std::ostream &operator<<(std::ostream &out, const stim_internal::DetectorErrorModel &v);
+std::ostream &operator<<(std::ostream &out, const stim_internal::DemRelativeSymptom &v);
+std::ostream &operator<<(std::ostream &out, const stim_internal::DemInstruction &v);
+
+#endif

--- a/src/dem/detector_error_model.test.cc
+++ b/src/dem/detector_error_model.test.cc
@@ -1,0 +1,325 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "detector_error_model.h"
+#include "../test_util.test.h"
+
+#include <gtest/gtest.h>
+
+using namespace stim_internal;
+
+TEST(detector_error_model, init_equality) {
+    DetectorErrorModel model1;
+    DetectorErrorModel model2;
+    ASSERT_TRUE(model1 == model2);
+    ASSERT_TRUE(!(model1 != model2));
+    model1.append_tick(5);
+    ASSERT_TRUE(model1 != model2);
+    ASSERT_TRUE(!(model1 == model2));
+    model2.append_tick(4);
+    ASSERT_NE(model1, model2);
+    model1.clear();
+    model2.clear();
+    ASSERT_EQ(model1, model2);
+
+    model1.append_repeat_block(5, {});
+    model2.append_repeat_block(4, {});
+    ASSERT_NE(model1, model2);
+
+    model1.append_error(5, {});
+    model2.append_repeat_block(4, {});
+    ASSERT_NE(model1, model2);
+}
+
+TEST(detector_error_model, build) {
+    DetectorErrorModel model;
+    ASSERT_EQ(model.instructions.size(), 0);
+    ASSERT_EQ(model.blocks.size(), 0);
+    model.append_tick(5);
+    ASSERT_EQ(model.instructions.size(), 1);
+    ASSERT_EQ(model.instructions[0].type, DEM_TICK);
+    ASSERT_EQ(model.instructions[0].target_data.size(), 1);
+    ASSERT_EQ(model.instructions[0].target_data[0].t.data, 5);
+    ASSERT_EQ(model.blocks.size(), 0);
+
+    std::vector<DemRelativeSymptom> symptoms;
+    symptoms.push_back(DemRelativeSymptom::observable_id(3));
+    symptoms.push_back(DemRelativeSymptom::detector_id(DemRelValue::unspecified(), DemRelValue::unspecified(), DemRelValue::absolute(4)));
+    model.append_error(0.25, symptoms);
+    ASSERT_EQ(model.instructions.size(), 2);
+    ASSERT_EQ(model.blocks.size(), 0);
+    ASSERT_EQ(model.instructions[1].type, DEM_ERROR);
+    ASSERT_EQ(model.instructions[1].target_data, (PointerRange<DemRelativeSymptom>)symptoms);
+    ASSERT_EQ(model.instructions[1].probability, 0.25);
+
+    model.clear();
+    ASSERT_EQ(model.instructions.size(), 0);
+
+    symptoms.push_back(DemRelativeSymptom::separator());
+    symptoms.push_back(DemRelativeSymptom::observable_id(4));
+    ASSERT_THROW({
+        model.append_error(0.125, symptoms);
+    }, std::invalid_argument);
+
+    model.append_reducible_error(0.125, symptoms);
+    ASSERT_EQ(model.instructions.size(), 1);
+    ASSERT_EQ(model.blocks.size(), 0);
+    ASSERT_EQ(model.instructions[0].type, DEM_REDUCIBLE_ERROR);
+    ASSERT_EQ(model.instructions[0].target_data, (PointerRange<DemRelativeSymptom>)symptoms);
+    ASSERT_EQ(model.instructions[0].probability, 0.125);
+
+    model.clear();
+
+    DetectorErrorModel block;
+    block.append_tick(3);
+    DetectorErrorModel block2 = block;
+
+    model.append_repeat_block(5, block);
+    block.append_tick(4);
+    model.append_repeat_block(6, std::move(block));
+    model.append_repeat_block(20, block2);
+    ASSERT_EQ(model.instructions.size(), 3);
+    ASSERT_EQ(model.blocks.size(), 3);
+    ASSERT_EQ(model.instructions[0].type, DEM_REPEAT_BLOCK);
+    ASSERT_EQ(model.instructions[0].target_data[0].t.data, 5);
+    ASSERT_EQ(model.instructions[0].target_data[0].x.data, 0);
+    ASSERT_EQ(model.instructions[1].type, DEM_REPEAT_BLOCK);
+    ASSERT_EQ(model.instructions[1].target_data[0].t.data, 6);
+    ASSERT_EQ(model.instructions[1].target_data[0].x.data, 1);
+    ASSERT_EQ(model.instructions[2].type, DEM_REPEAT_BLOCK);
+    ASSERT_EQ(model.instructions[2].target_data[0].t.data, 20);
+    ASSERT_EQ(model.instructions[2].target_data[0].x.data, 2);
+    ASSERT_EQ(model.blocks[0], block2);
+    ASSERT_EQ(model.blocks[2], block2);
+    block2.append_tick(4);
+    ASSERT_EQ(model.blocks[1], block2);
+}
+
+TEST(detector_error_model, round_trip_str) {
+    const char *t = R"MODEL(error(0.125) D0
+repeat 100 {
+    repeat 200 {
+        reducible_error(0.25) D0 D1+t,5 L0 ^ D2
+        tick 10
+    }
+    error(0.375) D0 D0,1,2
+    tick 20
+}
+)MODEL";
+    ASSERT_EQ(DetectorErrorModel(t).str(), std::string(t));
+}
+
+TEST(detector_error_model, parse) {
+    DetectorErrorModel expected;
+    ASSERT_EQ(DetectorErrorModel(""), expected);
+
+    expected.append_error(0.125, (std::vector<DemRelativeSymptom>{DemRelativeSymptom::detector_id(DemRelValue::unspecified(), DemRelValue::unspecified(), DemRelValue::absolute(0))}));
+    ASSERT_EQ(DetectorErrorModel(R"MODEL(
+        error(0.125) D0
+    )MODEL"), expected);
+
+    expected.append_error(0.125, (std::vector<DemRelativeSymptom>{DemRelativeSymptom::detector_id(DemRelValue::unspecified(), DemRelValue::unspecified(), DemRelValue::relative(0))}));
+    ASSERT_EQ(DetectorErrorModel(R"MODEL(
+        error(0.125) D0
+        error(0.125) D0+t
+    )MODEL"), expected);
+
+    expected.append_error(0.125, (std::vector<DemRelativeSymptom>{DemRelativeSymptom::detector_id(DemRelValue::absolute(1), DemRelValue::absolute(2), DemRelValue::relative(3))}));
+    ASSERT_EQ(DetectorErrorModel(R"MODEL(
+        error(0.125) D0
+        error(0.125) D0+t
+        error(0.125) D1,2,3+t
+    )MODEL"), expected);
+
+    expected.append_reducible_error(0.25, (std::vector<DemRelativeSymptom>{DemRelativeSymptom::observable_id(0), DemRelativeSymptom::separator(), DemRelativeSymptom::observable_id(2)}));
+    ASSERT_EQ(DetectorErrorModel(R"MODEL(
+        error(0.125) D0
+        error(0.125) D0+t
+        error(0.125) D1,2,3+t
+        reducible_error(0.25) L0 ^ L2
+    )MODEL"), expected);
+
+    expected.append_tick(60);
+    ASSERT_EQ(DetectorErrorModel(R"MODEL(
+        error(0.125) D0
+        error(0.125) D0+t
+        error(0.125) D1,2,3+t
+        reducible_error(0.25) L0 ^ L2
+        tick 60
+    )MODEL"), expected);
+
+    expected.append_repeat_block(100, expected);
+    ASSERT_EQ(DetectorErrorModel(R"MODEL(
+        error(0.125) D0
+        error(0.125) D0+t
+        error(0.125) D1,2,3+t
+        reducible_error(0.25) L0 ^ L2
+        tick 60
+        repeat 100 {
+            error(0.125) D0
+            error(0.125) D0+t
+            error(0.125) D1,2,3+t
+            reducible_error(0.25) L0 ^ L2
+            tick 60
+        }
+    )MODEL"), expected);
+}
+
+TEST(detector_error_model, movement) {
+    const char *t = R"MODEL(
+        error(0.2) D0
+        REPEAT 100 {
+            REPEAT 200 {
+                reducible_error(0.1) D0 D1+t,5 L0 ^ D2
+                TICK 10
+            }
+            error(0.1) D0 D0,1,2
+            TICK 20
+        }
+    )MODEL";
+    DetectorErrorModel d1(t);
+    DetectorErrorModel d2(d1);
+    ASSERT_EQ(d1, d2);
+    ASSERT_EQ(d1, DetectorErrorModel(t));
+    DetectorErrorModel d3(std::move(d1));
+    ASSERT_EQ(d1, DetectorErrorModel());
+    ASSERT_EQ(d2, d3);
+    ASSERT_EQ(d2, DetectorErrorModel(t));
+    d1 = d3;
+    ASSERT_EQ(d1, d2);
+    ASSERT_EQ(d2, d3);
+    ASSERT_EQ(d2, DetectorErrorModel(t));
+    d1 = std::move(d2);
+    ASSERT_EQ(d1, d3);
+    ASSERT_EQ(d2, DetectorErrorModel());
+    ASSERT_EQ(d1, DetectorErrorModel(t));
+}
+
+
+TEST(dem_rel_value, general) {
+    auto a = DemRelValue::absolute(3);
+    auto u = DemRelValue::unspecified();
+    auto r = DemRelValue::relative(3);
+
+    ASSERT_TRUE(!a.is_unspecified());
+    ASSERT_TRUE(u.is_unspecified());
+    ASSERT_TRUE(!r.is_unspecified());
+
+    ASSERT_TRUE(!a.is_relative());
+    ASSERT_TRUE(!u.is_relative());
+    ASSERT_TRUE(r.is_relative());
+
+    ASSERT_TRUE(a.is_absolute());
+    ASSERT_TRUE(!u.is_absolute());
+    ASSERT_TRUE(!r.is_absolute());
+
+    ASSERT_EQ(u.absolute_value(0), 0);
+    ASSERT_EQ(u.absolute_value(20), 0);
+    ASSERT_EQ(a.absolute_value(0), 3);
+    ASSERT_EQ(a.absolute_value(20), 3);
+    ASSERT_EQ(r.absolute_value(0), 3);
+    ASSERT_EQ(r.absolute_value(20), 23);
+
+    ASSERT_TRUE(a == DemRelValue::absolute(3));
+    ASSERT_TRUE(!(a != DemRelValue::absolute(3)));
+    ASSERT_TRUE(!(a == DemRelValue::absolute(4)));
+    ASSERT_TRUE(a != DemRelValue::absolute(4));
+
+    ASSERT_EQ(u, DemRelValue::unspecified());
+    ASSERT_EQ(a, DemRelValue::absolute(3));
+    ASSERT_EQ(r, DemRelValue::relative(3));
+    ASSERT_NE(u, a);
+    ASSERT_NE(r, a);
+    ASSERT_NE(u, r);
+
+    ASSERT_EQ(u.raw_value(), 0);
+    ASSERT_EQ(a.raw_value(), 3);
+    ASSERT_EQ(r.raw_value(), 3);
+
+    ASSERT_EQ(a.str(), "3");
+    ASSERT_EQ(r.str(), "3+t");
+    ASSERT_EQ(u.str(), "unspecified");
+}
+
+TEST(dem_relative_symptom, general) {
+    auto u = DemRelValue::unspecified();
+    DemRelativeSymptom d = DemRelativeSymptom::detector_id(u, u, DemRelValue::relative(3));
+    ASSERT_TRUE(d == DemRelativeSymptom::detector_id(u, u, DemRelValue::relative(3)));
+    ASSERT_TRUE(!(d != DemRelativeSymptom::detector_id(u, u, DemRelValue::relative(3))));
+    ASSERT_TRUE(!(d == DemRelativeSymptom::detector_id(u, u, DemRelValue::relative(4))));
+    ASSERT_TRUE(d != DemRelativeSymptom::detector_id(u, u, DemRelValue::relative(4)));
+    ASSERT_EQ(d, DemRelativeSymptom::detector_id(u, u, DemRelValue::relative(3)));
+    ASSERT_NE(d, DemRelativeSymptom::detector_id(u, u, u));
+    ASSERT_NE(d, DemRelativeSymptom::detector_id(u, DemRelValue::relative(3), DemRelValue::relative(3)));
+    ASSERT_NE(d, DemRelativeSymptom::detector_id(DemRelValue::relative(3), u, DemRelValue::relative(3)));
+    ASSERT_NE(d, DemRelativeSymptom::observable_id(5));
+    ASSERT_NE(d, DemRelativeSymptom::separator());
+
+    DemRelativeSymptom d3 = DemRelativeSymptom::detector_id(DemRelValue::absolute(4), DemRelValue::absolute(6), DemRelValue::relative(3));
+    DemRelativeSymptom s = DemRelativeSymptom::separator();
+    DemRelativeSymptom o = DemRelativeSymptom::observable_id(3);
+    ASSERT_EQ(d.str(), "D3+t");
+    ASSERT_EQ(d3.str(), "D4,6,3+t");
+    ASSERT_EQ(o.str(), "L3");
+    ASSERT_EQ(s.str(), "^");
+
+    ASSERT_TRUE(!o.is_separator());
+    ASSERT_TRUE(!d3.is_separator());
+    ASSERT_TRUE(s.is_separator());
+
+    ASSERT_TRUE(o.is_observable_id());
+    ASSERT_TRUE(!d3.is_observable_id());
+    ASSERT_TRUE(!s.is_observable_id());
+
+    ASSERT_TRUE(!o.is_detector_id());
+    ASSERT_TRUE(d3.is_detector_id());
+    ASSERT_TRUE(!s.is_detector_id());
+}
+
+TEST(dem_instruction, general) {
+    std::vector<DemRelativeSymptom> d1;
+    d1.push_back(DemRelativeSymptom::observable_id(4));
+    d1.push_back(DemRelativeSymptom::detector_id(DemRelValue::unspecified(), DemRelValue::unspecified(), DemRelValue::absolute(3)));
+    std::vector<DemRelativeSymptom> d2;
+    d2.push_back(DemRelativeSymptom::observable_id(4));
+    DemInstruction i1{0.125, d1, DEM_ERROR};
+    DemInstruction i1a{0.125, d1, DEM_ERROR};
+    DemInstruction i2{0.125, d2, DEM_ERROR};
+    ASSERT_TRUE(i1 == i1a);
+    ASSERT_TRUE(!(i1 != i1a));
+    ASSERT_TRUE(!(i2 == i1a));
+    ASSERT_TRUE(i2 != i1a);
+
+    ASSERT_EQ(i1, (DemInstruction{0.125, d1, DEM_ERROR}));
+    ASSERT_NE(i1, (DemInstruction{0.125, d2, DEM_ERROR}));
+    ASSERT_NE(i1, (DemInstruction{0.25, d1, DEM_ERROR}));
+    ASSERT_NE(i1, (DemInstruction{0.125, d1, DEM_REDUCIBLE_ERROR}));
+
+    ASSERT_TRUE(i1.approx_equals(DemInstruction{0.125, d1, DEM_ERROR}, 0));
+    ASSERT_TRUE(!i1.approx_equals(DemInstruction{0.126, d1, DEM_ERROR}, 0));
+    ASSERT_TRUE(i1.approx_equals(DemInstruction{0.126, d1, DEM_ERROR}, 0.01));
+    ASSERT_TRUE(!i1.approx_equals(DemInstruction{0.125, d1, DEM_REDUCIBLE_ERROR}, 9999));
+    ASSERT_TRUE(!i1.approx_equals(DemInstruction{0.125, d2, DEM_REDUCIBLE_ERROR}, 9999));
+
+    ASSERT_EQ(i1.str(), "error(0.125) L4 D3");
+    ASSERT_EQ(i2.str(), "error(0.125) L4");
+
+    d1.push_back(DemRelativeSymptom::separator());
+    d1.push_back(DemRelativeSymptom::observable_id(11));
+    ASSERT_EQ((DemInstruction{0.25, d1, DEM_REDUCIBLE_ERROR}).str(), "reducible_error(0.25) L4 D3 ^ L11");
+    d2.clear();
+    d2.push_back({{4}, {5}, {6}});
+    ASSERT_EQ((DemInstruction{0, d2, DEM_TICK}).str(), "tick 6");
+    ASSERT_EQ((DemInstruction{0, d2, DEM_REPEAT_BLOCK}).str(), "repeat 6 { ... }");
+}

--- a/src/gen/circuit_gen_main.cc
+++ b/src/gen/circuit_gen_main.cc
@@ -37,26 +37,21 @@ int stim_internal::main_generate_circuit(int argc, const char **argv) {
     params.before_measure_flip_probability = find_float_argument("--before_measure_flip_probability", 0, 0, 1, argc, argv);
     params.after_reset_flip_probability = find_float_argument("--after_reset_flip_probability", 0, 0, 1, argc, argv);
     params.after_clifford_depolarization = find_float_argument("--after_clifford_depolarization", 0, 0, 1, argc, argv);
-    FILE *out = find_open_file_argument("--out", stdout, "w", argc, argv);
-
-    std::stringstream ss;
-    ss << "# Generated " << find_argument("--gen", argc, argv) << " circuit.\n";
-    ss << "# task: " << params.task << "\n";
-    ss << "# rounds: " << params.rounds << "\n";
-    ss << "# distance: " << params.distance << "\n";
-    ss << "# before_round_data_depolarization: " << params.before_round_data_depolarization << "\n";
-    ss << "# before_measure_flip_probability: " << params.before_measure_flip_probability << "\n";
-    ss << "# after_reset_flip_probability: " << params.after_reset_flip_probability << "\n";
-    ss << "# after_clifford_depolarization: " << params.after_clifford_depolarization << "\n";
-    ss << "# layout:\n";
+    auto out_stream = find_output_stream_argument("--out", true, argc, argv);
+    std::ostream &out = out_stream.stream();
+    out << "# Generated " << find_argument("--gen", argc, argv) << " circuit.\n";
+    out << "# task: " << params.task << "\n";
+    out << "# rounds: " << params.rounds << "\n";
+    out << "# distance: " << params.distance << "\n";
+    out << "# before_round_data_depolarization: " << params.before_round_data_depolarization << "\n";
+    out << "# before_measure_flip_probability: " << params.before_measure_flip_probability << "\n";
+    out << "# after_reset_flip_probability: " << params.after_reset_flip_probability << "\n";
+    out << "# after_clifford_depolarization: " << params.after_clifford_depolarization << "\n";
+    out << "# layout:\n";
     auto generated = func(params);
-    ss << generated.layout_str();
-    ss << generated.hint_str;
-    ss << generated.circuit;
-    ss << "\n";
-    fprintf(out, "%s", ss.str().data());
-    if (out != stdout) {
-        fclose(out);
-    }
+    out << generated.layout_str();
+    out << generated.hint_str;
+    out << generated.circuit;
+    out << "\n";
     return 0;
 }

--- a/src/main_helper.cc
+++ b/src/main_helper.cc
@@ -116,14 +116,13 @@ int main_mode_analyze_errors(int argc, const char **argv) {
     bool fold_loops = find_bool_argument("--fold_loops", argc, argv);
     bool validate_detectors = !find_bool_argument("--allow_gauge_detectors", argc, argv);
     FILE *in = find_open_file_argument("--in", stdin, "r", argc, argv);
-    FILE *out = find_open_file_argument("--out", stdout, "w", argc, argv);
-    ErrorFuser::convert_circuit_out(Circuit::from_file(in), out, find_reducible_errors, fold_loops, validate_detectors);
+    auto out_stream = find_output_stream_argument("--out", true, argc, argv);
+    std::ostream &out = out_stream.stream();
+    auto circuit = Circuit::from_file(in);
     if (in != stdin) {
         fclose(in);
     }
-    if (out != stdout) {
-        fclose(out);
-    }
+    out << ErrorFuser::circuit_to_detector_error_model(circuit, find_reducible_errors, fold_loops, validate_detectors);
     return EXIT_SUCCESS;
 }
 

--- a/src/main_helper.test.cc
+++ b/src/main_helper.test.cc
@@ -586,9 +586,9 @@ REPEAT 1000 {
 }
             )input")),
         trim(R"output(
-REPEAT 1000 {
-    error(0.25) D0
-    TICK 1
+repeat 1000 {
+    error(0.25) D0+t
+    tick 1
 }
             )output"));
 }

--- a/src/simd/pointer_range.h
+++ b/src/simd/pointer_range.h
@@ -126,6 +126,12 @@ struct ConstPointerRange {
     const T *end() const {
         return ptr_end;
     }
+    const T &front() const {
+        return &ptr_start;
+    }
+    const T &back() const {
+        return *(ptr_end - 1);
+    }
     const T &operator[](size_t index) const {
         return ptr_start[index];
     }


### PR DESCRIPTION
- Add stim::DetectorErrorModel
- Add stim_internal::{DemInstructionType,RelValue,DemRelativeSymptom,DemInstruction}
- Add stim_internal::ConstPointerRange::{front,back}
- Move several circuit parsing methods up to circuit.h for re-use
- Fix circuit move constructor/assignment copying target data instead of moving it
    - Bit worried about the Chesterton fence aspect of removing this. I think I originally added it because it was necessary, but I think that was when the target data was accessed using a vector pointer plus offset instead of just a pointer range. It was the vector pointer that was going stale, so now it *should* be safe to move...
- Fix Hadamard gate help redundantly saying the bloch rotation
- Add stim_internal::{ostream_else_cout,find_output_stream_argument} and use it in circuit gen / error analysis modes