### PR TITLE
Add sample_write methods to compiled samplers

### DIFF
--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -32,6 +32,7 @@
     - [`stim.CircuitInstruction.__init__`](#stim.CircuitInstruction.__init__)
     - [`stim.CircuitInstruction.__ne__`](#stim.CircuitInstruction.__ne__)
     - [`stim.CircuitInstruction.__repr__`](#stim.CircuitInstruction.__repr__)
+    - [`stim.CircuitInstruction.__str__`](#stim.CircuitInstruction.__str__)
     - [`stim.CircuitInstruction.gate_args_copy`](#stim.CircuitInstruction.gate_args_copy)
     - [`stim.CircuitInstruction.name`](#stim.CircuitInstruction.name)
     - [`stim.CircuitInstruction.targets_copy`](#stim.CircuitInstruction.targets_copy)
@@ -46,10 +47,12 @@
     - [`stim.CompiledDetectorSampler.__repr__`](#stim.CompiledDetectorSampler.__repr__)
     - [`stim.CompiledDetectorSampler.sample`](#stim.CompiledDetectorSampler.sample)
     - [`stim.CompiledDetectorSampler.sample_bit_packed`](#stim.CompiledDetectorSampler.sample_bit_packed)
+    - [`stim.CompiledDetectorSampler.sample_write`](#stim.CompiledDetectorSampler.sample_write)
 - [`stim.CompiledMeasurementSampler`](#stim.CompiledMeasurementSampler)
     - [`stim.CompiledMeasurementSampler.__repr__`](#stim.CompiledMeasurementSampler.__repr__)
     - [`stim.CompiledMeasurementSampler.sample`](#stim.CompiledMeasurementSampler.sample)
     - [`stim.CompiledMeasurementSampler.sample_bit_packed`](#stim.CompiledMeasurementSampler.sample_bit_packed)
+    - [`stim.CompiledMeasurementSampler.sample_write`](#stim.CompiledMeasurementSampler.sample_write)
 - [`stim.DemInstruction`](#stim.DemInstruction)
     - [`stim.DemInstruction.__eq__`](#stim.DemInstruction.__eq__)
     - [`stim.DemInstruction.__init__`](#stim.DemInstruction.__init__)
@@ -1112,6 +1115,11 @@
 > Returns text that is a valid python expression evaluating to an equivalent `stim.CircuitInstruction`.
 > ```
 
+### `stim.CircuitInstruction.__str__(self) -> str`<a name="stim.CircuitInstruction.__str__"></a>
+> ```
+> Returns a text description of the instruction as a stim circuit file line.
+> ```
+
 ### `stim.CircuitInstruction.gate_args_copy(self) -> List[float]`<a name="stim.CircuitInstruction.gate_args_copy"></a>
 > ```
 > Returns the gate's arguments (numbers parameterizing the instruction).
@@ -1241,6 +1249,42 @@
 >     The bit for detection event `m` in shot `s` is at `result[s, (m // 8)] & 2**(m % 8)`.
 > ```
 
+### `stim.CompiledDetectorSampler.sample_write(self, shots: int, *, filepath: str, format: str, prepend_observables: bool = False, append_observables: bool = False) -> None`<a name="stim.CompiledDetectorSampler.sample_write"></a>
+> ```
+> Samples detection events from the circuit and writes them to a file.
+> 
+> Examples:
+>     >>> import stim
+>     >>> import tempfile
+>     >>> with tempfile.TemporaryDirectory() as d:
+>     ...     path = f"{d}/tmp.dat"
+>     ...     c = stim.Circuit('''
+>     ...         X_ERROR(1) 0
+>     ...         M 0 1
+>     ...         DETECTOR rec[-2]
+>     ...         DETECTOR rec[-1]
+>     ...     ''')
+>     ...     c.compile_detector_sampler().sample_write(3, filepath=path, format="dets")
+>     ...     with open(path) as f:
+>     ...         print(f.read(), end='')
+>     shot D0
+>     shot D0
+>     shot D0
+> 
+> Args:
+>     shots: The number of times to sample every measurement in the circuit.
+>     filepath: The file to write the results to.
+>     format: The output format to write the results with.
+>         Valid values are "01", "b8", "r8", "hits", "dets", and "ptb64".
+>     prepend_observables: Sample observables as part of each shot, and put them at the start of the detector
+>         data.
+>     append_observables: Sample observables as part of each shot, and put them at the end of the detector
+>         data.
+> 
+> Returns:
+>     None.
+> ```
+
 ### `stim.CompiledMeasurementSampler.__repr__(self) -> str`<a name="stim.CompiledMeasurementSampler.__repr__"></a>
 > ```
 > Returns text that is a valid python expression evaluating to an equivalent `stim.CompiledMeasurementSampler`.
@@ -1288,6 +1332,38 @@
 > Returns:
 >     A numpy array with `dtype=uint8` and `shape=(shots, (num_measurements + 7) // 8)`.
 >     The bit for measurement `m` in shot `s` is at `result[s, (m // 8)] & 2**(m % 8)`.
+> ```
+
+### `stim.CompiledMeasurementSampler.sample_write(self, shots: int, *, filepath: str, format: str) -> None`<a name="stim.CompiledMeasurementSampler.sample_write"></a>
+> ```
+> Samples measurements from the circuit and writes them to a file.
+> 
+> Examples:
+>     >>> import stim
+>     >>> import tempfile
+>     >>> with tempfile.TemporaryDirectory() as d:
+>     ...     path = f"{d}/tmp.dat"
+>     ...     c = stim.Circuit('''
+>     ...         X 0   2 3
+>     ...         M 0 1 2 3
+>     ...     ''')
+>     ...     c.compile_sampler().sample_write(5, filepath=path, format="01")
+>     ...     with open(path) as f:
+>     ...         print(f.read(), end='')
+>     1011
+>     1011
+>     1011
+>     1011
+>     1011
+> 
+> Args:
+>     shots: The number of times to sample every measurement in the circuit.
+>     filepath: The file to write the results to.
+>     format: The output format to write the results with.
+>         Valid values are "01", "b8", "r8", "hits", "dets", and "ptb64".
+> 
+> Returns:
+>     None.
 > ```
 
 ### `stim.DemInstruction.__eq__(self, arg0: stim.DemInstruction) -> bool`<a name="stim.DemInstruction.__eq__"></a>

--- a/src/circuit/circuit.cc
+++ b/src/circuit/circuit.cc
@@ -973,6 +973,9 @@ Circuit Circuit::py_get_slice(int64_t start, int64_t step, int64_t slice_length)
 }
 
 void Circuit::append_repeat_block(uint64_t repeat_count, Circuit &&body) {
+    if (repeat_count == 0) {
+        throw std::invalid_argument("Can't repeat 0 times.");
+    }
     target_buf.append_tail(GateTarget{(uint32_t)blocks.size()});
     target_buf.append_tail(GateTarget{(uint32_t)(repeat_count & 0xFFFFFFFFULL)});
     target_buf.append_tail(GateTarget{(uint32_t)(repeat_count >> 32)});
@@ -982,6 +985,9 @@ void Circuit::append_repeat_block(uint64_t repeat_count, Circuit &&body) {
 }
 
 void Circuit::append_repeat_block(uint64_t repeat_count, const Circuit &body) {
+    if (repeat_count == 0) {
+        throw std::invalid_argument("Can't repeat 0 times.");
+    }
     target_buf.append_tail(GateTarget{(uint32_t)blocks.size()});
     target_buf.append_tail(GateTarget{(uint32_t)(repeat_count & 0xFFFFFFFFULL)});
     target_buf.append_tail(GateTarget{(uint32_t)(repeat_count >> 32)});

--- a/src/circuit/circuit.pybind.cc
+++ b/src/circuit/circuit.pybind.cc
@@ -483,11 +483,7 @@ void pybind_circuit(pybind11::module &m) {
                 }
 
                 const CircuitInstruction &instruction = pybind11::cast<CircuitInstruction>(obj);
-                std::vector<uint32_t> raw_targets;
-                for (const auto &t : instruction.targets) {
-                    raw_targets.push_back(t.data);
-                }
-                self.append_op(instruction.gate.name, raw_targets, instruction.gate_args);
+                self.append_op(instruction.gate.name, instruction.raw_targets(), instruction.gate_args);
             } else if (pybind11::isinstance<CircuitRepeatBlock>(obj)) {
                 if (!targets.empty() || !arg.is_none()) {
                     throw std::invalid_argument(

--- a/src/circuit/circuit.test.cc
+++ b/src/circuit/circuit.test.cc
@@ -975,4 +975,7 @@ TEST(circuit, append_repeat_block) {
             X 0
         }
     )CIRCUIT"));
+
+    ASSERT_THROW({ c.append_repeat_block(0, a); }, std::invalid_argument);
+    ASSERT_THROW({ c.append_repeat_block(0, std::move(a)); }, std::invalid_argument);
 }

--- a/src/circuit/circuit_instruction.pybind.cc
+++ b/src/circuit/circuit_instruction.pybind.cc
@@ -54,9 +54,24 @@ std::string CircuitInstruction::repr() const {
     result << "], [" << comma_sep(gate_args) << "])";
     return result.str();
 }
+
+std::string CircuitInstruction::str() {
+    std::stringstream result;
+    result << Operation{&gate, {gate_args, targets}};
+    return result.str();
+}
+
 std::string CircuitInstruction::name() const {
     return gate.name;
 }
+std::vector<uint32_t> CircuitInstruction::raw_targets() const {
+    std::vector<uint32_t> result;
+    for (const auto &t : targets) {
+        result.push_back(t.data);
+    }
+    return result;
+};
+
 std::vector<GateTarget> CircuitInstruction::targets_copy() const {
     return targets;
 }
@@ -137,4 +152,8 @@ void pybind_circuit_instruction(pybind11::module &m) {
         "__repr__",
         &CircuitInstruction::repr,
         "Returns text that is a valid python expression evaluating to an equivalent `stim.CircuitInstruction`.");
+    c.def(
+        "__str__",
+        &CircuitInstruction::str,
+        "Returns a text description of the instruction as a stim circuit file line.");
 }

--- a/src/circuit/circuit_instruction.pybind.h
+++ b/src/circuit/circuit_instruction.pybind.h
@@ -36,10 +36,12 @@ struct CircuitInstruction {
     std::string name() const;
     std::vector<stim_internal::GateTarget> targets_copy() const;
     std::vector<double> gate_args_copy() const;
+    std::vector<uint32_t> raw_targets() const;
     bool operator==(const CircuitInstruction &other) const;
     bool operator!=(const CircuitInstruction &other) const;
 
     std::string repr() const;
+    std::string str();
 };
 
 #endif

--- a/src/circuit/circuit_instruction_pybind_test.py
+++ b/src/circuit/circuit_instruction_pybind_test.py
@@ -38,3 +38,7 @@ def test_init_and_equality():
 def test_repr(value):
     assert eval(repr(value), {'stim': stim}) == value
     assert repr(eval(repr(value), {'stim': stim})) == repr(value)
+
+
+def test_str():
+    assert str(stim.CircuitInstruction("X_ERROR", [stim.GateTarget(5)], [0.5])) == "X_ERROR(0.5) 5"

--- a/src/circuit/circuit_pybind_test.py
+++ b/src/circuit/circuit_pybind_test.py
@@ -463,6 +463,9 @@ def test_append_instructions_and_blocks():
     c.append_operation("TICK")
     assert c == stim.Circuit("TICK")
 
+    with pytest.raises(ValueError, match="no targets"):
+        c.append_operation("TICK", [1, 2, 3])
+
     c.append_operation(stim.Circuit("H 1")[0])
     assert c == stim.Circuit("TICK\nH 1")
 
@@ -508,3 +511,6 @@ def test_append_instructions_and_blocks():
 
     with pytest.raises(ValueError, match="arg"):
         c.append_operation((stim.Circuit("H 1") * 5)[0], [], 0.1)
+
+    with pytest.raises(ValueError, match="repeat 0"):
+        c.append_operation(stim.CircuitRepeatBlock(0, stim.Circuit("H 1")))

--- a/src/circuit/circuit_repeat_block.pybind.cc
+++ b/src/circuit/circuit_repeat_block.pybind.cc
@@ -21,6 +21,13 @@
 
 using namespace stim_internal;
 
+CircuitRepeatBlock::CircuitRepeatBlock(uint64_t repeat_count, stim_internal::Circuit body)
+    : repeat_count(repeat_count), body(body) {
+    if (repeat_count == 0) {
+        throw std::invalid_argument("Can't repeat 0 times.");
+    }
+}
+
 Circuit CircuitRepeatBlock::body_copy() {
     return body;
 }

--- a/src/circuit/circuit_repeat_block.pybind.h
+++ b/src/circuit/circuit_repeat_block.pybind.h
@@ -24,6 +24,7 @@ void pybind_circuit_repeat_block(pybind11::module &m);
 struct CircuitRepeatBlock {
     uint64_t repeat_count;
     stim_internal::Circuit body;
+    CircuitRepeatBlock(uint64_t repeat_count, stim_internal::Circuit body);
     stim_internal::Circuit body_copy();
     bool operator==(const CircuitRepeatBlock &other) const;
     bool operator!=(const CircuitRepeatBlock &other) const;

--- a/src/circuit/circuit_repeat_block_test.py
+++ b/src/circuit/circuit_repeat_block_test.py
@@ -28,6 +28,9 @@ def test_init_and_equality():
     r2 = stim.CircuitRepeatBlock(repeat_count=500, body=stim.Circuit("X 0"))
     assert r == r2
 
+    with pytest.raises(ValueError, match="repeat 0"):
+        stim.CircuitRepeatBlock(0, stim.Circuit())
+
 
 @pytest.mark.parametrize("value", [
     stim.CircuitRepeatBlock(500, stim.Circuit("X 0")),

--- a/src/py/base.pybind.cc
+++ b/src/py/base.pybind.cc
@@ -95,3 +95,21 @@ bool normalize_index_or_slice(
     }
     return true;
 }
+
+SampleFormat format_to_enum(const std::string &format) {
+    if (format == "01") {
+        return SAMPLE_FORMAT_01;
+    } else if (format == "hits") {
+        return SAMPLE_FORMAT_HITS;
+    } else if (format == "b8") {
+        return SAMPLE_FORMAT_B8;
+    } else if (format == "r8") {
+        return SAMPLE_FORMAT_R8;
+    } else if (format == "dets") {
+        return SAMPLE_FORMAT_DETS;
+    } else if (format == "ptb64") {
+        return SAMPLE_FORMAT_PTB64;
+    } else {
+        throw std::invalid_argument("Unrecognized format. Expected '01', 'hits', 'b8', 'r8', 'dets', or 'ptb64'.");
+    }
+}

--- a/src/py/base.pybind.h
+++ b/src/py/base.pybind.h
@@ -20,9 +20,11 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <random>
+#include "../circuit/circuit.h"
 
 std::mt19937_64 &PYBIND_SHARED_RNG();
 std::string clean_doc_string(const char *c);
+stim_internal::SampleFormat format_to_enum(const std::string &format);
 bool normalize_index_or_slice(
     const pybind11::object &index_or_slice,
     size_t length,

--- a/src/py/base.pybind.h
+++ b/src/py/base.pybind.h
@@ -20,6 +20,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <random>
+
 #include "../circuit/circuit.h"
 
 std::mt19937_64 &PYBIND_SHARED_RNG();

--- a/src/py/compiled_detector_sampler.pybind.cc
+++ b/src/py/compiled_detector_sampler.pybind.cc
@@ -69,7 +69,12 @@ pybind11::array_t<uint8_t> CompiledDetectorSampler::sample_bit_packed(
     return pybind11::array_t<uint8_t>(pybind11::buffer_info(ptr, itemsize, format, 2, shape, stride, readonly));
 }
 
-void CompiledDetectorSampler::sample_write(size_t num_samples, const std::string &filepath, const std::string &format, bool prepend_observables, bool append_observables) {
+void CompiledDetectorSampler::sample_write(
+    size_t num_samples,
+    const std::string &filepath,
+    const std::string &format,
+    bool prepend_observables,
+    bool append_observables) {
     auto f = format_to_enum(format);
     FILE *out = fopen(filepath.data(), "w");
     detector_samples_out(circuit, num_samples, prepend_observables, append_observables, out, f, PYBIND_SHARED_RNG());

--- a/src/py/compiled_detector_sampler.pybind.h
+++ b/src/py/compiled_detector_sampler.pybind.h
@@ -30,6 +30,7 @@ struct CompiledDetectorSampler {
     CompiledDetectorSampler(stim_internal::Circuit circuit);
     pybind11::array_t<uint8_t> sample(size_t num_shots, bool prepend_observables, bool append_observables);
     pybind11::array_t<uint8_t> sample_bit_packed(size_t num_shots, bool prepend_observables, bool append_observables);
+    void sample_write(size_t num_samples, const std::string &filepath, const std::string &format, bool prepend_observables, bool append_observables);
     std::string repr() const;
 };
 

--- a/src/py/compiled_detector_sampler.pybind.h
+++ b/src/py/compiled_detector_sampler.pybind.h
@@ -30,7 +30,12 @@ struct CompiledDetectorSampler {
     CompiledDetectorSampler(stim_internal::Circuit circuit);
     pybind11::array_t<uint8_t> sample(size_t num_shots, bool prepend_observables, bool append_observables);
     pybind11::array_t<uint8_t> sample_bit_packed(size_t num_shots, bool prepend_observables, bool append_observables);
-    void sample_write(size_t num_samples, const std::string &filepath, const std::string &format, bool prepend_observables, bool append_observables);
+    void sample_write(
+        size_t num_samples,
+        const std::string &filepath,
+        const std::string &format,
+        bool prepend_observables,
+        bool append_observables);
     std::string repr() const;
 };
 

--- a/src/py/compiled_detector_sampler_pybind_test.py
+++ b/src/py/compiled_detector_sampler_pybind_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import tempfile
 
 import numpy as np
 import stim
@@ -73,3 +74,17 @@ def test_compiled_detector_sampler_sample():
             [0b011],
             [0b011],
         ], dtype=np.uint8))
+
+    with tempfile.TemporaryDirectory() as d:
+        path = f"{d}/tmp.dat"
+        c.compile_detector_sampler().sample_write(5, filepath=path, format='b8')
+        with open(path, 'rb') as f:
+            assert f.read() == b'\x03' * 5
+
+        c.compile_detector_sampler().sample_write(5, filepath=path, format='01', prepend_observables=True)
+        with open(path, 'r') as f:
+            assert f.readlines() == ['1000110\n'] * 5
+
+        c.compile_detector_sampler().sample_write(5, filepath=path, format='01', append_observables=True)
+        with open(path, 'r') as f:
+            assert f.readlines() == ['1101000\n'] * 5

--- a/src/py/compiled_measurement_sampler.pybind.cc
+++ b/src/py/compiled_measurement_sampler.pybind.cc
@@ -61,6 +61,13 @@ pybind11::array_t<uint8_t> CompiledMeasurementSampler::sample_bit_packed(size_t 
     return pybind11::array_t<uint8_t>(pybind11::buffer_info(ptr, itemsize, format, 2, shape, stride, readonly));
 }
 
+void CompiledMeasurementSampler::sample_write(size_t num_samples, const std::string &filepath, const std::string &format) {
+    auto f = format_to_enum(format);
+    FILE *out = fopen(filepath.data(), "w");
+    FrameSimulator::sample_out(circuit, ref, num_samples, out, f, PYBIND_SHARED_RNG());
+    fclose(out);
+}
+
 std::string CompiledMeasurementSampler::repr() const {
     std::stringstream result;
     result << "stim.CompiledMeasurementSampler(";
@@ -124,6 +131,45 @@ void pybind_compiled_measurement_sampler(pybind11::module &m) {
             Returns:
                 A numpy array with `dtype=uint8` and `shape=(shots, (num_measurements + 7) // 8)`.
                 The bit for measurement `m` in shot `s` is at `result[s, (m // 8)] & 2**(m % 8)`.
+        )DOC")
+            .data());
+
+    c.def(
+        "sample_write",
+        &CompiledMeasurementSampler::sample_write,
+        pybind11::arg("shots"),
+        pybind11::kw_only(),
+        pybind11::arg("filepath"),
+        pybind11::arg("format"),
+        clean_doc_string(u8R"DOC(
+            Samples measurements from the circuit and writes them to a file.
+
+            Examples:
+                >>> import stim
+                >>> import tempfile
+                >>> with tempfile.TemporaryDirectory() as d:
+                ...     path = f"{d}/tmp.dat"
+                ...     c = stim.Circuit('''
+                ...         X 0   2 3
+                ...         M 0 1 2 3
+                ...     ''')
+                ...     c.compile_sampler().sample_write(5, filepath=path, format="01")
+                ...     with open(path) as f:
+                ...         print(f.read(), end='')
+                1011
+                1011
+                1011
+                1011
+                1011
+
+            Args:
+                shots: The number of times to sample every measurement in the circuit.
+                filepath: The file to write the results to.
+                format: The output format to write the results with.
+                    Valid values are "01", "b8", "r8", "hits", "dets", and "ptb64".
+
+            Returns:
+                None.
         )DOC")
             .data());
 

--- a/src/py/compiled_measurement_sampler.pybind.cc
+++ b/src/py/compiled_measurement_sampler.pybind.cc
@@ -61,7 +61,8 @@ pybind11::array_t<uint8_t> CompiledMeasurementSampler::sample_bit_packed(size_t 
     return pybind11::array_t<uint8_t>(pybind11::buffer_info(ptr, itemsize, format, 2, shape, stride, readonly));
 }
 
-void CompiledMeasurementSampler::sample_write(size_t num_samples, const std::string &filepath, const std::string &format) {
+void CompiledMeasurementSampler::sample_write(
+    size_t num_samples, const std::string &filepath, const std::string &format) {
     auto f = format_to_enum(format);
     FILE *out = fopen(filepath.data(), "w");
     FrameSimulator::sample_out(circuit, ref, num_samples, out, f, PYBIND_SHARED_RNG());

--- a/src/py/compiled_measurement_sampler.pybind.h
+++ b/src/py/compiled_measurement_sampler.pybind.h
@@ -30,6 +30,7 @@ struct CompiledMeasurementSampler {
     CompiledMeasurementSampler(stim_internal::Circuit circuit);
     pybind11::array_t<uint8_t> sample(size_t num_samples);
     pybind11::array_t<uint8_t> sample_bit_packed(size_t num_samples);
+    void sample_write(size_t num_samples, const std::string &filepath, const std::string &format);
     std::string repr() const;
 };
 

--- a/src/py/compiled_measurement_sampler_pybind_test.py
+++ b/src/py/compiled_measurement_sampler_pybind_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import tempfile
 
 import numpy as np
 import stim
@@ -68,3 +69,19 @@ def test_measurements_vs_resets():
         MRY 1
         MRZ 2
     """).compile_sampler().sample(shots=100))
+
+
+def test_sample_write():
+    c = stim.Circuit("""
+        X 0 4 5
+        M 0 1 2 3 4 5 6
+    """)
+    with tempfile.TemporaryDirectory() as d:
+        path = f"{d}/tmp.dat"
+        c.compile_sampler().sample_write(5, filepath=path, format='b8')
+        with open(path, 'rb') as f:
+            assert f.read() == b'\x31' * 5
+
+        c.compile_sampler().sample_write(5, filepath=path, format='01')
+        with open(path, 'r') as f:
+            assert f.readlines() == ['1000110\n'] * 5


### PR DESCRIPTION
Adds some missing repetition count validation.

Fixes https://github.com/quantumlib/Stim/issues/118
Fixes https://github.com/quantumlib/Stim/issues/124