### PR TITLE
Add circuit and detector error model slicing

### DIFF
--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -258,8 +258,8 @@
 >     5
 >     >>> repeat_block.body_copy()
 >     stim.Circuit('''
->     CX 0 1
->     CZ 1 2
+>         CX 0 1
+>         CZ 1 2
 >     ''')
 > ```
 
@@ -305,8 +305,8 @@
 >     ... ''')
 >     >>> model[0]
 >     stim.DemRepeatBlock(100, stim.DetectorErrorModel('''
->     error(0.125) D0 D1
->     shift_detectors 1
+>         error(0.125) D0 D1
+>         shift_detectors 1
 >     '''))
 > ```
 
@@ -340,9 +340,9 @@
 >     ...     DETECTOR rec[-1]
 >     ... ''').detector_error_model()
 >     stim.DetectorErrorModel('''
->     error(0.125) D0
->     error(0.375) D0 D1
->     error(0.25) D1
+>         error(0.125) D0
+>         error(0.375) D0 D1
+>         error(0.25) D1
 >     ''')
 > ```
 
@@ -524,9 +524,13 @@
 > Determines if two circuits have identical contents.
 > ```
 
-### `stim.Circuit.__getitem__(self, arg0: int) -> object`<a name="stim.Circuit.__getitem__"></a>
+### `stim.Circuit.__getitem__(self, index_or_slice: object) -> object`<a name="stim.Circuit.__getitem__"></a>
 > ```
 > Returns copies of instructions from the circuit.
+> 
+> Args:
+>     index_or_slice: An integer index picking out an instruction to return, or a slice picking out a range
+>         of instructions to return as a circuit.
 > 
 > Examples:
 >     >>> import stim
@@ -545,9 +549,15 @@
 >     stim.CircuitInstruction('X_ERROR', [stim.GateTarget(1), stim.GateTarget(2)], [0.5])
 >     >>> circuit[2]
 >     stim.CircuitRepeatBlock(100, stim.Circuit('''
->     X 0
->     Y 1 2
+>         X 0
+>         Y 1 2
 >     '''))
+>     >>> circuit[1::2]
+>     stim.Circuit('''
+>         X_ERROR(0.5) 1 2
+>         TICK
+>         DETECTOR rec[-1]
+>     ''')
 > ```
 
 ### `stim.Circuit.__iadd__(self, second: stim.Circuit) -> stim.Circuit`<a name="stim.Circuit.__iadd__"></a>
@@ -864,9 +874,9 @@
 >     ...     DETECTOR rec[-1]
 >     ... ''').detector_error_model()
 >     stim.DetectorErrorModel('''
->     error(0.125) D0
->     error(0.375) D0 D1
->     error(0.25) D1
+>         error(0.125) D0
+>         error(0.375) D0 D1
+>         error(0.25) D1
 >     ''')
 > ```
 
@@ -1149,8 +1159,8 @@
 >     >>> repeat_block = circuit[1]
 >     >>> repeat_block.body_copy()
 >     stim.Circuit('''
->     CX 0 1
->     CZ 1 2
+>         CX 0 1
+>         CZ 1 2
 >     ''')
 > ```
 
@@ -1411,12 +1421,41 @@
 > Determines if two detector error models have identical contents.
 > ```
 
-### `stim.DetectorErrorModel.__getitem__(self, arg0: int) -> object`<a name="stim.DetectorErrorModel.__getitem__"></a>
+### `stim.DetectorErrorModel.__getitem__(self, index_or_slice: object) -> object`<a name="stim.DetectorErrorModel.__getitem__"></a>
 > ```
 > Returns copies of instructions from the detector error model.
 > 
+> Args:
+>     index_or_slice: An integer index picking out an instruction to return, or a slice picking out a range
+>         of instructions to return as a detector error model.
+> 
+> Examples:
 > Examples:
 >     >>> import stim
+>     >>> model = stim.DetectorErrorModel('''
+>     ...    error(0.125) D0
+>     ...    error(0.125) D1 L1
+>     ...    REPEAT 100 {
+>     ...        error(0.125) D1 D2
+>     ...        shift_detectors 1
+>     ...    }
+>     ...    error(0.125) D2
+>     ...    logical_observable L0
+>     ...    detector D5
+>     ... ''')
+>     >>> model[1]
+>     stim.DemInstruction('error', [0.125], [stim.target_relative_detector_id(1), stim.target_logical_observable_id(1)])
+>     >>> model[2]
+>     stim.DemRepeatBlock(100, stim.DetectorErrorModel('''
+>         error(0.125) D1 D2
+>         shift_detectors 1
+>     '''))
+>     >>> model[1::2]
+>     stim.DetectorErrorModel('''
+>         error(0.125) D1 L1
+>         error(0.125) D2
+>         detector D5
+>     ''')
 > ```
 
 ### `stim.DetectorErrorModel.__init__(self, detector_error_model_text: str = '') -> None`<a name="stim.DetectorErrorModel.__init__"></a>
@@ -1639,12 +1678,8 @@
 > Determines if two Pauli strings have identical contents.
 > ```
 
-### `stim.PauliString.__getitem__(*args, **kwargs)`<a name="stim.PauliString.__getitem__"></a>
+### `stim.PauliString.__getitem__(self, index_or_slice: object) -> object`<a name="stim.PauliString.__getitem__"></a>
 > ```
-> Overloaded function.
-> 
-> 1. __getitem__(self: stim.PauliString, index: int) -> int
-> 
 > Returns an individual Pauli or Pauli string slice from the pauli string.
 > 
 > Individual Paulis are returned as an int using the encoding 0=I, 1=X, 2=Y, 3=Z.
@@ -1663,36 +1698,7 @@
 >     stim.PauliString("+ZYX_")
 > 
 > Args:
->     index: The index of the pauli to return or slice of paulis to return.
-> 
-> Returns:
->     0: Identity.
->     1: Pauli X.
->     2: Pauli Y.
->     3: Pauli Z.
-> 
-> 
-> 2. __getitem__(self: stim.PauliString, slice: slice) -> stim.PauliString
-> 
-> Returns an individual Pauli or Pauli string slice from the pauli string.
-> 
-> Individual Paulis are returned as an int using the encoding 0=I, 1=X, 2=Y, 3=Z.
-> Slices are returned as a stim.PauliString (always with positive sign).
-> 
-> Examples:
->     >>> import stim
->     >>> p = stim.PauliString("_XYZ")
->     >>> p[2]
->     2
->     >>> p[-1]
->     3
->     >>> p[:2]
->     stim.PauliString("+_X")
->     >>> p[::-1]
->     stim.PauliString("+ZYX_")
-> 
-> Args:
->     index: The index of the pauli to return or slice of paulis to return.
+>     index_or_slice: The index of the pauli to return, or the slice of paulis to return.
 > 
 > Returns:
 >     0: Identity.
@@ -1976,13 +1982,13 @@
 >     ValueError: The scalar phase factor isn't 1, -1, 1j, or -1j.
 > ```
 
-### `stim.PauliString.__setitem__(*args, **kwargs)`<a name="stim.PauliString.__setitem__"></a>
+### `stim.PauliString.__setitem__(self, index: int, new_pauli: object) -> None`<a name="stim.PauliString.__setitem__"></a>
 > ```
-> Overloaded function.
-> 
-> 1. __setitem__(self: stim.PauliString, index: int, new_pauli: str) -> None
-> 
 > Mutates an entry in the pauli string using the encoding 0=I, 1=X, 2=Y, 3=Z.
+> 
+> Args:
+>     index: The index of the pauli to overwrite.
+>     new_pauli: Either a character from '_IXYZ' or an integer from range(4).
 > 
 > Examples:
 >     >>> import stim
@@ -2004,38 +2010,6 @@
 >     >>> p[-1] = 'Y'
 >     >>> print(p)
 >     +_XYY
-> 
-> Args:
->     index: The index of the pauli to return.
-> 
-> 
-> 2. __setitem__(self: stim.PauliString, index: int, new_pauli: int) -> None
-> 
-> Mutates an entry in the pauli string using the encoding 0=I, 1=X, 2=Y, 3=Z.
-> 
-> Examples:
->     >>> import stim
->     >>> p = stim.PauliString(4)
->     >>> p[2] = 1
->     >>> print(p)
->     +__X_
->     >>> p[0] = 3
->     >>> p[1] = 2
->     >>> p[3] = 0
->     >>> print(p)
->     +ZYX_
->     >>> p[0] = 'I'
->     >>> p[1] = 'X'
->     >>> p[2] = 'Y'
->     >>> p[3] = 'Z'
->     >>> print(p)
->     +_XYZ
->     >>> p[-1] = 'Y'
->     >>> print(p)
->     +_XYY
-> 
-> Args:
->     index: The index of the pauli to return.
 > ```
 
 ### `stim.PauliString.__str__(self) -> str`<a name="stim.PauliString.__str__"></a>

--- a/glue/cirq/stimcirq/_cirq_to_stim.py
+++ b/glue/cirq/stimcirq/_cirq_to_stim.py
@@ -55,19 +55,19 @@ def cirq_circuit_to_stim_circuit(circuit: cirq.Circuit,
         ...     cirq.Moment(cirq.measure(a, b)),
         ... ), qubit_to_index_dict={a: 0, b: 2})
         stim.Circuit('''
-        H 0
-        TICK
-        CX 0 2
-        TICK
-        X_ERROR(0.25) 0
-        Z_ERROR(0.25) 2
-        TICK
-        TICK
-        TICK
-        DEPOLARIZE2(0.125) 2 0
-        TICK
-        M 0 2
-        TICK
+            H 0
+            TICK
+            CX 0 2
+            TICK
+            X_ERROR(0.25) 0
+            Z_ERROR(0.25) 2
+            TICK
+            TICK
+            TICK
+            DEPOLARIZE2(0.125) 2 0
+            TICK
+            M 0 2
+            TICK
         ''')
 
     Here is an example of a _stim_conversion_ method:

--- a/src/circuit/circuit.cc
+++ b/src/circuit/circuit.cc
@@ -137,8 +137,9 @@ void validate_gate(const Gate &gate, ConstPointerRange<uint32_t> targets, ConstP
         for (const auto p : args) {
             if (p < 0 || p != round(p)) {
                 throw std::invalid_argument(
-                    "Gate " + std::string(gate.name) + " only takes non-negative integer arguments, but one of its arguments (" +
-                    comma_sep(args).str() + ") wasn't a non-negative integer.");
+                    "Gate " + std::string(gate.name) +
+                    " only takes non-negative integer arguments, but one of its arguments (" + comma_sep(args).str() +
+                    ") wasn't a non-negative integer.");
             }
         }
     }
@@ -870,7 +871,7 @@ Circuit Circuit::py_get_slice(int64_t start, int64_t step, int64_t slice_length)
     assert(slice_length >= 0);
     Circuit result;
     for (size_t k = 0; k < (size_t)slice_length; k++) {
-        const auto &op = operations[start + step*k];
+        const auto &op = operations[start + step * k];
         if (op.gate->id == gate_name_to_id("REPEAT")) {
             result.target_buf.append_tail(result.blocks.size());
             result.target_buf.append_tail(op.target_data.targets[1]);

--- a/src/circuit/circuit.h
+++ b/src/circuit/circuit.h
@@ -201,6 +201,9 @@ struct Circuit {
     /// Approximate equality.
     bool approx_equals(const Circuit &other, double atol) const;
 
+    /// Gets a python-style slice of the circuit's instructions.
+    Circuit py_get_slice(int64_t start, int64_t step, int64_t slice_length) const;
+
     template <typename CALLBACK>
     void for_each_operation(const CALLBACK &callback) const {
         for (const auto &op : operations) {
@@ -379,6 +382,7 @@ void read_parens_arguments(int &c, const char *name, SOURCE read_char, Monotonic
 
 std::ostream &operator<<(std::ostream &out, const Circuit &c);
 std::ostream &operator<<(std::ostream &out, const Operation &op);
+void print_circuit(std::ostream &out, const Circuit &c, const std::string &indentation);
 
 }  // namespace stim_internal
 

--- a/src/circuit/circuit.pybind.cc
+++ b/src/circuit/circuit.pybind.cc
@@ -32,7 +32,11 @@ std::string circuit_repr(const Circuit &self) {
     if (self.operations.empty()) {
         return "stim.Circuit()";
     }
-    return "stim.Circuit('''\n" + self.str() + "\n''')";
+    std::stringstream ss;
+    ss << "stim.Circuit('''\n";
+    print_circuit(ss, self, "    ");
+    ss << "\n''')";
+    return ss.str();
 }
 
 void pybind_circuit(pybind11::module &m) {
@@ -722,14 +726,12 @@ void pybind_circuit(pybind11::module &m) {
 
     c.def(
         "__getitem__",
-        [](const Circuit &self, ssize_t index) -> pybind11::object {
-            auto n = (ssize_t)self.operations.size();
-            if (index < 0) {
-                index += (ssize_t)n;
+        [](const Circuit &self, pybind11::object index_or_slice) -> pybind11::object {
+            pybind11::ssize_t index, step, slice_length;
+            if (normalize_index_or_slice(index_or_slice, self.operations.size(), &index, &step, &slice_length)) {
+                return pybind11::cast(self.py_get_slice(index, step, slice_length));
             }
-            if (index < 0 || index >= n) {
-                throw std::out_of_range("index");
-            }
+
             auto &op = self.operations[index];
             if (op.gate->id == gate_name_to_id("REPEAT")) {
                 return pybind11::cast(
@@ -745,8 +747,13 @@ void pybind_circuit(pybind11::module &m) {
             }
             return pybind11::cast(CircuitInstruction(*op.gate, targets, args));
         },
+        pybind11::arg("index_or_slice"),
         clean_doc_string(u8R"DOC(
             Returns copies of instructions from the circuit.
+
+            Args:
+                index_or_slice: An integer index picking out an instruction to return, or a slice picking out a range
+                    of instructions to return as a circuit.
 
             Examples:
                 >>> import stim
@@ -765,11 +772,16 @@ void pybind_circuit(pybind11::module &m) {
                 stim.CircuitInstruction('X_ERROR', [stim.GateTarget(1), stim.GateTarget(2)], [0.5])
                 >>> circuit[2]
                 stim.CircuitRepeatBlock(100, stim.Circuit('''
-                X 0
-                Y 1 2
+                    X 0
+                    Y 1 2
                 '''))
-        )DOC")
-            .data());
+                >>> circuit[1::2]
+                stim.Circuit('''
+                    X_ERROR(0.5) 1 2
+                    TICK
+                    DETECTOR rec[-1]
+                ''')
+        )DOC").data());
 
     c.def(
         "detector_error_model",
@@ -834,9 +846,9 @@ void pybind_circuit(pybind11::module &m) {
                 ...     DETECTOR rec[-1]
                 ... ''').detector_error_model()
                 stim.DetectorErrorModel('''
-                error(0.125) D0
-                error(0.375) D0 D1
-                error(0.25) D1
+                    error(0.125) D0
+                    error(0.375) D0 D1
+                    error(0.25) D1
                 ''')
         )DOC")
             .data());

--- a/src/circuit/circuit.pybind.cc
+++ b/src/circuit/circuit.pybind.cc
@@ -781,7 +781,8 @@ void pybind_circuit(pybind11::module &m) {
                     TICK
                     DETECTOR rec[-1]
                 ''')
-        )DOC").data());
+        )DOC")
+            .data());
 
     c.def(
         "detector_error_model",

--- a/src/circuit/circuit.test.cc
+++ b/src/circuit/circuit.test.cc
@@ -811,3 +811,72 @@ TEST(circuit, negative_float_coordinates) {
         Circuit("QUBIT_COORDS(1e10000) 0");
     });
 }
+
+TEST(circuit, py_get_slice) {
+    Circuit c(R"CIRCUIT(
+        H 0
+        CNOT 0 1
+        M(0.125) 0 1
+        REPEAT 100 {
+            E(0.25) X0 Y5
+            REPEAT 20 {
+                H 0
+            }
+        }
+        H 1
+        REPEAT 999 {
+            H 2
+        }
+    )CIRCUIT");
+    ASSERT_EQ(c.py_get_slice(0, 1, 6), c);
+    ASSERT_EQ(c.py_get_slice(0, 1, 4), Circuit(R"CIRCUIT(
+        H 0
+        CNOT 0 1
+        M(0.125) 0 1
+        REPEAT 100 {
+            E(0.25) X0 Y5
+            REPEAT 20 {
+                H 0
+            }
+        }
+    )CIRCUIT"));
+    ASSERT_EQ(c.py_get_slice(2, 1, 3), Circuit(R"CIRCUIT(
+        M(0.125) 0 1
+        REPEAT 100 {
+            E(0.25) X0 Y5
+            REPEAT 20 {
+                H 0
+            }
+        }
+        H 1
+    )CIRCUIT"));
+
+    ASSERT_EQ(c.py_get_slice(4, -1, 3), Circuit(R"CIRCUIT(
+        H 1
+        REPEAT 100 {
+            E(0.25) X0 Y5
+            REPEAT 20 {
+                H 0
+            }
+        }
+        M(0.125) 0 1
+    )CIRCUIT"));
+
+    ASSERT_EQ(c.py_get_slice(5, -2, 3), Circuit(R"CIRCUIT(
+        REPEAT 999 {
+            H 2
+        }
+        REPEAT 100 {
+            E(0.25) X0 Y5
+            REPEAT 20 {
+                H 0
+            }
+        }
+        CNOT 0 1
+    )CIRCUIT"));
+
+    Circuit c2 = c;
+    Circuit c3 = c2.py_get_slice(0, 1, 6);
+    c2.clear();
+    ASSERT_EQ(c, c3);
+}

--- a/src/circuit/circuit.test.cc
+++ b/src/circuit/circuit.test.cc
@@ -800,16 +800,12 @@ TEST(circuit, negative_float_coordinates) {
     )CIRCUIT");
     ASSERT_EQ(c.operations[0].target_data.args[2], -3);
     ASSERT_EQ(c.operations[2].target_data.args[0], -3.5);
-    ASSERT_ANY_THROW({
-        Circuit("M(-0.1) 0");
-    });
+    ASSERT_ANY_THROW({ Circuit("M(-0.1) 0"); });
     c = Circuit("QUBIT_COORDS(1e20) 0");
     ASSERT_EQ(c.operations[0].target_data.args[0], 1e20);
     c = Circuit("QUBIT_COORDS(1E+20) 0");
     ASSERT_EQ(c.operations[0].target_data.args[0], 1E+20);
-    ASSERT_ANY_THROW({
-        Circuit("QUBIT_COORDS(1e10000) 0");
-    });
+    ASSERT_ANY_THROW({ Circuit("QUBIT_COORDS(1e10000) 0"); });
 }
 
 TEST(circuit, py_get_slice) {

--- a/src/circuit/circuit_pybind_test.py
+++ b/src/circuit/circuit_pybind_test.py
@@ -414,3 +414,28 @@ def test_indexing_operations():
         stim.CircuitRepeatBlock(1000, stim.Circuit('H 5')),
         stim.CircuitInstruction('M', [stim.GateTarget(stim.target_inv(0))]),
     ]
+
+
+def test_slicing():
+    c = stim.Circuit("""
+        H 0
+        REPEAT 5 {
+            X 1
+        }
+        Y 2
+        Z 3
+    """)
+    assert c[:] is not c
+    assert c[:] == c
+    assert c[1:-1] == stim.Circuit("""
+        REPEAT 5 {
+            X 1
+        }
+        Y 2
+    """)
+    assert c[::2] == stim.Circuit("""
+        REPEAT 5 {
+            X 1
+        }
+        Z 3
+    """)

--- a/src/circuit/circuit_pybind_test.py
+++ b/src/circuit/circuit_pybind_test.py
@@ -169,8 +169,8 @@ def test_circuit_repr():
     """)
     r = repr(v)
     assert r == """stim.Circuit('''
-X 0
-M 0
+    X 0
+    M 0
 ''')"""
     assert eval(r, {'stim': stim}) == v
 

--- a/src/circuit/circuit_pybind_test.py
+++ b/src/circuit/circuit_pybind_test.py
@@ -217,7 +217,7 @@ def test_circuit_compile_sampler():
     s = c.compile_sampler()
     assert repr(s) == """
 stim.CompiledMeasurementSampler(stim.Circuit('''
-M 0
+    M 0
 '''))
     """.strip()
 
@@ -227,9 +227,9 @@ M 0
     r = repr(s)
     assert r == """
 stim.CompiledMeasurementSampler(stim.Circuit('''
-M 0
-H 0 1 2 3 4
-M 0 1 2 3 4
+    M 0
+    H 0 1 2 3 4
+    M 0 1 2 3 4
 '''))
     """.strip() == str(stim.CompiledMeasurementSampler(c))
 
@@ -247,8 +247,8 @@ def test_circuit_compile_detector_sampler():
     r = repr(s)
     assert r == """
 stim.CompiledDetectorSampler(stim.Circuit('''
-M 0
-DETECTOR rec[-1]
+    M 0
+    DETECTOR rec[-1]
 '''))
     """.strip()
 
@@ -434,6 +434,10 @@ def test_slicing():
         Y 2
     """)
     assert c[::2] == stim.Circuit("""
+        H 0
+        Y 2
+    """)
+    assert c[1::2] == stim.Circuit("""
         REPEAT 5 {
             X 1
         }

--- a/src/circuit/circuit_repeat_block.pybind.cc
+++ b/src/circuit/circuit_repeat_block.pybind.cc
@@ -16,6 +16,7 @@
 
 #include "../py/base.pybind.h"
 #include "circuit.h"
+#include "circuit.pybind.h"
 #include "circuit_instruction.pybind.h"
 
 using namespace stim_internal;
@@ -30,7 +31,7 @@ bool CircuitRepeatBlock::operator!=(const CircuitRepeatBlock &other) const {
     return !(*this == other);
 }
 std::string CircuitRepeatBlock::repr() const {
-    return "stim.CircuitRepeatBlock(" + std::to_string(repeat_count) + ", stim.Circuit('''\n" + body.str() + "\n'''))";
+    return "stim.CircuitRepeatBlock(" + std::to_string(repeat_count) + ", " + circuit_repr(body) + ")";
 }
 
 void pybind_circuit_repeat_block(pybind11::module &m) {
@@ -54,8 +55,8 @@ void pybind_circuit_repeat_block(pybind11::module &m) {
                 5
                 >>> repeat_block.body_copy()
                 stim.Circuit('''
-                CX 0 1
-                CZ 1 2
+                    CX 0 1
+                    CZ 1 2
                 ''')
         )DOC")
             .data());
@@ -115,8 +116,8 @@ void pybind_circuit_repeat_block(pybind11::module &m) {
                 >>> repeat_block = circuit[1]
                 >>> repeat_block.body_copy()
                 stim.Circuit('''
-                CX 0 1
-                CZ 1 2
+                    CX 0 1
+                    CZ 1 2
                 ''')
         )DOC")
             .data());

--- a/src/dem/detector_error_model.cc
+++ b/src/dem/detector_error_model.cc
@@ -652,7 +652,7 @@ DetectorErrorModel DetectorErrorModel::py_get_slice(int64_t start, int64_t step,
     assert(slice_length >= 0);
     DetectorErrorModel result;
     for (size_t k = 0; k < (size_t)slice_length; k++) {
-        const auto &op = instructions[start + step*k];
+        const auto &op = instructions[start + step * k];
         if (op.type == DEM_REPEAT_BLOCK) {
             result.append_repeat_block(op.target_data[0].data, blocks[op.target_data[1].data]);
         } else {

--- a/src/dem/detector_error_model.cc
+++ b/src/dem/detector_error_model.cc
@@ -308,7 +308,7 @@ std::string DetectorErrorModel::str() const {
     return s.str();
 }
 
-void stream_out_indent(std::ostream &out, const DetectorErrorModel &v, size_t indent) {
+void stim_internal::print_detector_error_model(std::ostream &out, const DetectorErrorModel &v, size_t indent) {
     bool first = true;
     for (const auto &e : v.instructions) {
         if (first) {
@@ -321,7 +321,7 @@ void stream_out_indent(std::ostream &out, const DetectorErrorModel &v, size_t in
         }
         if (e.type == DEM_REPEAT_BLOCK) {
             out << "repeat " << e.target_data[0].data << " {\n";
-            stream_out_indent(out, v.blocks[(size_t)e.target_data[1].data], indent + 4);
+            print_detector_error_model(out, v.blocks[(size_t)e.target_data[1].data], indent + 4);
             out << "\n";
             for (size_t k = 0; k < indent; k++) {
                 out << " ";
@@ -335,7 +335,7 @@ void stream_out_indent(std::ostream &out, const DetectorErrorModel &v, size_t in
 
 std::ostream &stim_internal::operator<<(std::ostream &out, const DetectorErrorModel &v) {
     out << std::setprecision(std::numeric_limits<long double>::digits10 + 1);
-    stream_out_indent(out, v, 0);
+    print_detector_error_model(out, v, 0);
     return out;
 }
 
@@ -645,4 +645,21 @@ uint64_t DetectorErrorModel::count_observables() const {
         }
     }
     return max_num;
+}
+
+DetectorErrorModel DetectorErrorModel::py_get_slice(int64_t start, int64_t step, int64_t slice_length) const {
+    assert(start >= 0);
+    assert(slice_length >= 0);
+    DetectorErrorModel result;
+    for (size_t k = 0; k < (size_t)slice_length; k++) {
+        const auto &op = instructions[start + step*k];
+        if (op.type == DEM_REPEAT_BLOCK) {
+            result.append_repeat_block(op.target_data[0].data, blocks[op.target_data[1].data]);
+        } else {
+            auto args = result.arg_buf.take_copy(op.arg_data);
+            auto targets = result.target_buf.take_copy(op.target_data);
+            result.instructions.push_back(DemInstruction{args, targets, op.type});
+        }
+    }
+    return result;
 }

--- a/src/dem/detector_error_model.h
+++ b/src/dem/detector_error_model.h
@@ -118,8 +118,12 @@ struct DetectorErrorModel {
     uint64_t count_observables() const;
 
     void clear();
+
+    /// Gets a python-style slice of the error model's instructions.
+    DetectorErrorModel py_get_slice(int64_t start, int64_t step, int64_t slice_length) const;
 };
 
+void print_detector_error_model(std::ostream &out, const DetectorErrorModel &v, size_t indent);
 std::ostream &operator<<(std::ostream &out, const DemInstructionType &type);
 std::ostream &operator<<(std::ostream &out, const DetectorErrorModel &v);
 std::ostream &operator<<(std::ostream &out, const DemTarget &v);

--- a/src/dem/detector_error_model_pybind_test.py
+++ b/src/dem/detector_error_model_pybind_test.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import stim
-import pytest
-import numpy as np
 
 
 def test_init_get():

--- a/src/dem/detector_error_model_repeat_block.pybind.cc
+++ b/src/dem/detector_error_model_repeat_block.pybind.cc
@@ -37,8 +37,8 @@ void pybind_detector_error_model_repeat_block(pybind11::module &m) {
                 ... ''')
                 >>> model[0]
                 stim.DemRepeatBlock(100, stim.DetectorErrorModel('''
-                error(0.125) D0 D1
-                shift_detectors 1
+                    error(0.125) D0 D1
+                    shift_detectors 1
                 '''))
         )DOC")
             .data());

--- a/src/py/base.pybind.cc
+++ b/src/py/base.pybind.cc
@@ -61,3 +61,32 @@ std::string clean_doc_string(const char *c) {
 
     return result;
 }
+
+bool normalize_index_or_slice(const pybind11::object &index_or_slice, size_t length, pybind11::ssize_t *start, pybind11::ssize_t *step, pybind11::ssize_t *slice_length) {
+    try {
+        *start = pybind11::cast<pybind11::ssize_t>(index_or_slice);
+        if (*start < 0) {
+            *start += length;
+        }
+        if (*start < 0 || (size_t)*start >= length) {
+            throw std::out_of_range(
+                "Index " + std::to_string(pybind11::cast<pybind11::ssize_t>(index_or_slice)) +
+                " not in range for sequence of length " + std::to_string(length) + ".");
+        }
+        return false;
+    } catch (const pybind11::cast_error &) {
+    }
+
+    pybind11::slice slice;
+    try {
+        slice = pybind11::cast<pybind11::slice>(index_or_slice);
+    } catch (const pybind11::cast_error &ex) {
+        throw pybind11::type_error("Expected an integer index or a slice.");
+    }
+
+    pybind11::ssize_t stop;
+    if (!slice.compute(length, start, &stop, step, slice_length)) {
+        throw pybind11::error_already_set();
+    }
+    return true;
+}

--- a/src/py/base.pybind.cc
+++ b/src/py/base.pybind.cc
@@ -62,7 +62,12 @@ std::string clean_doc_string(const char *c) {
     return result;
 }
 
-bool normalize_index_or_slice(const pybind11::object &index_or_slice, size_t length, pybind11::ssize_t *start, pybind11::ssize_t *step, pybind11::ssize_t *slice_length) {
+bool normalize_index_or_slice(
+    const pybind11::object &index_or_slice,
+    size_t length,
+    pybind11::ssize_t *start,
+    pybind11::ssize_t *step,
+    pybind11::ssize_t *slice_length) {
     try {
         *start = pybind11::cast<pybind11::ssize_t>(index_or_slice);
         if (*start < 0) {

--- a/src/py/base.pybind.h
+++ b/src/py/base.pybind.h
@@ -23,6 +23,11 @@
 
 std::mt19937_64 &PYBIND_SHARED_RNG();
 std::string clean_doc_string(const char *c);
-bool normalize_index_or_slice(const pybind11::object &index_or_slice, size_t length, pybind11::ssize_t *start, pybind11::ssize_t *step, pybind11::ssize_t *slice_length);
+bool normalize_index_or_slice(
+    const pybind11::object &index_or_slice,
+    size_t length,
+    pybind11::ssize_t *start,
+    pybind11::ssize_t *step,
+    pybind11::ssize_t *slice_length);
 
 #endif

--- a/src/py/base.pybind.h
+++ b/src/py/base.pybind.h
@@ -23,5 +23,6 @@
 
 std::mt19937_64 &PYBIND_SHARED_RNG();
 std::string clean_doc_string(const char *c);
+bool normalize_index_or_slice(const pybind11::object &index_or_slice, size_t length, pybind11::ssize_t *start, pybind11::ssize_t *step, pybind11::ssize_t *slice_length);
 
 #endif

--- a/src/stabilizers/pauli_string.cc
+++ b/src/stabilizers/pauli_string.cc
@@ -14,6 +14,7 @@
 
 #include "pauli_string.h"
 
+#include <cassert>
 #include <cstring>
 #include <string>
 
@@ -133,4 +134,25 @@ void PauliString::ensure_num_qubits(size_t min_num_qubits) {
     xs = std::move(new_xs);
     zs = std::move(new_zs);
     num_qubits = min_num_qubits;
+}
+
+uint8_t PauliString::py_get_item(int64_t index) const {
+    if (index < 0) {
+        index += num_qubits;
+    }
+    if (index < 0 || (size_t)index >= num_qubits) {
+        throw std::out_of_range("index");
+    }
+    size_t u = (size_t)index;
+    int x = xs[u];
+    int z = zs[u];
+    return pauli_xz_to_xyz(x, z);
+}
+
+PauliString PauliString::py_get_slice(int64_t start, int64_t step, int64_t slice_length) const {
+    assert(start >= 0);
+    return PauliString::from_func(false, slice_length, [&](size_t i) {
+        int j = start + i * step;
+        return "_XZY"[xs[j] + zs[j] * 2];
+    });
 }

--- a/src/stabilizers/pauli_string.h
+++ b/src/stabilizers/pauli_string.h
@@ -103,6 +103,11 @@ struct PauliString {
     /// Explicit conversion to a const reference.
     const PauliStringRef ref() const;
 
+    /// Returns a python-style slice of the Paulis in the Pauli string.
+    PauliString py_get_slice(int64_t start, int64_t step, int64_t slice_length) const;
+    /// Returns a Pauli from the pauli string, allowing python-style negative indices, using IXYZ encoding.
+    uint8_t py_get_item(int64_t index) const;
+
     /// Returns a string describing the given Pauli string, with one character per qubit.
     std::string str() const;
 

--- a/src/stabilizers/pauli_string.pybind.cc
+++ b/src/stabilizers/pauli_string.pybind.cc
@@ -834,6 +834,10 @@ void pybind_pauli_string(pybind11::module &m) {
         clean_doc_string(u8R"DOC(
            Mutates an entry in the pauli string using the encoding 0=I, 1=X, 2=Y, 3=Z.
 
+           Args:
+               index: The index of the pauli to overwrite.
+               new_pauli: Either a character from '_IXYZ' or an integer from range(4).
+
            Examples:
                >>> import stim
                >>> p = stim.PauliString(4)
@@ -854,9 +858,6 @@ void pybind_pauli_string(pybind11::module &m) {
                >>> p[-1] = 'Y'
                >>> print(p)
                +_XYY
-
-           Args:
-               index: The index of the pauli to return.
         )DOC").data());
 
     c.def(

--- a/src/stabilizers/pauli_string.pybind.cc
+++ b/src/stabilizers/pauli_string.pybind.cc
@@ -858,7 +858,8 @@ void pybind_pauli_string(pybind11::module &m) {
                >>> p[-1] = 'Y'
                >>> print(p)
                +_XYY
-        )DOC").data());
+        )DOC")
+            .data());
 
     c.def(
         "__getitem__",
@@ -871,8 +872,7 @@ void pybind_pauli_string(pybind11::module &m) {
             }
         },
         pybind11::arg("index_or_slice"),
-        clean_doc_string(
-        u8R"DOC(
+        clean_doc_string(u8R"DOC(
             Returns an individual Pauli or Pauli string slice from the pauli string.
 
             Individual Paulis are returned as an int using the encoding 0=I, 1=X, 2=Y, 3=Z.
@@ -898,5 +898,6 @@ void pybind_pauli_string(pybind11::module &m) {
                 1: Pauli X.
                 2: Pauli Y.
                 3: Pauli Z.
-        )DOC").data());
+        )DOC")
+            .data());
 }

--- a/src/stabilizers/pauli_string.test.cc
+++ b/src/stabilizers/pauli_string.test.cc
@@ -327,3 +327,37 @@ TEST(PauliString, pauli_xyz_to_xz) {
     ASSERT_EQ(pauli_xyz_to_xz(2), x + z);
     ASSERT_EQ(pauli_xyz_to_xz(3), z);
 }
+
+TEST(PauliString, py_get_item) {
+    auto p = PauliString::from_str("-XYZ_XYZ_XX");
+    ASSERT_EQ(p.py_get_item(0), 1);
+    ASSERT_EQ(p.py_get_item(1), 2);
+    ASSERT_EQ(p.py_get_item(2), 3);
+    ASSERT_EQ(p.py_get_item(3), 0);
+    ASSERT_EQ(p.py_get_item(8), 1);
+    ASSERT_EQ(p.py_get_item(9), 1);
+
+    ASSERT_EQ(p.py_get_item(-1), 1);
+    ASSERT_EQ(p.py_get_item(-2), 1);
+    ASSERT_EQ(p.py_get_item(-3), 0);
+    ASSERT_EQ(p.py_get_item(-4), 3);
+    ASSERT_EQ(p.py_get_item(-9), 2);
+    ASSERT_EQ(p.py_get_item(-10), 1);
+
+    ASSERT_ANY_THROW({
+        p.py_get_item(10);
+    });
+    ASSERT_ANY_THROW({
+        p.py_get_item(-11);
+    });
+}
+
+TEST(PauliString, py_get_slice) {
+    auto p = PauliString::from_str("-XYZ_XYZ_YX");
+    ASSERT_EQ(p.py_get_slice(0, 2, 0), PauliString::from_str(""));
+    ASSERT_EQ(p.py_get_slice(0, 2, 1), PauliString::from_str("X"));
+    ASSERT_EQ(p.py_get_slice(0, 2, 2), PauliString::from_str("XZ"));
+    ASSERT_EQ(p.py_get_slice(1, 2, 2), PauliString::from_str("Y_"));
+    ASSERT_EQ(p.py_get_slice(5, 1, 4), PauliString::from_str("YZ_Y"));
+    ASSERT_EQ(p.py_get_slice(5, -1, 4), PauliString::from_str("YX_Z"));
+}

--- a/src/stabilizers/pauli_string.test.cc
+++ b/src/stabilizers/pauli_string.test.cc
@@ -344,12 +344,8 @@ TEST(PauliString, py_get_item) {
     ASSERT_EQ(p.py_get_item(-9), 2);
     ASSERT_EQ(p.py_get_item(-10), 1);
 
-    ASSERT_ANY_THROW({
-        p.py_get_item(10);
-    });
-    ASSERT_ANY_THROW({
-        p.py_get_item(-11);
-    });
+    ASSERT_ANY_THROW({ p.py_get_item(10); });
+    ASSERT_ANY_THROW({ p.py_get_item(-11); });
 }
 
 TEST(PauliString, py_get_slice) {


### PR DESCRIPTION
- Fix `stim.Circuit.__repr__` not indenting instructions
- Fix `stim.DetectorErrorModel.__repr__` not indenting instructions
- Add `stim.Circuit.__getitem__` slicing
- Add `stim.DetectorErrorModel.__getitem__` slicing
- Fix `stim.PauliString.__getitem__` having doubled documentation
- Fix `stim.PauliString.__setitem__` having doubled documentation
- Add Circuit::py_get_slice, DetectorErrorModel::py_get_slice, PauliString::py_get_slice
- Add pybind normalize_index_or_slice utility for `__getitem__` methods

Fixes https://github.com/quantumlib/Stim/issues/92