### PR TITLE
Add noisy measurements and fix MY=MRY bug

### DIFF
--- a/doc/gates.md
+++ b/doc/gates.md
@@ -1455,8 +1455,10 @@
     
     Alternate name: <a name="MZ"></a>`MZ`
     
-    Z-basis measurement.
+    Z-basis measurement (optionally noisy).
     Projects each target qubit into `|0>` or `|1>` and reports its value (false=`|0>`, true=`|1>`).
+    If this gate is parameterized by a probability argument, the recorded result will be flipped with that probability. If not, the recorded result is noiseless. Note that the noise only affects the recorded result, not the target qubit's state.
+    
     Prefixing a target with ! inverts its recorded measurement result.
     
     - Example:
@@ -1464,13 +1466,13 @@
         ```
         M 5
         M !42
-        M 5 !42
+        M(0.001) 5 !42
         ```
         
     - Stabilizer Generators:
     
         ```
-        Z -> m
+        Z -> m xor chance(p)
         Z -> +Z
         ```
         
@@ -1479,8 +1481,10 @@
     
     Alternate name: <a name="MRZ"></a>`MRZ`
     
-    Z-basis demolition measurement.
+    Z-basis demolition measurement (optionally noisy).
     Projects each target qubit into `|0>` or `|1>`, reports its value (false=`|0>`, true=`|1>`), then resets to `|0>`.
+    If this gate is parameterized by a probability argument, the recorded result will be flipped with that probability. If not, the recorded result is noiseless. Note that the noise only affects the recorded result, not the target qubit's state.
+    
     Prefixing a target with ! inverts its recorded measurement result.
     
     - Example:
@@ -1488,21 +1492,23 @@
         ```
         MR 5
         MR !42
-        MR 5 !42
+        MR(0.001) 5 !42
         ```
         
     - Stabilizer Generators:
     
         ```
-        Z -> m
+        Z -> m xor chance(p)
         1 -> +Z
         ```
         
     
 - <a name="MRX"></a>**`MRX`**
     
-    X-basis demolition measurement.
+    X-basis demolition measurement (optionally noisy).
     Projects each target qubit into `|+>` or `|->`, reports its value (false=`|+>`, true=`|->`), then resets to `|+>`.
+    If this gate is parameterized by a probability argument, the recorded result will be flipped with that probability. If not, the recorded result is noiseless. Note that the noise only affects the recorded result, not the target qubit's state.
+    
     Prefixing a target with ! inverts its recorded measurement result.
     
     - Example:
@@ -1510,21 +1516,23 @@
         ```
         MRX 5
         MRX !42
-        MRX 5 !42
+        MRX(0.001) 5 !42
         ```
         
     - Stabilizer Generators:
     
         ```
-        X -> m
+        X -> m xor chance(p)
         1 -> +X
         ```
         
     
 - <a name="MRY"></a>**`MRY`**
     
-    Y-basis demolition measurement.
+    Y-basis demolition measurement (optionally noisy).
     Projects each target qubit into `|i>` or `|-i>`, reports its value (false=`|i>`, true=`|-i>`), then resets to `|i>`.
+    If this gate is parameterized by a probability argument, the recorded result will be flipped with that probability. If not, the recorded result is noiseless. Note that the noise only affects the recorded result, not the target qubit's state.
+    
     Prefixing a target with ! inverts its recorded measurement result.
     
     - Example:
@@ -1532,21 +1540,23 @@
         ```
         MRY 5
         MRY !42
-        MRY 5 !42
+        MRY(0.001) 5 !42
         ```
         
     - Stabilizer Generators:
     
         ```
-        Y -> m
+        Y -> m xor chance(p)
         1 -> +Y
         ```
         
     
 - <a name="MX"></a>**`MX`**
     
-    X-basis measurement.
+    X-basis measurement (optionally noisy).
     Projects each target qubit into `|+>` or `|->` and reports its value (false=`|+>`, true=`|->`).
+    If this gate is parameterized by a probability argument, the recorded result will be flipped with that probability. If not, the recorded result is noiseless. Note that the noise only affects the recorded result, not the target qubit's state.
+    
     Prefixing a target with ! inverts its recorded measurement result.
     
     - Example:
@@ -1554,21 +1564,23 @@
         ```
         MX 5
         MX !42
-        MX 5 !42
+        MX(0.001) 5 !42
         ```
         
     - Stabilizer Generators:
     
         ```
-        X -> m
+        X -> +m xor chance(p)
         X -> +X
         ```
         
     
 - <a name="MY"></a>**`MY`**
     
-    Y-basis measurement.
+    Y-basis measurement (optionally noisy).
     Projects each target qubit into `|i>` or `|-i>` and reports its value (false=`|i>`, true=`|-i>`).
+    If this gate is parameterized by a probability argument, the recorded result will be flipped with that probability. If not, the recorded result is noiseless. Note that the noise only affects the recorded result, not the target qubit's state.
+    
     Prefixing a target with ! inverts its recorded measurement result.
     
     - Example:
@@ -1576,13 +1588,13 @@
         ```
         MY 5
         MY !42
-        MY 5 !42
+        MY(0.001) 5 !42
         ```
         
     - Stabilizer Generators:
     
         ```
-        Y -> m
+        Y -> m xor chance(p)
         Y -> +Y
         ```
         

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -920,7 +920,7 @@
 > structure.)
 > 
 > Args:
->     type: A string identifying the type of circuit to generate. Available types are:
+>     code_task: A string identifying the type of circuit to generate. Available types are:
 >         - `repetition_code:memory`
 >         - `surface_code:rotated_memory_x`
 >         - `surface_code:rotated_memory_z`

--- a/glue/cirq/stimcirq/_cirq_to_stim.py
+++ b/glue/cirq/stimcirq/_cirq_to_stim.py
@@ -102,6 +102,15 @@ def cirq_circuit_to_stim_data(
         q2i = {q: i for i, q in enumerate(sorted(circuit.all_qubits()))}
     out = stim.Circuit()
     key_out: List[Tuple[str, int]] = []
+
+    for q in sorted(circuit.all_qubits()):
+        if isinstance(q, cirq.LineQubit):
+            i = q2i[q]
+            if i != q.x:
+                out.append_operation("QUBIT_COORDS", [i], [q.x])
+        elif isinstance(q, cirq.GridQubit):
+            out.append_operation("QUBIT_COORDS", [q2i[q]], [q.row, q.col])
+
     for moment in circuit:
         _c2s_helper(moment, q2i, out, key_out)
         out.append_operation("TICK", [])

--- a/glue/javascript/tableau_simulator.js.cc
+++ b/glue/javascript/tableau_simulator.js.cc
@@ -52,7 +52,7 @@ static TempArgData args_to_target_pairs(TableauSimulator &self, const emscripten
     return result;
 }
 
-ExposedTableauSimulator::ExposedTableauSimulator() : sim(0, JS_BIND_SHARED_RNG()) {
+ExposedTableauSimulator::ExposedTableauSimulator() : sim(JS_BIND_SHARED_RNG(), 0) {
 }
 
 bool ExposedTableauSimulator::measure(size_t target) {

--- a/src/circuit/circuit.pybind.cc
+++ b/src/circuit/circuit.pybind.cc
@@ -617,7 +617,7 @@ void pybind_circuit(pybind11::module &m) {
             structure.)
 
             Args:
-                type: A string identifying the type of circuit to generate. Available types are:
+                code_task: A string identifying the type of circuit to generate. Available types are:
                     - `repetition_code:memory`
                     - `surface_code:rotated_memory_x`
                     - `surface_code:rotated_memory_z`

--- a/src/circuit/circuit.test.cc
+++ b/src/circuit/circuit.test.cc
@@ -283,7 +283,10 @@ TEST(circuit, append_op_validation) {
     ASSERT_THROW({ c.append_op("M", {0 | TARGET_PAULI_X_BIT}); }, std::invalid_argument);
     ASSERT_THROW({ c.append_op("M", {0 | TARGET_PAULI_Z_BIT}); }, std::invalid_argument);
     c.append_op("M", {0 | TARGET_INVERTED_BIT});
-    ASSERT_THROW({ c.append_op("M", {0}, 0.5); }, std::invalid_argument);
+    c.append_op("M", {0 | TARGET_INVERTED_BIT}, 0.125);
+    ASSERT_THROW({ c.append_op("M", {0}, 1.5); }, std::invalid_argument);
+    ASSERT_THROW({ c.append_op("M", {0}, -1.5); }, std::invalid_argument);
+    ASSERT_THROW({ c.append_op("M", {0}, {0.125, 0.25}); }, std::invalid_argument);
 
     c.append_op("CORRELATED_ERROR", {0 | TARGET_PAULI_X_BIT}, 0.1);
     c.append_op("CORRELATED_ERROR", {0 | TARGET_PAULI_Z_BIT}, 0.1);

--- a/src/circuit/gate_data.h
+++ b/src/circuit/gate_data.h
@@ -40,7 +40,8 @@ struct Tableau;
 struct Operation;
 struct ErrorAnalyzer;
 
-constexpr uint8_t ARG_COUNT_VARIABLE = uint8_t{0xFF};
+constexpr uint8_t ARG_COUNT_SYGIL_ANY = uint8_t{0xFF};
+constexpr uint8_t ARG_COUNT_SYGIL_ZERO_OR_ONE = uint8_t{0xFE};
 
 inline uint8_t gate_name_to_id(const char *v, size_t n) {
     // HACK: A collision is considered to be an error.
@@ -88,7 +89,7 @@ enum GateFlags : uint16_t {
     GATE_ARGS_ARE_DISJOINT_PROBABILITIES = 1 << 2,
     // Indicates whether the gate puts data into the measurement record or not.
     // Also determines whether or not inverted targets (like "!3") are permitted.
-    GATE_PRODUCES_RESULTS = 1 << 3,
+    GATE_PRODUCES_NOISY_RESULTS = 1 << 3,
     // Prevents the same gate on adjacent lines from being combined into one longer invocation.
     GATE_IS_NOT_FUSABLE = 1 << 4,
     // Controls block functionality for instructions like REPEAT.

--- a/src/circuit/gate_data_annotations.cc
+++ b/src/circuit/gate_data_annotations.cc
@@ -26,7 +26,7 @@ void GateDataMap::add_gate_data_annotations(bool &failed) {
         failed,
         Gate{
             "DETECTOR",
-            ARG_COUNT_VARIABLE,
+            ARG_COUNT_SYGIL_ANY,
             &TableauSimulator::I,
             &FrameSimulator::I,
             &ErrorAnalyzer::DETECTOR,
@@ -146,7 +146,7 @@ For example, used by `stimcirq` to preserve the moment structure of cirq circuit
         failed,
         Gate{
             "QUBIT_COORDS",
-            ARG_COUNT_VARIABLE,
+            ARG_COUNT_SYGIL_ANY,
             &TableauSimulator::I,
             &FrameSimulator::I,
             &ErrorAnalyzer::I,
@@ -190,7 +190,7 @@ For example, this could be used to indicate a simulated qubit is iteratively pla
         failed,
         Gate{
             "SHIFT_COORDS",
-            ARG_COUNT_VARIABLE,
+            ARG_COUNT_SYGIL_ANY,
             &TableauSimulator::I,
             &FrameSimulator::I,
             &ErrorAnalyzer::SHIFT_COORDS,

--- a/src/circuit/gate_data_collapsing.cc
+++ b/src/circuit/gate_data_collapsing.cc
@@ -27,20 +27,20 @@ void GateDataMap::add_gate_data_collapsing(bool &failed) {
         failed,
         Gate{
             "MX",
-            0,
+            ARG_COUNT_SYGIL_ZERO_OR_ONE,
             &TableauSimulator::measure_x,
             &FrameSimulator::measure_x,
             &ErrorAnalyzer::MX,
-            GATE_PRODUCES_RESULTS,
+            (GateFlags)(GATE_PRODUCES_NOISY_RESULTS | GATE_ARGS_ARE_DISJOINT_PROBABILITIES),
             []() -> ExtraGateData {
                 return {
                     "L_Collapsing Gates",
                     R"MARKDOWN(
-X-basis measurement.
+X-basis measurement (optionally noisy).
 Projects each target qubit into `|+>` or `|->` and reports its value (false=`|+>`, true=`|->`).
 )MARKDOWN",
                     {},
-                    {"X -> m", "X -> +X"},
+                    {"X -> +m xor chance(p)", "X -> +X"},
                 };
             },
         });
@@ -48,20 +48,20 @@ Projects each target qubit into `|+>` or `|->` and reports its value (false=`|+>
         failed,
         Gate{
             "MY",
-            0,
+            ARG_COUNT_SYGIL_ZERO_OR_ONE,
             &TableauSimulator::measure_y,
             &FrameSimulator::measure_y,
             &ErrorAnalyzer::MY,
-            GATE_PRODUCES_RESULTS,
+            (GateFlags)(GATE_PRODUCES_NOISY_RESULTS | GATE_ARGS_ARE_DISJOINT_PROBABILITIES),
             []() -> ExtraGateData {
                 return {
                     "L_Collapsing Gates",
                     R"MARKDOWN(
-Y-basis measurement.
+Y-basis measurement (optionally noisy).
 Projects each target qubit into `|i>` or `|-i>` and reports its value (false=`|i>`, true=`|-i>`).
 )MARKDOWN",
                     {},
-                    {"Y -> m", "Y -> +Y"},
+                    {"Y -> m xor chance(p)", "Y -> +Y"},
                 };
             },
         });
@@ -69,20 +69,20 @@ Projects each target qubit into `|i>` or `|-i>` and reports its value (false=`|i
         failed,
         Gate{
             "M",
-            0,
+            ARG_COUNT_SYGIL_ZERO_OR_ONE,
             &TableauSimulator::measure_z,
             &FrameSimulator::measure_z,
             &ErrorAnalyzer::MZ,
-            GATE_PRODUCES_RESULTS,
+            (GateFlags)(GATE_PRODUCES_NOISY_RESULTS | GATE_ARGS_ARE_DISJOINT_PROBABILITIES),
             []() -> ExtraGateData {
                 return {
                     "L_Collapsing Gates",
                     R"MARKDOWN(
-Z-basis measurement.
+Z-basis measurement (optionally noisy).
 Projects each target qubit into `|0>` or `|1>` and reports its value (false=`|0>`, true=`|1>`).
 )MARKDOWN",
                     {},
-                    {"Z -> m", "Z -> +Z"},
+                    {"Z -> m xor chance(p)", "Z -> +Z"},
                 };
             },
         });
@@ -93,20 +93,20 @@ Projects each target qubit into `|0>` or `|1>` and reports its value (false=`|0>
         failed,
         Gate{
             "MRX",
-            0,
+            ARG_COUNT_SYGIL_ZERO_OR_ONE,
             &TableauSimulator::measure_reset_x,
             &FrameSimulator::measure_reset_x,
             &ErrorAnalyzer::MRX,
-            GATE_PRODUCES_RESULTS,
+            (GateFlags)(GATE_PRODUCES_NOISY_RESULTS | GATE_ARGS_ARE_DISJOINT_PROBABILITIES),
             []() -> ExtraGateData {
                 return {
                     "L_Collapsing Gates",
                     R"MARKDOWN(
-X-basis demolition measurement.
+X-basis demolition measurement (optionally noisy).
 Projects each target qubit into `|+>` or `|->`, reports its value (false=`|+>`, true=`|->`), then resets to `|+>`.
 )MARKDOWN",
                     {},
-                    {"X -> m", "1 -> +X"},
+                    {"X -> m xor chance(p)", "1 -> +X"},
                 };
             },
         });
@@ -114,20 +114,20 @@ Projects each target qubit into `|+>` or `|->`, reports its value (false=`|+>`, 
         failed,
         Gate{
             "MRY",
-            0,
+            ARG_COUNT_SYGIL_ZERO_OR_ONE,
             &TableauSimulator::measure_reset_y,
             &FrameSimulator::measure_reset_y,
             &ErrorAnalyzer::MRY,
-            GATE_PRODUCES_RESULTS,
+            (GateFlags)(GATE_PRODUCES_NOISY_RESULTS | GATE_ARGS_ARE_DISJOINT_PROBABILITIES),
             []() -> ExtraGateData {
                 return {
                     "L_Collapsing Gates",
                     R"MARKDOWN(
-Y-basis demolition measurement.
+Y-basis demolition measurement (optionally noisy).
 Projects each target qubit into `|i>` or `|-i>`, reports its value (false=`|i>`, true=`|-i>`), then resets to `|i>`.
 )MARKDOWN",
                     {},
-                    {"Y -> m", "1 -> +Y"},
+                    {"Y -> m xor chance(p)", "1 -> +Y"},
                 };
             },
         });
@@ -135,20 +135,20 @@ Projects each target qubit into `|i>` or `|-i>`, reports its value (false=`|i>`,
         failed,
         Gate{
             "MR",
-            0,
+            ARG_COUNT_SYGIL_ZERO_OR_ONE,
             &TableauSimulator::measure_reset_z,
             &FrameSimulator::measure_reset_z,
             &ErrorAnalyzer::MRZ,
-            GATE_PRODUCES_RESULTS,
+            (GateFlags)(GATE_PRODUCES_NOISY_RESULTS | GATE_ARGS_ARE_DISJOINT_PROBABILITIES),
             []() -> ExtraGateData {
                 return {
                     "L_Collapsing Gates",
                     R"MARKDOWN(
-Z-basis demolition measurement.
+Z-basis demolition measurement (optionally noisy).
 Projects each target qubit into `|0>` or `|1>`, reports its value (false=`|0>`, true=`|1>`), then resets to `|0>`.
 )MARKDOWN",
                     {},
-                    {"Z -> m", "1 -> +Z"},
+                    {"Z -> m xor chance(p)", "1 -> +Z"},
                 };
             },
         });

--- a/src/dem/detector_error_model.cc
+++ b/src/dem/detector_error_model.cc
@@ -483,7 +483,7 @@ void dem_read_instruction(DetectorErrorModel &model, char lead_char, SOURCE read
                 throw std::invalid_argument("Missing '{' at start of repeat block.");
             }
         } else {
-            read_parens_arguments(c, "detector error model instruction", read_char, ARG_COUNT_VARIABLE, model.arg_buf);
+            read_parens_arguments(c, "detector error model instruction", read_char, model.arg_buf);
             if (type == DEM_SHIFT_DETECTORS) {
                 if (read_until_next_line_arg(c, read_char)) {
                     model.target_buf.append_tail(DemTarget{read_uint60_t(c, read_char)});

--- a/src/gate_help.cc
+++ b/src/gate_help.cc
@@ -80,7 +80,7 @@ void print_example(Acc &out, const char *name, const Gate &gate) {
     out << "```\n";
     for (size_t k = 0; k < 3; k++) {
         out << name;
-        if (gate.flags & GATE_IS_NOISE) {
+        if ((gate.flags & GATE_IS_NOISE) || (k == 2 && (gate.flags & GATE_PRODUCES_NOISY_RESULTS))) {
             out << "(" << 0.001 << ")";
         }
         if (k != 1) {
@@ -91,7 +91,7 @@ void print_example(Acc &out, const char *name, const Gate &gate) {
         }
         if (k != 0) {
             out << " ";
-            if (gate.flags & GATE_PRODUCES_RESULTS) {
+            if (gate.flags & GATE_PRODUCES_NOISY_RESULTS) {
                 out << "!";
             }
             out << 42;
@@ -280,7 +280,12 @@ std::string generate_per_gate_help_markdown(const Gate &alt_gate, int indent, bo
     }
     auto data = gate.extra_data_func();
     out << data.description;
-    if (gate.flags & GATE_PRODUCES_RESULTS) {
+    if (gate.flags & GATE_PRODUCES_NOISY_RESULTS) {
+        out << "If this gate is parameterized by a probability argument, the "
+               "recorded result will be flipped with that probability. "
+               "If not, the recorded result is noiseless. "
+               "Note that the noise only affects the recorded result, not the "
+               "target qubit's state.\n\n";
         out << "Prefixing a target with ! inverts its recorded measurement result.\n";
     }
 

--- a/src/io/measure_record_batch.h
+++ b/src/io/measure_record_batch.h
@@ -60,8 +60,14 @@ struct MeasureRecordBatch {
     /// Returns:
     ///     A reference into the storage table, with the bit at offset k corresponding to the measurement from stream k.
     simd_bits_range_ref lookback(size_t lookback) const;
+    /// Xors a batch measurement result into pre-reserved noisy storage.
+    void xor_record_reserved_result(simd_bits_range_ref result);
     /// Appends a batch measurement result into storage.
     void record_result(simd_bits_range_ref result);
+    /// Reserves space for storing measurement results. Initializes bits to be noisy with the given probability.
+    void reserve_noisy_space_for_results(const OperationData &target_data, std::mt19937_64 &rng);
+    /// Ensures there is enough space for storing a number of measurement results, without moving memory.
+    void reserve_space_for_results(size_t count);
     /// Resets the record to an empty state.
     void clear();
 };

--- a/src/simd/simd_bits.cc
+++ b/src/simd/simd_bits.cc
@@ -162,3 +162,7 @@ simd_bits &simd_bits::swap_with(simd_bits_range_ref other) {
     simd_bits_range_ref(*this).swap_with(other);
     return *this;
 }
+
+size_t simd_bits::popcnt() const {
+    return simd_bits_range_ref(*this).popcnt();
+}

--- a/src/simd/simd_bits.h
+++ b/src/simd/simd_bits.h
@@ -89,6 +89,9 @@ struct simd_bits {
         return simd_bits_range_ref(ptr_simd + word_offset, sub_num_simd_words);
     }
 
+    /// Returns the number of bits that are 1 in the bit range.
+    size_t popcnt() const;
+
     /// Inverts all bits in the range.
     void invert_bits();
     /// Sets all bits in the range to zero.

--- a/src/simd/simd_bits.test.cc
+++ b/src/simd/simd_bits.test.cc
@@ -277,3 +277,15 @@ TEST(simd_bits, truncated_overwrite_from) {
         ASSERT_EQ(mut[k], k < 455 ? dat[k] : old[k]) << k;
     }
 }
+
+TEST(simd_bits, popcnt) {
+    simd_bits data(1024);
+    ASSERT_EQ(data.popcnt(), 0);
+    data[101] = 1;
+    ASSERT_EQ(data.popcnt(), 1);
+    data[0] = 1;
+    ASSERT_EQ(data.popcnt(), 2);
+    data.u64[8] = 0xFFFFFFFFFFFFFFFFULL;
+    ASSERT_EQ(data.popcnt(), 66);
+    ASSERT_EQ(simd_bits(0).popcnt(), 0);
+}

--- a/src/simd/simd_bits_range_ref.cc
+++ b/src/simd/simd_bits_range_ref.cc
@@ -119,3 +119,11 @@ void simd_bits_range_ref::truncated_overwrite_from(simd_bits_range_ref other, si
         u8[n8] |= other.u8[n8] & m8;
     }
 }
+size_t simd_bits_range_ref::popcnt() const {
+    auto end = u64 + num_u64_padded();
+    size_t result = 0;
+    for (const uint64_t *p = u64; p != end; p++) {
+        result += popcnt64(*p);
+    }
+    return result;
+}

--- a/src/simd/simd_bits_range_ref.h
+++ b/src/simd/simd_bits_range_ref.h
@@ -85,6 +85,8 @@ struct simd_bits_range_ref {
     void clear();
     /// Randomizes the bits in the referenced range, up to the given bit count. Leaves further bits unchanged.
     void randomize(size_t num_bits, std::mt19937_64 &rng);
+    /// Returns the number of bits that are 1 in the bit range.
+    size_t popcnt() const;
 
     /// Writes bits from another location.
     /// Bits not part of the write are unchanged.

--- a/src/simd/simd_bits_range_ref.test.cc
+++ b/src/simd/simd_bits_range_ref.test.cc
@@ -236,3 +236,15 @@ TEST(simd_bits_range_ref, truncated_overwrite_from) {
         ASSERT_EQ(mut[k], k < 455 ? dat[k] : old[k]) << k;
     }
 }
+
+TEST(simd_bits_range_ref, popcnt) {
+    simd_bits data(1024);
+    simd_bits_range_ref ref(data);
+    ASSERT_EQ(ref.popcnt(), 0);
+    data[101] = 1;
+    ASSERT_EQ(ref.popcnt(), 1);
+    data[0] = 1;
+    ASSERT_EQ(ref.popcnt(), 2);
+    data.u64[8] = 0xFFFFFFFFFFFFFFFFULL;
+    ASSERT_EQ(ref.popcnt(), 66);
+}

--- a/src/simd/sparse_xor_vec.h
+++ b/src/simd/sparse_xor_vec.h
@@ -96,7 +96,7 @@ inline void xor_merge_sort_temp_buffer_callback(
 
 template <typename T>
 struct SparseXorVec;
-}
+}  // namespace stim_internal
 
 template <typename T>
 std::ostream &operator<<(std::ostream &out, const stim_internal::SparseXorVec<T> &v);

--- a/src/simulators/detection_simulator.test.cc
+++ b/src/simulators/detection_simulator.test.cc
@@ -219,3 +219,243 @@ TEST(DetectionSimulator, stream_results_triple_shot) {
         ASSERT_EQ(result[s + 30000], '\n');
     }
 }
+
+TEST(DetectorSimulator, noisy_measurement_x) {
+    auto r = detector_samples(
+        Circuit(R"CIRCUIT(
+        RX 0
+        MX(0.05) 0
+        MX 0
+        DETECTOR rec[-2]
+        DETECTOR rec[-1]
+    )CIRCUIT"),
+        10000,
+        false,
+        false,
+        SHARED_TEST_RNG());
+    ASSERT_FALSE(r[1].not_zero());
+    auto m1 = r[0].popcnt();
+    ASSERT_GT(m1, 300);
+    ASSERT_LT(m1, 700);
+
+    r = detector_samples(
+        Circuit(R"CIRCUIT(
+        RX 0 1
+        Z_ERROR(1) 0 1
+        MX(0.05) 0 1
+        MX 0 1
+        DETECTOR rec[-4]
+        DETECTOR rec[-3]
+        DETECTOR rec[-2]
+        DETECTOR rec[-1]
+    )CIRCUIT"),
+        5000,
+        false,
+        false,
+        SHARED_TEST_RNG());
+    auto m2 = r[0].popcnt() + r[1].popcnt();
+    ASSERT_LT(m2, 10000 - 300);
+    ASSERT_GT(m2, 10000 - 700);
+    ASSERT_EQ(r[2].popcnt(), 5000);
+    ASSERT_EQ(r[3].popcnt(), 5000);
+}
+
+TEST(DetectorSimulator, noisy_measurement_y) {
+    auto r = detector_samples(
+        Circuit(R"CIRCUIT(
+        RY 0
+        MY(0.05) 0
+        MY 0
+        DETECTOR rec[-2]
+        DETECTOR rec[-1]
+    )CIRCUIT"),
+        10000,
+        false,
+        false,
+        SHARED_TEST_RNG());
+    ASSERT_FALSE(r[1].not_zero());
+    auto m1 = r[0].popcnt();
+    ASSERT_GT(m1, 300);
+    ASSERT_LT(m1, 700);
+
+    r = detector_samples(
+        Circuit(R"CIRCUIT(
+        RY 0 1
+        Z_ERROR(1) 0 1
+        MY(0.05) 0 1
+        MY 0 1
+        DETECTOR rec[-4]
+        DETECTOR rec[-3]
+        DETECTOR rec[-2]
+        DETECTOR rec[-1]
+    )CIRCUIT"),
+        5000,
+        false,
+        false,
+        SHARED_TEST_RNG());
+    auto m2 = r[0].popcnt() + r[1].popcnt();
+    ASSERT_LT(m2, 10000 - 300);
+    ASSERT_GT(m2, 10000 - 700);
+    ASSERT_EQ(r[2].popcnt(), 5000);
+    ASSERT_EQ(r[3].popcnt(), 5000);
+}
+
+TEST(DetectorSimulator, noisy_measurement_z) {
+    auto r = detector_samples(
+        Circuit(R"CIRCUIT(
+        RZ 0
+        MZ(0.05) 0
+        MZ 0
+        DETECTOR rec[-2]
+        DETECTOR rec[-1]
+    )CIRCUIT"),
+        10000,
+        false,
+        false,
+        SHARED_TEST_RNG());
+    ASSERT_FALSE(r[1].not_zero());
+    auto m1 = r[0].popcnt();
+    ASSERT_GT(m1, 300);
+    ASSERT_LT(m1, 700);
+
+    r = detector_samples(
+        Circuit(R"CIRCUIT(
+        RZ 0 1
+        X_ERROR(1) 0 1
+        MZ(0.05) 0 1
+        MZ 0 1
+        DETECTOR rec[-4]
+        DETECTOR rec[-3]
+        DETECTOR rec[-2]
+        DETECTOR rec[-1]
+    )CIRCUIT"),
+        5000,
+        false,
+        false,
+        SHARED_TEST_RNG());
+    auto m2 = r[0].popcnt() + r[1].popcnt();
+    ASSERT_LT(m2, 10000 - 300);
+    ASSERT_GT(m2, 10000 - 700);
+    ASSERT_EQ(r[2].popcnt(), 5000);
+    ASSERT_EQ(r[3].popcnt(), 5000);
+}
+
+TEST(DetectorSimulator, noisy_measure_reset_x) {
+    auto r = detector_samples(
+        Circuit(R"CIRCUIT(
+        RX 0
+        MRX(0.05) 0
+        MRX 0
+        DETECTOR rec[-2]
+        DETECTOR rec[-1]
+    )CIRCUIT"),
+        10000,
+        false,
+        false,
+        SHARED_TEST_RNG());
+    ASSERT_FALSE(r[1].not_zero());
+    auto m1 = r[0].popcnt();
+    ASSERT_GT(m1, 300);
+    ASSERT_LT(m1, 700);
+
+    r = detector_samples(
+        Circuit(R"CIRCUIT(
+        RX 0 1
+        Z_ERROR(1) 0 1
+        MRX(0.05) 0 1
+        MRX 0 1
+        DETECTOR rec[-4]
+        DETECTOR rec[-3]
+        DETECTOR rec[-2]
+        DETECTOR rec[-1]
+    )CIRCUIT"),
+        5000,
+        false,
+        false,
+        SHARED_TEST_RNG());
+    auto m2 = r[0].popcnt() + r[1].popcnt();
+    ASSERT_LT(m2, 10000 - 300);
+    ASSERT_GT(m2, 10000 - 700);
+    ASSERT_EQ(r[2].popcnt(), 0);
+    ASSERT_EQ(r[3].popcnt(), 0);
+}
+
+TEST(DetectorSimulator, noisy_measure_reset_y) {
+    auto r = detector_samples(
+        Circuit(R"CIRCUIT(
+        RY 0
+        MRY(0.05) 0
+        MRY 0
+        DETECTOR rec[-2]
+        DETECTOR rec[-1]
+    )CIRCUIT"),
+        10000,
+        false,
+        false,
+        SHARED_TEST_RNG());
+    ASSERT_FALSE(r[1].not_zero());
+    auto m1 = r[0].popcnt();
+    ASSERT_GT(m1, 300);
+    ASSERT_LT(m1, 700);
+
+    r = detector_samples(
+        Circuit(R"CIRCUIT(
+        RY 0 1
+        Z_ERROR(1) 0 1
+        MRY(0.05) 0 1
+        MRY 0 1
+        DETECTOR rec[-4]
+        DETECTOR rec[-3]
+        DETECTOR rec[-2]
+        DETECTOR rec[-1]
+    )CIRCUIT"),
+        5000,
+        false,
+        false,
+        SHARED_TEST_RNG());
+    auto m2 = r[0].popcnt() + r[1].popcnt();
+    ASSERT_LT(m2, 10000 - 300);
+    ASSERT_GT(m2, 10000 - 700);
+    ASSERT_EQ(r[2].popcnt(), 0);
+    ASSERT_EQ(r[3].popcnt(), 0);
+}
+
+TEST(DetectorSimulator, noisy_measure_reset_z) {
+    auto r = detector_samples(
+        Circuit(R"CIRCUIT(
+        RZ 0
+        MRZ(0.05) 0
+        MRZ 0
+        DETECTOR rec[-2]
+        DETECTOR rec[-1]
+    )CIRCUIT"),
+        10000,
+        false,
+        false,
+        SHARED_TEST_RNG());
+    ASSERT_FALSE(r[1].not_zero());
+    auto m1 = r[0].popcnt();
+    ASSERT_GT(m1, 300);
+    ASSERT_LT(m1, 700);
+
+    r = detector_samples(
+        Circuit(R"CIRCUIT(
+        RZ 0 1
+        X_ERROR(1) 0 1
+        MRZ(0.05) 0 1
+        MRZ 0 1
+        DETECTOR rec[-4]
+        DETECTOR rec[-3]
+        DETECTOR rec[-2]
+        DETECTOR rec[-1]
+    )CIRCUIT"),
+        5000,
+        false,
+        false,
+        SHARED_TEST_RNG());
+    auto m2 = r[0].popcnt() + r[1].popcnt();
+    ASSERT_LT(m2, 10000 - 300);
+    ASSERT_GT(m2, 10000 - 700);
+    ASSERT_EQ(r[2].popcnt(), 0);
+    ASSERT_EQ(r[3].popcnt(), 0);
+}

--- a/src/simulators/error_analyzer.h
+++ b/src/simulators/error_analyzer.h
@@ -126,6 +126,8 @@ struct ErrorAnalyzer {
     /// When detectors anti-commute with a reset, that set of detectors becomes a degree of freedom.
     /// Use that degree of freedom to delete the largest detector in the set from the system.
     void remove_gauge(ConstPointerRange<DemTarget> sorted);
+    /// Sorts the targets coming out of the measurement queue, then optionally inserts a measurement error.
+    void xor_sort_measurement_error(std::vector<DemTarget> &queued, const OperationData &dat);
     void check_for_gauge(const SparseXorVec<DemTarget> &potential_gauge, const char *context);
     void check_for_gauge(
         SparseXorVec<DemTarget> &potential_gauge_summand_1,
@@ -135,7 +137,7 @@ struct ErrorAnalyzer {
     void shift_active_detector_ids(int64_t shift);
     void flush();
     void run_loop(const Circuit &loop, uint64_t iterations);
-    ConstPointerRange<DemTarget> add_error(double probability, ConstPointerRange<DemTarget> data);
+    ConstPointerRange<DemTarget> add_error(double probability, ConstPointerRange<DemTarget> flipped_sorted);
     ConstPointerRange<DemTarget> add_xored_error(
         double probability, ConstPointerRange<DemTarget> flipped1, ConstPointerRange<DemTarget> flipped2);
     ConstPointerRange<DemTarget> add_error_in_sorted_jagged_tail(double probability);
@@ -155,7 +157,7 @@ struct ErrorAnalyzer {
     ///
     /// Returns:
     ///    A range over the stored data.
-    ConstPointerRange<DemTarget> mono_dedupe_store(ConstPointerRange<DemTarget> data);
+    ConstPointerRange<DemTarget> mono_dedupe_store(ConstPointerRange<DemTarget> sorted);
 
     /// Adds each given error, and also each possible combination of the given errors, to the possible errors.
     ///

--- a/src/simulators/error_analyzer.test.cc
+++ b/src/simulators/error_analyzer.test.cc
@@ -1891,3 +1891,201 @@ TEST(ErrorAnalyzer, duplicate_records_in_detectors) {
     ASSERT_EQ(m0, m2);
     ASSERT_EQ(m1, m3);
 }
+
+TEST(ErrorAnalyzer, noisy_measurement_mx) {
+    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(
+        Circuit(R"CIRCUIT(
+            RX 0
+            MX(0.125) 0
+            MX 0
+            DETECTOR rec[-2]
+            DETECTOR rec[-1]
+        )CIRCUIT"), false, false, false, false),
+        DetectorErrorModel(R"MODEL(
+            error(0.125) D0
+            detector D1
+        )MODEL"));
+
+    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(
+        Circuit(R"CIRCUIT(
+            RX 0 1
+            Y_ERROR(1) 0 1
+            MX(0.125) 0 1
+            MX 0 1
+            DETECTOR rec[-4]
+            DETECTOR rec[-3]
+            DETECTOR rec[-2]
+            DETECTOR rec[-1]
+        )CIRCUIT"), false, false, false, false),
+        DetectorErrorModel(R"MODEL(
+            error(0.125) D0
+            error(1) D0 D2
+            error(0.125) D1
+            error(1) D1 D3
+        )MODEL"));
+}
+
+TEST(ErrorAnalyzer, noisy_measurement_my) {
+    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(
+        Circuit(R"CIRCUIT(
+            RY 0
+            MY(0.125) 0
+            MY 0
+            DETECTOR rec[-2]
+            DETECTOR rec[-1]
+        )CIRCUIT"), false, false, false, false),
+        DetectorErrorModel(R"MODEL(
+            error(0.125) D0
+            detector D1
+        )MODEL"));
+
+    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(
+        Circuit(R"CIRCUIT(
+            RY 0 1
+            Z_ERROR(1) 0 1
+            MY(0.125) 0 1
+            MY 0 1
+            DETECTOR rec[-4]
+            DETECTOR rec[-3]
+            DETECTOR rec[-2]
+            DETECTOR rec[-1]
+        )CIRCUIT"), false, false, false, false),
+        DetectorErrorModel(R"MODEL(
+            error(0.125) D0
+            error(1) D0 D2
+            error(0.125) D1
+            error(1) D1 D3
+        )MODEL"));
+}
+
+TEST(ErrorAnalyzer, noisy_measurement_mz) {
+    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(
+        Circuit(R"CIRCUIT(
+            RZ 0
+            MZ(0.125) 0
+            MZ 0
+            DETECTOR rec[-2]
+            DETECTOR rec[-1]
+        )CIRCUIT"), false, false, false, false),
+        DetectorErrorModel(R"MODEL(
+            error(0.125) D0
+            detector D1
+        )MODEL"));
+
+    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(
+        Circuit(R"CIRCUIT(
+            RZ 0 1
+            X_ERROR(1) 0 1
+            MZ(0.125) 0 1
+            MZ 0 1
+            DETECTOR rec[-4]
+            DETECTOR rec[-3]
+            DETECTOR rec[-2]
+            DETECTOR rec[-1]
+        )CIRCUIT"), false, false, false, false),
+        DetectorErrorModel(R"MODEL(
+            error(0.125) D0
+            error(1) D0 D2
+            error(0.125) D1
+            error(1) D1 D3
+        )MODEL"));
+}
+
+TEST(ErrorAnalyzer, noisy_measurement_mrx) {
+    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(
+        Circuit(R"CIRCUIT(
+            RX 0
+            MRX(0.125) 0
+            MRX 0
+            DETECTOR rec[-2]
+            DETECTOR rec[-1]
+        )CIRCUIT"), false, false, false, false),
+        DetectorErrorModel(R"MODEL(
+            error(0.125) D0
+            detector D1
+        )MODEL"));
+
+    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(
+        Circuit(R"CIRCUIT(
+            RX 0 1
+            Z_ERROR(1) 0 1
+            MRX(0.125) 0 1
+            MRX 0 1
+            DETECTOR rec[-4]
+            DETECTOR rec[-3]
+            DETECTOR rec[-2]
+            DETECTOR rec[-1]
+        )CIRCUIT"), false, false, false, false),
+        DetectorErrorModel(R"MODEL(
+            error(0.875) D0
+            error(0.875) D1
+            detector D2
+            detector D3
+        )MODEL"));
+}
+
+TEST(ErrorAnalyzer, noisy_measurement_mry) {
+    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(
+        Circuit(R"CIRCUIT(
+            RY 0
+            MRY(0.125) 0
+            MRY 0
+            DETECTOR rec[-2]
+            DETECTOR rec[-1]
+        )CIRCUIT"), false, false, false, false),
+        DetectorErrorModel(R"MODEL(
+            error(0.125) D0
+            detector D1
+        )MODEL"));
+
+    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(
+        Circuit(R"CIRCUIT(
+            RY 0 1
+            X_ERROR(1) 0 1
+            MRY(0.125) 0 1
+            MRY 0 1
+            DETECTOR rec[-4]
+            DETECTOR rec[-3]
+            DETECTOR rec[-2]
+            DETECTOR rec[-1]
+        )CIRCUIT"), false, false, false, false),
+        DetectorErrorModel(R"MODEL(
+            error(0.875) D0
+            error(0.875) D1
+            detector D2
+            detector D3
+        )MODEL"));
+}
+
+TEST(ErrorAnalyzer, noisy_measurement_mrz) {
+    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(
+        Circuit(R"CIRCUIT(
+            RZ 0
+            MRZ(0.125) 0
+            MRZ 0
+            DETECTOR rec[-2]
+            DETECTOR rec[-1]
+        )CIRCUIT"), false, false, false, false),
+        DetectorErrorModel(R"MODEL(
+            error(0.125) D0
+            detector D1
+        )MODEL"));
+
+    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(
+        Circuit(R"CIRCUIT(
+            RZ 0 1
+            X_ERROR(1) 0 1
+            MRZ(0.125) 0 1
+            MRZ 0 1
+            DETECTOR rec[-4]
+            DETECTOR rec[-3]
+            DETECTOR rec[-2]
+            DETECTOR rec[-1]
+        )CIRCUIT"), false, false, false, false),
+        DetectorErrorModel(R"MODEL(
+            error(0.875) D0
+            error(0.875) D1
+            detector D2
+            detector D3
+        )MODEL"));
+}

--- a/src/simulators/frame_simulator.h
+++ b/src/simulators/frame_simulator.h
@@ -20,9 +20,9 @@
 #include <random>
 
 #include "../circuit/circuit.h"
+#include "../io/measure_record_batch.h"
 #include "../simd/simd_bit_table.h"
 #include "../stabilizers/pauli_string.h"
-#include "../io/measure_record_batch.h"
 
 namespace stim_internal {
 
@@ -44,9 +44,32 @@ struct FrameSimulator {
 
     FrameSimulator(size_t num_qubits, size_t batch_size, size_t max_lookback, std::mt19937_64 &rng);
 
-    static simd_bit_table sample_flipped_measurements(const Circuit &circuit, size_t num_samples, std::mt19937_64 &rng);
+    /// Returns a batch of measurement-flipped samples from the circuit.
+    ///
+    /// Args:
+    ///     circuit: The circuit to sample from.
+    ///     num_shots: The number of shots of the circuit to run.
+    ///     rng: Random number generator.
+    ///
+    /// Returns:
+    ///     A table of results. First index (major) is measurement index, second index (minor) is shot index.
+    ///     Each bit in the table is whether a specific measurement was flipped in a specific shot.
+    static simd_bit_table sample_flipped_measurements(const Circuit &circuit, size_t num_shots, std::mt19937_64 &rng);
+
+    /// Returns a batch of samples from the circuit.
+    ///
+    /// Args:
+    ///     circuit: The circuit to sample from.
+    ///     reference_sample: A known-good sample from the circuit, collected without any noise processes.
+    ///     num_shots: The number of shots of the circuit to run.
+    ///     rng: Random number generator.
+    ///
+    /// Returns:
+    ///     A table of results. First index (major) is measurement index, second index (minor) is shot index.
+    ///     Each bit in the table is a measurement result.
     static simd_bit_table sample(
         const Circuit &circuit, const simd_bits &reference_sample, size_t num_samples, std::mt19937_64 &rng);
+
     static void sample_out(
         const Circuit &circuit,
         const simd_bits &reference_sample,

--- a/src/simulators/tableau_simulator.h
+++ b/src/simulators/tableau_simulator.h
@@ -25,9 +25,9 @@
 #include <sstream>
 
 #include "../circuit/circuit.h"
+#include "../io/measure_record.h"
 #include "../stabilizers/tableau.h"
 #include "../stabilizers/tableau_transposed_raii.h"
-#include "../io/measure_record.h"
 #include "vector_simulator.h"
 
 namespace stim_internal {
@@ -45,7 +45,7 @@ struct TableauSimulator {
     ///     sign_bias: 0 means collapse randomly, -1 means collapse towards True, +1 means collapse towards False.
     ///     record: Measurement record configuration.
     explicit TableauSimulator(
-        size_t num_qubits, std::mt19937_64 &rng, int8_t sign_bias = 0, MeasureRecord record = MeasureRecord());
+        std::mt19937_64 &rng, size_t num_qubits = 0, int8_t sign_bias = 0, MeasureRecord record = MeasureRecord());
 
     /// Samples the given circuit in a deterministic fashion.
     ///
@@ -134,6 +134,11 @@ struct TableauSimulator {
     bool is_deterministic_y(size_t target) const;
     /// Determines if a qubit's Z observable commutes (vs anti-commutes) with the current stabilizer generators.
     bool is_deterministic_z(size_t target) const;
+
+    /// Runs all of the operations in the given circuit.
+    ///
+    /// Automatically expands the tableau simulator's state, if needed.
+    void expand_do_circuit(const Circuit &circuit);
 
     std::vector<PauliString> canonical_stabilizers() const;
 
@@ -240,6 +245,9 @@ struct TableauSimulator {
     /// themselves (possibly negated) and that it maps all other qubits to Pauli products not involving the target
     /// qubit.
     void collapse_isolate_qubit_z(size_t target, TableauTransposedRaii &transposed_raii);
+
+   private:
+    void noisify_new_measurements(const OperationData &target_data);
 };
 
 template <size_t Q, typename RESET_FLAG, typename ELSE_CORR>

--- a/src/simulators/tableau_simulator.perf.cc
+++ b/src/simulators/tableau_simulator.perf.cc
@@ -21,7 +21,7 @@ using namespace stim_internal;
 BENCHMARK(TableauSimulator_CX_10Kqubits) {
     size_t num_qubits = 10 * 1000;
     std::mt19937_64 rng(0);  // NOLINT(cert-msc51-cpp)
-    TableauSimulator sim(num_qubits, rng);
+    TableauSimulator sim(rng, num_qubits);
 
     std::vector<uint32_t> targets;
     for (size_t k = 0; k < num_qubits; k++) {

--- a/src/simulators/tableau_simulator.pybind.cc
+++ b/src/simulators/tableau_simulator.pybind.cc
@@ -31,7 +31,7 @@ struct TempViewableData {
 };
 
 TableauSimulator create_tableau_simulator() {
-    return TableauSimulator(0, PYBIND_SHARED_RNG());
+    return TableauSimulator(PYBIND_SHARED_RNG(), 0);
 }
 
 TempViewableData args_to_targets(TableauSimulator &self, const pybind11::args &args) {
@@ -273,7 +273,7 @@ void pybind_tableau_simulator(pybind11::module &m) {
 
     c.def(
         "do",
-        TableauSimulator::expand_do_circuit,
+        &TableauSimulator::expand_do_circuit,
         pybind11::arg("circuit"),
         clean_doc_string(u8R"DOC(
             Applies all the operations in the given stim.Circuit to the simulator's state.

--- a/src/simulators/tableau_simulator.pybind.cc
+++ b/src/simulators/tableau_simulator.pybind.cc
@@ -273,12 +273,7 @@ void pybind_tableau_simulator(pybind11::module &m) {
 
     c.def(
         "do",
-        [](TableauSimulator &self, const Circuit &circuit) {
-            self.ensure_large_enough_for_qubits(circuit.count_qubits());
-            circuit.for_each_operation([&](const Operation &op) {
-                (self.*op.gate->tableau_simulator_function)(op.target_data);
-            });
-        },
+        TableauSimulator::expand_do_circuit,
         pybind11::arg("circuit"),
         clean_doc_string(u8R"DOC(
             Applies all the operations in the given stim.Circuit to the simulator's state.

--- a/src/simulators/tableau_simulator.test.cc
+++ b/src/simulators/tableau_simulator.test.cc
@@ -17,13 +17,12 @@
 #include <gtest/gtest.h>
 
 #include "../circuit/circuit.test.h"
-#include "../circuit/gate_data.h"
 #include "../test_util.test.h"
 
 using namespace stim_internal;
 
 TEST(TableauSimulator, identity) {
-    auto s = TableauSimulator(1, SHARED_TEST_RNG());
+    auto s = TableauSimulator(SHARED_TEST_RNG(), 1);
     ASSERT_EQ(s.measurement_record.storage, (std::vector<bool>{}));
     s.measure_z(OpDat(0));
     ASSERT_EQ(s.measurement_record.storage, (std::vector<bool>{false}));
@@ -32,7 +31,7 @@ TEST(TableauSimulator, identity) {
 }
 
 TEST(TableauSimulator, bit_flip) {
-    auto s = TableauSimulator(1, SHARED_TEST_RNG());
+    auto s = TableauSimulator(SHARED_TEST_RNG(), 1);
     s.H_XZ(OpDat(0));
     s.SQRT_Z(OpDat(0));
     s.SQRT_Z(OpDat(0));
@@ -44,7 +43,7 @@ TEST(TableauSimulator, bit_flip) {
 }
 
 TEST(TableauSimulator, identity2) {
-    auto s = TableauSimulator(2, SHARED_TEST_RNG());
+    auto s = TableauSimulator(SHARED_TEST_RNG(), 2);
     s.measure_z(OpDat(0));
     ASSERT_EQ(s.measurement_record.storage, (std::vector<bool>{false}));
     s.measure_z(OpDat(1));
@@ -52,7 +51,7 @@ TEST(TableauSimulator, identity2) {
 }
 
 TEST(TableauSimulator, bit_flip_2) {
-    auto s = TableauSimulator(2, SHARED_TEST_RNG());
+    auto s = TableauSimulator(SHARED_TEST_RNG(), 2);
     s.H_XZ(OpDat(0));
     s.SQRT_Z(OpDat(0));
     s.SQRT_Z(OpDat(0));
@@ -64,7 +63,7 @@ TEST(TableauSimulator, bit_flip_2) {
 }
 
 TEST(TableauSimulator, epr) {
-    auto s = TableauSimulator(2, SHARED_TEST_RNG());
+    auto s = TableauSimulator(SHARED_TEST_RNG(), 2);
     s.H_XZ(OpDat(0));
     s.ZCX(OpDat({0, 1}));
     ASSERT_EQ(s.is_deterministic_z(0), false);
@@ -77,7 +76,7 @@ TEST(TableauSimulator, epr) {
 }
 
 TEST(TableauSimulator, big_determinism) {
-    auto s = TableauSimulator(1000, SHARED_TEST_RNG());
+    auto s = TableauSimulator(SHARED_TEST_RNG(), 1000);
     s.H_XZ(OpDat(0));
     s.H_YZ(OpDat(1));
     ASSERT_FALSE(s.is_deterministic_z(0));
@@ -95,7 +94,7 @@ TEST(TableauSimulator, big_determinism) {
 
 TEST(TableauSimulator, phase_kickback_consume_s_state) {
     for (size_t k = 0; k < 8; k++) {
-        auto s = TableauSimulator(2, SHARED_TEST_RNG());
+        auto s = TableauSimulator(SHARED_TEST_RNG(), 2);
         s.H_XZ(OpDat(1));
         s.SQRT_Z(OpDat(1));
         s.H_XZ(OpDat(0));
@@ -116,7 +115,7 @@ TEST(TableauSimulator, phase_kickback_consume_s_state) {
 }
 
 TEST(TableauSimulator, phase_kickback_preserve_s_state) {
-    auto s = TableauSimulator(2, SHARED_TEST_RNG());
+    auto s = TableauSimulator(SHARED_TEST_RNG(), 2);
 
     // Prepare S state.
     s.H_XZ(OpDat(1));
@@ -145,7 +144,7 @@ TEST(TableauSimulator, phase_kickback_preserve_s_state) {
 }
 
 TEST(TableauSimulator, kickback_vs_stabilizer) {
-    auto sim = TableauSimulator(3, SHARED_TEST_RNG());
+    auto sim = TableauSimulator(SHARED_TEST_RNG(), 3);
     sim.H_XZ(OpDat(2));
     sim.ZCX(OpDat({2, 0}));
     sim.ZCX(OpDat({2, 1}));
@@ -165,7 +164,7 @@ TEST(TableauSimulator, kickback_vs_stabilizer) {
 
 TEST(TableauSimulator, s_state_distillation_low_depth) {
     for (size_t reps = 0; reps < 10; reps++) {
-        auto sim = TableauSimulator(9, SHARED_TEST_RNG());
+        auto sim = TableauSimulator(SHARED_TEST_RNG(), 9);
 
         std::vector<std::vector<uint8_t>> stabilizers = {
             {0, 1, 2, 3},
@@ -236,7 +235,7 @@ TEST(TableauSimulator, s_state_distillation_low_depth) {
 
 TEST(TableauSimulator, s_state_distillation_low_space) {
     for (size_t rep = 0; rep < 10; rep++) {
-        auto sim = TableauSimulator(5, SHARED_TEST_RNG());
+        auto sim = TableauSimulator(SHARED_TEST_RNG(), 5);
 
         std::vector<std::vector<uint8_t>> phasors = {
             {
@@ -289,7 +288,7 @@ TEST(TableauSimulator, s_state_distillation_low_space) {
 
 TEST(TableauSimulator, unitary_gates_consistent_with_tableau_data) {
     auto t = Tableau::random(10, SHARED_TEST_RNG());
-    TableauSimulator sim(10, SHARED_TEST_RNG());
+    TableauSimulator sim(SHARED_TEST_RNG(), 10);
     sim.inv_state = t;
     for (const auto &gate : GATE_DATA.gates()) {
         if (!(gate.flags & GATE_IS_UNITARY)) {
@@ -310,8 +309,8 @@ TEST(TableauSimulator, unitary_gates_consistent_with_tableau_data) {
 }
 
 TEST(TableauSimulator, certain_errors_consistent_with_gates) {
-    TableauSimulator sim1(2, SHARED_TEST_RNG());
-    TableauSimulator sim2(2, SHARED_TEST_RNG());
+    TableauSimulator sim1(SHARED_TEST_RNG(), 2);
+    TableauSimulator sim2(SHARED_TEST_RNG(), 2);
     uint32_t targets[]{0};
     double p0 = 0.0;
     double p1 = 1.0;
@@ -364,7 +363,7 @@ TEST(TableauSimulator, simulate_reset) {
 }
 
 TEST(TableauSimulator, to_vector_sim) {
-    TableauSimulator sim_tab(2, SHARED_TEST_RNG());
+    TableauSimulator sim_tab(SHARED_TEST_RNG(), 2);
     VectorSimulator sim_vec(2);
     ASSERT_TRUE(sim_tab.to_vector_sim().approximate_equals(sim_vec, true));
 
@@ -394,13 +393,13 @@ TEST(TableauSimulator, to_vector_sim) {
 }
 
 TEST(TableauSimulator, to_state_vector) {
-    auto v = TableauSimulator(0, SHARED_TEST_RNG()).to_state_vector();
+    auto v = TableauSimulator(SHARED_TEST_RNG(), 0).to_state_vector();
     ASSERT_EQ(v.size(), 1);
     auto r = v[0].real();
     auto i = v[0].imag();
     ASSERT_LT(r * r + i * i - 1, 1e-4);
 
-    TableauSimulator sim_tab(3, SHARED_TEST_RNG());
+    TableauSimulator sim_tab(SHARED_TEST_RNG(), 3);
     auto sim_vec = sim_tab.to_vector_sim();
     VectorSimulator sim_vec2(3);
     sim_vec2.state = sim_tab.to_state_vector();
@@ -408,7 +407,7 @@ TEST(TableauSimulator, to_state_vector) {
 }
 
 bool vec_sim_corroborates_measurement_process(const Tableau &state, const std::vector<uint32_t> &measurement_targets) {
-    TableauSimulator sim_tab(2, SHARED_TEST_RNG());
+    TableauSimulator sim_tab(SHARED_TEST_RNG(), 2);
     sim_tab.inv_state = state;
     auto vec_sim = sim_tab.to_vector_sim();
     sim_tab.measure_z(OpDat(measurement_targets));
@@ -740,7 +739,7 @@ TEST(TableauSimulator, mr_repeated_target) {
 }
 
 TEST(TableauSimulator, peek_bloch) {
-    TableauSimulator sim(3, SHARED_TEST_RNG());
+    TableauSimulator sim(SHARED_TEST_RNG(), 3);
     ASSERT_EQ(sim.peek_bloch(0), PauliString::from_str("+Z"));
     ASSERT_EQ(sim.peek_bloch(1), PauliString::from_str("+Z"));
     ASSERT_EQ(sim.peek_bloch(2), PauliString::from_str("+Z"));
@@ -798,8 +797,8 @@ TEST(TableauSimulator, peek_bloch) {
 }
 
 TEST(TableauSimulator, paulis) {
-    TableauSimulator sim1(500, SHARED_TEST_RNG());
-    TableauSimulator sim2(500, SHARED_TEST_RNG());
+    TableauSimulator sim1(SHARED_TEST_RNG(), 500);
+    TableauSimulator sim2(SHARED_TEST_RNG(), 500);
     sim1.inv_state = Tableau::random(500, SHARED_TEST_RNG());
     sim2.inv_state = sim1.inv_state;
 
@@ -818,8 +817,8 @@ TEST(TableauSimulator, paulis) {
 }
 
 TEST(TableauSimulator, set_num_qubits) {
-    TableauSimulator sim1(10, SHARED_TEST_RNG());
-    TableauSimulator sim2(10, SHARED_TEST_RNG());
+    TableauSimulator sim1(SHARED_TEST_RNG(), 10);
+    TableauSimulator sim2(SHARED_TEST_RNG(), 10);
     sim1.inv_state = Tableau::random(10, SHARED_TEST_RNG());
     sim2.inv_state = sim1.inv_state;
 
@@ -841,7 +840,7 @@ TEST(TableauSimulator, set_num_qubits) {
 }
 
 TEST(TableauSimulator, set_num_qubits_reduce_random) {
-    TableauSimulator sim(10, SHARED_TEST_RNG());
+    TableauSimulator sim(SHARED_TEST_RNG(), 10);
     sim.inv_state = Tableau::random(10, SHARED_TEST_RNG());
     sim.set_num_qubits(5);
     ASSERT_EQ(sim.inv_state.num_qubits, 5);
@@ -870,7 +869,7 @@ void scramble_stabilizers(TableauSimulator &s) {
 }
 
 TEST(TableauSimulator, canonical_stabilizers) {
-    TableauSimulator sim(2, SHARED_TEST_RNG());
+    TableauSimulator sim(SHARED_TEST_RNG(), 2);
     sim.H_XZ(OpDat(0));
     sim.ZCX(OpDat({0, 1}));
     ASSERT_EQ(
@@ -912,7 +911,7 @@ TEST(TableauSimulator, canonical_stabilizers) {
 }
 
 TEST(TableauSimulator, canonical_stabilizers_random) {
-    TableauSimulator sim(4, SHARED_TEST_RNG());
+    TableauSimulator sim(SHARED_TEST_RNG(), 4);
     sim.inv_state = Tableau::random(4, SHARED_TEST_RNG());
     auto s1 = sim.canonical_stabilizers();
     scramble_stabilizers(sim);
@@ -922,7 +921,7 @@ TEST(TableauSimulator, canonical_stabilizers_random) {
 
 TEST(TableauSimulator, set_num_qubits_reduce_preserves_scrambled_stabilizers) {
     auto &rng = SHARED_TEST_RNG();
-    TableauSimulator sim(4, rng);
+    TableauSimulator sim(rng, 4);
     sim.inv_state = Tableau::random(4, SHARED_TEST_RNG());
     auto s1 = sim.canonical_stabilizers();
     sim.inv_state.expand(8);
@@ -933,7 +932,7 @@ TEST(TableauSimulator, set_num_qubits_reduce_preserves_scrambled_stabilizers) {
 }
 
 TEST(TableauSimulator, measure_kickback_z) {
-    TableauSimulator sim(4, SHARED_TEST_RNG());
+    TableauSimulator sim(SHARED_TEST_RNG(), 4);
     sim.H_XZ(OpDat({0, 2}));
     sim.ZCX(OpDat({0, 1, 2, 3}));
     auto k1 = sim.measure_kickback_z(1);
@@ -952,7 +951,7 @@ TEST(TableauSimulator, measure_kickback_z) {
 }
 
 TEST(TableauSimulator, measure_kickback_x) {
-    TableauSimulator sim(4, SHARED_TEST_RNG());
+    TableauSimulator sim(SHARED_TEST_RNG(), 4);
     sim.H_XZ(OpDat({0, 2}));
     sim.ZCX(OpDat({0, 1, 2, 3}));
     auto k1 = sim.measure_kickback_x(1);
@@ -971,7 +970,7 @@ TEST(TableauSimulator, measure_kickback_x) {
 }
 
 TEST(TableauSimulator, measure_kickback_y) {
-    TableauSimulator sim(4, SHARED_TEST_RNG());
+    TableauSimulator sim(SHARED_TEST_RNG(), 4);
     sim.H_XZ(OpDat({0, 2}));
     sim.ZCX(OpDat({0, 1, 2, 3}));
     auto k1 = sim.measure_kickback_y(1);
@@ -990,7 +989,7 @@ TEST(TableauSimulator, measure_kickback_y) {
 }
 
 TEST(TableauSimulator, measure_kickback_isolates) {
-    TableauSimulator sim(4, SHARED_TEST_RNG());
+    TableauSimulator sim(SHARED_TEST_RNG(), 4);
     sim.inv_state = Tableau::random(4, SHARED_TEST_RNG());
     for (size_t k = 0; k < 4; k++) {
         auto result = sim.measure_kickback_z(k);
@@ -1003,7 +1002,7 @@ TEST(TableauSimulator, measure_kickback_isolates) {
 
 TEST(TableauSimulator, collapse_isolate_completely) {
     for (size_t k = 0; k < 10; k++) {
-        TableauSimulator sim(6, SHARED_TEST_RNG());
+        TableauSimulator sim(SHARED_TEST_RNG(), 6);
         sim.inv_state = Tableau::random(6, SHARED_TEST_RNG());
         {
             TableauTransposedRaii tmp(sim.inv_state);
@@ -1019,7 +1018,7 @@ TEST(TableauSimulator, collapse_isolate_completely) {
 }
 
 TEST(TableauSimulator, reset_pure) {
-    TableauSimulator t(1, SHARED_TEST_RNG());
+    TableauSimulator t(SHARED_TEST_RNG(), 1);
     ASSERT_EQ(t.peek_bloch(0), PauliString::from_str("+Z"));
     t.reset_y(OpDat(0));
     ASSERT_EQ(t.peek_bloch(0), PauliString::from_str("+Y"));
@@ -1032,7 +1031,7 @@ TEST(TableauSimulator, reset_pure) {
 }
 
 TEST(TableauSimulator, reset_random) {
-    TableauSimulator t(5, SHARED_TEST_RNG());
+    TableauSimulator t(SHARED_TEST_RNG(), 5);
 
     t.inv_state = Tableau::random(5, SHARED_TEST_RNG());
     t.reset_x(OpDat(0));
@@ -1060,7 +1059,7 @@ TEST(TableauSimulator, reset_random) {
 }
 
 TEST(TableauSimulator, reset_x_entangled) {
-    TableauSimulator t(2, SHARED_TEST_RNG());
+    TableauSimulator t(SHARED_TEST_RNG(), 2);
     t.H_XZ(OpDat(0));
     t.ZCX(OpDat({0, 1}));
     t.reset_x(OpDat(0));
@@ -1072,7 +1071,7 @@ TEST(TableauSimulator, reset_x_entangled) {
 }
 
 TEST(TableauSimulator, reset_y_entangled) {
-    TableauSimulator t(2, SHARED_TEST_RNG());
+    TableauSimulator t(SHARED_TEST_RNG(), 2);
     t.H_XZ(OpDat(0));
     t.ZCX(OpDat({0, 1}));
     t.reset_y(OpDat(0));
@@ -1084,7 +1083,7 @@ TEST(TableauSimulator, reset_y_entangled) {
 }
 
 TEST(TableauSimulator, reset_z_entangled) {
-    TableauSimulator t(2, SHARED_TEST_RNG());
+    TableauSimulator t(SHARED_TEST_RNG(), 2);
     t.H_XZ(OpDat(0));
     t.ZCX(OpDat({0, 1}));
     t.reset_z(OpDat(0));
@@ -1096,7 +1095,7 @@ TEST(TableauSimulator, reset_z_entangled) {
 }
 
 TEST(TableauSimulator, measure_x_entangled) {
-    TableauSimulator t(2, SHARED_TEST_RNG());
+    TableauSimulator t(SHARED_TEST_RNG(), 2);
     t.H_XZ(OpDat(0));
     t.ZCX(OpDat({0, 1}));
     t.measure_x(OpDat(0));
@@ -1110,7 +1109,7 @@ TEST(TableauSimulator, measure_x_entangled) {
 }
 
 TEST(TableauSimulator, measure_y_entangled) {
-    TableauSimulator t(2, SHARED_TEST_RNG());
+    TableauSimulator t(SHARED_TEST_RNG(), 2);
     t.H_XZ(OpDat(0));
     t.ZCX(OpDat({0, 1}));
     t.measure_y(OpDat(0));
@@ -1124,7 +1123,7 @@ TEST(TableauSimulator, measure_y_entangled) {
 }
 
 TEST(TableauSimulator, measure_z_entangled) {
-    TableauSimulator t(2, SHARED_TEST_RNG());
+    TableauSimulator t(SHARED_TEST_RNG(), 2);
     t.H_XZ(OpDat(0));
     t.ZCX(OpDat({0, 1}));
     t.measure_z(OpDat(0));
@@ -1138,7 +1137,7 @@ TEST(TableauSimulator, measure_z_entangled) {
 }
 
 TEST(TableauSimulator, measure_reset_x_entangled) {
-    TableauSimulator t(2, SHARED_TEST_RNG());
+    TableauSimulator t(SHARED_TEST_RNG(), 2);
     t.H_XZ(OpDat(0));
     t.ZCX(OpDat({0, 1}));
     t.measure_reset_x(OpDat(0));
@@ -1151,7 +1150,7 @@ TEST(TableauSimulator, measure_reset_x_entangled) {
 }
 
 TEST(TableauSimulator, measure_reset_y_entangled) {
-    TableauSimulator t(2, SHARED_TEST_RNG());
+    TableauSimulator t(SHARED_TEST_RNG(), 2);
     t.H_XZ(OpDat(0));
     t.ZCX(OpDat({0, 1}));
     t.measure_reset_y(OpDat(0));
@@ -1164,7 +1163,7 @@ TEST(TableauSimulator, measure_reset_y_entangled) {
 }
 
 TEST(TableauSimulator, measure_reset_z_entangled) {
-    TableauSimulator t(2, SHARED_TEST_RNG());
+    TableauSimulator t(SHARED_TEST_RNG(), 2);
     t.H_XZ(OpDat(0));
     t.ZCX(OpDat({0, 1}));
     t.measure_reset_z(OpDat(0));
@@ -1328,4 +1327,178 @@ TEST(TableauSimulator, resets_vs_measurements) {
             true,
             false,
         }));
+}
+
+TEST(TableauSimulator, noisy_measurement_x) {
+    TableauSimulator t(SHARED_TEST_RNG());
+    t.expand_do_circuit(R"CIRCUIT(
+        RX 0
+        REPEAT 10000 {
+            MX(0.05) 0
+        }
+    )CIRCUIT");
+    auto m1 = std::accumulate(t.measurement_record.storage.begin(), t.measurement_record.storage.end(), 0);
+    ASSERT_GT(m1, 300);
+    ASSERT_LT(m1, 700);
+    t.expand_do_circuit("MX 0");
+    ASSERT_FALSE(t.measurement_record.storage.back());
+
+    t.measurement_record.storage.clear();
+    t.expand_do_circuit(R"CIRCUIT(
+        RX 0 1
+        Y 0 1
+        REPEAT 5000 {
+            MX(0.05) 0 1
+        }
+    )CIRCUIT");
+    m1 = std::accumulate(t.measurement_record.storage.begin(), t.measurement_record.storage.end(), 0);
+    ASSERT_GT(m1, 10000 - 700);
+    ASSERT_LT(m1, 10000 - 300);
+    t.expand_do_circuit("MX 0");
+    ASSERT_TRUE(t.measurement_record.storage.back());
+}
+
+TEST(TableauSimulator, noisy_measurement_y) {
+    TableauSimulator t(SHARED_TEST_RNG());
+    t.expand_do_circuit(R"CIRCUIT(
+        RY 0
+        REPEAT 10000 {
+            MY(0.05) 0
+        }
+    )CIRCUIT");
+    auto m1 = std::accumulate(t.measurement_record.storage.begin(), t.measurement_record.storage.end(), 0);
+    ASSERT_GT(m1, 300);
+    ASSERT_LT(m1, 700);
+    t.expand_do_circuit("MY 0");
+    ASSERT_FALSE(t.measurement_record.storage.back());
+
+    t.measurement_record.storage.clear();
+    t.expand_do_circuit(R"CIRCUIT(
+        RY 0 1
+        X 0 1
+        REPEAT 5000 {
+            MY(0.05) 0 1
+        }
+    )CIRCUIT");
+    m1 = std::accumulate(t.measurement_record.storage.begin(), t.measurement_record.storage.end(), 0);
+    ASSERT_GT(m1, 10000 - 700);
+    ASSERT_LT(m1, 10000 - 300);
+    t.expand_do_circuit("MY 0");
+    ASSERT_TRUE(t.measurement_record.storage.back());
+}
+
+TEST(TableauSimulator, noisy_measurement_z) {
+    TableauSimulator t(SHARED_TEST_RNG());
+    t.expand_do_circuit(R"CIRCUIT(
+        RZ 0
+        REPEAT 10000 {
+            MZ(0.05) 0
+        }
+    )CIRCUIT");
+    auto m1 = std::accumulate(t.measurement_record.storage.begin(), t.measurement_record.storage.end(), 0);
+    ASSERT_GT(m1, 300);
+    ASSERT_LT(m1, 700);
+    t.expand_do_circuit("MZ 0");
+    ASSERT_FALSE(t.measurement_record.storage.back());
+
+    t.measurement_record.storage.clear();
+    t.expand_do_circuit(R"CIRCUIT(
+        RZ 0 1
+        X 0 1
+        REPEAT 5000 {
+            MZ(0.05) 0 1
+        }
+    )CIRCUIT");
+    m1 = std::accumulate(t.measurement_record.storage.begin(), t.measurement_record.storage.end(), 0);
+    ASSERT_GT(m1, 10000 - 700);
+    ASSERT_LT(m1, 10000 - 300);
+    t.expand_do_circuit("MZ 0");
+    ASSERT_TRUE(t.measurement_record.storage.back());
+}
+
+TEST(TableauSimulator, noisy_measure_reset_x) {
+    TableauSimulator t(SHARED_TEST_RNG());
+    t.expand_do_circuit(R"CIRCUIT(
+        RX 0
+        REPEAT 10000 {
+            MRX(0.05) 0
+        }
+    )CIRCUIT");
+    auto m1 = std::accumulate(t.measurement_record.storage.begin(), t.measurement_record.storage.end(), 0);
+    ASSERT_GT(m1, 300);
+    ASSERT_LT(m1, 700);
+    t.expand_do_circuit("MX 0");
+    ASSERT_FALSE(t.measurement_record.storage.back());
+
+    t.measurement_record.storage.clear();
+    t.expand_do_circuit(R"CIRCUIT(
+        RX 0 1
+        REPEAT 5000 {
+            Z 0 1
+            MRX(0.05) 0 1
+        }
+    )CIRCUIT");
+    m1 = std::accumulate(t.measurement_record.storage.begin(), t.measurement_record.storage.end(), 0);
+    ASSERT_GT(m1, 10000 - 700);
+    ASSERT_LT(m1, 10000 - 300);
+    t.expand_do_circuit("MX 0");
+    ASSERT_FALSE(t.measurement_record.storage.back());
+}
+
+TEST(TableauSimulator, noisy_measure_reset_y) {
+    TableauSimulator t(SHARED_TEST_RNG());
+    t.expand_do_circuit(R"CIRCUIT(
+        RY 0 1
+        REPEAT 5000 {
+            MRY(0.05) 0 1
+        }
+    )CIRCUIT");
+    auto m1 = std::accumulate(t.measurement_record.storage.begin(), t.measurement_record.storage.end(), 0);
+    ASSERT_GT(m1, 300);
+    ASSERT_LT(m1, 700);
+    t.expand_do_circuit("MY 0");
+    ASSERT_FALSE(t.measurement_record.storage.back());
+
+    t.measurement_record.storage.clear();
+    t.expand_do_circuit(R"CIRCUIT(
+        RY 0 1
+        REPEAT 5000 {
+            X 0 1
+            MRY(0.05) 0 1
+        }
+    )CIRCUIT");
+    m1 = std::accumulate(t.measurement_record.storage.begin(), t.measurement_record.storage.end(), 0);
+    ASSERT_GT(m1, 10000 - 700);
+    ASSERT_LT(m1, 10000 - 300);
+    t.expand_do_circuit("MY 0");
+    ASSERT_FALSE(t.measurement_record.storage.back());
+}
+
+TEST(TableauSimulator, noisy_measure_reset_z) {
+    TableauSimulator t(SHARED_TEST_RNG());
+    t.expand_do_circuit(R"CIRCUIT(
+        RZ 0 1
+        REPEAT 5000 {
+            MRZ(0.05) 0 1
+        }
+    )CIRCUIT");
+    auto m1 = std::accumulate(t.measurement_record.storage.begin(), t.measurement_record.storage.end(), 0);
+    ASSERT_GT(m1, 300);
+    ASSERT_LT(m1, 700);
+    t.expand_do_circuit("MZ 0");
+    ASSERT_FALSE(t.measurement_record.storage.back());
+
+    t.measurement_record.storage.clear();
+    t.expand_do_circuit(R"CIRCUIT(
+        RZ 0 1
+        REPEAT 5000 {
+            X 0 1
+            MRZ(0.05) 0 1
+        }
+    )CIRCUIT");
+    m1 = std::accumulate(t.measurement_record.storage.begin(), t.measurement_record.storage.end(), 0);
+    ASSERT_GT(m1, 10000 - 700);
+    ASSERT_LT(m1, 10000 - 300);
+    t.expand_do_circuit("MZ 0");
+    ASSERT_FALSE(t.measurement_record.storage.back());
 }

--- a/src/stim_include.cc
+++ b/src/stim_include.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "include/stim.h"
 #include "circuit/gate_data.h"
+#include "include/stim.h"
 
 const stim_internal::GateDataMap &stim::GATE_DATA = stim_internal::GATE_DATA;

--- a/src/stim_include.test.cc
+++ b/src/stim_include.test.cc
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include "include/stim.h"
-
 #include "gtest/gtest.h"
+
+#include "include/stim.h"
 
 TEST(stim, include1) {
     stim::Circuit c("H 0");

--- a/src/stim_include_again.test.cc
+++ b/src/stim_include_again.test.cc
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include "include/stim.h"
-
 #include "gtest/gtest.h"
+
+#include "include/stim.h"
 
 TEST(stim, include2) {
     stim::Circuit c("H 0");


### PR DESCRIPTION
- Fix MY acting like MRY in frame simulator
- Add popcnt to simd_bits
- Add reserve_space_for_results, reserve_noisy_space_for_results, xor_record_reserved_result to MeasureRecordBatch
- Rename ARG_COUNT_VARIABLE to ARG_COUNT_SYGIL_ANY
- Introduce ARG_COUNT_SYGIL_ZERO_OR_ONE and use it on measurement gates
- Rename GATE_PRODUCES_RESULTS to GATE_PRODUCES_NOISY_RESULTS
- Swap argument order to TableauSimulator so num qubits can default to 0
- Add noisify_new_measurements to TableauSimulator
- Add expand_do_circuit to TableauSimulator
- Remove argument count validation logic from inside circuit parsing code
- Update stimcirq to be able to round trip probabilistic measurements
- Update stimcirq to use coordinate data for round tripping line qubits and grid qubits
- Fixes https://github.com/quantumlib/Stim/issues/85
- Fixes https://github.com/quantumlib/Stim/issues/84
- Fixes https://github.com/quantumlib/Stim/issues/90
- Fixes https://github.com/quantumlib/Stim/issues/71