### PR TITLE
Add a fallback  error analysis decomposition strategy that uses other errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ set(TEST_FILES
         src/main_helper.test.cc
         src/probability_util.test.cc
         src/simd/bit_ref.test.cc
+        src/simd/fixed_cap_vector.test.cc
         src/simd/monotonic_buffer.test.cc
         src/simd/simd_bit_table.test.cc
         src/simd/simd_bits.test.cc

--- a/src/main_helper.test.cc
+++ b/src/main_helper.test.cc
@@ -638,7 +638,8 @@ DETECTOR rec[-1]
 DETECTOR rec[-2]
             )input")),
         trim(R"output(
-[exception=The detectors D0, D1 anti-commuted with a Z-basis reset, and allow_gauge_detectors isn't set.]
+[exception=The detectors D0, D1 anti-commuted with a Z-basis reset, and allow_gauge_detectors isn't set.
+Context: analyzing the circuit operation at offset 0 which is 'R 0'.]
             )output"));
 }
 
@@ -662,7 +663,8 @@ M 0
 DETECTOR rec[-1]
             )input")),
         trim(R"output(
-[exception=Handling PAULI_CHANNEL_1 requires `approximate_disjoint_errors` argument to be specified.]
+[exception=Handling PAULI_CHANNEL_1 requires `approximate_disjoint_errors` argument to be specified.
+Context: analyzing the circuit operation at offset 1 which is 'PAULI_CHANNEL_1(0.125, 0.25, 0.375) 0'.]
             )output"));
 
     ASSERT_EQ(
@@ -673,7 +675,8 @@ M 0
 DETECTOR rec[-1]
             )input")),
         trim(R"output(
-[exception=PAULI_CHANNEL_1 has a component probability '0.375000' larger than the `approximate_disjoint_errors` threshold of '0.300000'.]
+[exception=PAULI_CHANNEL_1 has a component probability '0.375000' larger than the `approximate_disjoint_errors` threshold of '0.300000'.
+Context: analyzing the circuit operation at offset 1 which is 'PAULI_CHANNEL_1(0.125, 0.25, 0.375) 0'.]
             )output"));
 }
 

--- a/src/simd/fixed_cap_vector.h
+++ b/src/simd/fixed_cap_vector.h
@@ -135,8 +135,8 @@ class FixedCapVector {
         return !(*this == other);
     }
     bool operator<(const FixedCapVector<T, max_size> &other) const {
-        if (num_used < other.num_used) {
-            return true;
+        if (num_used != other.num_used) {
+            return num_used < other.num_used;
         }
         for (size_t k = 0; k < num_used; k++) {
             if (data[k] != other.data[k]) {

--- a/src/simd/fixed_cap_vector.h
+++ b/src/simd/fixed_cap_vector.h
@@ -95,6 +95,10 @@ class FixedCapVector {
         return p;
     }
 
+    void clear() {
+        num_used = 0;
+    }
+
     void push_back(const T &item) {
         if (num_used == data.size()) {
             throw std::out_of_range("CappedVector capacity exceeded.");
@@ -138,9 +142,21 @@ class FixedCapVector {
                 return true;
             }
         }
-        return true;
+        return false;
+    }
+
+    std::string str() const {
+        std::stringstream ss;
+        ss << *this;
+        return ss.str();
     }
 };
+
+template <typename T, size_t max_size>
+std::ostream &operator<<(std::ostream &out, FixedCapVector<T, max_size> v) {
+    out << "FixedCapVector{" << comma_sep(v) << "}";
+    return out;
+}
 
 }  // namespace stim_internal
 

--- a/src/simd/fixed_cap_vector.h
+++ b/src/simd/fixed_cap_vector.h
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <cstddef>
+#include <sstream>
 #include <stdexcept>
 
 namespace stim_internal {
@@ -138,8 +139,8 @@ class FixedCapVector {
             return true;
         }
         for (size_t k = 0; k < num_used; k++) {
-            if (data[k] < other.data[k]) {
-                return true;
+            if (data[k] != other.data[k]) {
+                return data[k] < other.data[k];
             }
         }
         return false;
@@ -154,7 +155,17 @@ class FixedCapVector {
 
 template <typename T, size_t max_size>
 std::ostream &operator<<(std::ostream &out, FixedCapVector<T, max_size> v) {
-    out << "FixedCapVector{" << comma_sep(v) << "}";
+    out << "FixedCapVector{";
+    bool first = true;
+    for (const auto &t : v) {
+        if (first) {
+            first = false;
+        } else {
+            out << ", ";
+        }
+        out << t;
+    }
+    out << "}";
     return out;
 }
 

--- a/src/simd/fixed_cap_vector.test.cc
+++ b/src/simd/fixed_cap_vector.test.cc
@@ -51,32 +51,32 @@ TEST(FixedCapVector, basic_usage) {
 }
 
 TEST(FixedCapVector, push_pop) {
-    auto v = FixedCapVector<std::vector<int>, 5>();
-    std::vector<int> v2{1, 2, 3};
+    auto v = FixedCapVector<std::string, 5>();
+    std::string v2 = "123";
 
     v.push_back(v2);
-    ASSERT_EQ(v2, (std::vector<int>{1, 2, 3}));
-    ASSERT_EQ(v, (FixedCapVector<std::vector<int>, 5>{std::vector<int>{1, 2, 3}}));
+    ASSERT_EQ(v2, "123");
+    ASSERT_EQ(v, (FixedCapVector<std::string, 5>{"123"}));
 
-    v2.push_back(4);
+    v2.push_back('4');
     v.push_back(std::move(v2));
-    ASSERT_EQ(v2, (std::vector<int>{}));
+    ASSERT_EQ(v2, "");
     ASSERT_EQ(
         v,
-        (FixedCapVector<std::vector<int>, 5>{
-            std::vector<int>{1, 2, 3},
-            std::vector<int>{1, 2, 3, 4},
+        (FixedCapVector<std::string, 5>{
+            "123",
+            "1234",
         }));
 
     v.pop_back();
     ASSERT_EQ(
         v,
-        (FixedCapVector<std::vector<int>, 5>{
-            std::vector<int>{1, 2, 3},
+        (FixedCapVector<std::string, 5>{
+            "123",
         }));
 
     v.pop_back();
-    ASSERT_EQ(v, (FixedCapVector<std::vector<int>, 5>{}));
+    ASSERT_EQ(v, (FixedCapVector<std::string, 5>{}));
 
     ASSERT_THROW({ v.pop_back(); }, std::out_of_range);
 }
@@ -88,6 +88,12 @@ TEST(FixedCapVector, ordering) {
     auto v423 = FixedCapVector<int, 3>{4, 2, 3};
     ASSERT_LT(v123, v423);
     ASSERT_LT(v12, v123);
+    ASSERT_TRUE((FixedCapVector<int, 3>{4, 2} < FixedCapVector<int, 3>{4, 2, 1}));
+    ASSERT_TRUE((FixedCapVector<int, 3>{4, 2, 0} < FixedCapVector<int, 3>{4, 2, 1}));
+    ASSERT_FALSE((FixedCapVector<int, 3>{4, 2, 2} < FixedCapVector<int, 3>{4, 2, 1}));
+    ASSERT_TRUE((FixedCapVector<int, 3>{4, 1, 2} < FixedCapVector<int, 3>{4, 2, 1}));
+    ASSERT_FALSE((FixedCapVector<int, 3>{4, 3, 2} < FixedCapVector<int, 3>{4, 2, 1}));
+    ASSERT_FALSE((FixedCapVector<int, 3>{4, 3, 1} < FixedCapVector<int, 3>{4, 2, 2}));
     ASSERT_TRUE(v123 < v423);
     ASSERT_FALSE(v423 < v123);
     ASSERT_TRUE(v12 == w12);
@@ -96,4 +102,8 @@ TEST(FixedCapVector, ordering) {
     ASSERT_TRUE(!(v12 == v123));
     ASSERT_TRUE(v423 != v123);
     ASSERT_TRUE(!(v423 == v123));
+}
+
+TEST(FixedCapVector, str) {
+    ASSERT_EQ((FixedCapVector<int, 3>{1, 2, 3}.str()), "FixedCapVector{1, 2, 3}");
 }

--- a/src/simd/fixed_cap_vector.test.cc
+++ b/src/simd/fixed_cap_vector.test.cc
@@ -88,6 +88,8 @@ TEST(FixedCapVector, ordering) {
     auto v423 = FixedCapVector<int, 3>{4, 2, 3};
     ASSERT_LT(v123, v423);
     ASSERT_LT(v12, v123);
+    ASSERT_TRUE(v123 < v423);
+    ASSERT_FALSE(v423 < v123);
     ASSERT_TRUE(v12 == w12);
     ASSERT_TRUE(!(v12 != w12));
     ASSERT_TRUE(v12 != v123);

--- a/src/simulators/error_analyzer.h
+++ b/src/simulators/error_analyzer.h
@@ -169,8 +169,7 @@ struct ErrorAnalyzer {
     ///     basis_errors: Building blocks for the error combinations.
     template <size_t s>
     void add_error_combinations(
-        std::array<double, 1 << s> independent_probabilities,
-        std::array<ConstPointerRange<DemTarget>, s> basis_errors);
+        std::array<double, 1 << s> independent_probabilities, std::array<ConstPointerRange<DemTarget>, s> basis_errors);
 
     template <size_t s>
     void decompose_helper_add_error_combinations(
@@ -178,8 +177,8 @@ struct ErrorAnalyzer {
         std::array<ConstPointerRange<DemTarget>, 1 << s> &stored_ids);
 
     void decompose_and_append_component_to_tail(
-            ConstPointerRange<DemTarget> component,
-            const std::map<FixedCapVector<DemTarget, 2>, ConstPointerRange<DemTarget>> &known_symptoms);
+        ConstPointerRange<DemTarget> component,
+        const std::map<FixedCapVector<DemTarget, 2>, ConstPointerRange<DemTarget>> &known_symptoms);
 
     /// Performs a final check that all errors are decomposed.
     /// If any aren't, attempts to decompose them using other errors in the system.

--- a/src/simulators/error_analyzer.test.cc
+++ b/src/simulators/error_analyzer.test.cc
@@ -2123,21 +2123,21 @@ std::string check_catch(std::string expected_substring, std::function<void(void)
 }
 
 TEST(ErrorAnalyzer, context_clues_for_errors) {
-    ASSERT_EQ("", check_catch<std::invalid_argument>("operation at offset 1", [&]{
-        ErrorAnalyzer::circuit_to_detector_error_model(
-            Circuit(R"CIRCUIT(
+    ASSERT_EQ("", check_catch<std::invalid_argument>("operation at offset 1", [&] {
+                  ErrorAnalyzer::circuit_to_detector_error_model(
+                      Circuit(R"CIRCUIT(
                 X 0
                 DEPOLARIZE1(1) 0
             )CIRCUIT"),
-            false,
-            false,
-            false,
-            false);
-    }));
+                      false,
+                      false,
+                      false,
+                      false);
+              }));
 
-    ASSERT_EQ("", check_catch<std::invalid_argument>("REPEAT block at offset 2", [&]{
-        ErrorAnalyzer::circuit_to_detector_error_model(
-            Circuit(R"CIRCUIT(
+    ASSERT_EQ("", check_catch<std::invalid_argument>("REPEAT block at offset 2", [&] {
+                  ErrorAnalyzer::circuit_to_detector_error_model(
+                      Circuit(R"CIRCUIT(
                 X 0
                 Y 1
                 REPEAT 500 {
@@ -2145,11 +2145,11 @@ TEST(ErrorAnalyzer, context_clues_for_errors) {
                 }
                 Z 3
             )CIRCUIT"),
-            false,
-            false,
-            false,
-            false);
-    }));
+                      false,
+                      false,
+                      false,
+                      false);
+              }));
 }
 
 TEST(ErrorAnalyzer, too_many_symptoms) {
@@ -2177,58 +2177,48 @@ TEST(ErrorAnalyzer, too_many_symptoms) {
         DETECTOR rec[-1]
         DETECTOR rec[-1]
     )CIRCUIT");
-    ASSERT_EQ("", check_catch<std::invalid_argument>("max supported number of symptoms", [&]{
-        ErrorAnalyzer::circuit_to_detector_error_model(
-            symptoms_20,
-            true,
-            false,
-            false,
-            false);
-    }));
-    ASSERT_EQ("", check_catch<std::invalid_argument>("max supported number of symptoms", [&]{
-        ErrorAnalyzer::circuit_to_detector_error_model(
-            symptoms_20,
-            false,
-            false,
-            false,
-            false);
-    }));
+    ASSERT_EQ("", check_catch<std::invalid_argument>("max supported number of symptoms", [&] {
+                  ErrorAnalyzer::circuit_to_detector_error_model(symptoms_20, true, false, false, false);
+              }));
+    ASSERT_EQ("", check_catch<std::invalid_argument>("max supported number of symptoms", [&] {
+                  ErrorAnalyzer::circuit_to_detector_error_model(symptoms_20, false, false, false, false);
+              }));
 }
 
 TEST(ErrorAnalyzer, decompose_error_failures) {
-    ASSERT_EQ("", check_catch<std::invalid_argument>("failed to decompose is 'D0, D1, D2'",[]{
-        ErrorAnalyzer::circuit_to_detector_error_model(
-            Circuit(R"CIRCUIT(
+    ASSERT_EQ("", check_catch<std::invalid_argument>("failed to decompose is 'D0, D1, D2'", [] {
+                  ErrorAnalyzer::circuit_to_detector_error_model(
+                      Circuit(R"CIRCUIT(
                 DEPOLARIZE1(0.001) 0
                 M 0
                 DETECTOR rec[-1]
                 DETECTOR rec[-1]
                 DETECTOR rec[-1]
             )CIRCUIT"),
-            true,
-            false,
-            false,
-            false);
-    }));
+                      true,
+                      false,
+                      false,
+                      false);
+              }));
 
-    ASSERT_EQ("", check_catch<std::invalid_argument>("decompose errors into graphlike components", []{
-        ErrorAnalyzer::circuit_to_detector_error_model(
-            Circuit(R"CIRCUIT(
+    ASSERT_EQ("", check_catch<std::invalid_argument>("decompose errors into graphlike components", [] {
+                  ErrorAnalyzer::circuit_to_detector_error_model(
+                      Circuit(R"CIRCUIT(
                 X_ERROR(0.001) 0
                 M 0
                 DETECTOR rec[-1]
                 DETECTOR rec[-1]
                 DETECTOR rec[-1]
             )CIRCUIT"),
-            true,
-            false,
-            false,
-            false);
-    }));
+                      true,
+                      false,
+                      false,
+                      false);
+              }));
 
-    ASSERT_EQ("", check_catch<std::invalid_argument>("failed to decompose is 'D0, D1, D2, L5'", []{
-        ErrorAnalyzer::circuit_to_detector_error_model(
-            Circuit(R"CIRCUIT(
+    ASSERT_EQ("", check_catch<std::invalid_argument>("failed to decompose is 'D0, D1, D2, L5'", [] {
+                  ErrorAnalyzer::circuit_to_detector_error_model(
+                      Circuit(R"CIRCUIT(
                 X_ERROR(0.001) 0
                 M 0
                 DETECTOR rec[-1]
@@ -2236,11 +2226,11 @@ TEST(ErrorAnalyzer, decompose_error_failures) {
                 DETECTOR rec[-1]
                 OBSERVABLE_INCLUDE(5) rec[-1]
             )CIRCUIT"),
-            true,
-            false,
-            false,
-            false);
-    }));
+                      true,
+                      false,
+                      false,
+                      false);
+              }));
 }
 
 TEST(ErrorAnalyzer, other_error_decomposition_fallback) {
@@ -2364,4 +2354,70 @@ TEST(ErrorAnalyzer, is_graph_like) {
         DemTarget::separator(),
         DemTarget::separator(),
     }));
+}
+
+TEST(ErrorAnalyzer, honeycomb_code_decomposes) {
+    ErrorAnalyzer::circuit_to_detector_error_model(
+        Circuit(R"CIRCUIT(
+            R 3 5 7 9 11 13 18 20 22 24 26 28
+            X_ERROR(0.001) 3 5 7 9 11 13 18 20 22 24 26 28
+            DEPOLARIZE1(0.001) 0 1 2 4 6 8 10 12 14 15 16 17 19 21 23 25 27 29
+            XCX 24 1 7 6 11 12 3 15 20 21 28 27
+            R 0 8 14 17 23 29
+            DEPOLARIZE2(0.001) 24 1 7 6 11 12 3 15 20 21 28 27
+            X_ERROR(0.001) 0 8 14 17 23 29
+            YCX 20 0 7 8 3 14 11 17 24 23 28 29
+            XCX 9 1 5 6 13 12 18 15 22 21 26 27
+            R 2 4 10 16 19 25
+            DEPOLARIZE2(0.001) 20 0 7 8 3 14 11 17 24 23 28 29 9 1 5 6 13 12 18 15 22 21 26 27
+            X_ERROR(0.001) 2 4 10 16 19 25
+            X_ERROR(0.001) 1 6 12 15 21 27
+            CX 28 2 3 4 11 10 7 16 20 19 24 25
+            YCX 5 0 9 8 13 14 26 17 22 23 18 29
+            MR 1 6 12 15 21 27
+            OBSERVABLE_INCLUDE(0) rec[-5] rec[-4]
+            DEPOLARIZE2(0.001) 28 2 3 4 11 10 7 16 20 19 24 25 5 0 9 8 13 14 26 17 22 23 18 29
+            X_ERROR(0.001) 1 6 12 15 21 27
+            X_ERROR(0.001) 0 8 14 17 23 29
+            XCX 24 1 7 6 11 12 3 15 20 21 28 27
+            CX 13 2 5 4 9 10 22 16 18 19 26 25
+            MR 0 8 14 17 23 29
+            OBSERVABLE_INCLUDE(0) rec[-5] rec[-4]
+            DETECTOR rec[-12] rec[-11] rec[-8] rec[-6] rec[-5] rec[-2]
+            DETECTOR rec[-10] rec[-9] rec[-7] rec[-4] rec[-3] rec[-1]
+            DEPOLARIZE2(0.001) 24 1 7 6 11 12 3 15 20 21 28 27 13 2 5 4 9 10 22 16 18 19 26 25
+            X_ERROR(0.001) 0 8 14 17 23 29
+            X_ERROR(0.001) 2 4 10 16 19 25
+            YCX 20 0 7 8 3 14 11 17 24 23 28 29
+            XCX 9 1 5 6 13 12 18 15 22 21 26 27
+            MR 2 4 10 16 19 25
+            OBSERVABLE_INCLUDE(0) rec[-5] rec[-4]
+            DEPOLARIZE2(0.001) 20 0 7 8 3 14 11 17 24 23 28 29 9 1 5 6 13 12 18 15 22 21 26 27
+            X_ERROR(0.001) 2 4 10 16 19 25
+            X_ERROR(0.001) 1 6 12 15 21 27
+            YCX 5 0 9 8 13 14 26 17 22 23 18 29
+            MR 1 6 12 15 21 27
+            OBSERVABLE_INCLUDE(0) rec[-5] rec[-4]
+            DETECTOR rec[-24] rec[-22] rec[-19] rec[-12] rec[-10] rec[-7] rec[-6] rec[-4] rec[-1]
+            DETECTOR rec[-23] rec[-21] rec[-20] rec[-11] rec[-9] rec[-8] rec[-5] rec[-3] rec[-2]
+            DEPOLARIZE2(0.001) 5 0 9 8 13 14 26 17 22 23 18 29
+            X_ERROR(0.001) 1 6 12 15 21 27
+            X_ERROR(0.001) 0 8 14 17 23 29
+            MR 0 8 14 17 23 29
+            OBSERVABLE_INCLUDE(0) rec[-5] rec[-4]
+            DETECTOR rec[-30] rec[-29] rec[-26] rec[-24] rec[-23] rec[-20] rec[-12] rec[-11] rec[-8] rec[-6] rec[-5] rec[-2]
+            DETECTOR rec[-28] rec[-27] rec[-25] rec[-22] rec[-21] rec[-19] rec[-10] rec[-9] rec[-7] rec[-4] rec[-3] rec[-1]
+            X_ERROR(0.001) 0 8 14 17 23 29
+            X_ERROR(0.001) 3 5 7 9 11 13 18 20 22 24 26 28
+            M 3 5 7 9 11 13 18 20 22 24 26 28
+            DETECTOR rec[-36] rec[-34] rec[-31] rec[-30] rec[-29] rec[-26] rec[-18] rec[-16] rec[-13] rec[-12] rec[-11] rec[-7] rec[-6] rec[-5] rec[-1]
+            DETECTOR rec[-35] rec[-33] rec[-32] rec[-28] rec[-27] rec[-25] rec[-17] rec[-15] rec[-14] rec[-10] rec[-9] rec[-8] rec[-4] rec[-3] rec[-2]
+            DETECTOR rec[-24] rec[-23] rec[-20] rec[-18] rec[-17] rec[-14] rec[-11] rec[-10] rec[-9] rec[-5] rec[-4] rec[-3]
+            DETECTOR rec[-22] rec[-21] rec[-19] rec[-16] rec[-15] rec[-13] rec[-12] rec[-8] rec[-7] rec[-6] rec[-2] rec[-1]
+            OBSERVABLE_INCLUDE(0) rec[-12] rec[-10] rec[-9] rec[-7]
+        )CIRCUIT"),
+        true,
+        false,
+        false,
+        false);
 }

--- a/src/simulators/error_analyzer.test.cc
+++ b/src/simulators/error_analyzer.test.cc
@@ -1380,48 +1380,6 @@ TEST(ErrorAnalyzer, loop_folding_rep_code_circuit) {
     ASSERT_TRUE(actual.approx_equals(expected, 0.00001)) << actual;
 }
 
-TEST(ErrorAnalyzer, reduce_error_detector_dependence_error_message) {
-    ASSERT_THROW(
-        {
-            try {
-                ErrorAnalyzer::circuit_to_detector_error_model(
-                    Circuit(
-                        R"CIRCUIT(
-                        R 0
-                        DEPOLARIZE1(0.01) 0
-                        M 0
-                        DETECTOR rec[-1]
-                        DETECTOR rec[-1]
-                        DETECTOR rec[-1]
-                        DETECTOR rec[-1]
-                        DETECTOR rec[-1]
-                        DETECTOR rec[-1]
-                        DETECTOR rec[-1]
-                        DETECTOR rec[-1]
-                        DETECTOR rec[-1]
-                        DETECTOR rec[-1]
-                        DETECTOR rec[-1]
-                        DETECTOR rec[-1]
-                        DETECTOR rec[-1]
-                        DETECTOR rec[-1]
-                        DETECTOR rec[-1]
-                        DETECTOR rec[-1]
-                        DETECTOR rec[-1]
-                        DETECTOR rec[-1]
-                    )CIRCUIT"),
-                    true,
-                    false,
-                    false,
-                    0.0);
-            } catch (const std::out_of_range &e) {
-                std::string s(e.what());
-                EXPECT_NE(s.find("error involves too many detectors"), std::string::npos);
-                throw;
-            }
-        },
-        std::out_of_range);
-}
-
 TEST(ErrorAnalyzer, multi_round_gauge_detectors_dont_grow) {
     ASSERT_EQ(
         ErrorAnalyzer::circuit_to_detector_error_model(
@@ -1982,12 +1940,12 @@ TEST(ErrorAnalyzer, noisy_measurement_mz) {
     ASSERT_EQ(
         ErrorAnalyzer::circuit_to_detector_error_model(
             Circuit(R"CIRCUIT(
-            RZ 0
-            MZ(0.125) 0
-            MZ 0
-            DETECTOR rec[-2]
-            DETECTOR rec[-1]
-        )CIRCUIT"),
+                RZ 0
+                MZ(0.125) 0
+                MZ 0
+                DETECTOR rec[-2]
+                DETECTOR rec[-1]
+            )CIRCUIT"),
             false,
             false,
             false,
@@ -2000,15 +1958,15 @@ TEST(ErrorAnalyzer, noisy_measurement_mz) {
     ASSERT_EQ(
         ErrorAnalyzer::circuit_to_detector_error_model(
             Circuit(R"CIRCUIT(
-            RZ 0 1
-            X_ERROR(1) 0 1
-            MZ(0.125) 0 1
-            MZ 0 1
-            DETECTOR rec[-4]
-            DETECTOR rec[-3]
-            DETECTOR rec[-2]
-            DETECTOR rec[-1]
-        )CIRCUIT"),
+                RZ 0 1
+                X_ERROR(1) 0 1
+                MZ(0.125) 0 1
+                MZ 0 1
+                DETECTOR rec[-4]
+                DETECTOR rec[-3]
+                DETECTOR rec[-2]
+                DETECTOR rec[-1]
+            )CIRCUIT"),
             false,
             false,
             false,
@@ -2025,12 +1983,12 @@ TEST(ErrorAnalyzer, noisy_measurement_mrx) {
     ASSERT_EQ(
         ErrorAnalyzer::circuit_to_detector_error_model(
             Circuit(R"CIRCUIT(
-            RX 0
-            MRX(0.125) 0
-            MRX 0
-            DETECTOR rec[-2]
-            DETECTOR rec[-1]
-        )CIRCUIT"),
+                RX 0
+                MRX(0.125) 0
+                MRX 0
+                DETECTOR rec[-2]
+                DETECTOR rec[-1]
+            )CIRCUIT"),
             false,
             false,
             false,
@@ -2043,15 +2001,15 @@ TEST(ErrorAnalyzer, noisy_measurement_mrx) {
     ASSERT_EQ(
         ErrorAnalyzer::circuit_to_detector_error_model(
             Circuit(R"CIRCUIT(
-            RX 0 1
-            Z_ERROR(1) 0 1
-            MRX(0.125) 0 1
-            MRX 0 1
-            DETECTOR rec[-4]
-            DETECTOR rec[-3]
-            DETECTOR rec[-2]
-            DETECTOR rec[-1]
-        )CIRCUIT"),
+                RX 0 1
+                Z_ERROR(1) 0 1
+                MRX(0.125) 0 1
+                MRX 0 1
+                DETECTOR rec[-4]
+                DETECTOR rec[-3]
+                DETECTOR rec[-2]
+                DETECTOR rec[-1]
+            )CIRCUIT"),
             false,
             false,
             false,
@@ -2068,12 +2026,12 @@ TEST(ErrorAnalyzer, noisy_measurement_mry) {
     ASSERT_EQ(
         ErrorAnalyzer::circuit_to_detector_error_model(
             Circuit(R"CIRCUIT(
-            RY 0
-            MRY(0.125) 0
-            MRY 0
-            DETECTOR rec[-2]
-            DETECTOR rec[-1]
-        )CIRCUIT"),
+                RY 0
+                MRY(0.125) 0
+                MRY 0
+                DETECTOR rec[-2]
+                DETECTOR rec[-1]
+            )CIRCUIT"),
             false,
             false,
             false,
@@ -2086,15 +2044,15 @@ TEST(ErrorAnalyzer, noisy_measurement_mry) {
     ASSERT_EQ(
         ErrorAnalyzer::circuit_to_detector_error_model(
             Circuit(R"CIRCUIT(
-            RY 0 1
-            X_ERROR(1) 0 1
-            MRY(0.125) 0 1
-            MRY 0 1
-            DETECTOR rec[-4]
-            DETECTOR rec[-3]
-            DETECTOR rec[-2]
-            DETECTOR rec[-1]
-        )CIRCUIT"),
+                RY 0 1
+                X_ERROR(1) 0 1
+                MRY(0.125) 0 1
+                MRY 0 1
+                DETECTOR rec[-4]
+                DETECTOR rec[-3]
+                DETECTOR rec[-2]
+                DETECTOR rec[-1]
+            )CIRCUIT"),
             false,
             false,
             false,
@@ -2111,12 +2069,12 @@ TEST(ErrorAnalyzer, noisy_measurement_mrz) {
     ASSERT_EQ(
         ErrorAnalyzer::circuit_to_detector_error_model(
             Circuit(R"CIRCUIT(
-            RZ 0
-            MRZ(0.125) 0
-            MRZ 0
-            DETECTOR rec[-2]
-            DETECTOR rec[-1]
-        )CIRCUIT"),
+                RZ 0
+                MRZ(0.125) 0
+                MRZ 0
+                DETECTOR rec[-2]
+                DETECTOR rec[-1]
+            )CIRCUIT"),
             false,
             false,
             false,
@@ -2129,15 +2087,15 @@ TEST(ErrorAnalyzer, noisy_measurement_mrz) {
     ASSERT_EQ(
         ErrorAnalyzer::circuit_to_detector_error_model(
             Circuit(R"CIRCUIT(
-            RZ 0 1
-            X_ERROR(1) 0 1
-            MRZ(0.125) 0 1
-            MRZ 0 1
-            DETECTOR rec[-4]
-            DETECTOR rec[-3]
-            DETECTOR rec[-2]
-            DETECTOR rec[-1]
-        )CIRCUIT"),
+                RZ 0 1
+                X_ERROR(1) 0 1
+                MRZ(0.125) 0 1
+                MRZ 0 1
+                DETECTOR rec[-4]
+                DETECTOR rec[-3]
+                DETECTOR rec[-2]
+                DETECTOR rec[-1]
+            )CIRCUIT"),
             false,
             false,
             false,
@@ -2148,4 +2106,262 @@ TEST(ErrorAnalyzer, noisy_measurement_mrz) {
             detector D2
             detector D3
         )MODEL"));
+}
+
+template <typename TEx>
+std::string check_catch(std::string expected_substring, std::function<void(void)> func) {
+    try {
+        func();
+        return "Expected an exception with message '" + expected_substring + "', but no exception was thrown.";
+    } catch (const TEx &ex) {
+        std::string s = ex.what();
+        if (s.find(expected_substring) == std::string::npos) {
+            return "Didn't find '" + expected_substring + "' in '" + std::string(ex.what()) + "'.";
+        }
+        return "";
+    }
+}
+
+TEST(ErrorAnalyzer, context_clues_for_errors) {
+    ASSERT_EQ("", check_catch<std::invalid_argument>("operation at offset 1", [&]{
+        ErrorAnalyzer::circuit_to_detector_error_model(
+            Circuit(R"CIRCUIT(
+                X 0
+                DEPOLARIZE1(1) 0
+            )CIRCUIT"),
+            false,
+            false,
+            false,
+            false);
+    }));
+
+    ASSERT_EQ("", check_catch<std::invalid_argument>("REPEAT block at offset 2", [&]{
+        ErrorAnalyzer::circuit_to_detector_error_model(
+            Circuit(R"CIRCUIT(
+                X 0
+                Y 1
+                REPEAT 500 {
+                    DEPOLARIZE1(1) 0
+                }
+                Z 3
+            )CIRCUIT"),
+            false,
+            false,
+            false,
+            false);
+    }));
+}
+
+TEST(ErrorAnalyzer, too_many_symptoms) {
+    auto symptoms_20 = Circuit(R"CIRCUIT(
+        DEPOLARIZE1(0.001) 0
+        M 0
+        DETECTOR rec[-1]
+        DETECTOR rec[-1]
+        DETECTOR rec[-1]
+        DETECTOR rec[-1]
+        DETECTOR rec[-1]
+        DETECTOR rec[-1]
+        DETECTOR rec[-1]
+        DETECTOR rec[-1]
+        DETECTOR rec[-1]
+        DETECTOR rec[-1]
+        DETECTOR rec[-1]
+        DETECTOR rec[-1]
+        DETECTOR rec[-1]
+        DETECTOR rec[-1]
+        DETECTOR rec[-1]
+        DETECTOR rec[-1]
+        DETECTOR rec[-1]
+        DETECTOR rec[-1]
+        DETECTOR rec[-1]
+        DETECTOR rec[-1]
+    )CIRCUIT");
+    ASSERT_EQ("", check_catch<std::invalid_argument>("max supported number of symptoms", [&]{
+        ErrorAnalyzer::circuit_to_detector_error_model(
+            symptoms_20,
+            true,
+            false,
+            false,
+            false);
+    }));
+    ASSERT_EQ("", check_catch<std::invalid_argument>("max supported number of symptoms", [&]{
+        ErrorAnalyzer::circuit_to_detector_error_model(
+            symptoms_20,
+            false,
+            false,
+            false,
+            false);
+    }));
+}
+
+TEST(ErrorAnalyzer, decompose_error_failures) {
+    ASSERT_EQ("", check_catch<std::invalid_argument>("failed to decompose is 'D0, D1, D2'",[]{
+        ErrorAnalyzer::circuit_to_detector_error_model(
+            Circuit(R"CIRCUIT(
+                DEPOLARIZE1(0.001) 0
+                M 0
+                DETECTOR rec[-1]
+                DETECTOR rec[-1]
+                DETECTOR rec[-1]
+            )CIRCUIT"),
+            true,
+            false,
+            false,
+            false);
+    }));
+
+    ASSERT_EQ("", check_catch<std::invalid_argument>("decompose errors into graphlike components", []{
+        ErrorAnalyzer::circuit_to_detector_error_model(
+            Circuit(R"CIRCUIT(
+                X_ERROR(0.001) 0
+                M 0
+                DETECTOR rec[-1]
+                DETECTOR rec[-1]
+                DETECTOR rec[-1]
+            )CIRCUIT"),
+            true,
+            false,
+            false,
+            false);
+    }));
+
+    ASSERT_EQ("", check_catch<std::invalid_argument>("failed to decompose is 'D0, D1, D2, L5'", []{
+        ErrorAnalyzer::circuit_to_detector_error_model(
+            Circuit(R"CIRCUIT(
+                X_ERROR(0.001) 0
+                M 0
+                DETECTOR rec[-1]
+                DETECTOR rec[-1]
+                DETECTOR rec[-1]
+                OBSERVABLE_INCLUDE(5) rec[-1]
+            )CIRCUIT"),
+            true,
+            false,
+            false,
+            false);
+    }));
+}
+
+TEST(ErrorAnalyzer, other_error_decomposition_fallback) {
+    ASSERT_EQ(
+        ErrorAnalyzer::circuit_to_detector_error_model(
+            Circuit(R"CIRCUIT(
+                X_ERROR(0.125) 0
+                MR 0
+                X_ERROR(0.25) 0
+                MR 0
+                DETECTOR rec[-2]
+                DETECTOR rec[-2]
+                DETECTOR rec[-1] rec[-2]
+                DETECTOR rec[-1] rec[-2]
+                OBSERVABLE_INCLUDE(5) rec[-2]
+                OBSERVABLE_INCLUDE(6) rec[-1]
+            )CIRCUIT"),
+            true,
+            false,
+            false,
+            false),
+        DetectorErrorModel(R"MODEL(
+            error(0.25) D2 D3 L6
+            error(0.125) D2 D3 L6 ^ D0 D1 L5 L6
+        )MODEL"));
+
+    ASSERT_EQ(
+        ErrorAnalyzer::circuit_to_detector_error_model(
+            Circuit(R"CIRCUIT(
+                X_ERROR(0.125) 0
+                MR 0
+                X_ERROR(0.25) 0
+                MR 0
+                DETECTOR rec[-2]
+                DETECTOR rec[-2]
+                DETECTOR rec[-1] rec[-2]
+                DETECTOR rec[-1] rec[-2]
+            )CIRCUIT"),
+            true,
+            false,
+            false,
+            false),
+        DetectorErrorModel(R"MODEL(
+            error(0.25) D2 D3
+            error(0.125) D2 D3 ^ D0 D1
+        )MODEL"));
+
+    ASSERT_EQ(
+        ErrorAnalyzer::circuit_to_detector_error_model(
+            Circuit(R"CIRCUIT(
+                X_ERROR(0.125) 0
+                MR 0
+                X_ERROR(0.25) 0
+                MR 0
+                DETECTOR rec[-1]
+                DETECTOR rec[-1]
+                DETECTOR rec[-1] rec[-2]
+                DETECTOR rec[-1] rec[-2]
+            )CIRCUIT"),
+            true,
+            false,
+            false,
+            false),
+        DetectorErrorModel(R"MODEL(
+            error(0.125) D2 D3
+            error(0.25) D2 D3 ^ D0 D1
+        )MODEL"));
+}
+
+TEST(ErrorAnalyzer, is_graph_like) {
+    ASSERT_TRUE(is_graphlike(std::vector<DemTarget>{}));
+    ASSERT_TRUE(is_graphlike(std::vector<DemTarget>{DemTarget::separator()}));
+    ASSERT_TRUE(is_graphlike(std::vector<DemTarget>{
+        DemTarget::observable_id(0),
+        DemTarget::observable_id(1),
+        DemTarget::observable_id(2),
+        DemTarget::separator(),
+        DemTarget::observable_id(1),
+    }));
+    ASSERT_TRUE(is_graphlike(std::vector<DemTarget>{
+        DemTarget::observable_id(0),
+        DemTarget::relative_detector_id(1),
+        DemTarget::observable_id(2),
+        DemTarget::separator(),
+        DemTarget::observable_id(1),
+    }));
+    ASSERT_TRUE(is_graphlike(std::vector<DemTarget>{
+        DemTarget::observable_id(0),
+        DemTarget::relative_detector_id(1),
+        DemTarget::relative_detector_id(2),
+        DemTarget::separator(),
+        DemTarget::observable_id(1),
+    }));
+    ASSERT_FALSE(is_graphlike(std::vector<DemTarget>{
+        DemTarget::relative_detector_id(0),
+        DemTarget::relative_detector_id(1),
+        DemTarget::relative_detector_id(2),
+        DemTarget::separator(),
+        DemTarget::observable_id(1),
+    }));
+    ASSERT_FALSE(is_graphlike(std::vector<DemTarget>{
+        DemTarget::relative_detector_id(0),
+        DemTarget::relative_detector_id(1),
+        DemTarget::relative_detector_id(2),
+    }));
+    ASSERT_FALSE(is_graphlike(std::vector<DemTarget>{
+        DemTarget::separator(),
+        DemTarget::separator(),
+        DemTarget::relative_detector_id(0),
+        DemTarget::relative_detector_id(1),
+        DemTarget::relative_detector_id(2),
+        DemTarget::separator(),
+        DemTarget::separator(),
+    }));
+    ASSERT_TRUE(is_graphlike(std::vector<DemTarget>{
+        DemTarget::separator(),
+        DemTarget::relative_detector_id(0),
+        DemTarget::separator(),
+        DemTarget::relative_detector_id(1),
+        DemTarget::relative_detector_id(2),
+        DemTarget::separator(),
+        DemTarget::separator(),
+    }));
 }

--- a/src/simulators/frame_simulator.cc
+++ b/src/simulators/frame_simulator.cc
@@ -408,10 +408,10 @@ void FrameSimulator::DEPOLARIZE2(const OperationData &target_data) {
         auto sample_index = s % batch_size;
         size_t t1 = targets[target_index];
         size_t t2 = targets[target_index + 1];
-        x_table[t1][sample_index] ^= p & 1;
-        z_table[t1][sample_index] ^= p & 2;
-        x_table[t2][sample_index] ^= p & 4;
-        z_table[t2][sample_index] ^= p & 8;
+        x_table[t1][sample_index] ^= (bool)(p & 1);
+        z_table[t1][sample_index] ^= (bool)(p & 2);
+        x_table[t2][sample_index] ^= (bool)(p & 4);
+        z_table[t2][sample_index] ^= (bool)(p & 8);
     });
 }
 

--- a/src/test_util.test.h
+++ b/src/test_util.test.h
@@ -29,4 +29,3 @@ struct RaiiTempNamedFile {
     RaiiTempNamedFile();
     ~RaiiTempNamedFile();
 };
-


### PR DESCRIPTION
- Add str/clear/<< to FixedCapVector
- Fix FixedCapVector::operator< always returning true
- Move decompose
- Add ErrorAnalyzer::do_global_error_decomposition_pass
- Make do_global_error_decomposition_pass verify all errors are decomposed
- Move ErrorAnalyzer::add_error_combinations body into .cc file
- Extract ErrorAnalyzer::decompose_helper_add_error_combinations

Fixes https://github.com/quantumlib/Stim/issues/106
Fixes https://github.com/quantumlib/Stim/issues/103