### PR TITLE
Add MPP operation for measuring Pauli products

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ set(SOURCE_FILES_NO_MAIN
         src/circuit/gate_data_period_4.cc
         src/circuit/gate_data_pp.cc
         src/circuit/gate_data_swaps.cc
+        src/circuit/gate_target.cc
         src/dem/detector_error_model.cc
         src/gate_help.cc
         src/gen/circuit_gen_main.cc
@@ -81,6 +82,7 @@ set(TEST_FILES
         src/arg_parse.test.cc
         src/circuit/circuit.test.cc
         src/circuit/gate_data.test.cc
+        src/circuit/gate_target.test.cc
         src/dem/detector_error_model.test.cc
         src/gen/circuit_gen_main.test.cc
         src/gen/circuit_gen_params.test.cc

--- a/doc/file_format_stim_circuit.md
+++ b/doc/file_format_stim_circuit.md
@@ -61,17 +61,19 @@ An *argument* is a double precision floating point number.
 
 A *target* can either be a qubit target (a non-negative integer),
 a measurement record target (a negative integer prefixed by `rec[` and suffixed by `]`),
-an inverted result qubit target (a non-negative integer prefixed by `!`),
-or a Pauli target (an integer prefixed by `X`, `Y`, or `Z`).
+a Pauli target (an integer prefixed by `X`, `Y`, or `Z`),
+or a combiner (`*`).
+Additionally, qubit targets and Pauli targets may be prefixed by a `!` to indicate that
+measurement results should be negated.
 
 ```
 <NAME> ::= /[a-zA-Z][a-zA-Z0-9_]*/ 
 <ARG> ::= <double> 
-<TARG> ::= <QUBIT_TARGET> | <MEASUREMENT_RECORD_TARGET> | <INVERTED_RESULT_QUBIT_TARGET> | <PAULI_TARGET> 
-<QUBIT_TARGET> ::= <uint>
+<TARG> ::= <QUBIT_TARGET> | <MEASUREMENT_RECORD_TARGET> | <PAULI_TARGET> | <COMBINER_TARGET> 
+<QUBIT_TARGET> ::= '!'? <uint>
 <MEASUREMENT_RECORD_TARGET> ::= "rec[-" <uint> "]"
-<PAULI_TARGET> ::= /[XYZ]/ <uint>
-<INVERTED_RESULT_QUBIT_TARGET> ::= "!" <uint> 
+<PAULI_TARGET> ::= '!'? /[XYZ]/ <uint>
+<COMBINER_TARGET> ::= '*'
 ```
 
 A *block initiator* is an instruction suffixed with `{`.
@@ -122,11 +124,15 @@ which indicate that the block's instructions should be iterated over `K` times i
 
 ### Target Types
 
-There are four types of targets that can be given to instructions:
-qubit targets, measurement record targets, inverted result qubit targets, and Pauli targets.
+There are three types of targets that can be given to instructions:
+qubit targets, measurement record targets, and Pauli targets.
 
 A qubit target refers to a qubit by index.
 There's a qubit `0`, a qubit `1`, a qubit `2`, and so forth.
+A qubit target may be prefixed by `!`, like `!2`, to mark it as inverted.
+Inverted qubit targets are only meaningful for operations that produce measurement results.
+They indicate that the recorded measurement result, for the given qubit target, should be inverted.
+For example `M 0 !1` measures qubit `0` and qubit `1`, but also inverts the result recorded for qubit `1`.
 
 A measurement record target refers to a recorded measurement result, relative to the current end of the measurement record.
 For example, `rec[-1]` is the most recent measurement result, `rec[-2]` is the second most recent, and so forth.
@@ -134,14 +140,14 @@ For example, `rec[-1]` is the most recent measurement result, `rec[-2]` is the s
 The reason negative indices are used is to make it possible to write loops.)
 It is an error to refer to a measurement result so far back that it would precede the start of the circuit.
 
-An inverted result qubit target is a qubit target prefixed by `!`, like `!2`.
-These targets are only meaningful for operations that produce measurement results.
-They indicate that the recorded measurement result, for the given qubit target, should be inverted.
-For example `M 0 !1` measures qubit `0` and qubit `1`, but also inverts the result recorded for qubit `1`.
-
 A Pauli target is a qubit target prefixed by a Pauli operation `X`, `Y`, or `Z`.
 They are used when specifying Pauli products.
 For example, `CORRELATED_ERROR(0.1) X1 Y3 Z2` uses Pauli targets to specify the error that is applied.
+Pauli targets may be grouped using combiners (`*`) and may be prefixed by `!` to mark them as inverted.
+Inverted Pauli targets are only meaningful for operations that produce measurement results.
+They indicate that the recorded measurement result, for the given group of Paulis, should be inverted.
+For example `MPP !X1*Z2 Y3` measures the Pauli product `X1*Z2` and inverts the result, then also measures
+the Pauli `Y3`.
 
 ### Broadcasting
 

--- a/doc/gates.md
+++ b/doc/gates.md
@@ -20,6 +20,7 @@
 - [ISWAP](#ISWAP)
 - [ISWAP_DAG](#ISWAP_DAG)
 - [M](#M)
+- [MPP](#MPP)
 - [MR](#MR)
 - [MRX](#MRX)
 - [MRY](#MRY)
@@ -1474,6 +1475,31 @@
         ```
         Z -> m xor chance(p)
         Z -> +Z
+        ```
+        
+    
+- <a name="MPP"></a>**`MPP`**
+    
+    Measure Pauli products.
+    
+    - Example:
+    
+        ```
+        MPP X1*Y2           # Join products using '*'
+        MPP X1*Y2 Z3*Z4     # Separate products using spaces with no '*'.
+        MPP !Z5             # Negate products (invert results) using '!'.
+        MPP !Z5*X4
+        MPP(0.001) Z1*Z2*Z3 # Add result noise using a probability argument.
+        ```
+    
+    If this gate is parameterized by a probability argument, the recorded result will be flipped with that probability. If not, the recorded result is noiseless. Note that the noise only affects the recorded result, not the target qubit's state.
+    
+    Prefixing a target with ! inverts its recorded measurement result.
+    - Stabilizer Generators:
+    
+        ```
+        P -> m xor chance(p)
+        P -> P
         ```
         
     

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -92,8 +92,10 @@
     - [`stim.GateTarget.__init__`](#stim.GateTarget.__init__)
     - [`stim.GateTarget.__ne__`](#stim.GateTarget.__ne__)
     - [`stim.GateTarget.__repr__`](#stim.GateTarget.__repr__)
+    - [`stim.GateTarget.is_combiner`](#stim.GateTarget.is_combiner)
     - [`stim.GateTarget.is_inverted_result_target`](#stim.GateTarget.is_inverted_result_target)
     - [`stim.GateTarget.is_measurement_record_target`](#stim.GateTarget.is_measurement_record_target)
+    - [`stim.GateTarget.is_qubit_target`](#stim.GateTarget.is_qubit_target)
     - [`stim.GateTarget.is_x_target`](#stim.GateTarget.is_x_target)
     - [`stim.GateTarget.is_y_target`](#stim.GateTarget.is_y_target)
     - [`stim.GateTarget.is_z_target`](#stim.GateTarget.is_z_target)
@@ -190,6 +192,7 @@
     - [`stim.TableauSimulator.ycy`](#stim.TableauSimulator.ycy)
     - [`stim.TableauSimulator.ycz`](#stim.TableauSimulator.ycz)
     - [`stim.TableauSimulator.z`](#stim.TableauSimulator.z)
+- [`stim.target_combiner`](#stim.target_combiner)
 - [`stim.target_inv`](#stim.target_inv)
 - [`stim.target_logical_observable_id`](#stim.target_logical_observable_id)
 - [`stim.target_rec`](#stim.target_rec)
@@ -442,6 +445,11 @@
 >     )
 > ```
 
+## `stim.target_combiner() -> stim.GateTarget`<a name="stim.target_combiner"></a>
+> ```
+> Returns a target combiner (`*` in circuit files) that can be used as an operation target.
+> ```
+
 ## `stim.target_inv(qubit_index: int) -> int`<a name="stim.target_inv"></a>
 > ```
 > Returns a target flagged as inverted that can be passed into Circuit.append_operation
@@ -482,19 +490,19 @@
 > Returns a target separator (e.g. "^" in a .dem file).
 > ```
 
-## `stim.target_x(qubit_index: int) -> int`<a name="stim.target_x"></a>
+## `stim.target_x(qubit_index: int, invert: bool = False) -> int`<a name="stim.target_x"></a>
 > ```
 > Returns a target flagged as Pauli X that can be passed into Circuit.append_operation
 > For example, the 'X1' in 'CORRELATED_ERROR(0.1) X1 Y2 Z3' is qubit 1 flagged as Pauli X.
 > ```
 
-## `stim.target_y(qubit_index: int) -> int`<a name="stim.target_y"></a>
+## `stim.target_y(qubit_index: int, invert: bool = False) -> int`<a name="stim.target_y"></a>
 > ```
 > Returns a target flagged as Pauli Y that can be passed into Circuit.append_operation
 > For example, the 'Y2' in 'CORRELATED_ERROR(0.1) X1 Y2 Z3' is qubit 2 flagged as Pauli Y.
 > ```
 
-## `stim.target_z(qubit_index: int) -> int`<a name="stim.target_z"></a>
+## `stim.target_z(qubit_index: int, invert: bool = False) -> int`<a name="stim.target_z"></a>
 > ```
 > Returns a target flagged as Pauli Z that can be passed into Circuit.append_operation
 > For example, the 'Z3' in 'CORRELATED_ERROR(0.1) X1 Y2 Z3' is qubit 3 flagged as Pauli Z.
@@ -733,7 +741,7 @@
 >     text: The STIM program text containing the circuit operations to append.
 > ```
 
-### `stim.Circuit.append_operation(self, name: str, targets: List[int], arg: object = None) -> None`<a name="stim.Circuit.append_operation"></a>
+### `stim.Circuit.append_operation(self, name: str, targets: List[object], arg: object = None) -> None`<a name="stim.Circuit.append_operation"></a>
 > ```
 > Appends an operation into the circuit.
 > 
@@ -1076,7 +1084,7 @@
 > Determines if two `stim.CircuitInstruction`s are identical.
 > ```
 
-### `stim.CircuitInstruction.__init__(self, name: str, targets: List[GateTarget], gate_args: List[float] = ()) -> None`<a name="stim.CircuitInstruction.__init__"></a>
+### `stim.CircuitInstruction.__init__(self, name: str, targets: List[object], gate_args: List[float] = ()) -> None`<a name="stim.CircuitInstruction.__init__"></a>
 > ```
 > Initializes a `stim.CircuitInstruction`.
 > 
@@ -1111,7 +1119,7 @@
 > The name of the instruction (e.g. `H` or `X_ERROR` or `DETECTOR`).
 > ```
 
-### `stim.CircuitInstruction.targets_copy(self) -> List[GateTarget]`<a name="stim.CircuitInstruction.targets_copy"></a>
+### `stim.CircuitInstruction.targets_copy(self) -> List[stim.GateTarget]`<a name="stim.CircuitInstruction.targets_copy"></a>
 > ```
 > Returns a copy of the targets of the instruction.
 > ```
@@ -1621,14 +1629,27 @@
 > Returns text that is a valid python expression evaluating to an equivalent `stim.GateTarget`.
 > ```
 
+### `stim.GateTarget.is_combiner`<a name="stim.GateTarget.is_combiner"></a>
+> ```
+> Returns whether or not this is a `stim.target_combiner()` (a `*` in a circuit file).
+> ```
+
 ### `stim.GateTarget.is_inverted_result_target`<a name="stim.GateTarget.is_inverted_result_target"></a>
 > ```
-> Returns whether or not this is a `stim.target_inv` target (e.g. `!5` in a circuit file).
+> Returns whether or not this is an inverted target.
+> 
+> Inverted targets include inverted qubit targets `stim.target_inv(5)` (`!5` in a circuit file) and
+> inverted Pauli targets like `stim.target_x(4, invert=True)` (`!X4` in a circuit file).
 > ```
 
 ### `stim.GateTarget.is_measurement_record_target`<a name="stim.GateTarget.is_measurement_record_target"></a>
 > ```
 > Returns whether or not this is a `stim.target_rec` target (e.g. `rec[-5]` in a circuit file).
+> ```
+
+### `stim.GateTarget.is_qubit_target`<a name="stim.GateTarget.is_qubit_target"></a>
+> ```
+> Returns true if this is a qubit target (e.g. `5`) or an inverted qubit target (e.g. `stim.target_inv(4)`).
 > ```
 
 ### `stim.GateTarget.is_x_target`<a name="stim.GateTarget.is_x_target"></a>

--- a/src/circuit/circuit.pybind.cc
+++ b/src/circuit/circuit.pybind.cc
@@ -268,18 +268,18 @@ void pybind_circuit(pybind11::module &m) {
                 pybind11::list args;
                 pybind11::list targets;
                 for (auto t : op.target_data.targets) {
-                    auto v = t & TARGET_VALUE_MASK;
-                    if (t & TARGET_INVERTED_BIT) {
+                    auto v = t.qubit_value();
+                    if (t.data & TARGET_INVERTED_BIT) {
                         targets.append(pybind11::make_tuple("inv", v));
-                    } else if (t & (TARGET_PAULI_X_BIT | TARGET_PAULI_Z_BIT)) {
-                        if (!(t & TARGET_PAULI_Z_BIT)) {
+                    } else if (t.data & (TARGET_PAULI_X_BIT | TARGET_PAULI_Z_BIT)) {
+                        if (!(t.data & TARGET_PAULI_Z_BIT)) {
                             targets.append(pybind11::make_tuple("X", v));
-                        } else if (!(t & TARGET_PAULI_X_BIT)) {
+                        } else if (!(t.data & TARGET_PAULI_X_BIT)) {
                             targets.append(pybind11::make_tuple("Z", v));
                         } else {
                             targets.append(pybind11::make_tuple("Y", v));
                         }
-                    } else if (t & TARGET_RECORD_BIT) {
+                    } else if (t.data & TARGET_RECORD_BIT) {
                         targets.append(pybind11::make_tuple("rec", -(long long)v));
                     } else {
                         targets.append(pybind11::int_(v));

--- a/src/circuit/circuit.pybind.cc
+++ b/src/circuit/circuit.pybind.cc
@@ -66,8 +66,8 @@ void pybind_circuit(pybind11::module &m) {
             .data());
 
     pybind_circuit_repeat_block(m);
-    pybind_circuit_instruction(m);
     pybind_circuit_gate_target(m);
+    pybind_circuit_instruction(m);
 
     c.def(
         pybind11::init([](const char *stim_program_text) {

--- a/src/circuit/circuit.pybind.cc
+++ b/src/circuit/circuit.pybind.cc
@@ -446,7 +446,7 @@ void pybind_circuit(pybind11::module &m) {
 
     c.def(
         "append_operation",
-        [](Circuit &self, const std::string &gate_name, const std::vector<uint32_t> &targets, pybind11::object arg) {
+        [](Circuit &self, const std::string &gate_name, const std::vector<pybind11::object> &targets, pybind11::object arg) {
             if (arg.is(pybind11::none())) {
                 if (GATE_DATA.at(gate_name).arg_count == 1) {
                     arg = pybind11::make_tuple(0.0);
@@ -454,15 +454,19 @@ void pybind_circuit(pybind11::module &m) {
                     arg = pybind11::make_tuple();
                 }
             }
+            std::vector<uint32_t> raw_targets;
+            for (const auto &obj : targets) {
+                raw_targets.push_back(obj_to_gate_target(obj).data);
+            }
             try {
                 auto d = pybind11::cast<double>(arg);
-                self.append_op(gate_name, targets, d);
+                self.append_op(gate_name, raw_targets, d);
                 return;
             } catch (const pybind11::cast_error &ex) {
             }
             try {
                 auto args = pybind11::cast<std::vector<double>>(arg);
-                self.append_op(gate_name, targets, args);
+                self.append_op(gate_name, raw_targets, args);
                 return;
             } catch (const pybind11::cast_error &ex) {
             }

--- a/src/circuit/circuit.test.h
+++ b/src/circuit/circuit.test.h
@@ -21,7 +21,7 @@
 
 // Helper class for creating temporary operation data.
 struct OpDat {
-    std::vector<uint32_t> targets;
+    std::vector<stim_internal::GateTarget> targets;
     OpDat(uint32_t target);
     OpDat(std::vector<uint32_t> targets);
     static OpDat flipped(size_t target);

--- a/src/circuit/circuit_gate_target.pybind.cc
+++ b/src/circuit/circuit_gate_target.pybind.cc
@@ -120,6 +120,14 @@ void pybind_circuit_gate_target(pybind11::module &m) {
         )DOC")
             .data());
 
+    c.def_property_readonly(
+        "is_combiner",
+        &GateTarget::is_combiner,
+        clean_doc_string(u8R"DOC(
+            Returns whether or not this is a `stim.target_combiner()` (a `*` in a circuit file).
+        )DOC")
+            .data());
+
     c.def(pybind11::self == pybind11::self, "Determines if two `stim.GateTarget`s are identical.");
     c.def(pybind11::self != pybind11::self, "Determines if two `stim.GateTarget`s are different.");
     c.def(

--- a/src/circuit/circuit_gate_target.pybind.h
+++ b/src/circuit/circuit_gate_target.pybind.h
@@ -19,22 +19,9 @@
 #include <pybind11/pybind11.h>
 #include <string>
 
-void pybind_circuit_gate_target(pybind11::module &m);
+#include "gate_target.h"
 
-struct GateTarget {
-    uint32_t target;
-    GateTarget(uint32_t target);
-    GateTarget(pybind11::object init_target);
-    int32_t value() const;
-    bool is_x_target() const;
-    bool is_y_target() const;
-    bool is_z_target() const;
-    bool is_inverted_result_target() const;
-    bool is_measurement_record_target() const;
-    bool operator==(const GateTarget &other) const;
-    bool operator!=(const GateTarget &other) const;
-    std::string repr_inner() const;
-    std::string repr() const;
-};
+void pybind_circuit_gate_target(pybind11::module &m);
+stim_internal::GateTarget obj_to_gate_target(const pybind11::object &obj);
 
 #endif

--- a/src/circuit/circuit_gate_target_pybind_test.py
+++ b/src/circuit/circuit_gate_target_pybind_test.py
@@ -34,6 +34,8 @@ def test_properties():
     assert not g.is_z_target
     assert not g.is_inverted_result_target
     assert not g.is_measurement_record_target
+    assert not g.is_combiner
+    assert g.is_qubit_target
 
     g = stim.GateTarget(stim.target_rec(-4))
     assert g.value == -4
@@ -42,6 +44,8 @@ def test_properties():
     assert not g.is_z_target
     assert not g.is_inverted_result_target
     assert g.is_measurement_record_target
+    assert not g.is_combiner
+    assert not g.is_qubit_target
 
     g = stim.GateTarget(stim.target_x(3))
     assert g.value == 3
@@ -50,6 +54,8 @@ def test_properties():
     assert not g.is_z_target
     assert not g.is_inverted_result_target
     assert not g.is_measurement_record_target
+    assert not g.is_combiner
+    assert not g.is_qubit_target
 
     g = stim.GateTarget(stim.target_y(3))
     assert g.value == 3
@@ -58,6 +64,8 @@ def test_properties():
     assert not g.is_z_target
     assert not g.is_inverted_result_target
     assert not g.is_measurement_record_target
+    assert not g.is_combiner
+    assert not g.is_qubit_target
 
     g = stim.GateTarget(stim.target_z(3))
     assert g.value == 3
@@ -66,6 +74,18 @@ def test_properties():
     assert g.is_z_target
     assert not g.is_inverted_result_target
     assert not g.is_measurement_record_target
+    assert not g.is_combiner
+    assert not g.is_qubit_target
+
+    g = stim.GateTarget(stim.target_z(3, invert=True))
+    assert g.value == 3
+    assert not g.is_x_target
+    assert not g.is_y_target
+    assert g.is_z_target
+    assert g.is_inverted_result_target
+    assert not g.is_measurement_record_target
+    assert not g.is_combiner
+    assert not g.is_qubit_target
 
     g = stim.GateTarget(stim.target_inv(3))
     assert g.value == 3
@@ -74,6 +94,17 @@ def test_properties():
     assert not g.is_z_target
     assert g.is_inverted_result_target
     assert not g.is_measurement_record_target
+    assert not g.is_combiner
+    assert g.is_qubit_target
+
+    g = stim.target_combiner()
+    assert not g.is_x_target
+    assert not g.is_y_target
+    assert not g.is_z_target
+    assert not g.is_inverted_result_target
+    assert not g.is_measurement_record_target
+    assert not g.is_qubit_target
+    assert g.is_combiner
 
 
 @pytest.mark.parametrize("value", [

--- a/src/circuit/circuit_instruction.pybind.cc
+++ b/src/circuit/circuit_instruction.pybind.cc
@@ -21,8 +21,12 @@
 
 using namespace stim_internal;
 
-CircuitInstruction::CircuitInstruction(const char *name, std::vector<GateTarget> targets, std::vector<double> gate_args)
-    : gate(GATE_DATA.at(name)), targets(targets), gate_args(gate_args) {
+CircuitInstruction::CircuitInstruction(
+    const char *name, const std::vector<pybind11::object> &init_targets, const std::vector<double> &gate_args)
+    : gate(GATE_DATA.at(name)), gate_args(gate_args) {
+    for (const auto &obj : init_targets) {
+        targets.push_back(obj_to_gate_target(obj));
+    }
 }
 CircuitInstruction::CircuitInstruction(const Gate &gate, std::vector<GateTarget> targets, std::vector<double> gate_args)
     : gate(gate), targets(targets), gate_args(gate_args) {
@@ -84,7 +88,7 @@ void pybind_circuit_instruction(pybind11::module &m) {
             .data());
 
     c.def(
-        pybind11::init<const char *, std::vector<GateTarget>, std::vector<double>>(),
+        pybind11::init<const char *, std::vector<pybind11::object>, std::vector<double>>(),
         pybind11::arg("name"),
         pybind11::arg("targets"),
         pybind11::arg("gate_args") = std::make_tuple(),

--- a/src/circuit/circuit_instruction.pybind.h
+++ b/src/circuit/circuit_instruction.pybind.h
@@ -19,19 +19,22 @@
 
 #include "circuit_gate_target.pybind.h"
 #include "gate_data.h"
+#include "gate_target.h"
 
 void pybind_circuit_instruction(pybind11::module &m);
 
 struct CircuitInstruction {
     const stim_internal::Gate &gate;
-    std::vector<GateTarget> targets;
+    std::vector<stim_internal::GateTarget> targets;
     std::vector<double> gate_args;
 
-    CircuitInstruction(const char *name, std::vector<GateTarget> targets, std::vector<double> gate_args);
-    CircuitInstruction(const stim_internal::Gate &gate, std::vector<GateTarget> targets, std::vector<double> gate_args);
+    CircuitInstruction(
+        const char *name, const std::vector<pybind11::object> &targets, const std::vector<double> &gate_args);
+    CircuitInstruction(
+        const stim_internal::Gate &gate, std::vector<stim_internal::GateTarget> targets, std::vector<double> gate_args);
 
     std::string name() const;
-    std::vector<GateTarget> targets_copy() const;
+    std::vector<stim_internal::GateTarget> targets_copy() const;
     std::vector<double> gate_args_copy() const;
     bool operator==(const CircuitInstruction &other) const;
     bool operator!=(const CircuitInstruction &other) const;

--- a/src/circuit/circuit_pybind_test.py
+++ b/src/circuit/circuit_pybind_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import cast
 
 import stim
 import pytest
@@ -443,3 +444,14 @@ def test_slicing():
         }
         Z 3
     """)
+
+
+def test_reappend_gate_targets():
+    expected = stim.Circuit("""
+        MPP !X0 * X1
+        CX rec[-1] 5
+    """)
+    c = stim.Circuit()
+    c.append_operation("MPP", cast(stim.CircuitInstruction, expected[0]).targets_copy())
+    c.append_operation("CX", cast(stim.CircuitInstruction, expected[1]).targets_copy())
+    assert c == expected

--- a/src/circuit/gate_data.cc
+++ b/src/circuit/gate_data.cc
@@ -106,7 +106,7 @@ Gate::Gate(
       extra_data_func(extra_data_func),
       flags(flags),
       arg_count(arg_count),
-      name_len(strlen(name)),
+      name_len((uint8_t)strlen(name)),
       id(gate_name_to_id(name)) {
 }
 
@@ -139,7 +139,7 @@ void GateDataMap::add_gate_alias(bool &failed, const char *alt_name, const char 
         return;
     }
     g_alt.name = alt_name;
-    g_alt.name_len = strlen(alt_name);
+    g_alt.name_len = (uint8_t)strlen(alt_name);
     g_alt.id = h_canon;
 }
 

--- a/src/circuit/gate_data.h
+++ b/src/circuit/gate_data.h
@@ -106,6 +106,8 @@ enum GateFlags : uint16_t {
     GATE_TAKES_NO_TARGETS = 1 << 10,
     // Controls validation of index arguments like OBSERVABLE_INCLUDE(1).
     GATE_ARGS_ARE_UNSIGNED_INTEGERS = 1 << 11,
+    // Controls instructions like MPP taking Pauli product combiners ("X1*Y2 Z3").
+    GATE_TARGETS_COMBINERS = 1 << 12,
 };
 
 struct ExtraGateData {
@@ -275,6 +277,13 @@ struct GateDataMap {
 };
 
 extern const GateDataMap GATE_DATA;
+
+void decompose_mpp_operation(
+    const OperationData &target_data,
+    size_t num_qubits,
+    const std::function<void(
+        const OperationData &h_xz, const OperationData &h_yz, const OperationData &cnot, const OperationData &meas)>
+        &callback);
 
 }  // namespace stim_internal
 

--- a/src/circuit/gate_data_collapsing.cc
+++ b/src/circuit/gate_data_collapsing.cc
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <complex>
-
 #include "../simulators/error_analyzer.h"
 #include "../simulators/frame_simulator.h"
 #include "../simulators/tableau_simulator.h"
@@ -219,4 +217,110 @@ Forces each target qubit into the `|0>` state by silently measuring it in the Z 
             },
         });
     add_gate_alias(failed, "RZ", "R");
+
+    add_gate(
+        failed,
+        Gate{
+            "MPP",
+            ARG_COUNT_SYGIL_ZERO_OR_ONE,
+            &TableauSimulator::MPP,
+            &FrameSimulator::MPP,
+            &ErrorAnalyzer::MPP,
+            (GateFlags)(GATE_PRODUCES_NOISY_RESULTS | GATE_TARGETS_PAULI_STRING | GATE_TARGETS_COMBINERS | GATE_ARGS_ARE_DISJOINT_PROBABILITIES),
+            []() -> ExtraGateData {
+                return {
+                    "L_Collapsing Gates",
+                    R"MARKDOWN(
+Measure Pauli products.
+
+- Example:
+
+    ```
+    MPP X1*Y2           # Join products using '*'
+    MPP X1*Y2 Z3*Z4     # Separate products using spaces with no '*'.
+    MPP !Z5             # Negate products (invert results) using '!'.
+    MPP !Z5*X4
+    MPP(0.001) Z1*Z2*Z3 # Add result noise using a probability argument.
+    ```
+
+)MARKDOWN",
+                    {},
+                    {"1 -> +Z"},
+                };
+            },
+        });
+}
+
+void stim_internal::decompose_mpp_operation(
+    const OperationData &target_data,
+    size_t num_qubits,
+    const std::function<void(
+        const OperationData &h_xz, const OperationData &h_yz, const OperationData &cnot, const OperationData &meas)>
+        &callback) {
+    simd_bits used(num_qubits);
+    simd_bits inner_used(num_qubits);
+    std::vector<GateTarget> h_xz;
+    std::vector<GateTarget> h_yz;
+    std::vector<GateTarget> cnot;
+    std::vector<GateTarget> meas;
+
+    auto op_dat = [](std::vector<GateTarget> &targets, PointerRange<double> args) {
+        return OperationData{args, targets};
+    };
+    size_t start = 0;
+    while (start < target_data.targets.size()) {
+        size_t end = start + 1;
+        while (end < target_data.targets.size() && target_data.targets[end].is_combiner()) {
+            end += 2;
+        }
+
+        // Determine which qubits are being touched by the next group.
+        inner_used.clear();
+        for (size_t i = start; i < end; i += 2) {
+            auto t = target_data.targets[i];
+            if (inner_used[t.qubit_value()]) {
+                throw std::invalid_argument(
+                    "A pauli product specified the same qubit twice.\n"
+                    "The operation: MPP" +
+                    target_data.str());
+            }
+            inner_used[t.qubit_value()] = true;
+        }
+
+        // If there's overlap with previous groups, the previous groups have to be flushed first.
+        if (inner_used.intersects(used)) {
+            callback(op_dat(h_xz, {}), op_dat(h_yz, {}), op_dat(cnot, {}), op_dat(meas, target_data.args));
+            h_xz.clear();
+            h_yz.clear();
+            cnot.clear();
+            meas.clear();
+            used.clear();
+        }
+        used |= inner_used;
+
+        // Append operations that are equivalent to the desired measurement.
+        for (size_t i = start; i < end; i += 2) {
+            auto t = target_data.targets[i];
+            auto q = t.qubit_value();
+            if (t.data & TARGET_PAULI_X_BIT) {
+                if (t.data & TARGET_PAULI_Z_BIT) {
+                    h_yz.push_back({q});
+                } else {
+                    h_xz.push_back({q});
+                }
+            }
+            if (i == start) {
+                meas.push_back({q});
+            } else {
+                cnot.push_back({q});
+                cnot.push_back({meas.back().qubit_value()});
+            }
+            meas.back().data ^= t.data & TARGET_INVERTED_BIT;
+        }
+
+        start = end;
+    }
+
+    // Flush remaining groups.
+    callback(op_dat(h_xz, {}), op_dat(h_yz, {}), op_dat(cnot, {}), op_dat(meas, target_data.args));
 }

--- a/src/circuit/gate_data_collapsing.cc
+++ b/src/circuit/gate_data_collapsing.cc
@@ -245,7 +245,7 @@ Measure Pauli products.
 
 )MARKDOWN",
                     {},
-                    {"1 -> +Z"},
+                    {"P -> m xor chance(p)", "P -> P"},
                 };
             },
         });

--- a/src/circuit/gate_target.cc
+++ b/src/circuit/gate_target.cc
@@ -55,7 +55,7 @@ uint32_t GateTarget::qubit_value() const {
 }
 
 int32_t GateTarget::value() const {
-    ssize_t result = data & TARGET_VALUE_MASK;
+    int32_t result = (int32_t)(data & TARGET_VALUE_MASK);
     if (is_measurement_record_target()) {
         return -result;
     }

--- a/src/circuit/gate_target.cc
+++ b/src/circuit/gate_target.cc
@@ -1,0 +1,144 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gate_target.h"
+
+using namespace stim_internal;
+
+GateTarget GateTarget::x(uint32_t qubit, bool inverted) {
+    if (qubit != (qubit & TARGET_VALUE_MASK)) {
+        throw std::invalid_argument("qubit target larger than " + std::to_string(TARGET_VALUE_MASK));
+    }
+    return {qubit | (TARGET_INVERTED_BIT * inverted) | TARGET_PAULI_X_BIT};
+}
+GateTarget GateTarget::y(uint32_t qubit, bool inverted) {
+    if (qubit != (qubit & TARGET_VALUE_MASK)) {
+        throw std::invalid_argument("qubit target larger than " + std::to_string(TARGET_VALUE_MASK));
+    }
+    return {qubit | (TARGET_INVERTED_BIT * inverted) | TARGET_PAULI_X_BIT | TARGET_PAULI_Z_BIT};
+}
+GateTarget GateTarget::z(uint32_t qubit, bool inverted) {
+    if (qubit != (qubit & TARGET_VALUE_MASK)) {
+        throw std::invalid_argument("qubit target larger than " + std::to_string(TARGET_VALUE_MASK));
+    }
+    return {qubit | (TARGET_INVERTED_BIT * inverted) | TARGET_PAULI_Z_BIT};
+}
+GateTarget GateTarget::qubit(uint32_t qubit, bool inverted) {
+    if (qubit != (qubit & TARGET_VALUE_MASK)) {
+        throw std::invalid_argument("qubit target larger than " + std::to_string(TARGET_VALUE_MASK));
+    }
+    return {qubit | (TARGET_INVERTED_BIT * inverted)};
+}
+GateTarget GateTarget::rec(int32_t lookback) {
+    if (lookback >= 0 || lookback < -(int32_t)TARGET_VALUE_MASK) {
+        throw std::invalid_argument("lookback further than " + std::to_string(-(int32_t)TARGET_VALUE_MASK));
+    }
+    return {((uint32_t)-lookback) | TARGET_RECORD_BIT};
+}
+GateTarget GateTarget::combiner() {
+    return {TARGET_COMBINER};
+}
+
+uint32_t GateTarget::qubit_value() const {
+    return data & TARGET_VALUE_MASK;
+}
+
+int32_t GateTarget::value() const {
+    ssize_t result = data & TARGET_VALUE_MASK;
+    if (is_measurement_record_target()) {
+        return -result;
+    }
+    return result;
+}
+bool GateTarget::is_x_target() const {
+    return (data & TARGET_PAULI_X_BIT) && !(data & TARGET_PAULI_Z_BIT);
+}
+bool GateTarget::is_y_target() const {
+    return (data & TARGET_PAULI_X_BIT) && (data & TARGET_PAULI_Z_BIT);
+}
+bool GateTarget::is_z_target() const {
+    return !(data & TARGET_PAULI_X_BIT) && (data & TARGET_PAULI_Z_BIT);
+}
+bool GateTarget::is_inverted_result_target() const {
+    return data & TARGET_INVERTED_BIT;
+}
+bool GateTarget::is_measurement_record_target() const {
+    return data & TARGET_RECORD_BIT;
+}
+bool GateTarget::is_qubit_target() const {
+    return !(data & (TARGET_PAULI_X_BIT | TARGET_PAULI_Z_BIT | TARGET_RECORD_BIT | TARGET_COMBINER));
+}
+bool GateTarget::is_combiner() const {
+    return data == TARGET_COMBINER;
+}
+bool GateTarget::operator==(const GateTarget &other) const {
+    return data == other.data;
+}
+bool GateTarget::operator<(const GateTarget &other) const {
+    return data < other.data;
+}
+bool GateTarget::operator!=(const GateTarget &other) const {
+    return data != other.data;
+}
+
+std::ostream &stim_internal::operator<<(std::ostream &out, const GateTarget &t) {
+    if (t.is_combiner()) {
+        return out << "stim.GateTarget.combiner()";
+    }
+    if (t.is_qubit_target()) {
+        if (t.is_inverted_result_target()) {
+            return out << "stim.target_inv(" << t.value() << ")";
+        }
+        return out << t.value();
+    }
+    if (t.is_measurement_record_target()) {
+        return out << "stim.target_rec(" << t.value() << ")";
+    }
+    if (t.is_x_target()) {
+        out << "stim.target_x(" << t.value();
+        if (t.is_inverted_result_target()) {
+            out << ", invert=True";
+        }
+        return out << ")";
+    }
+    if (t.is_y_target()) {
+        out << "stim.target_y(" << t.value();
+        if (t.is_inverted_result_target()) {
+            out << ", invert=True";
+        }
+        return out << ")";
+    }
+    if (t.is_z_target()) {
+        out << "stim.target_z(" << t.value();
+        if (t.is_inverted_result_target()) {
+            out << ", invert=True";
+        }
+        return out << ")";
+    }
+    throw std::invalid_argument("Malformed target.");
+}
+
+std::string GateTarget::str() const {
+    std::stringstream ss;
+    ss << *this;
+    return ss.str();
+}
+
+std::string GateTarget::repr() const {
+    std::stringstream ss;
+    ss << "stim.GateTarget(";
+    ss << *this;
+    ss << ")";
+    return ss.str();
+}

--- a/src/circuit/gate_target.h
+++ b/src/circuit/gate_target.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef STIM_GATE_TARGET_H
+#define STIM_GATE_TARGET_H
+
+#include <iostream>
+
+#include "gate_data.h"
+
+namespace stim_internal {
+
+#define TARGET_VALUE_MASK ((uint32_t{1} << 24) - uint32_t{1})
+#define TARGET_INVERTED_BIT (uint32_t{1} << 31)
+#define TARGET_PAULI_X_BIT (uint32_t{1} << 30)
+#define TARGET_PAULI_Z_BIT (uint32_t{1} << 29)
+#define TARGET_RECORD_BIT (uint32_t{1} << 28)
+#define TARGET_COMBINER (uint32_t{1} << 27)
+
+struct GateTarget {
+    uint32_t data;
+    int32_t value() const;
+
+    static GateTarget x(uint32_t qubit, bool inverted = false);
+    static GateTarget y(uint32_t qubit, bool inverted = false);
+    static GateTarget z(uint32_t qubit, bool inverted = false);
+    static GateTarget qubit(uint32_t qubit, bool inverted = false);
+    static GateTarget rec(int32_t lookback);
+    static GateTarget combiner();
+
+    bool is_combiner() const;
+    bool is_x_target() const;
+    bool is_y_target() const;
+    bool is_z_target() const;
+    bool is_inverted_result_target() const;
+    bool is_measurement_record_target() const;
+    bool is_qubit_target() const;
+    uint32_t qubit_value() const;
+    bool operator==(const GateTarget &other) const;
+    bool operator!=(const GateTarget &other) const;
+    bool operator<(const GateTarget &other) const;
+    std::string str() const;
+    std::string repr() const;
+};
+
+std::ostream &operator<<(std::ostream &out, const GateTarget &t);
+
+}  // namespace stim_internal
+
+#endif

--- a/src/circuit/gate_target.test.cc
+++ b/src/circuit/gate_target.test.cc
@@ -1,0 +1,162 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gate_target.h"
+
+#include <gtest/gtest.h>
+
+#include "../test_util.test.h"
+
+using namespace stim_internal;
+
+TEST(gate_target, xyz) {
+    ASSERT_THROW({ GateTarget::x(UINT32_MAX); }, std::invalid_argument);
+    ASSERT_THROW({ GateTarget::y(UINT32_MAX, true); }, std::invalid_argument);
+    ASSERT_THROW({ GateTarget::z(UINT32_MAX, false); }, std::invalid_argument);
+
+    auto t = GateTarget::x(5, false);
+    ASSERT_EQ(t.is_combiner(), false);
+    ASSERT_EQ(t.is_inverted_result_target(), false);
+    ASSERT_EQ(t.is_measurement_record_target(), false);
+    ASSERT_EQ(t.is_qubit_target(), false);
+    ASSERT_EQ(t.is_x_target(), true);
+    ASSERT_EQ(t.is_y_target(), false);
+    ASSERT_EQ(t.is_z_target(), false);
+    ASSERT_EQ(t.str(), "stim.target_x(5)");
+    ASSERT_EQ(t.value(), 5);
+
+    t = GateTarget::x(7, true);
+    ASSERT_EQ(t.is_combiner(), false);
+    ASSERT_EQ(t.is_inverted_result_target(), true);
+    ASSERT_EQ(t.is_measurement_record_target(), false);
+    ASSERT_EQ(t.is_qubit_target(), false);
+    ASSERT_EQ(t.is_x_target(), true);
+    ASSERT_EQ(t.is_y_target(), false);
+    ASSERT_EQ(t.is_z_target(), false);
+    ASSERT_EQ(t.str(), "stim.target_x(7, invert=True)");
+    ASSERT_EQ(t.value(), 7);
+
+    t = GateTarget::y(11, false);
+    ASSERT_EQ(t.is_combiner(), false);
+    ASSERT_EQ(t.is_inverted_result_target(), false);
+    ASSERT_EQ(t.is_measurement_record_target(), false);
+    ASSERT_EQ(t.is_qubit_target(), false);
+    ASSERT_EQ(t.is_x_target(), false);
+    ASSERT_EQ(t.is_y_target(), true);
+    ASSERT_EQ(t.is_z_target(), false);
+    ASSERT_EQ(t.str(), "stim.target_y(11)");
+    ASSERT_EQ(t.value(), 11);
+
+    t = GateTarget::y(13, true);
+    ASSERT_EQ(t.is_combiner(), false);
+    ASSERT_EQ(t.is_inverted_result_target(), true);
+    ASSERT_EQ(t.is_measurement_record_target(), false);
+    ASSERT_EQ(t.is_qubit_target(), false);
+    ASSERT_EQ(t.is_x_target(), false);
+    ASSERT_EQ(t.is_y_target(), true);
+    ASSERT_EQ(t.is_z_target(), false);
+    ASSERT_EQ(t.str(), "stim.target_y(13, invert=True)");
+    ASSERT_EQ(t.value(), 13);
+
+    t = GateTarget::z(17, false);
+    ASSERT_EQ(t.is_combiner(), false);
+    ASSERT_EQ(t.is_inverted_result_target(), false);
+    ASSERT_EQ(t.is_measurement_record_target(), false);
+    ASSERT_EQ(t.is_qubit_target(), false);
+    ASSERT_EQ(t.is_x_target(), false);
+    ASSERT_EQ(t.is_y_target(), false);
+    ASSERT_EQ(t.is_z_target(), true);
+    ASSERT_EQ(t.str(), "stim.target_z(17)");
+    ASSERT_EQ(t.value(), 17);
+
+    t = GateTarget::z(19, true);
+    ASSERT_EQ(t.is_combiner(), false);
+    ASSERT_EQ(t.is_inverted_result_target(), true);
+    ASSERT_EQ(t.is_measurement_record_target(), false);
+    ASSERT_EQ(t.is_qubit_target(), false);
+    ASSERT_EQ(t.is_x_target(), false);
+    ASSERT_EQ(t.is_y_target(), false);
+    ASSERT_EQ(t.is_z_target(), true);
+    ASSERT_EQ(t.str(), "stim.target_z(19, invert=True)");
+    ASSERT_EQ(t.value(), 19);
+    ASSERT_EQ(t.qubit_value(), 19);
+}
+
+TEST(gate_target, qubit) {
+    ASSERT_THROW({ GateTarget::qubit(UINT32_MAX); }, std::invalid_argument);
+
+    auto t = GateTarget::qubit(5, false);
+    ASSERT_EQ(t.is_combiner(), false);
+    ASSERT_EQ(t.is_inverted_result_target(), false);
+    ASSERT_EQ(t.is_measurement_record_target(), false);
+    ASSERT_EQ(t.is_qubit_target(), true);
+    ASSERT_EQ(t.is_x_target(), false);
+    ASSERT_EQ(t.is_y_target(), false);
+    ASSERT_EQ(t.is_z_target(), false);
+    ASSERT_EQ(t.str(), "5");
+    ASSERT_EQ(t.value(), 5);
+    ASSERT_EQ(t.qubit_value(), 5);
+
+    t = GateTarget::qubit(7, true);
+    ASSERT_EQ(t.is_combiner(), false);
+    ASSERT_EQ(t.is_inverted_result_target(), true);
+    ASSERT_EQ(t.is_measurement_record_target(), false);
+    ASSERT_EQ(t.is_qubit_target(), true);
+    ASSERT_EQ(t.is_x_target(), false);
+    ASSERT_EQ(t.is_y_target(), false);
+    ASSERT_EQ(t.is_z_target(), false);
+    ASSERT_EQ(t.str(), "stim.target_inv(7)");
+    ASSERT_EQ(t.value(), 7);
+}
+
+TEST(gate_target, record) {
+    ASSERT_THROW({ GateTarget::rec(1); }, std::invalid_argument);
+    ASSERT_THROW({ GateTarget::rec(0); }, std::invalid_argument);
+    ASSERT_THROW({ GateTarget::rec(-(int32_t{1} << 30)); }, std::invalid_argument);
+
+    auto t = GateTarget::rec(-5);
+    ASSERT_EQ(t.is_combiner(), false);
+    ASSERT_EQ(t.is_inverted_result_target(), false);
+    ASSERT_EQ(t.is_measurement_record_target(), true);
+    ASSERT_EQ(t.is_qubit_target(), false);
+    ASSERT_EQ(t.is_x_target(), false);
+    ASSERT_EQ(t.is_y_target(), false);
+    ASSERT_EQ(t.is_z_target(), false);
+    ASSERT_EQ(t.str(), "stim.target_rec(-5)");
+    ASSERT_EQ(t.value(), -5);
+    ASSERT_EQ(t.qubit_value(), 5);
+}
+
+TEST(gate_target, combiner) {
+    auto t = GateTarget::combiner();
+    ASSERT_EQ(t.is_combiner(), true);
+    ASSERT_EQ(t.is_inverted_result_target(), false);
+    ASSERT_EQ(t.is_measurement_record_target(), false);
+    ASSERT_EQ(t.is_qubit_target(), false);
+    ASSERT_EQ(t.is_x_target(), false);
+    ASSERT_EQ(t.is_y_target(), false);
+    ASSERT_EQ(t.is_z_target(), false);
+    ASSERT_EQ(t.str(), "stim.GateTarget.combiner()");
+    ASSERT_EQ(t.qubit_value(), 0);
+}
+
+TEST(gate_target, equality) {
+    ASSERT_TRUE(GateTarget{0} == GateTarget{0});
+    ASSERT_FALSE(GateTarget{0} == GateTarget{1});
+    ASSERT_TRUE(GateTarget{0} != GateTarget{1});
+    ASSERT_FALSE(GateTarget{0} != GateTarget{0});
+    ASSERT_TRUE(GateTarget{0} < GateTarget{1});
+    ASSERT_FALSE(GateTarget{1} < GateTarget{0});
+    ASSERT_FALSE(GateTarget{0} < GateTarget{0});
+}

--- a/src/dem/detector_error_model.cc
+++ b/src/dem/detector_error_model.cc
@@ -27,7 +27,10 @@ using namespace stim_internal;
 constexpr uint64_t OBSERVABLE_BIT = uint64_t{1} << 63;
 constexpr uint64_t SEPARATOR_SYGIL = UINT64_MAX;
 
-DemTarget DemTarget::observable_id(uint32_t id) {
+DemTarget DemTarget::observable_id(uint64_t id) {
+    if (id > 0xFFFFFFFF) {
+        throw std::invalid_argument("id > 0xFFFFFFFF");
+    }
     return {OBSERVABLE_BIT | id};
 }
 DemTarget DemTarget::relative_detector_id(uint64_t id) {

--- a/src/dem/detector_error_model.h
+++ b/src/dem/detector_error_model.h
@@ -38,7 +38,7 @@ enum DemInstructionType : uint8_t {
 struct DemTarget {
     uint64_t data;
 
-    static DemTarget observable_id(uint32_t id);
+    static DemTarget observable_id(uint64_t id);
     static DemTarget relative_detector_id(uint64_t id);
     static constexpr DemTarget separator() {
         return {UINT64_MAX};

--- a/src/gen/circuit_gen_params.cc
+++ b/src/gen/circuit_gen_params.cc
@@ -4,7 +4,7 @@
 
 using namespace stim_internal;
 
-void append_anti_basis_error(Circuit &circuit, const std::vector<uint32_t> &targets, float p, char basis) {
+void append_anti_basis_error(Circuit &circuit, const std::vector<uint32_t> &targets, double p, char basis) {
     if (p > 0) {
         if (basis == 'X') {
             circuit.append_op("Z_ERROR", targets, p);

--- a/src/gen/gen_color_code.cc
+++ b/src/gen/gen_color_code.cc
@@ -55,7 +55,7 @@ GeneratedCircuit stim_internal::generate_color_code_circuit(const CircuitGenPara
     for (size_t y = 0; y < w; y++) {
         for (size_t x = 0; x < w - y; x++) {
             coord q{x + y / 2.0f, (float)y};
-            auto i = p2q.size();
+            auto i = (uint32_t)p2q.size();
             p2q[q] = i;
             if ((x + 2 * y) % 3 == 2) {
                 measure_coords.insert(q);
@@ -83,11 +83,11 @@ GeneratedCircuit stim_internal::generate_color_code_circuit(const CircuitGenPara
         q2p[kv.second] = kv.first;
     }
     for (auto q : data_qubits) {
-        auto i = data_coord_to_order.size();
+        auto i = (uint32_t)data_coord_to_order.size();
         data_coord_to_order[q2p[q]] = i;
     }
     for (auto q : measurement_qubits) {
-        auto i = measure_coord_to_order.size();
+        auto i = (uint32_t)measure_coord_to_order.size();
         measure_coord_to_order[q2p[q]] = i;
     }
 
@@ -124,7 +124,7 @@ GeneratedCircuit stim_internal::generate_color_code_circuit(const CircuitGenPara
 
     // Build the start of the circuit, getting a state that's ready to cycle.
     // In particular, the first cycle has different detectors and so has to be handled special.
-    uint32_t m = measurement_qubits.size();
+    auto m = (uint32_t)measurement_qubits.size();
     Circuit head;
     for (auto q : all_qubits) {
         coord c = q2p[q];
@@ -159,7 +159,7 @@ GeneratedCircuit stim_internal::generate_color_code_circuit(const CircuitGenPara
         for (auto delta : deltas) {
             auto data = measure + delta;
             if (p2q.find(data) != p2q.end()) {
-                detectors.push_back((data_qubits.size() - data_coord_to_order[data]) | TARGET_RECORD_BIT);
+                detectors.push_back((uint32_t)(data_qubits.size() - data_coord_to_order[data]) | TARGET_RECORD_BIT);
             }
         }
         uint32_t p =

--- a/src/py/stim.pybind.cc
+++ b/src/py/stim.pybind.cc
@@ -81,6 +81,14 @@ PYBIND11_MODULE(stim, m) {
             .data());
 
     m.def(
+        "target_combiner",
+        &GateTarget::combiner,
+        clean_doc_string(u8R"DOC(
+            Returns a target combiner (`*` in circuit files) that can be used as an operation target.
+        )DOC")
+            .data());
+
+    m.def(
         "target_x",
         &target_x,
         pybind11::arg("qubit_index"),

--- a/src/py/stim.pybind.cc
+++ b/src/py/stim.pybind.cc
@@ -59,6 +59,19 @@ PYBIND11_MODULE(stim, m) {
         Stim: A fast stabilizer circuit simulator library.
     )pbdoc";
 
+    // CAUTION: The ordering of these is important!
+    // If a class references another before it is registered, method signatures can get messed up.
+    // For example, if DetectorErrorModel is defined after Circuit then Circuit.detector_error_model's return type is
+    // described as `stim_internal::DetectorErrorModel` instead of `stim.DetectorErrorModel`.
+
+    pybind_detector_error_model(m);
+    pybind_compiled_detector_sampler(m);
+    pybind_compiled_measurement_sampler(m);
+    pybind_circuit(m);
+    pybind_pauli_string(m);
+    pybind_tableau(m);
+    pybind_tableau_simulator(m);
+
     m.def(
         "target_rec",
         &target_rec,
@@ -120,17 +133,4 @@ PYBIND11_MODULE(stim, m) {
             For example, the 'Z3' in 'CORRELATED_ERROR(0.1) X1 Y2 Z3' is qubit 3 flagged as Pauli Z.
         )DOC")
             .data());
-
-    // CAUTION: The ordering of these is important!
-    // If a class references another before it is registered, method signatures can get messed up.
-    // For example, if DetectorErrorModel is defined after Circuit then Circuit.detector_error_model's return type is
-    // described as `stim_internal::DetectorErrorModel` instead of `stim.DetectorErrorMode`.
-
-    pybind_detector_error_model(m);
-    pybind_compiled_detector_sampler(m);
-    pybind_compiled_measurement_sampler(m);
-    pybind_circuit(m);
-    pybind_pauli_string(m);
-    pybind_tableau(m);
-    pybind_tableau_simulator(m);
 }

--- a/src/py/stim.pybind.cc
+++ b/src/py/stim.pybind.cc
@@ -38,19 +38,19 @@ uint32_t target_rec(int32_t lookback) {
 }
 
 uint32_t target_inv(uint32_t qubit) {
-    return qubit | TARGET_INVERTED_BIT;
+    return GateTarget::qubit(qubit, true).data;
 }
 
-uint32_t target_x(uint32_t qubit) {
-    return qubit | TARGET_PAULI_X_BIT;
+uint32_t target_x(uint32_t qubit, bool invert) {
+    return GateTarget::x(qubit, invert).data;
 }
 
-uint32_t target_y(uint32_t qubit) {
-    return qubit | TARGET_PAULI_X_BIT | TARGET_PAULI_Z_BIT;
+uint32_t target_y(uint32_t qubit, bool invert) {
+    return GateTarget::y(qubit, invert).data;
 }
 
-uint32_t target_z(uint32_t qubit) {
-    return qubit | TARGET_PAULI_Z_BIT;
+uint32_t target_z(uint32_t qubit, bool invert) {
+    return GateTarget::z(qubit, invert).data;
 }
 
 PYBIND11_MODULE(stim, m) {
@@ -84,6 +84,7 @@ PYBIND11_MODULE(stim, m) {
         "target_x",
         &target_x,
         pybind11::arg("qubit_index"),
+        pybind11::arg("invert") = false,
         clean_doc_string(u8R"DOC(
             Returns a target flagged as Pauli X that can be passed into Circuit.append_operation
             For example, the 'X1' in 'CORRELATED_ERROR(0.1) X1 Y2 Z3' is qubit 1 flagged as Pauli X.
@@ -94,6 +95,7 @@ PYBIND11_MODULE(stim, m) {
         "target_y",
         &target_y,
         pybind11::arg("qubit_index"),
+        pybind11::arg("invert") = false,
         clean_doc_string(u8R"DOC(
             Returns a target flagged as Pauli Y that can be passed into Circuit.append_operation
             For example, the 'Y2' in 'CORRELATED_ERROR(0.1) X1 Y2 Z3' is qubit 2 flagged as Pauli Y.
@@ -104,6 +106,7 @@ PYBIND11_MODULE(stim, m) {
         "target_z",
         &target_z,
         pybind11::arg("qubit_index"),
+        pybind11::arg("invert") = false,
         clean_doc_string(u8R"DOC(
             Returns a target flagged as Pauli Z that can be passed into Circuit.append_operation
             For example, the 'Z3' in 'CORRELATED_ERROR(0.1) X1 Y2 Z3' is qubit 3 flagged as Pauli Z.

--- a/src/py/stim_pybind_test.py
+++ b/src/py/stim_pybind_test.py
@@ -26,5 +26,4 @@ def test_targets():
     assert stim.target_z(5) & 0xFFFF == 5
     assert stim.target_inv(5) & 0xFFFF == 5
     assert stim.target_rec(-5) & 0xFFFF == 5
-    assert stim.target_separator() & 0xFFFF == 0
-    assert stim.target_combiner() & 0xFFFF == 0
+    assert isinstance(stim.target_combiner(), stim.GateTarget)

--- a/src/py/stim_pybind_test.py
+++ b/src/py/stim_pybind_test.py
@@ -18,3 +18,13 @@ import re
 
 def test_version():
     assert re.match(r"^\d\.\d+", stim.__version__)
+
+
+def test_targets():
+    assert stim.target_x(5) & 0xFFFF == 5
+    assert stim.target_y(5) == (stim.target_x(5) | stim.target_z(5))
+    assert stim.target_z(5) & 0xFFFF == 5
+    assert stim.target_inv(5) & 0xFFFF == 5
+    assert stim.target_rec(-5) & 0xFFFF == 5
+    assert stim.target_separator() & 0xFFFF == 0
+    assert stim.target_combiner() & 0xFFFF == 0

--- a/src/simd/pointer_range.h
+++ b/src/simd/pointer_range.h
@@ -61,6 +61,12 @@ struct PointerRange {
     T *end() {
         return ptr_end;
     }
+    T &back() {
+        return *(ptr_end - 1);
+    }
+    T &front() {
+        return *ptr_start;
+    }
     const T &operator[](size_t index) const {
         return ptr_start[index];
     }

--- a/src/simd/simd_bits.cc
+++ b/src/simd/simd_bits.cc
@@ -154,6 +154,10 @@ bool simd_bits::not_zero() const {
     return simd_bits_range_ref(*this).not_zero();
 }
 
+bool simd_bits::intersects(const simd_bits_range_ref other) const {
+    return simd_bits_range_ref(*this).intersects(other);
+}
+
 std::string simd_bits::str() const {
     return simd_bits_range_ref(*this).str();
 }

--- a/src/simd/simd_bits.h
+++ b/src/simd/simd_bits.h
@@ -102,6 +102,9 @@ struct simd_bits {
     /// Padding bits beyond the minimum number of bits are not randomized.
     static simd_bits random(size_t min_bits, std::mt19937_64 &rng);
 
+    /// Returns whether or not the two ranges have set bits in common.
+    bool intersects(const simd_bits_range_ref other) const;
+
     /// Writes bits from another location.
     /// Bits not part of the write are unchanged.
     void truncated_overwrite_from(simd_bits_range_ref other, size_t num_bits);

--- a/src/simd/simd_bits_range_ref.cc
+++ b/src/simd/simd_bits_range_ref.cc
@@ -127,3 +127,11 @@ size_t simd_bits_range_ref::popcnt() const {
     }
     return result;
 }
+bool simd_bits_range_ref::intersects(const simd_bits_range_ref other) const {
+    size_t n = std::min(num_u64_padded(), other.num_u64_padded());
+    uint64_t v = 0;
+    for (size_t k = 0; k < n; k++) {
+        v |= u64[k] & other.u64[k];
+    }
+    return v != 0;
+}

--- a/src/simd/simd_bits_range_ref.h
+++ b/src/simd/simd_bits_range_ref.h
@@ -87,6 +87,8 @@ struct simd_bits_range_ref {
     void randomize(size_t num_bits, std::mt19937_64 &rng);
     /// Returns the number of bits that are 1 in the bit range.
     size_t popcnt() const;
+    /// Returns whether or not the two ranges have set bits in common.
+    bool intersects(const simd_bits_range_ref other) const;
 
     /// Writes bits from another location.
     /// Bits not part of the write are unchanged.

--- a/src/simd/simd_bits_range_ref.test.cc
+++ b/src/simd/simd_bits_range_ref.test.cc
@@ -248,3 +248,26 @@ TEST(simd_bits_range_ref, popcnt) {
     data.u64[8] = 0xFFFFFFFFFFFFFFFFULL;
     ASSERT_EQ(ref.popcnt(), 66);
 }
+
+TEST(simd_bits_range_ref, intersects) {
+    simd_bits data(1024);
+    simd_bits other(512);
+    simd_bits_range_ref ref(data);
+    ASSERT_EQ(data.intersects(other), false);
+    ASSERT_EQ(ref.intersects(other), false);
+    other[511] = true;
+    ASSERT_EQ(data.intersects(other), false);
+    ASSERT_EQ(ref.intersects(other), false);
+    data[513] = true;
+    ASSERT_EQ(data.intersects(other), false);
+    ASSERT_EQ(ref.intersects(other), false);
+    data[511] = true;
+    ASSERT_EQ(data.intersects(other), true);
+    ASSERT_EQ(ref.intersects(other), true);
+    data[101] = true;
+    ASSERT_EQ(data.intersects(other), true);
+    ASSERT_EQ(ref.intersects(other), true);
+    other[101] = true;
+    ASSERT_EQ(data.intersects(other), true);
+    ASSERT_EQ(ref.intersects(other), true);
+}

--- a/src/simulators/detection_simulator.cc
+++ b/src/simulators/detection_simulator.cc
@@ -85,8 +85,8 @@ void detector_sample_out_helper_stream(
             simd_bits_range_ref result = detector_buffer[buffered_detectors];
             result.clear();
             for (auto t : op.target_data.targets) {
-                assert(t & TARGET_RECORD_BIT);
-                result ^= sim.m_record.lookback(t ^ TARGET_RECORD_BIT);
+                assert(t.data & TARGET_RECORD_BIT);
+                result ^= sim.m_record.lookback(t.data ^ TARGET_RECORD_BIT);
             }
             buffered_detectors++;
             if (buffered_detectors == 1024) {
@@ -102,8 +102,8 @@ void detector_sample_out_helper_stream(
                 simd_bits_range_ref result = observables[id];
 
                 for (auto t : op.target_data.targets) {
-                    assert(t & TARGET_RECORD_BIT);
-                    result ^= sim.m_record.lookback(t ^ TARGET_RECORD_BIT);
+                    assert(t.data & TARGET_RECORD_BIT);
+                    result ^= sim.m_record.lookback(t.data ^ TARGET_RECORD_BIT);
                 }
             }
         } else {

--- a/src/simulators/error_analyzer.cc
+++ b/src/simulators/error_analyzer.cc
@@ -43,7 +43,7 @@ void ErrorAnalyzer::remove_gauge(ConstPointerRange<DemTarget> sorted) {
 
 void ErrorAnalyzer::RX(const OperationData &dat) {
     for (size_t k = dat.targets.size(); k-- > 0;) {
-        auto q = dat.targets[k];
+        auto q = dat.targets[k].qubit_value();
         check_for_gauge(zs[q], "an X-basis reset");
         xs[q].clear();
         zs[q].clear();
@@ -52,7 +52,7 @@ void ErrorAnalyzer::RX(const OperationData &dat) {
 
 void ErrorAnalyzer::RY(const OperationData &dat) {
     for (size_t k = dat.targets.size(); k-- > 0;) {
-        auto q = dat.targets[k];
+        auto q = dat.targets[k].qubit_value();
         check_for_gauge(xs[q], zs[q], "a Y-basis reset");
         xs[q].clear();
         zs[q].clear();
@@ -61,7 +61,7 @@ void ErrorAnalyzer::RY(const OperationData &dat) {
 
 void ErrorAnalyzer::RZ(const OperationData &dat) {
     for (size_t k = dat.targets.size(); k-- > 0;) {
-        auto q = dat.targets[k];
+        auto q = dat.targets[k].qubit_value();
         check_for_gauge(xs[q], "a Z-basis reset");
         xs[q].clear();
         zs[q].clear();
@@ -140,7 +140,7 @@ void ErrorAnalyzer::xor_sort_measurement_error(std::vector<DemTarget> &d, const 
 
 void ErrorAnalyzer::MX(const OperationData &dat) {
     for (size_t k = dat.targets.size(); k-- > 0;) {
-        auto q = dat.targets[k] & TARGET_VALUE_MASK;
+        auto q = dat.targets[k].qubit_value();
         scheduled_measurement_time++;
 
         std::vector<DemTarget> &d = measurement_to_detectors[scheduled_measurement_time];
@@ -152,7 +152,7 @@ void ErrorAnalyzer::MX(const OperationData &dat) {
 
 void ErrorAnalyzer::MY(const OperationData &dat) {
     for (size_t k = dat.targets.size(); k-- > 0;) {
-        auto q = dat.targets[k] & TARGET_VALUE_MASK;
+        auto q = dat.targets[k].qubit_value();
         scheduled_measurement_time++;
 
         std::vector<DemTarget> &d = measurement_to_detectors[scheduled_measurement_time];
@@ -165,7 +165,7 @@ void ErrorAnalyzer::MY(const OperationData &dat) {
 
 void ErrorAnalyzer::MZ(const OperationData &dat) {
     for (size_t k = dat.targets.size(); k-- > 0;) {
-        auto q = dat.targets[k] & TARGET_VALUE_MASK;
+        auto q = dat.targets[k].qubit_value();
         scheduled_measurement_time++;
 
         std::vector<DemTarget> &d = measurement_to_detectors[scheduled_measurement_time];
@@ -205,28 +205,28 @@ void ErrorAnalyzer::MRZ(const OperationData &dat) {
 
 void ErrorAnalyzer::H_XZ(const OperationData &dat) {
     for (size_t k = dat.targets.size(); k-- > 0;) {
-        auto q = dat.targets[k];
+        auto q = dat.targets[k].data;
         std::swap(xs[q], zs[q]);
     }
 }
 
 void ErrorAnalyzer::H_XY(const OperationData &dat) {
     for (size_t k = dat.targets.size(); k-- > 0;) {
-        auto q = dat.targets[k];
+        auto q = dat.targets[k].data;
         zs[q] ^= xs[q];
     }
 }
 
 void ErrorAnalyzer::H_YZ(const OperationData &dat) {
     for (size_t k = dat.targets.size(); k-- > 0;) {
-        auto q = dat.targets[k];
+        auto q = dat.targets[k].data;
         xs[q] ^= zs[q];
     }
 }
 
 void ErrorAnalyzer::C_XYZ(const OperationData &dat) {
     for (size_t k = dat.targets.size(); k-- > 0;) {
-        auto q = dat.targets[k];
+        auto q = dat.targets[k].data;
         zs[q] ^= xs[q];
         xs[q] ^= zs[q];
     }
@@ -234,7 +234,7 @@ void ErrorAnalyzer::C_XYZ(const OperationData &dat) {
 
 void ErrorAnalyzer::C_ZYX(const OperationData &dat) {
     for (size_t k = dat.targets.size(); k-- > 0;) {
-        auto q = dat.targets[k];
+        auto q = dat.targets[k].data;
         xs[q] ^= zs[q];
         zs[q] ^= xs[q];
     }
@@ -242,8 +242,8 @@ void ErrorAnalyzer::C_ZYX(const OperationData &dat) {
 
 void ErrorAnalyzer::XCX(const OperationData &dat) {
     for (size_t k = dat.targets.size() - 2; k + 2 != 0; k -= 2) {
-        auto q1 = dat.targets[k];
-        auto q2 = dat.targets[k + 1];
+        auto q1 = dat.targets[k].data;
+        auto q2 = dat.targets[k + 1].data;
         xs[q1] ^= zs[q2];
         xs[q2] ^= zs[q1];
     }
@@ -251,8 +251,8 @@ void ErrorAnalyzer::XCX(const OperationData &dat) {
 
 void ErrorAnalyzer::XCY(const OperationData &dat) {
     for (size_t k = dat.targets.size() - 2; k + 2 != 0; k -= 2) {
-        auto tx = dat.targets[k];
-        auto ty = dat.targets[k + 1];
+        auto tx = dat.targets[k].data;
+        auto ty = dat.targets[k + 1].data;
         xs[tx] ^= xs[ty];
         xs[tx] ^= zs[ty];
         xs[ty] ^= zs[tx];
@@ -262,8 +262,8 @@ void ErrorAnalyzer::XCY(const OperationData &dat) {
 
 void ErrorAnalyzer::YCX(const OperationData &dat) {
     for (size_t k = dat.targets.size() - 2; k + 2 != 0; k -= 2) {
-        auto tx = dat.targets[k + 1];
-        auto ty = dat.targets[k];
+        auto tx = dat.targets[k + 1].data;
+        auto ty = dat.targets[k].data;
         xs[tx] ^= xs[ty];
         xs[tx] ^= zs[ty];
         xs[ty] ^= zs[tx];
@@ -273,24 +273,24 @@ void ErrorAnalyzer::YCX(const OperationData &dat) {
 
 void ErrorAnalyzer::ZCY(const OperationData &dat) {
     for (size_t k = dat.targets.size() - 2; k + 2 != 0; k -= 2) {
-        auto c = dat.targets[k];
-        auto t = dat.targets[k + 1];
+        auto c = dat.targets[k].data;
+        auto t = dat.targets[k + 1].data;
         single_cy(c, t);
     }
 }
 
 void ErrorAnalyzer::YCZ(const OperationData &dat) {
     for (size_t k = dat.targets.size() - 2; k + 2 != 0; k -= 2) {
-        auto t = dat.targets[k];
-        auto c = dat.targets[k + 1];
+        auto t = dat.targets[k].data;
+        auto c = dat.targets[k + 1].data;
         single_cy(c, t);
     }
 }
 
 void ErrorAnalyzer::YCY(const OperationData &dat) {
     for (size_t k = dat.targets.size() - 2; k + 2 != 0; k -= 2) {
-        auto a = dat.targets[k];
-        auto b = dat.targets[k + 1];
+        auto a = dat.targets[k].data;
+        auto b = dat.targets[k + 1].data;
         zs[a] ^= xs[b];
         zs[a] ^= zs[b];
         xs[a] ^= xs[b];
@@ -305,16 +305,16 @@ void ErrorAnalyzer::YCY(const OperationData &dat) {
 
 void ErrorAnalyzer::ZCX(const OperationData &dat) {
     for (size_t k = dat.targets.size() - 2; k + 2 != 0; k -= 2) {
-        auto c = dat.targets[k];
-        auto t = dat.targets[k + 1];
+        auto c = dat.targets[k].data;
+        auto t = dat.targets[k + 1].data;
         single_cx(c, t);
     }
 }
 
 void ErrorAnalyzer::SQRT_XX(const OperationData &dat) {
     for (size_t k = dat.targets.size() - 2; k + 2 != 0; k -= 2) {
-        auto a = dat.targets[k];
-        auto b = dat.targets[k + 1];
+        auto a = dat.targets[k].data;
+        auto b = dat.targets[k + 1].data;
         xs[a] ^= zs[a];
         xs[a] ^= zs[b];
         xs[b] ^= zs[a];
@@ -324,8 +324,8 @@ void ErrorAnalyzer::SQRT_XX(const OperationData &dat) {
 
 void ErrorAnalyzer::SQRT_YY(const OperationData &dat) {
     for (size_t k = dat.targets.size() - 2; k + 2 != 0; k -= 2) {
-        auto a = dat.targets[k];
-        auto b = dat.targets[k + 1];
+        auto a = dat.targets[k].data;
+        auto b = dat.targets[k + 1].data;
         zs[a] ^= xs[a];
         zs[b] ^= xs[b];
         xs[a] ^= zs[a];
@@ -339,8 +339,8 @@ void ErrorAnalyzer::SQRT_YY(const OperationData &dat) {
 
 void ErrorAnalyzer::SQRT_ZZ(const OperationData &dat) {
     for (size_t k = dat.targets.size() - 2; k + 2 != 0; k -= 2) {
-        auto a = dat.targets[k];
-        auto b = dat.targets[k + 1];
+        auto a = dat.targets[k].data;
+        auto b = dat.targets[k + 1].data;
         zs[a] ^= xs[a];
         zs[a] ^= xs[b];
         zs[b] ^= xs[a];
@@ -406,16 +406,16 @@ void ErrorAnalyzer::single_cz(uint32_t c, uint32_t t) {
 
 void ErrorAnalyzer::XCZ(const OperationData &dat) {
     for (size_t k = dat.targets.size() - 2; k + 2 != 0; k -= 2) {
-        auto t = dat.targets[k];
-        auto c = dat.targets[k + 1];
+        auto t = dat.targets[k].data;
+        auto c = dat.targets[k + 1].data;
         single_cx(c, t);
     }
 }
 
 void ErrorAnalyzer::ZCZ(const OperationData &dat) {
     for (size_t k = dat.targets.size() - 2; k + 2 != 0; k -= 2) {
-        auto q1 = dat.targets[k];
-        auto q2 = dat.targets[k + 1];
+        auto q1 = dat.targets[k].data;
+        auto q2 = dat.targets[k + 1].data;
         single_cz(q1, q2);
     }
 }
@@ -425,8 +425,8 @@ void ErrorAnalyzer::I(const OperationData &dat) {
 
 void ErrorAnalyzer::SWAP(const OperationData &dat) {
     for (size_t k = dat.targets.size() - 2; k + 2 != 0; k -= 2) {
-        auto a = dat.targets[k];
-        auto b = dat.targets[k + 1];
+        auto a = dat.targets[k].data;
+        auto b = dat.targets[k + 1].data;
         std::swap(xs[a], xs[b]);
         std::swap(zs[a], zs[b]);
     }
@@ -434,8 +434,8 @@ void ErrorAnalyzer::SWAP(const OperationData &dat) {
 
 void ErrorAnalyzer::ISWAP(const OperationData &dat) {
     for (size_t k = dat.targets.size() - 2; k + 2 != 0; k -= 2) {
-        auto a = dat.targets[k];
-        auto b = dat.targets[k + 1];
+        auto a = dat.targets[k].data;
+        auto b = dat.targets[k + 1].data;
         zs[a] ^= xs[a];
         zs[a] ^= xs[b];
         zs[b] ^= xs[a];
@@ -449,7 +449,7 @@ void ErrorAnalyzer::DETECTOR(const OperationData &dat) {
     used_detectors++;
     auto id = DemTarget::relative_detector_id(total_detectors - used_detectors);
     for (auto t : dat.targets) {
-        auto delay = t & TARGET_VALUE_MASK;
+        auto delay = t.qubit_value();
         measurement_to_detectors[scheduled_measurement_time + delay].push_back(id);
     }
     flushed_reversed_model.append_detector_instruction(dat.args, id);
@@ -458,7 +458,7 @@ void ErrorAnalyzer::DETECTOR(const OperationData &dat) {
 void ErrorAnalyzer::OBSERVABLE_INCLUDE(const OperationData &dat) {
     auto id = DemTarget::observable_id((int32_t)dat.args[0]);
     for (auto t : dat.targets) {
-        auto delay = t & TARGET_VALUE_MASK;
+        auto delay = t.qubit_value();
         measurement_to_detectors[scheduled_measurement_time + delay].push_back(id);
     }
     flushed_reversed_model.append_logical_observable_instruction(id);
@@ -489,9 +489,10 @@ void ErrorAnalyzer::run_circuit(const Circuit &circuit) {
         assert(op.gate != nullptr);
         if (op.gate->id == gate_name_to_id("REPEAT")) {
             assert(op.target_data.targets.size() == 3);
-            assert(op.target_data.targets[0] < circuit.blocks.size());
+            auto b = op.target_data.targets[0].data;
+            assert(op.target_data.targets[0].data < circuit.blocks.size());
             uint64_t repeats = op_data_rep_count(op.target_data);
-            const auto &block = circuit.blocks[op.target_data.targets[0]];
+            const auto &block = circuit.blocks[b];
             try {
                 run_loop(block, repeats);
             } catch (std::invalid_argument &ex) {
@@ -522,7 +523,7 @@ void ErrorAnalyzer::X_ERROR(const OperationData &dat) {
         return;
     }
     for (auto q : dat.targets) {
-        add_error(dat.args[0], zs[q].range());
+        add_error(dat.args[0], zs[q.data].range());
     }
 }
 
@@ -531,7 +532,7 @@ void ErrorAnalyzer::Y_ERROR(const OperationData &dat) {
         return;
     }
     for (auto q : dat.targets) {
-        add_xored_error(dat.args[0], xs[q].range(), zs[q].range());
+        add_xored_error(dat.args[0], xs[q.data].range(), zs[q.data].range());
     }
 }
 
@@ -540,7 +541,7 @@ void ErrorAnalyzer::Z_ERROR(const OperationData &dat) {
         return;
     }
     for (auto q : dat.targets) {
-        add_error(dat.args[0], xs[q].range());
+        add_error(dat.args[0], xs[q.data].range());
     }
 }
 
@@ -559,11 +560,11 @@ void ErrorAnalyzer::CORRELATED_ERROR(const OperationData &dat) {
         return;
     }
     for (auto qp : dat.targets) {
-        auto q = qp & TARGET_VALUE_MASK;
-        if (qp & TARGET_PAULI_Z_BIT) {
+        auto q = qp.qubit_value();
+        if (qp.data & TARGET_PAULI_Z_BIT) {
             inplace_xor_tail(mono_buf, xs[q]);
         }
-        if (qp & TARGET_PAULI_X_BIT) {
+        if (qp.data & TARGET_PAULI_X_BIT) {
             inplace_xor_tail(mono_buf, zs[q]);
         }
     }
@@ -582,8 +583,8 @@ void ErrorAnalyzer::DEPOLARIZE1(const OperationData &dat) {
         add_error_combinations<2>(
             {0, p, p, p},
             {
-                xs[q].range(),
-                zs[q].range(),
+                xs[q.data].range(),
+                zs[q.data].range(),
             });
     }
 }
@@ -602,10 +603,10 @@ void ErrorAnalyzer::DEPOLARIZE2(const OperationData &dat) {
         add_error_combinations<4>(
             {0, p, p, p, p, p, p, p, p, p, p, p, p, p, p, p},
             {
-                xs[a].range(),
-                zs[a].range(),
-                xs[b].range(),
-                zs[b].range(),
+                xs[a.data].range(),
+                zs[a.data].range(),
+                xs[b.data].range(),
+                zs[b.data].range(),
             });
     }
 }
@@ -640,8 +641,8 @@ void ErrorAnalyzer::PAULI_CHANNEL_1(const OperationData &dat) {
         add_error_combinations<2>(
             probabilities,
             {
-                zs[q].range(),
-                xs[q].range(),
+                zs[q.data].range(),
+                xs[q.data].range(),
             });
     }
 }
@@ -674,10 +675,10 @@ void ErrorAnalyzer::PAULI_CHANNEL_2(const OperationData &dat) {
         add_error_combinations<4>(
             probabilities,
             {
-                zs[b].range(),
-                xs[b].range(),
-                zs[a].range(),
-                xs[a].range(),
+                zs[b.data].range(),
+                xs[b.data].range(),
+                zs[a.data].range(),
+                xs[a.data].range(),
             });
     }
 }
@@ -1253,4 +1254,22 @@ void ErrorAnalyzer::add_error_combinations(
     for (size_t k = 1; k < 1 << s; k++) {
         add_error(independent_probabilities[k], stored_ids[k]);
     }
+}
+
+void ErrorAnalyzer::MPP(const OperationData &target_data) {
+    decompose_mpp_operation(
+        target_data,
+        xs.size(),
+        [&](const OperationData &h_xz,
+            const OperationData &h_yz,
+            const OperationData &cnot,
+            const OperationData &meas) {
+            H_XZ(h_xz);
+            H_YZ(h_yz);
+            ZCX(cnot);
+            MZ(meas);
+            ZCX(cnot);
+            H_YZ(h_yz);
+            H_XZ(h_xz);
+        });
 }

--- a/src/simulators/error_analyzer.h
+++ b/src/simulators/error_analyzer.h
@@ -82,6 +82,7 @@ struct ErrorAnalyzer {
     void MX(const OperationData &dat);
     void MY(const OperationData &dat);
     void MZ(const OperationData &dat);
+    void MPP(const OperationData &dat);
     void MRX(const OperationData &dat);
     void MRY(const OperationData &dat);
     void MRZ(const OperationData &dat);

--- a/src/simulators/error_analyzer.test.cc
+++ b/src/simulators/error_analyzer.test.cc
@@ -287,7 +287,10 @@ TEST(ErrorAnalyzer, unitary_gates_match_frame_simulator) {
         }
     }
 
-    std::vector<uint32_t> data{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+    std::vector<GateTarget> data;
+    for (size_t k = 0; k < 16; k++) {
+        data.push_back(GateTarget::qubit(k));
+    }
     OperationData targets = {{}, data};
     for (const auto &gate : GATE_DATA.gates()) {
         if (gate.flags & GATE_IS_UNITARY) {
@@ -2420,4 +2423,36 @@ TEST(ErrorAnalyzer, honeycomb_code_decomposes) {
         false,
         false,
         false);
+}
+
+TEST(ErrorAnalyzer, measure_pauli_product_4body) {
+    ASSERT_EQ(
+        ErrorAnalyzer::circuit_to_detector_error_model(
+            Circuit(R"CIRCUIT(
+                RX 0
+                Z_ERROR(0.125) 0
+                MPP X0*Z1
+                DETECTOR rec[-1]
+            )CIRCUIT"),
+            false,
+            false,
+            false,
+            false),
+        DetectorErrorModel(R"MODEL(
+            error(0.125) D0
+        )MODEL"));
+
+    ASSERT_EQ(
+        ErrorAnalyzer::circuit_to_detector_error_model(
+            Circuit(R"CIRCUIT(
+                MPP(0.25) Z0*Z1
+                DETECTOR rec[-1]
+            )CIRCUIT"),
+            false,
+            false,
+            false,
+            false),
+        DetectorErrorModel(R"MODEL(
+            error(0.25) D0
+        )MODEL"));
 }

--- a/src/simulators/frame_simulator.cc
+++ b/src/simulators/frame_simulator.cc
@@ -42,8 +42,8 @@ inline void for_each_target_pair(FrameSimulator &sim, const OperationData &targe
     const auto &targets = target_data.targets;
     assert((targets.size() & 1) == 0);
     for (size_t k = 0; k < targets.size(); k += 2) {
-        size_t q1 = targets[k];
-        size_t q2 = targets[k + 1];
+        size_t q1 = targets[k].data;
+        size_t q2 = targets[k + 1].data;
         sim.x_table[q1].for_each_word(sim.z_table[q1], sim.x_table[q2], sim.z_table[q2], body);
     }
 }
@@ -80,8 +80,8 @@ void FrameSimulator::reset_all_and_run(const Circuit &circuit) {
 
 void FrameSimulator::measure_x(const OperationData &target_data) {
     m_record.reserve_noisy_space_for_results(target_data, rng);
-    for (auto q : target_data.targets) {
-        q &= TARGET_VALUE_MASK;  // Flipping is ignored because it is accounted for in the reference sample.
+    for (auto t : target_data.targets) {
+        auto q = t.qubit_value();  // Flipping is ignored because it is accounted for in the reference sample.
         m_record.xor_record_reserved_result(z_table[q]);
         x_table[q].randomize(x_table[q].num_bits_padded(), rng);
     }
@@ -89,8 +89,8 @@ void FrameSimulator::measure_x(const OperationData &target_data) {
 
 void FrameSimulator::measure_y(const OperationData &target_data) {
     m_record.reserve_noisy_space_for_results(target_data, rng);
-    for (auto q : target_data.targets) {
-        q &= TARGET_VALUE_MASK;  // Flipping is ignored because it is accounted for in the reference sample.
+    for (auto t : target_data.targets) {
+        auto q = t.qubit_value();  // Flipping is ignored because it is accounted for in the reference sample.
         x_table[q] ^= z_table[q];
         m_record.xor_record_reserved_result(x_table[q]);
         z_table[q].randomize(z_table[q].num_bits_padded(), rng);
@@ -100,28 +100,31 @@ void FrameSimulator::measure_y(const OperationData &target_data) {
 
 void FrameSimulator::measure_z(const OperationData &target_data) {
     m_record.reserve_noisy_space_for_results(target_data, rng);
-    for (auto q : target_data.targets) {
-        q &= TARGET_VALUE_MASK;  // Flipping is ignored because it is accounted for in the reference sample.
+    for (auto t : target_data.targets) {
+        auto q = t.qubit_value();  // Flipping is ignored because it is accounted for in the reference sample.
         m_record.xor_record_reserved_result(x_table[q]);
         z_table[q].randomize(z_table[q].num_bits_padded(), rng);
     }
 }
 void FrameSimulator::reset_x(const OperationData &target_data) {
-    for (auto q : target_data.targets) {
+    for (auto t : target_data.targets) {
+        auto q = t.data;
         x_table[q].randomize(z_table[q].num_bits_padded(), rng);
         z_table[q].clear();
     }
 }
 
 void FrameSimulator::reset_y(const OperationData &target_data) {
-    for (auto q : target_data.targets) {
+    for (auto t : target_data.targets) {
+        auto q = t.data;
         z_table[q].randomize(z_table[q].num_bits_padded(), rng);
         x_table[q] = z_table[q];
     }
 }
 
 void FrameSimulator::reset_z(const OperationData &target_data) {
-    for (auto q : target_data.targets) {
+    for (auto t : target_data.targets) {
+        auto q = t.data;
         x_table[q].clear();
         z_table[q].randomize(z_table[q].num_bits_padded(), rng);
     }
@@ -130,8 +133,8 @@ void FrameSimulator::reset_z(const OperationData &target_data) {
 void FrameSimulator::measure_reset_x(const OperationData &target_data) {
     // Note: Caution when implementing this. Can't group the resets. because the same qubit target may appear twice.
     m_record.reserve_noisy_space_for_results(target_data, rng);
-    for (auto q : target_data.targets) {
-        q &= TARGET_VALUE_MASK;  // Flipping is ignored because it is accounted for in the reference sample.
+    for (auto t : target_data.targets) {
+        auto q = t.qubit_value();  // Flipping is ignored because it is accounted for in the reference sample.
         m_record.xor_record_reserved_result(z_table[q]);
         z_table[q].clear();
         x_table[q].randomize(x_table[q].num_bits_padded(), rng);
@@ -141,8 +144,8 @@ void FrameSimulator::measure_reset_x(const OperationData &target_data) {
 void FrameSimulator::measure_reset_y(const OperationData &target_data) {
     // Note: Caution when implementing this. Can't group the resets. because the same qubit target may appear twice.
     m_record.reserve_noisy_space_for_results(target_data, rng);
-    for (auto q : target_data.targets) {
-        q &= TARGET_VALUE_MASK;  // Flipping is ignored because it is accounted for in the reference sample.
+    for (auto t : target_data.targets) {
+        auto q = t.qubit_value();  // Flipping is ignored because it is accounted for in the reference sample.
         x_table[q] ^= z_table[q];
         m_record.xor_record_reserved_result(x_table[q]);
         z_table[q].randomize(z_table[q].num_bits_padded(), rng);
@@ -153,8 +156,8 @@ void FrameSimulator::measure_reset_y(const OperationData &target_data) {
 void FrameSimulator::measure_reset_z(const OperationData &target_data) {
     // Note: Caution when implementing this. Can't group the resets. because the same qubit target may appear twice.
     m_record.reserve_noisy_space_for_results(target_data, rng);
-    for (auto q : target_data.targets) {
-        q &= TARGET_VALUE_MASK;  // Flipping is ignored because it is accounted for in the reference sample.
+    for (auto t : target_data.targets) {
+        auto q = t.qubit_value();  // Flipping is ignored because it is accounted for in the reference sample.
         m_record.xor_record_reserved_result(x_table[q]);
         x_table[q].clear();
         z_table[q].randomize(z_table[q].num_bits_padded(), rng);
@@ -184,32 +187,37 @@ void FrameSimulator::set_frame(size_t sample_index, const PauliStringRef &new_fr
 }
 
 void FrameSimulator::H_XZ(const OperationData &target_data) {
-    for (auto q : target_data.targets) {
+    for (auto t : target_data.targets) {
+        auto q = t.data;
         x_table[q].swap_with(z_table[q]);
     }
 }
 
 void FrameSimulator::H_XY(const OperationData &target_data) {
-    for (auto q : target_data.targets) {
+    for (auto t : target_data.targets) {
+        auto q = t.data;
         z_table[q] ^= x_table[q];
     }
 }
 
 void FrameSimulator::H_YZ(const OperationData &target_data) {
-    for (auto q : target_data.targets) {
+    for (auto t : target_data.targets) {
+        auto q = t.data;
         x_table[q] ^= z_table[q];
     }
 }
 
 void FrameSimulator::C_XYZ(const OperationData &target_data) {
-    for (auto q : target_data.targets) {
+    for (auto t : target_data.targets) {
+        auto q = t.data;
         x_table[q] ^= z_table[q];
         z_table[q] ^= x_table[q];
     }
 }
 
 void FrameSimulator::C_ZYX(const OperationData &target_data) {
-    for (auto q : target_data.targets) {
+    for (auto t : target_data.targets) {
+        auto q = t.data;
         z_table[q] ^= x_table[q];
         x_table[q] ^= z_table[q];
     }
@@ -251,7 +259,7 @@ void FrameSimulator::ZCX(const OperationData &target_data) {
     const auto &targets = target_data.targets;
     assert((targets.size() & 1) == 0);
     for (size_t k = 0; k < targets.size(); k += 2) {
-        single_cx(targets[k], targets[k + 1]);
+        single_cx(targets[k].data, targets[k + 1].data);
     }
 }
 
@@ -259,7 +267,7 @@ void FrameSimulator::ZCY(const OperationData &target_data) {
     const auto &targets = target_data.targets;
     assert((targets.size() & 1) == 0);
     for (size_t k = 0; k < targets.size(); k += 2) {
-        single_cy(targets[k], targets[k + 1]);
+        single_cy(targets[k].data, targets[k + 1].data);
     }
 }
 
@@ -267,8 +275,8 @@ void FrameSimulator::ZCZ(const OperationData &target_data) {
     const auto &targets = target_data.targets;
     assert((targets.size() & 1) == 0);
     for (size_t k = 0; k < targets.size(); k += 2) {
-        size_t c = targets[k];
-        size_t t = targets[k + 1];
+        size_t c = targets[k].data;
+        size_t t = targets[k + 1].data;
         if (!((c | t) & TARGET_RECORD_BIT)) {
             x_table[c].for_each_word(
                 z_table[c], x_table[t], z_table[t], [](simd_word &x1, simd_word &z1, simd_word &x2, simd_word &z2) {
@@ -289,8 +297,8 @@ void FrameSimulator::SWAP(const OperationData &target_data) {
     const auto &targets = target_data.targets;
     assert((targets.size() & 1) == 0);
     for (size_t k = 0; k < targets.size(); k += 2) {
-        size_t q1 = targets[k];
-        size_t q2 = targets[k + 1];
+        size_t q1 = targets[k].data;
+        size_t q2 = targets[k + 1].data;
         x_table[q1].for_each_word(
             z_table[q1], x_table[q2], z_table[q2], [](simd_word &x1, simd_word &z1, simd_word &x2, simd_word &z2) {
                 std::swap(z1, z2);
@@ -355,7 +363,7 @@ void FrameSimulator::XCZ(const OperationData &target_data) {
     const auto &targets = target_data.targets;
     assert((targets.size() & 1) == 0);
     for (size_t k = 0; k < targets.size(); k += 2) {
-        single_cx(targets[k + 1], targets[k]);
+        single_cx(targets[k + 1].data, targets[k].data);
     }
 }
 
@@ -382,7 +390,7 @@ void FrameSimulator::YCZ(const OperationData &target_data) {
     const auto &targets = target_data.targets;
     assert((targets.size() & 1) == 0);
     for (size_t k = 0; k < targets.size(); k += 2) {
-        single_cy(targets[k + 1], targets[k]);
+        single_cy(targets[k + 1].data, targets[k].data);
     }
 }
 
@@ -393,8 +401,8 @@ void FrameSimulator::DEPOLARIZE1(const OperationData &target_data) {
         auto target_index = s / batch_size;
         auto sample_index = s % batch_size;
         auto t = targets[target_index];
-        x_table[t][sample_index] ^= p & 1;
-        z_table[t][sample_index] ^= p & 2;
+        x_table[t.data][sample_index] ^= p & 1;
+        z_table[t.data][sample_index] ^= p & 2;
     });
 }
 
@@ -406,8 +414,8 @@ void FrameSimulator::DEPOLARIZE2(const OperationData &target_data) {
         auto p = 1 + (rng() % 15);
         auto target_index = (s / batch_size) << 1;
         auto sample_index = s % batch_size;
-        size_t t1 = targets[target_index];
-        size_t t2 = targets[target_index + 1];
+        size_t t1 = targets[target_index].data;
+        size_t t2 = targets[target_index + 1].data;
         x_table[t1][sample_index] ^= (bool)(p & 1);
         z_table[t1][sample_index] ^= (bool)(p & 2);
         x_table[t2][sample_index] ^= (bool)(p & 4);
@@ -421,7 +429,7 @@ void FrameSimulator::X_ERROR(const OperationData &target_data) {
         auto target_index = s / batch_size;
         auto sample_index = s % batch_size;
         auto t = targets[target_index];
-        x_table[t][sample_index] ^= true;
+        x_table[t.data][sample_index] ^= true;
     });
 }
 
@@ -431,8 +439,8 @@ void FrameSimulator::Y_ERROR(const OperationData &target_data) {
         auto target_index = s / batch_size;
         auto sample_index = s % batch_size;
         auto t = targets[target_index];
-        x_table[t][sample_index] ^= true;
-        z_table[t][sample_index] ^= true;
+        x_table[t.data][sample_index] ^= true;
+        z_table[t.data][sample_index] ^= true;
     });
 }
 
@@ -442,8 +450,26 @@ void FrameSimulator::Z_ERROR(const OperationData &target_data) {
         auto target_index = s / batch_size;
         auto sample_index = s % batch_size;
         auto t = targets[target_index];
-        z_table[t][sample_index] ^= true;
+        z_table[t.data][sample_index] ^= true;
     });
+}
+
+void FrameSimulator::MPP(const OperationData &target_data) {
+    decompose_mpp_operation(
+        target_data,
+        num_qubits,
+        [&](const OperationData &h_xz,
+            const OperationData &h_yz,
+            const OperationData &cnot,
+            const OperationData &meas) {
+            H_XZ(h_xz);
+            H_YZ(h_yz);
+            ZCX(cnot);
+            measure_z(meas);
+            ZCX(cnot);
+            H_YZ(h_yz);
+            H_XZ(h_xz);
+        });
 }
 
 void FrameSimulator::PAULI_CHANNEL_1(const OperationData &target_data) {
@@ -504,14 +530,14 @@ void FrameSimulator::ELSE_CORRELATED_ERROR(const OperationData &target_data) {
 
     // Apply error to only the indicated frames.
     for (auto qxz : target_data.targets) {
-        auto q = qxz & TARGET_VALUE_MASK;
-        if (qxz & TARGET_RECORD_BIT) {
-            measurement_record_ref(qxz) ^= rng_buffer;
+        if (qxz.data & TARGET_RECORD_BIT) {
+            measurement_record_ref(qxz.data) ^= rng_buffer;
         }
-        if (qxz & TARGET_PAULI_X_BIT) {
+        auto q = qxz.qubit_value();
+        if (qxz.data & TARGET_PAULI_X_BIT) {
             x_table[q] ^= rng_buffer;
         }
-        if (qxz & TARGET_PAULI_Z_BIT) {
+        if (qxz.data & TARGET_PAULI_Z_BIT) {
             z_table[q] ^= rng_buffer;
         }
     }

--- a/src/simulators/frame_simulator.h
+++ b/src/simulators/frame_simulator.h
@@ -111,6 +111,7 @@ struct FrameSimulator {
     void YCZ(const OperationData &target_data);
     void SWAP(const OperationData &target_data);
     void ISWAP(const OperationData &target_data);
+    void MPP(const OperationData &target_data);
 
     void SQRT_XX(const OperationData &target_data);
     void SQRT_YY(const OperationData &target_data);

--- a/src/simulators/frame_simulator.perf.cc
+++ b/src/simulators/frame_simulator.perf.cc
@@ -25,9 +25,9 @@ BENCHMARK(FrameSimulator_depolarize1_100Kqubits_1Ksamples_per1000) {
     std::mt19937_64 rng(0);  // NOLINT(cert-msc51-cpp)
     FrameSimulator sim(num_qubits, num_samples, SIZE_MAX, rng);
 
-    std::vector<uint32_t> targets;
-    for (size_t k = 0; k < num_qubits; k++) {
-        targets.push_back(k);
+    std::vector<GateTarget> targets;
+    for (uint32_t k = 0; k < (uint32_t)num_qubits; k++) {
+        targets.push_back(GateTarget{k});
     }
     OperationData op_data{{&probability}, targets};
     benchmark_go([&]() {
@@ -44,9 +44,9 @@ BENCHMARK(FrameSimulator_depolarize2_100Kqubits_1Ksamples_per1000) {
     std::mt19937_64 rng(0);  // NOLINT(cert-msc51-cpp)
     FrameSimulator sim(num_qubits, num_samples, SIZE_MAX, rng);
 
-    std::vector<uint32_t> targets;
-    for (size_t k = 0; k < num_qubits; k++) {
-        targets.push_back(k);
+    std::vector<GateTarget> targets;
+    for (uint32_t k = 0; k < (uint32_t)num_qubits; k++) {
+        targets.push_back({k});
     }
     OperationData op_data{{&probability}, targets};
 
@@ -63,9 +63,9 @@ BENCHMARK(FrameSimulator_hadamard_100Kqubits_1Ksamples) {
     std::mt19937_64 rng(0);  // NOLINT(cert-msc51-cpp)
     FrameSimulator sim(num_qubits, num_samples, SIZE_MAX, rng);
 
-    std::vector<uint32_t> targets;
-    for (size_t k = 0; k < num_qubits; k++) {
-        targets.push_back(k);
+    std::vector<GateTarget> targets;
+    for (uint32_t k = 0; k < (uint32_t)num_qubits; k++) {
+        targets.push_back({k});
     }
     OperationData op_data{{}, targets};
 
@@ -82,9 +82,9 @@ BENCHMARK(FrameSimulator_CX_100Kqubits_1Ksamples) {
     std::mt19937_64 rng(0);  // NOLINT(cert-msc51-cpp)
     FrameSimulator sim(num_qubits, num_samples, SIZE_MAX, rng);
 
-    std::vector<uint32_t> targets;
-    for (size_t k = 0; k < num_qubits; k++) {
-        targets.push_back(k);
+    std::vector<GateTarget> targets;
+    for (uint32_t k = 0; k < (uint32_t)num_qubits; k++) {
+        targets.push_back({k});
     }
     OperationData op_data{{}, targets};
 

--- a/src/simulators/tableau_simulator.perf.cc
+++ b/src/simulators/tableau_simulator.perf.cc
@@ -24,7 +24,7 @@ BENCHMARK(TableauSimulator_CX_10Kqubits) {
     TableauSimulator sim(rng, num_qubits);
 
     std::vector<GateTarget> targets;
-    for (size_t k = 0; k < num_qubits; k++) {
+    for (uint32_t k = 0; k < (uint32_t)num_qubits; k++) {
         targets.push_back(GateTarget{k});
     }
     OperationData op_data{{}, targets};

--- a/src/simulators/tableau_simulator.perf.cc
+++ b/src/simulators/tableau_simulator.perf.cc
@@ -23,9 +23,9 @@ BENCHMARK(TableauSimulator_CX_10Kqubits) {
     std::mt19937_64 rng(0);  // NOLINT(cert-msc51-cpp)
     TableauSimulator sim(rng, num_qubits);
 
-    std::vector<uint32_t> targets;
+    std::vector<GateTarget> targets;
     for (size_t k = 0; k < num_qubits; k++) {
-        targets.push_back(k);
+        targets.push_back(GateTarget{k});
     }
     OperationData op_data{{}, targets};
 


### PR DESCRIPTION
- Add decompose_mpp_operation utility method
- Move GateTarget class from pybind into main project
- Refactor OperationData to take a range of GateTarget instead of uint32_t
- Add simd_bits::intersects
- Add PointerRange::back/front
- Add MPP method to each simulator
- Add `stim.GateTarget.is_qubit_target`
- Add `stim.GateTarget.is_combiner`
- Add `stim.target_combiner`
- Fix `stim.Circuit.append_operation` not taking `stim.GateTarget` instances

Fixes https://github.com/quantumlib/Stim/issues/109
