### PR TITLE
Fix incompatibility with gtest 1.11

### DIFF
--- a/src/circuit/circuit.cc
+++ b/src/circuit/circuit.cc
@@ -595,7 +595,7 @@ void Circuit::append_from_file(FILE *file, bool stop_asap) {
         stop_asap ? READ_AS_LITTLE_AS_POSSIBLE : READ_UNTIL_END_OF_FILE);
 }
 
-std::ostream &operator<<(std::ostream &out, const Operation &op) {
+std::ostream &stim_internal::operator<<(std::ostream &out, const Operation &op) {
     out << op.gate->name;
     if (!op.target_data.args.empty()) {
         out << '(';
@@ -652,7 +652,7 @@ const Circuit &stim_internal::op_data_block_body(const Circuit &host, const Oper
     return host.blocks[data.targets[0]];
 }
 
-std::ostream &operator<<(std::ostream &out, const Circuit &c) {
+std::ostream &stim_internal::operator<<(std::ostream &out, const Circuit &c) {
     print_circuit(out, c, "");
     return out;
 }

--- a/src/circuit/circuit.h
+++ b/src/circuit/circuit.h
@@ -376,9 +376,9 @@ void read_parens_arguments(int &c, const char *name, SOURCE read_char, Monotonic
     c = read_char();
 }
 
-}  // namespace stim_internal
+std::ostream &operator<<(std::ostream &out, const Circuit &c);
+std::ostream &operator<<(std::ostream &out, const Operation &op);
 
-std::ostream &operator<<(std::ostream &out, const stim_internal::Circuit &c);
-std::ostream &operator<<(std::ostream &out, const stim_internal::Operation &op);
+}  // namespace stim_internal
 
 #endif

--- a/src/dem/detector_error_model.cc
+++ b/src/dem/detector_error_model.cc
@@ -65,7 +65,7 @@ bool DemTarget::operator!=(const DemTarget &other) const {
 bool DemTarget::operator<(const DemTarget &other) const {
     return data < other.data;
 }
-std::ostream &operator<<(std::ostream &out, const DemTarget &v) {
+std::ostream &stim_internal::operator<<(std::ostream &out, const DemTarget &v) {
     if (v.is_separator()) {
         out << "^";
         return out;
@@ -118,7 +118,7 @@ std::string DemInstruction::str() const {
     return s.str();
 }
 
-std::ostream &operator<<(std::ostream &out, const DemInstructionType &type) {
+std::ostream &stim_internal::operator<<(std::ostream &out, const DemInstructionType &type) {
     switch (type) {
         case DEM_ERROR:
             out << "error";
@@ -142,7 +142,7 @@ std::ostream &operator<<(std::ostream &out, const DemInstructionType &type) {
     return out;
 }
 
-std::ostream &operator<<(std::ostream &out, const DemInstruction &op) {
+std::ostream &stim_internal::operator<<(std::ostream &out, const DemInstruction &op) {
     out << op.type;
     if (!op.arg_data.empty()) {
         out << "(" << comma_sep(op.arg_data) << ")";
@@ -333,7 +333,7 @@ void stream_out_indent(std::ostream &out, const DetectorErrorModel &v, size_t in
     }
 }
 
-std::ostream &operator<<(std::ostream &out, const DetectorErrorModel &v) {
+std::ostream &stim_internal::operator<<(std::ostream &out, const DetectorErrorModel &v) {
     out << std::setprecision(std::numeric_limits<long double>::digits10 + 1);
     stream_out_indent(out, v, 0);
     return out;

--- a/src/dem/detector_error_model.h
+++ b/src/dem/detector_error_model.h
@@ -109,11 +109,11 @@ struct DetectorErrorModel {
     void clear();
 };
 
-}  // namespace stim_internal
+std::ostream &operator<<(std::ostream &out, const DemInstructionType &type);
+std::ostream &operator<<(std::ostream &out, const DetectorErrorModel &v);
+std::ostream &operator<<(std::ostream &out, const DemTarget &v);
+std::ostream &operator<<(std::ostream &out, const DemInstruction &v);
 
-std::ostream &operator<<(std::ostream &out, const stim_internal::DemInstructionType &type);
-std::ostream &operator<<(std::ostream &out, const stim_internal::DetectorErrorModel &v);
-std::ostream &operator<<(std::ostream &out, const stim_internal::DemTarget &v);
-std::ostream &operator<<(std::ostream &out, const stim_internal::DemInstruction &v);
+}  // namespace stim_internal
 
 #endif

--- a/src/simd/pointer_range.h
+++ b/src/simd/pointer_range.h
@@ -176,18 +176,18 @@ struct ConstPointerRange {
     }
 };
 
-}  // namespace stim_internal
-
 template <typename T>
-std::ostream &stim_internal::operator<<(std::ostream &out, stim_internal::ConstPointerRange<T> v) {
+std::ostream &operator<<(std::ostream &out, stim_internal::ConstPointerRange<T> v) {
     out << "ConstPointerRange{" << comma_sep(v) << "}";
     return out;
 }
 
 template <typename T>
-std::ostream &stim_internal::operator<<(std::ostream &out, stim_internal::PointerRange<T> v) {
+std::ostream &operator<<(std::ostream &out, stim_internal::PointerRange<T> v) {
     out << "PointerRange{" << comma_sep(v) << "}";
     return out;
 }
+
+}  // namespace stim_internal
 
 #endif

--- a/src/simd/pointer_range.h
+++ b/src/simd/pointer_range.h
@@ -179,13 +179,13 @@ struct ConstPointerRange {
 }  // namespace stim_internal
 
 template <typename T>
-std::ostream &operator<<(std::ostream &out, stim_internal::ConstPointerRange<T> v) {
+std::ostream &stim_internal::operator<<(std::ostream &out, stim_internal::ConstPointerRange<T> v) {
     out << "ConstPointerRange{" << comma_sep(v) << "}";
     return out;
 }
 
 template <typename T>
-std::ostream &operator<<(std::ostream &out, stim_internal::PointerRange<T> v) {
+std::ostream &stim_internal::operator<<(std::ostream &out, stim_internal::PointerRange<T> v) {
     out << "PointerRange{" << comma_sep(v) << "}";
     return out;
 }

--- a/src/simd/simd_bits_range_ref.cc
+++ b/src/simd/simd_bits_range_ref.cc
@@ -84,7 +84,7 @@ bool simd_bits_range_ref::operator!=(const simd_bits_range_ref other) const {
     return !(*this == other);
 }
 
-std::ostream &operator<<(std::ostream &out, const simd_bits_range_ref m) {
+std::ostream &stim_internal::operator<<(std::ostream &out, const simd_bits_range_ref m) {
     for (size_t k = 0; k < m.num_bits_padded(); k++) {
         out << "_1"[m[k]];
     }

--- a/src/simd/simd_bits_range_ref.h
+++ b/src/simd/simd_bits_range_ref.h
@@ -299,9 +299,9 @@ struct simd_bits_range_ref {
     }
 };
 
-}  // namespace stim_internal
-
 /// Writes a description of the contents of the range to `out`.
-std::ostream &operator<<(std::ostream &out, const stim_internal::simd_bits_range_ref m);
+std::ostream &operator<<(std::ostream &out, const simd_bits_range_ref m);
+
+}  // namespace stim_internal
 
 #endif

--- a/src/simd/simd_compat.test.cc
+++ b/src/simd/simd_compat.test.cc
@@ -14,6 +14,7 @@
 
 #include "simd_compat.h"
 
+#include <algorithm>
 #include <gtest/gtest.h>
 
 #include "../test_util.test.h"

--- a/src/simd/simd_util.test.cc
+++ b/src/simd/simd_util.test.cc
@@ -14,6 +14,7 @@
 
 #include "simd_util.h"
 
+#include <algorithm>
 #include <gtest/gtest.h>
 
 #include "../test_util.test.h"

--- a/src/simd/sparse_xor_vec.h
+++ b/src/simd/sparse_xor_vec.h
@@ -96,12 +96,10 @@ inline void xor_merge_sort_temp_buffer_callback(
 
 template <typename T>
 struct SparseXorVec;
-}  // namespace stim_internal
 
 template <typename T>
-std::ostream &operator<<(std::ostream &out, const stim_internal::SparseXorVec<T> &v);
+std::ostream &operator<<(std::ostream &out, const SparseXorVec<T> &v);
 
-namespace stim_internal {
 /// A sparse set of integers that supports efficient xoring (computing the symmetric difference).
 template <typename T>
 struct SparseXorVec {
@@ -214,12 +212,12 @@ struct SparseXorVec {
     }
 };
 
-}  // namespace stim_internal
-
 template <typename T>
-std::ostream &operator<<(std::ostream &out, const stim_internal::SparseXorVec<T> &v) {
+std::ostream &operator<<(std::ostream &out, const SparseXorVec<T> &v) {
     out << "SparseXorVec{" << comma_sep(v) << "}";
     return out;
 }
+
+}  // namespace stim_internal
 
 #endif

--- a/src/simulators/error_analyzer.test.cc
+++ b/src/simulators/error_analyzer.test.cc
@@ -1893,21 +1893,27 @@ TEST(ErrorAnalyzer, duplicate_records_in_detectors) {
 }
 
 TEST(ErrorAnalyzer, noisy_measurement_mx) {
-    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(
-        Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        ErrorAnalyzer::circuit_to_detector_error_model(
+            Circuit(R"CIRCUIT(
             RX 0
             MX(0.125) 0
             MX 0
             DETECTOR rec[-2]
             DETECTOR rec[-1]
-        )CIRCUIT"), false, false, false, false),
+        )CIRCUIT"),
+            false,
+            false,
+            false,
+            false),
         DetectorErrorModel(R"MODEL(
             error(0.125) D0
             detector D1
         )MODEL"));
 
-    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(
-        Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        ErrorAnalyzer::circuit_to_detector_error_model(
+            Circuit(R"CIRCUIT(
             RX 0 1
             Y_ERROR(1) 0 1
             MX(0.125) 0 1
@@ -1916,7 +1922,11 @@ TEST(ErrorAnalyzer, noisy_measurement_mx) {
             DETECTOR rec[-3]
             DETECTOR rec[-2]
             DETECTOR rec[-1]
-        )CIRCUIT"), false, false, false, false),
+        )CIRCUIT"),
+            false,
+            false,
+            false,
+            false),
         DetectorErrorModel(R"MODEL(
             error(0.125) D0
             error(1) D0 D2
@@ -1926,21 +1936,27 @@ TEST(ErrorAnalyzer, noisy_measurement_mx) {
 }
 
 TEST(ErrorAnalyzer, noisy_measurement_my) {
-    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(
-        Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        ErrorAnalyzer::circuit_to_detector_error_model(
+            Circuit(R"CIRCUIT(
             RY 0
             MY(0.125) 0
             MY 0
             DETECTOR rec[-2]
             DETECTOR rec[-1]
-        )CIRCUIT"), false, false, false, false),
+        )CIRCUIT"),
+            false,
+            false,
+            false,
+            false),
         DetectorErrorModel(R"MODEL(
             error(0.125) D0
             detector D1
         )MODEL"));
 
-    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(
-        Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        ErrorAnalyzer::circuit_to_detector_error_model(
+            Circuit(R"CIRCUIT(
             RY 0 1
             Z_ERROR(1) 0 1
             MY(0.125) 0 1
@@ -1949,7 +1965,11 @@ TEST(ErrorAnalyzer, noisy_measurement_my) {
             DETECTOR rec[-3]
             DETECTOR rec[-2]
             DETECTOR rec[-1]
-        )CIRCUIT"), false, false, false, false),
+        )CIRCUIT"),
+            false,
+            false,
+            false,
+            false),
         DetectorErrorModel(R"MODEL(
             error(0.125) D0
             error(1) D0 D2
@@ -1959,21 +1979,27 @@ TEST(ErrorAnalyzer, noisy_measurement_my) {
 }
 
 TEST(ErrorAnalyzer, noisy_measurement_mz) {
-    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(
-        Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        ErrorAnalyzer::circuit_to_detector_error_model(
+            Circuit(R"CIRCUIT(
             RZ 0
             MZ(0.125) 0
             MZ 0
             DETECTOR rec[-2]
             DETECTOR rec[-1]
-        )CIRCUIT"), false, false, false, false),
+        )CIRCUIT"),
+            false,
+            false,
+            false,
+            false),
         DetectorErrorModel(R"MODEL(
             error(0.125) D0
             detector D1
         )MODEL"));
 
-    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(
-        Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        ErrorAnalyzer::circuit_to_detector_error_model(
+            Circuit(R"CIRCUIT(
             RZ 0 1
             X_ERROR(1) 0 1
             MZ(0.125) 0 1
@@ -1982,7 +2008,11 @@ TEST(ErrorAnalyzer, noisy_measurement_mz) {
             DETECTOR rec[-3]
             DETECTOR rec[-2]
             DETECTOR rec[-1]
-        )CIRCUIT"), false, false, false, false),
+        )CIRCUIT"),
+            false,
+            false,
+            false,
+            false),
         DetectorErrorModel(R"MODEL(
             error(0.125) D0
             error(1) D0 D2
@@ -1992,21 +2022,27 @@ TEST(ErrorAnalyzer, noisy_measurement_mz) {
 }
 
 TEST(ErrorAnalyzer, noisy_measurement_mrx) {
-    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(
-        Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        ErrorAnalyzer::circuit_to_detector_error_model(
+            Circuit(R"CIRCUIT(
             RX 0
             MRX(0.125) 0
             MRX 0
             DETECTOR rec[-2]
             DETECTOR rec[-1]
-        )CIRCUIT"), false, false, false, false),
+        )CIRCUIT"),
+            false,
+            false,
+            false,
+            false),
         DetectorErrorModel(R"MODEL(
             error(0.125) D0
             detector D1
         )MODEL"));
 
-    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(
-        Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        ErrorAnalyzer::circuit_to_detector_error_model(
+            Circuit(R"CIRCUIT(
             RX 0 1
             Z_ERROR(1) 0 1
             MRX(0.125) 0 1
@@ -2015,7 +2051,11 @@ TEST(ErrorAnalyzer, noisy_measurement_mrx) {
             DETECTOR rec[-3]
             DETECTOR rec[-2]
             DETECTOR rec[-1]
-        )CIRCUIT"), false, false, false, false),
+        )CIRCUIT"),
+            false,
+            false,
+            false,
+            false),
         DetectorErrorModel(R"MODEL(
             error(0.875) D0
             error(0.875) D1
@@ -2025,21 +2065,27 @@ TEST(ErrorAnalyzer, noisy_measurement_mrx) {
 }
 
 TEST(ErrorAnalyzer, noisy_measurement_mry) {
-    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(
-        Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        ErrorAnalyzer::circuit_to_detector_error_model(
+            Circuit(R"CIRCUIT(
             RY 0
             MRY(0.125) 0
             MRY 0
             DETECTOR rec[-2]
             DETECTOR rec[-1]
-        )CIRCUIT"), false, false, false, false),
+        )CIRCUIT"),
+            false,
+            false,
+            false,
+            false),
         DetectorErrorModel(R"MODEL(
             error(0.125) D0
             detector D1
         )MODEL"));
 
-    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(
-        Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        ErrorAnalyzer::circuit_to_detector_error_model(
+            Circuit(R"CIRCUIT(
             RY 0 1
             X_ERROR(1) 0 1
             MRY(0.125) 0 1
@@ -2048,7 +2094,11 @@ TEST(ErrorAnalyzer, noisy_measurement_mry) {
             DETECTOR rec[-3]
             DETECTOR rec[-2]
             DETECTOR rec[-1]
-        )CIRCUIT"), false, false, false, false),
+        )CIRCUIT"),
+            false,
+            false,
+            false,
+            false),
         DetectorErrorModel(R"MODEL(
             error(0.875) D0
             error(0.875) D1
@@ -2058,21 +2108,27 @@ TEST(ErrorAnalyzer, noisy_measurement_mry) {
 }
 
 TEST(ErrorAnalyzer, noisy_measurement_mrz) {
-    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(
-        Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        ErrorAnalyzer::circuit_to_detector_error_model(
+            Circuit(R"CIRCUIT(
             RZ 0
             MRZ(0.125) 0
             MRZ 0
             DETECTOR rec[-2]
             DETECTOR rec[-1]
-        )CIRCUIT"), false, false, false, false),
+        )CIRCUIT"),
+            false,
+            false,
+            false,
+            false),
         DetectorErrorModel(R"MODEL(
             error(0.125) D0
             detector D1
         )MODEL"));
 
-    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(
-        Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        ErrorAnalyzer::circuit_to_detector_error_model(
+            Circuit(R"CIRCUIT(
             RZ 0 1
             X_ERROR(1) 0 1
             MRZ(0.125) 0 1
@@ -2081,7 +2137,11 @@ TEST(ErrorAnalyzer, noisy_measurement_mrz) {
             DETECTOR rec[-3]
             DETECTOR rec[-2]
             DETECTOR rec[-1]
-        )CIRCUIT"), false, false, false, false),
+        )CIRCUIT"),
+            false,
+            false,
+            false,
+            false),
         DetectorErrorModel(R"MODEL(
             error(0.875) D0
             error(0.875) D1

--- a/src/simulators/vector_simulator.cc
+++ b/src/simulators/vector_simulator.cc
@@ -200,7 +200,7 @@ std::string VectorSimulator::str() const {
     return ss.str();
 }
 
-std::ostream &operator<<(std::ostream &out, const VectorSimulator &sim) {
+std::ostream &stim_internal::operator<<(std::ostream &out, const VectorSimulator &sim) {
     out << "VectorSimulator {\n";
     for (size_t k = 0; k < sim.state.size(); k++) {
         out << "    " << k << ": " << sim.state[k] << "\n";

--- a/src/simulators/vector_simulator.h
+++ b/src/simulators/vector_simulator.h
@@ -65,9 +65,9 @@ struct VectorSimulator {
     std::string str() const;
 };
 
-}  // namespace stim_internal
-
 /// Writes a description of the state vector's state to an output stream.
-std::ostream &operator<<(std::ostream &out, const stim_internal::VectorSimulator &sim);
+std::ostream &operator<<(std::ostream &out, const VectorSimulator &sim);
+
+}  // namespace stim_internal
 
 #endif

--- a/src/stabilizers/pauli_string.cc
+++ b/src/stabilizers/pauli_string.cc
@@ -59,7 +59,7 @@ PauliString &PauliString::operator=(const PauliStringRef &other) noexcept {
     return *this;
 }
 
-std::ostream &operator<<(std::ostream &out, const PauliString &ps) {
+std::ostream &stim_internal::operator<<(std::ostream &out, const PauliString &ps) {
     return out << ps.ref();
 }
 

--- a/src/stabilizers/pauli_string.h
+++ b/src/stabilizers/pauli_string.h
@@ -109,9 +109,9 @@ struct PauliString {
     void ensure_num_qubits(size_t min_num_qubits);
 };
 
-}  // namespace stim_internal
-
 /// Writes a string describing the given Pauli string to an output stream.
-std::ostream &operator<<(std::ostream &out, const stim_internal::PauliString &ps);
+std::ostream &operator<<(std::ostream &out, const PauliString &ps);
+
+}  // namespace stim_internal
 
 #endif

--- a/src/stabilizers/pauli_string_ref.cc
+++ b/src/stabilizers/pauli_string_ref.cc
@@ -77,7 +77,7 @@ bool PauliStringRef::operator!=(const PauliStringRef &other) const {
     return !(*this == other);
 }
 
-std::ostream &operator<<(std::ostream &out, const PauliStringRef &ps) {
+std::ostream &stim_internal::operator<<(std::ostream &out, const PauliStringRef &ps) {
     out << "+-"[ps.sign];
     for (size_t k = 0; k < ps.num_qubits; k++) {
         out << "_XZY"[ps.xs[k] + 2 * ps.zs[k]];

--- a/src/stabilizers/pauli_string_ref.h
+++ b/src/stabilizers/pauli_string_ref.h
@@ -104,9 +104,9 @@ struct PauliStringRef {
     std::string sparse_str() const;
 };
 
-}  // namespace stim_internal
-
 /// Writes a string describing the given Pauli string to an output stream.
-std::ostream &operator<<(std::ostream &out, const stim_internal::PauliStringRef &ps);
+std::ostream &operator<<(std::ostream &out, const PauliStringRef &ps);
+
+}  // namespace stim_internal
 
 #endif

--- a/src/stabilizers/tableau.cc
+++ b/src/stabilizers/tableau.cc
@@ -116,7 +116,7 @@ Tableau Tableau::gate2(const char *x1, const char *z1, const char *x2, const cha
     return result;
 }
 
-std::ostream &operator<<(std::ostream &out, const Tableau &t) {
+std::ostream &stim_internal::operator<<(std::ostream &out, const Tableau &t) {
     out << "+-";
     for (size_t k = 0; k < t.num_qubits; k++) {
         out << 'x';

--- a/src/stabilizers/tableau.h
+++ b/src/stabilizers/tableau.h
@@ -187,8 +187,8 @@ struct Tableau {
     PauliString inverse_z_output(size_t input_index, bool skip_sign = false) const;
 };
 
-}  // namespace stim_internal
+std::ostream &operator<<(std::ostream &out, const Tableau &ps);
 
-std::ostream &operator<<(std::ostream &out, const stim_internal::Tableau &ps);
+}  // namespace stim_internal
 
 #endif

--- a/src/str_util.h
+++ b/src/str_util.h
@@ -25,12 +25,6 @@ namespace stim_internal {
 /// Wraps an iterable object so that its values are printed with comma separators.
 template <typename TIter>
 struct CommaSep;
-}  // namespace stim_internal
-
-template <typename TIter>
-std::ostream &operator<<(std::ostream &out, const stim_internal::CommaSep<TIter> &v);
-
-namespace stim_internal {
 
 /// A wrapper indicating a range of values should be printed with comma separators.
 template <typename TIter>
@@ -48,10 +42,8 @@ CommaSep<TIter> comma_sep(const TIter &v) {
     return CommaSep<TIter>{v};
 }
 
-}  // namespace stim_internal
-
 template <typename TIter>
-std::ostream &operator<<(std::ostream &out, const stim_internal::CommaSep<TIter> &v) {
+std::ostream &operator<<(std::ostream &out, const CommaSep<TIter> &v) {
     bool first = true;
     for (const auto &t : v.iter) {
         if (first) {
@@ -63,5 +55,7 @@ std::ostream &operator<<(std::ostream &out, const stim_internal::CommaSep<TIter>
     }
     return out;
 }
+
+}  // namespace stim_internal
 
 #endif


### PR DESCRIPTION
- The operator<< overloads can be moved inside the stim namespace? Was it gtest forcing me to put them outside it all along?

Fixes https://github.com/quantumlib/Stim/issues/86