### PR TITLE
Polish stimcirq coordinate preservation

### DIFF
--- a/glue/cirq/stimcirq/_stim_to_cirq.py
+++ b/glue/cirq/stimcirq/_stim_to_cirq.py
@@ -286,6 +286,8 @@ def _translate_flattened_operation(
         args: List[float] = [arg] if isinstance(arg, float) else arg
         for k in range(len(args)):
             args[k] += coord_tracker.origin[k]
+            if args[k] == int(args[k]):
+                args[k] = int(args[k])
         for t in targets:
             if len(args) == 1:
                 coord_tracker.qubit_coords[t] = cirq.LineQubit(*args)

--- a/src/circuit/circuit.cc
+++ b/src/circuit/circuit.cc
@@ -133,6 +133,14 @@ void validate_gate(const Gate &gate, ConstPointerRange<uint32_t> targets, ConstP
                 "The disjoint probability arguments (" + comma_sep(args).str() + ") given to gate " +
                 std::string(gate.name) + " sum to more than 1.");
         }
+    } else if (gate.flags & GATE_ARGS_ARE_UNSIGNED_INTEGERS) {
+        for (const auto p : args) {
+            if (p < 0 || p != round(p)) {
+                throw std::invalid_argument(
+                    "Gate " + std::string(gate.name) + " only takes non-negative integer arguments, but one of its arguments (" +
+                    comma_sep(args).str() + ") wasn't a non-negative integer.");
+            }
+        }
     }
 
     // Check that targets are in range.

--- a/src/circuit/circuit.h
+++ b/src/circuit/circuit.h
@@ -168,7 +168,7 @@ struct Circuit {
     ///         interactive (repl) mode, where measurements should produce results immediately instead of only after the
     ///         circuit is entirely specified. *This has significantly worse performance. It prevents measurement
     ///         batching.*
-    void append_from_file(FILE *file, bool stop_asap);
+    void append_from_file(FILE *file, bool stop_asap = false);
     /// Grows the circuit using operations from a string.
     ///
     /// Note: operations are automatically fused.

--- a/src/circuit/circuit.h
+++ b/src/circuit/circuit.h
@@ -17,6 +17,7 @@
 #ifndef STIM_CIRCUIT_H
 #define STIM_CIRCUIT_H
 
+#include <cmath>
 #include <cstring>
 #include <functional>
 #include <iostream>
@@ -333,7 +334,7 @@ inline bool is_double_char(int c) {
 }
 
 template <typename SOURCE>
-double read_non_negative_double(int &c, SOURCE read_char) {
+double read_normal_double(int &c, SOURCE read_char) {
     char buf[64];
     size_t n = 0;
     while (n < sizeof(buf) - 1 && is_double_char(c)) {
@@ -345,8 +346,8 @@ double read_non_negative_double(int &c, SOURCE read_char) {
 
     char *end;
     double result = strtod(buf, &end);
-    if (end != buf + n || !(result >= 0)) {
-        throw std::invalid_argument("Not a non-negative real number: " + std::string(buf));
+    if (end != buf + n || !std::isnormal(result)) {
+        throw std::invalid_argument("Not a real number: " + std::string(buf));
     }
     return result;
 }
@@ -360,7 +361,7 @@ void read_parens_arguments(int &c, const char *name, SOURCE read_char, Monotonic
 
     read_past_within_line_whitespace(c, read_char);
     while (true) {
-        out.append_tail(read_non_negative_double(c, read_char));
+        out.append_tail(read_normal_double(c, read_char));
         read_past_within_line_whitespace(c, read_char);
         if (c != ',') {
             break;

--- a/src/circuit/circuit.h
+++ b/src/circuit/circuit.h
@@ -346,7 +346,7 @@ double read_normal_double(int &c, SOURCE read_char) {
 
     char *end;
     double result = strtod(buf, &end);
-    if (end != buf + n || !std::isnormal(result)) {
+    if (end != buf + n || std::isinf(result) || std::isnan(result)) {
         throw std::invalid_argument("Not a real number: " + std::string(buf));
     }
     return result;

--- a/src/circuit/circuit.test.cc
+++ b/src/circuit/circuit.test.cc
@@ -791,3 +791,23 @@ TEST(circuit, zero_repetitions_not_allowed) {
         )CIRCUIT");
     });
 }
+
+TEST(circuit, negative_float_coordinates) {
+    auto c = Circuit(R"CIRCUIT(
+        SHIFT_COORDS(-1, -2, -3)
+        QUBIT_COORDS(1, -2) 1
+        QUBIT_COORDS(-3.5) 1
+    )CIRCUIT");
+    ASSERT_EQ(c.operations[0].target_data.args[2], -3);
+    ASSERT_EQ(c.operations[2].target_data.args[0], -3.5);
+    ASSERT_ANY_THROW({
+        Circuit("M(-0.1) 0");
+    });
+    c = Circuit("QUBIT_COORDS(1e20) 0");
+    ASSERT_EQ(c.operations[0].target_data.args[0], 1e20);
+    c = Circuit("QUBIT_COORDS(1E+20) 0");
+    ASSERT_EQ(c.operations[0].target_data.args[0], 1E+20);
+    ASSERT_ANY_THROW({
+        Circuit("QUBIT_COORDS(1e10000) 0");
+    });
+}

--- a/src/circuit/gate_data.h
+++ b/src/circuit/gate_data.h
@@ -104,6 +104,8 @@ enum GateFlags : uint16_t {
     GATE_CAN_TARGET_MEASUREMENT_RECORD = 1 << 9,
     // Controls whether the gate takes qubit/record targets.
     GATE_TAKES_NO_TARGETS = 1 << 10,
+    // Controls validation of index arguments like OBSERVABLE_INCLUDE(1).
+    GATE_ARGS_ARE_UNSIGNED_INTEGERS = 1 << 11,
 };
 
 struct ExtraGateData {

--- a/src/circuit/gate_data_annotations.cc
+++ b/src/circuit/gate_data_annotations.cc
@@ -74,7 +74,7 @@ does create detection events.
             &TableauSimulator::I,
             &FrameSimulator::I,
             &ErrorAnalyzer::OBSERVABLE_INCLUDE,
-            (GateFlags)(GATE_ONLY_TARGETS_MEASUREMENT_RECORD | GATE_IS_NOT_FUSABLE),
+            (GateFlags)(GATE_ONLY_TARGETS_MEASUREMENT_RECORD | GATE_IS_NOT_FUSABLE | GATE_ARGS_ARE_UNSIGNED_INTEGERS),
             []() -> ExtraGateData {
                 return {
                     "Z_Annotations",

--- a/src/dem/detector_error_model.cc
+++ b/src/dem/detector_error_model.cc
@@ -539,6 +539,15 @@ void model_read_operations(DetectorErrorModel &model, SOURCE read_char, DEM_READ
     } while (read_condition != DEM_READ_AS_LITTLE_AS_POSSIBLE);
 }
 
+void DetectorErrorModel::append_from_file(FILE *file, bool stop_asap) {
+    model_read_operations(
+        *this,
+        [&]() {
+            return getc(file);
+        },
+        stop_asap ? DEM_READ_AS_LITTLE_AS_POSSIBLE : DEM_READ_UNTIL_END_OF_FILE);
+}
+
 void DetectorErrorModel::append_from_text(const char *text) {
     size_t k = 0;
     model_read_operations(
@@ -547,6 +556,12 @@ void DetectorErrorModel::append_from_text(const char *text) {
             return text[k] != 0 ? text[k++] : EOF;
         },
         DEM_READ_UNTIL_END_OF_FILE);
+}
+
+DetectorErrorModel DetectorErrorModel::from_file(FILE *file) {
+    DetectorErrorModel result;
+    result.append_from_file(file, false);
+    return result;
 }
 
 DetectorErrorModel::DetectorErrorModel(const char *text) {

--- a/src/dem/detector_error_model.h
+++ b/src/dem/detector_error_model.h
@@ -95,7 +95,18 @@ struct DetectorErrorModel {
     void append_logical_observable_instruction(DemTarget target);
     void append_repeat_block(uint64_t repeat_count, DetectorErrorModel &&body);
     void append_repeat_block(uint64_t repeat_count, const DetectorErrorModel &body);
+
+    /// Grows the detector error model using operations from a string.
     void append_from_text(const char *text);
+    /// Grows the detector error model using operations from a file.
+    ///
+    /// Args:
+    ///     file: The opened file to read from.
+    ///     stop_asap: When set to true, the reading process stops after the next instruction or block is read. This is
+    ///         potentially useful for interactive/streaming usage, where errors are being processed on the fly.
+    void append_from_file(FILE *file, bool stop_asap = false);
+    /// Parses a detector error model from a file.
+    static DetectorErrorModel from_file(FILE *file);
 
     bool operator==(const DetectorErrorModel &other) const;
     bool operator!=(const DetectorErrorModel &other) const;


### PR DESCRIPTION
- Fix negative coordinates creating parse failures in stim Circuit repr
- Fix int coordinates degrading to floats when round tripping
- Add DetectorErrorModel::from_file methods
- Fix OBSERVABLE_INCLUDE argument not being validated to be a non-negative integer

Fixes https://github.com/quantumlib/Stim/issues/93
Fixes https://github.com/quantumlib/Stim/issues/81
Fixes https://github.com/quantumlib/Stim/issues/70
