### PR TITLE
Basic readers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ set(SOURCE_FILES_NO_MAIN
         src/io/measure_record_batch.cc
         src/io/measure_record_batch_writer.cc
         src/io/measure_record.cc
+        src/io/measure_record_reader.cc
         src/io/measure_record_writer.cc
         src/main_helper.cc
         src/probability_util.cc
@@ -92,6 +93,7 @@ set(TEST_FILES
         src/io/measure_record.test.cc
         src/io/measure_record_batch.test.cc
         src/io/measure_record_batch_writer.test.cc
+        src/io/measure_record_reader.test.cc
         src/io/measure_record_writer.test.cc
         src/main_helper.test.cc
         src/probability_util.test.cc

--- a/src/io/measure_record_reader.cc
+++ b/src/io/measure_record_reader.cc
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "measure_record_reader.h"
+
+#include <algorithm>
+
+using namespace stim_internal;
+
+std::unique_ptr<MeasureRecordReader> MeasureRecordReader::make(FILE *in, SampleFormat input_format, size_t max_bits) {
+    switch (input_format) {
+        case SAMPLE_FORMAT_01:
+            return std::unique_ptr<MeasureRecordReader>(new MeasureRecordReaderFormat01(in, max_bits));
+        case SAMPLE_FORMAT_B8:
+            return std::unique_ptr<MeasureRecordReader>(new MeasureRecordReaderFormatB8(in, max_bits));
+        case SAMPLE_FORMAT_DETS:
+            return std::unique_ptr<MeasureRecordReader>(new MeasureRecordReaderFormatDets(in, max_bits));
+        case SAMPLE_FORMAT_HITS:
+            return std::unique_ptr<MeasureRecordReader>(new MeasureRecordReaderFormatHits(in, max_bits));
+        case SAMPLE_FORMAT_PTB64:
+            throw std::invalid_argument("SAMPLE_FORMAT_PTB64 incompatible with SingleMeasurementRecord");
+        case SAMPLE_FORMAT_R8:
+            return std::unique_ptr<MeasureRecordReader>(new MeasureRecordReaderFormatR8(in, max_bits));
+        default:
+            throw std::invalid_argument("Sample format not recognized by SingleMeasurementRecord");
+    }
+}
+
+size_t MeasureRecordReader::read_bytes(PointerRange<uint8_t> data) {
+    size_t n = 0;
+    for (uint8_t &b : data) {
+        b = 0;
+        for (size_t k = 0; k < 8; k++) {
+            if (is_end_of_record()) {
+                return n;
+            }
+            b |= uint8_t(read_bit()) << k;
+            ++n;
+        }
+    }
+    return n;
+}
+
+bool MeasureRecordReader::is_end_of_record() {
+    return is_end_of_file();
+}
+
+char MeasureRecordReader::current_result_type() {
+    return 'M';
+}
+
+/// 01 format
+
+MeasureRecordReaderFormat01::MeasureRecordReaderFormat01(FILE *in, size_t max_bits) : in(in), payload(getc(in)), max_bits(max_bits) {
+}
+
+bool MeasureRecordReaderFormat01::read_bit() {
+    // We assume here that in practice bits_returned will never reach SIZE_MAX.
+    if (payload == EOF or bits_returned >= max_bits) {
+        throw std::out_of_range("Attempt to read past end-of-file");
+    }
+    if (payload == '\n') {
+        throw std::out_of_range("Attempt to read past end-of-record");
+    }
+    if (payload != '0' and payload != '1') {
+        throw std::invalid_argument("Character code " + std::to_string(payload) + " does not encode a bit");
+    }
+
+    bool bit = payload == '1';
+    payload = getc(in);
+    ++bits_returned;
+    return bit;
+}
+
+bool MeasureRecordReaderFormat01::is_end_of_record() {
+    bool eor = payload == EOF or bits_returned >= max_bits or payload == '\n';
+    if (payload == '\n') {
+        payload = getc(in);
+    }
+    return eor;
+}
+
+bool MeasureRecordReaderFormat01::is_end_of_file() {
+    return payload == EOF or bits_returned >= max_bits;
+}
+
+/// B8 format
+
+MeasureRecordReaderFormatB8::MeasureRecordReaderFormatB8(FILE *in, size_t max_bits) : in(in), max_bits(max_bits) {
+}
+
+size_t MeasureRecordReaderFormatB8::read_bytes(PointerRange<uint8_t> data) {
+    if (bits_returned >= max_bits) return 0;
+    if (bits_available == 0) {
+        size_t k = std::min<size_t>(data.ptr_end - data.ptr_start, (max_bits - bits_returned + 7) / 8);
+        k = 8 * fread(data.ptr_start, sizeof(uint8_t), k, in);
+        bits_returned += k;
+        return k;
+    }
+    return MeasureRecordReader::read_bytes(data);
+}
+
+bool MeasureRecordReaderFormatB8::read_bit() {
+    if (bits_available == 0) {
+        payload = getc(in);
+        if (payload != EOF) bits_available = 8;
+    }
+    if (payload == EOF or bits_returned >= max_bits) {
+        throw std::out_of_range("Attempt to read past end-of-file");
+    }
+    bool b = payload & 1;
+    payload >>= 1;
+    --bits_available;
+    ++bits_returned;
+    return b;
+}
+
+bool MeasureRecordReaderFormatB8::is_end_of_file() {
+    if (bits_returned >= max_bits) return true;
+    if (bits_available != 0) return false;
+    payload = getc(in);
+    if (payload != EOF) {
+        bits_available = 8;
+        return false;
+    }
+    return true;
+}
+
+/// Hits format
+
+MeasureRecordReaderFormatHits::MeasureRecordReaderFormatHits(FILE *in, size_t max_bits) : in(in), max_bits(max_bits) {
+    update_next_hit();
+}
+
+bool MeasureRecordReaderFormatHits::read_bit() {
+    if (bits_returned >= max_bits) throw std::out_of_range("Attempt to read past end-of-file");
+    if (bits_returned > next_hit) update_next_hit();
+
+    bool b = bits_returned == next_hit;
+    ++bits_returned;
+    return b;
+}
+
+bool MeasureRecordReaderFormatHits::is_end_of_file() {
+    return bits_returned >= max_bits;
+}
+
+void MeasureRecordReaderFormatHits::update_next_hit() {
+    int status = fscanf(in, "%zu,", &next_hit);
+    if (status == EOF) return;
+    if (status != 1) throw std::runtime_error("Failed to parse input");
+    if (next_hit < bits_returned) {
+        throw std::invalid_argument("New hit " + std::to_string(next_hit) + " is in the past of " + std::to_string(bits_returned));
+    }
+}
+
+/// R8 format
+
+MeasureRecordReaderFormatR8::MeasureRecordReaderFormatR8(FILE *in, size_t max_bits) : in(in), max_bits(max_bits) {
+    update_run_length();
+    run_length_1s = 0;
+}
+
+size_t MeasureRecordReaderFormatR8::read_bytes(PointerRange<uint8_t> data) {
+    if (bits_returned >= max_bits) return 0;
+    size_t n = 0;
+    for (uint8_t &b : data) {
+        if (run_length_0s >= generated_0s + 8 and max_bits >= bits_returned + 8) {
+            b = 0;
+            generated_0s += 8;
+            bits_returned += 8;
+            n += 8;
+            continue;
+        }
+        b = 0;
+        for (size_t k = 0; k < 8; k++) {
+            if (is_end_of_record()) {
+                return n;
+            }
+            b |= uint8_t(read_bit()) << k;
+            ++n;
+        }
+    }
+    return n;
+}
+
+bool MeasureRecordReaderFormatR8::read_bit() {
+    if (bits_returned >= max_bits) throw std::out_of_range("Attempt to read past end-of-file");
+    if (generated_1s < run_length_1s) {
+        ++generated_1s;
+        ++bits_returned;
+        return true;
+    }
+    if (generated_0s < run_length_0s) {
+        ++generated_0s;
+        ++bits_returned;
+        return false;
+    }
+    if (!update_run_length()) {
+        throw std::out_of_range("Attempt to read past end-of-file");
+    } else {
+        ++generated_1s;
+        ++bits_returned;
+        return true;
+    }
+}
+
+bool MeasureRecordReaderFormatR8::is_end_of_file() {
+    if (bits_returned >= max_bits) return true;
+    if (generated_0s < run_length_0s) return false;
+    if (generated_1s < run_length_1s) return false;
+    return !update_run_length();
+}
+
+bool MeasureRecordReaderFormatR8::update_run_length() {
+    size_t new_run_length_0s = 0;
+    int r = getc(in);
+    if (r == EOF) return false;
+    while (r == 0xFF) {
+        new_run_length_0s += 0xFF;
+        r = getc(in);
+    }
+    if (r > 0) new_run_length_0s += r;
+    run_length_0s = new_run_length_0s;
+    run_length_1s = 1;
+    generated_0s = 0;
+    generated_1s = 0;
+    return true;
+}
+
+/// DETS format
+
+MeasureRecordReaderFormatDets::MeasureRecordReaderFormatDets(FILE *in, size_t max_bits) : in(in), max_bits(max_bits) {
+    fscanf(in, "shot ");
+    read_next_shot();
+}
+
+bool MeasureRecordReaderFormatDets::read_bit() {
+    if (bits_returned >= max_bits) throw std::out_of_range("Attempt to read past end-of-file");
+    if (position > next_shot) read_next_shot();
+
+    bool b = position == next_shot;
+    ++bits_returned;
+    ++position;
+    return b;
+}
+
+bool MeasureRecordReaderFormatDets::is_end_of_record() {
+    if (position <= next_shot) return false;
+    bool eor = bits_returned >= max_bits or separator == '\n';
+    if (separator == '\n') {
+        fscanf(in, "shot ");
+    }
+    return eor;
+}
+
+bool MeasureRecordReaderFormatDets::is_end_of_file() {
+    return bits_returned >= max_bits or feof(in);
+}
+
+char MeasureRecordReaderFormatDets::current_result_type() {
+    return result_type;
+}
+
+void MeasureRecordReaderFormatDets::read_next_shot() {
+    char next_result_type;
+    int status = fscanf(in, "%c%zu%c", &next_result_type, &next_shot, &separator);
+    if (status == EOF) {
+        bits_returned = max_bits;
+        result_type = next_result_type;
+        return;
+    }
+    if (status != 3) {
+        throw std::runtime_error("Failed to parse input");
+    }
+    if (separator != ' ' and separator != '\n') {
+        throw std::invalid_argument("Unexpected separator: [" + std::to_string(separator) + "]");
+    }
+    if (next_result_type != result_type) {
+        position = 0;
+        result_type = next_result_type;
+    }
+    if (next_shot < position) {
+        throw std::invalid_argument("New shot " + std::to_string(next_shot) + " is in the past of " + std::to_string(bits_returned));
+    }
+}

--- a/src/io/measure_record_reader.cc
+++ b/src/io/measure_record_reader.cc
@@ -78,7 +78,7 @@ bool MeasureRecordReaderFormat01::read_bit() {
     if (payload == '\n') {
         throw std::out_of_range("Attempt to read past end-of-record");
     }
-    if (payload != '0' and payload != '1') {
+    if (payload != '0' && payload != '1') {
         throw std::runtime_error("Character code " + std::to_string(payload) + " does not encode a bit");
     }
 
@@ -88,13 +88,13 @@ bool MeasureRecordReaderFormat01::read_bit() {
 }
 
 bool MeasureRecordReaderFormat01::next_record() {
-    while (payload != EOF and payload != '\n') payload = getc(in);
+    while (payload != EOF && payload != '\n') payload = getc(in);
     payload = getc(in);
     return payload != EOF;
 }
 
 bool MeasureRecordReaderFormat01::is_end_of_record() {
-    return payload == EOF or payload == '\n';
+    return payload == EOF || payload == '\n';
 }
 
 /// B8 format
@@ -125,7 +125,7 @@ bool MeasureRecordReaderFormatB8::read_bit() {
 
 bool MeasureRecordReaderFormatB8::is_end_of_record() {
     maybe_update_payload();
-    return bits_available == 0 and payload == EOF;
+    return bits_available == 0 && payload == EOF;
 }
 
 void MeasureRecordReaderFormatB8::maybe_update_payload() {
@@ -141,13 +141,13 @@ MeasureRecordReaderFormatHits::MeasureRecordReaderFormatHits(FILE *in) : in(in) 
 }
 
 bool MeasureRecordReaderFormatHits::read_bit() {
-    if (position > next_hit and separator ==',') update_next_hit();
+    if (position > next_hit && separator ==',') update_next_hit();
     return next_hit == position++;
 }
 
 bool MeasureRecordReaderFormatHits::next_record() {
     bool success = true;
-    while (separator == ',' and success) success = update_next_hit();
+    while (separator == ',' && success) success = update_next_hit();
     if (separator == '\n') position = 0;
     return update_next_hit();
 }
@@ -160,7 +160,7 @@ bool MeasureRecordReaderFormatHits::update_next_hit() {
     if (status != 2) {
         throw std::runtime_error("Failed to parse input");
     }
-    if (separator != ',' and separator != '\n') {
+    if (separator != ',' && separator != '\n') {
         throw std::runtime_error("Invalid separator character " + std::to_string(separator));
     }
     if (next_hit < position) {
@@ -243,13 +243,13 @@ MeasureRecordReaderFormatDets::MeasureRecordReaderFormatDets(FILE *in) : in(in) 
 }
 
 bool MeasureRecordReaderFormatDets::read_bit() {
-    if (position > next_shot and separator == ' ') update_next_shot();
+    if (position > next_shot && separator == ' ') update_next_shot();
     return next_shot == position++;
 }
 
 bool MeasureRecordReaderFormatDets::next_record() {
     bool success = true;
-    while (separator == ' ' and success) success = update_next_shot();
+    while (separator == ' ' && success) success = update_next_shot();
     if (separator == '\n') {
         if (fscanf(in, "shot ") == EOF) return false;
         position = 0;
@@ -270,7 +270,7 @@ bool MeasureRecordReaderFormatDets::update_next_shot() {
     if (status != 3) {
         throw std::runtime_error("Failed to parse input");
     }
-    if (separator != ' ' and separator != '\n') {
+    if (separator != ' ' && separator != '\n') {
         throw std::invalid_argument("Unexpected separator: [" + std::to_string(separator) + "]");
     }
     if (next_result_type != result_type) {

--- a/src/io/measure_record_reader.cc
+++ b/src/io/measure_record_reader.cc
@@ -127,9 +127,10 @@ bool MeasureRecordReaderFormat01::read_bit() {
 }
 
 bool MeasureRecordReaderFormat01::next_record() {
-    while (payload != EOF && payload != '\n' && ++position < bits_per_record) payload = getc(in);
-
-    if (position > bits_per_record) throw std::runtime_error("Record too long");
+    while (payload != EOF && payload != '\n') {
+        payload = getc(in);
+        if (position++ > bits_per_record) throw std::runtime_error("Record too long");
+    }
 
     position = 0;
     payload = getc(in);

--- a/src/io/measure_record_reader.cc
+++ b/src/io/measure_record_reader.cc
@@ -117,7 +117,7 @@ bool MeasureRecordReaderFormat01::read_bit() {
         throw std::out_of_range("Attempt to read past end-of-record");
     }
     if (payload != '0' && payload != '1') {
-        throw std::runtime_error("Character code " + std::to_string(payload) + " does not encode a bit");
+        throw std::runtime_error("Expected '0' or '1' because input format was specified as '01'");
     }
 
     bool bit = payload == '1';

--- a/src/io/measure_record_reader.h
+++ b/src/io/measure_record_reader.h
@@ -89,9 +89,9 @@ struct MeasureRecordReaderFormatB8 : MeasureRecordReader {
 
 struct MeasureRecordReaderFormatHits : MeasureRecordReader {
     FILE *in;
-    char separator;
-    size_t next_hit = 0;
-    size_t position = 0;
+    int separator;
+    long next_hit = -1;
+    long position = 0;
 
     explicit MeasureRecordReaderFormatHits(FILE *in);
 
@@ -99,7 +99,7 @@ struct MeasureRecordReaderFormatHits : MeasureRecordReader {
     bool next_record() override;
 
   private:
-    bool update_next_hit();
+    void update_next_hit();
 };
 
 struct MeasureRecordReaderFormatR8 : MeasureRecordReader {
@@ -122,9 +122,9 @@ struct MeasureRecordReaderFormatR8 : MeasureRecordReader {
 struct MeasureRecordReaderFormatDets : MeasureRecordReader {
     FILE *in;
     char result_type = 'M';
-    char separator = '\n';
-    size_t next_shot = 0;
-    uint64_t position = 0;
+    int separator = '\n';
+    long next_shot = -1;
+    long position = 0;
 
     explicit MeasureRecordReaderFormatDets(FILE *in);
 
@@ -133,7 +133,7 @@ struct MeasureRecordReaderFormatDets : MeasureRecordReader {
     char current_result_type() override;
 
   private:
-    bool update_next_shot();
+    void update_next_shot();
 };
 
 }  // namespace stim_internal

--- a/src/io/measure_record_reader.h
+++ b/src/io/measure_record_reader.h
@@ -18,6 +18,7 @@
 #define STIM_RECORD_READER_H
 
 #include <memory>
+#include <sys/types.h>
 
 #include "../circuit/circuit.h"
 #include "../simd/pointer_range.h"

--- a/src/io/measure_record_reader.h
+++ b/src/io/measure_record_reader.h
@@ -101,9 +101,9 @@ struct MeasureRecordReaderFormatHits : MeasureRecordReader {
     FILE *in;
     int separator;
     bool no_next_hit = true;
-    size_t next_hit = 0;
-    size_t position = 0;
-    size_t bits_per_record;
+    uint64_t next_hit = 0;
+    uint64_t position = 0;
+    uint64_t bits_per_record;
 
     MeasureRecordReaderFormatHits(FILE *in, size_t bits_per_record);
 
@@ -141,14 +141,14 @@ struct MeasureRecordReaderFormatDets : MeasureRecordReader {
     char result_type = 'M';
     char next_shot_result_type = 'M';
     bool no_next_shot = true;
-    size_t next_shot = -1;
+    uint64_t next_shot = -1;
 
-    size_t position_m = 0;
-    size_t position_d = 0;
-    size_t position_l = 0;
-    size_t bits_per_m_record;
-    size_t bits_per_d_record;
-    size_t bits_per_l_record;
+    uint64_t position_m = 0;
+    uint64_t position_d = 0;
+    uint64_t position_l = 0;
+    uint64_t bits_per_m_record;
+    uint64_t bits_per_d_record;
+    uint64_t bits_per_l_record;
 
     MeasureRecordReaderFormatDets(FILE *in, size_t n_measurements, size_t n_detection_events = 0, size_t n_logical_observables = 0);
 

--- a/src/io/measure_record_reader.h
+++ b/src/io/measure_record_reader.h
@@ -32,13 +32,13 @@ namespace stim_internal {
 /// HITS and DETS encode any number of records. Record size in bits is fixed for each file and the client
 /// must specify it upfront.
 struct MeasureRecordReader {
-    size_t bits_returned = 0;
-    size_t bits_per_record;
+    ssize_t position = 0;
+    ssize_t bits_per_record;
 
     /// Creates a MeasureRecordReader that reads measurement records in the given format from the given FILE*.
     static std::unique_ptr<MeasureRecordReader> make(FILE *in, SampleFormat input_format, size_t bits_per_record);
 
-    MeasureRecordReader(size_t bits_per_record) : bits_per_record(bits_per_record) {}
+    MeasureRecordReader(size_t bits_per_record);
     virtual ~MeasureRecordReader() = default;
 
     /// Reads and returns one measurement result. If no result is available, exception is thrown.
@@ -92,8 +92,7 @@ struct MeasureRecordReaderFormatB8 : MeasureRecordReader {
 struct MeasureRecordReaderFormatHits : MeasureRecordReader {
     FILE *in;
     int separator;
-    long next_hit = -1;
-    long position = 0;
+    ssize_t next_hit = -1;
 
     MeasureRecordReaderFormatHits(FILE *in, size_t bits_per_record);
 
@@ -125,8 +124,7 @@ struct MeasureRecordReaderFormatDets : MeasureRecordReader {
     FILE *in;
     char result_type = 'M';
     int separator = '\n';
-    long next_shot = -1;
-    long position = 0;
+    ssize_t next_shot = -1;
 
     MeasureRecordReaderFormatDets(FILE *in, size_t bits_per_record);
 

--- a/src/io/measure_record_reader.h
+++ b/src/io/measure_record_reader.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef STIM_RECORD_READER_H
+#define STIM_RECORD_READER_H
+
+#include <memory>
+
+#include "../circuit/circuit.h"
+#include "../simd/pointer_range.h"
+#include "../simd/simd_bit_table.h"
+
+namespace stim_internal {
+
+/// Handles reading measurement data from the outside world.
+///
+/// Child classes implement the various input formats.
+struct MeasureRecordReader {
+    /// Creates a MeasureRecordReader that reads the given number of bits in the given format from the given FILE*.
+    /// Number of bits SIZE_MAX indicates that the reader is to determine the appropriate number on its own. Note
+    /// that some input formats do not provide any means to infer appropriate stream length. In this case, the
+    /// caller should treat the stream as essentially infinite and use other information to determine when to stop
+    /// reading from the stream.
+    static std::unique_ptr<MeasureRecordReader> make(FILE *in, SampleFormat input_format, size_t max_bits = SIZE_MAX);
+    virtual ~MeasureRecordReader() = default;
+
+    /// Reads and returns one measurement result.
+    /// If no result is available, exception is thrown.
+    /// If is_end_of_record() just returned false, then a result is available and no exception is thrown.
+    virtual bool read_bit() = 0;
+    /// Reads multiple measurement results. Returns the number of results read.
+    /// If no results are available, zero is returned.
+    /// Read terminates at end-of-record marker (e.g. a newline), at end-of-file or when data is filled up.
+    virtual size_t read_bytes(PointerRange<uint8_t> data);
+
+    /// Returns true when the stream is at enf-of-file or max_bits have already been read.
+    virtual bool is_end_of_file() = 0;
+    /// Returns true when the stream is at end-of-record marker (e.g. a newline), at end-of-file or max_bits have
+    /// been read. If the stream is at end-of-record marker, the function advances the stream to the next position.
+    virtual bool is_end_of_record();
+
+    /// Used to obtain the DETS format prefix character (M for measurement, D for detector, L for logical observable).
+    /// Readers of other formats always return 'M'.
+    virtual char current_result_type();
+};
+
+struct MeasureRecordReaderFormat01 : MeasureRecordReader {
+    FILE *in;
+    int payload;
+    size_t bits_returned = 0;
+    const size_t max_bits;
+
+    MeasureRecordReaderFormat01(FILE *in, size_t max_bits = SIZE_MAX);
+
+    bool read_bit() override;
+    bool is_end_of_record() override;
+    bool is_end_of_file() override;
+};
+
+struct MeasureRecordReaderFormatB8 : MeasureRecordReader {
+    FILE *in;
+    int payload = 0;
+    uint8_t bits_available = 0;
+    size_t bits_returned = 0;
+    const size_t max_bits;
+
+    MeasureRecordReaderFormatB8(FILE *in, size_t max_bits = SIZE_MAX);
+
+    size_t read_bytes(PointerRange<uint8_t> data) override;
+    bool read_bit() override;
+    bool is_end_of_file() override;
+};
+
+struct MeasureRecordReaderFormatHits : MeasureRecordReader {
+    FILE *in;
+    size_t next_hit = 0;
+    size_t bits_returned = 0;
+    const size_t max_bits;
+
+    MeasureRecordReaderFormatHits(FILE *in, size_t max_bits = SIZE_MAX);
+
+    bool read_bit() override;
+    bool is_end_of_file() override;
+  private:
+    void update_next_hit();
+};
+
+struct MeasureRecordReaderFormatR8 : MeasureRecordReader {
+    FILE *in;
+    size_t run_length_0s = 0;
+    size_t run_length_1s = 0;
+    size_t generated_0s = 0;
+    size_t generated_1s = 1;
+    size_t bits_returned = 0;
+    const size_t max_bits;
+
+    MeasureRecordReaderFormatR8(FILE *in, size_t max_bits = SIZE_MAX);
+
+    size_t read_bytes(PointerRange<uint8_t> data) override;
+    bool read_bit() override;
+    bool is_end_of_file() override;
+  private:
+    bool update_run_length();
+};
+
+struct MeasureRecordReaderFormatDets : MeasureRecordReader {
+    FILE *in;
+    char result_type = 'M';
+    char separator;
+    size_t next_shot;
+    uint64_t position = 0;
+    size_t bits_returned = 0;
+    const size_t max_bits;
+
+    MeasureRecordReaderFormatDets(FILE *in, size_t max_bits = SIZE_MAX);
+
+    bool read_bit() override;
+    bool is_end_of_record() override;
+    bool is_end_of_file() override;
+    char current_result_type() override;
+  private:
+    void read_next_shot();
+};
+
+}  // namespace stim_internal
+
+#endif

--- a/src/io/measure_record_reader.h
+++ b/src/io/measure_record_reader.h
@@ -37,11 +37,12 @@ struct MeasureRecordReader {
     /// and size of each is specified independently. All other formats support one type of record. It is
     /// an error to specify non-zero size of detection event records or logical observable records unless
     /// the input format is DETS.
-    static std::unique_ptr<MeasureRecordReader> make(FILE *in,
-                                                     SampleFormat input_format,
-                                                     size_t n_measurements,
-                                                     size_t n_detection_events = 0,
-                                                     size_t n_logical_observables = 0);
+    static std::unique_ptr<MeasureRecordReader> make(
+        FILE *in,
+        SampleFormat input_format,
+        size_t n_measurements,
+        size_t n_detection_events = 0,
+        size_t n_logical_observables = 0);
     virtual ~MeasureRecordReader() = default;
 
     /// Reads and returns one measurement result. If no result is available, exception is thrown.
@@ -93,7 +94,7 @@ struct MeasureRecordReaderFormatB8 : MeasureRecordReader {
     bool next_record() override;
     bool is_end_of_record() override;
 
-  private:
+   private:
     void maybe_update_payload();
 };
 
@@ -111,7 +112,7 @@ struct MeasureRecordReaderFormatHits : MeasureRecordReader {
     bool next_record() override;
     bool is_end_of_record() override;
 
-  private:
+   private:
     void update_next_hit();
 };
 
@@ -131,7 +132,7 @@ struct MeasureRecordReaderFormatR8 : MeasureRecordReader {
     bool next_record() override;
     bool is_end_of_record() override;
 
-  private:
+   private:
     bool update_run_length();
 };
 
@@ -150,16 +151,17 @@ struct MeasureRecordReaderFormatDets : MeasureRecordReader {
     uint64_t bits_per_d_record;
     uint64_t bits_per_l_record;
 
-    MeasureRecordReaderFormatDets(FILE *in, size_t n_measurements, size_t n_detection_events = 0, size_t n_logical_observables = 0);
+    MeasureRecordReaderFormatDets(
+        FILE *in, size_t n_measurements, size_t n_detection_events = 0, size_t n_logical_observables = 0);
 
     bool read_bit() override;
     bool next_record() override;
     bool is_end_of_record() override;
     char current_result_type() override;
 
-  private:
-    size_t& position();
-    size_t& bits_per_record();
+   private:
+    size_t &position();
+    size_t &bits_per_record();
 
     void update_next_shot();
 };

--- a/src/io/measure_record_reader.h
+++ b/src/io/measure_record_reader.h
@@ -18,7 +18,6 @@
 #define STIM_RECORD_READER_H
 
 #include <memory>
-#include <sys/types.h>
 
 #include "../circuit/circuit.h"
 #include "../simd/pointer_range.h"
@@ -104,9 +103,10 @@ struct MeasureRecordReaderFormatB8 : MeasureRecordReader {
 struct MeasureRecordReaderFormatHits : MeasureRecordReader {
     FILE *in;
     int separator;
-    ssize_t next_hit = -1;
-    ssize_t position = 0;
-    ssize_t bits_per_record;
+    bool no_next_hit = true;
+    size_t next_hit = 0;
+    size_t position = 0;
+    size_t bits_per_record;
 
     MeasureRecordReaderFormatHits(FILE *in, size_t bits_per_record);
 
@@ -143,14 +143,15 @@ struct MeasureRecordReaderFormatDets : MeasureRecordReader {
     int separator = '\n';
     char result_type = 'M';
     char next_shot_result_type = 'M';
-    ssize_t next_shot = -1;
+    bool no_next_shot = true;
+    size_t next_shot = -1;
 
-    ssize_t position_m = 0;
-    ssize_t position_d = 0;
-    ssize_t position_l = 0;
-    ssize_t bits_per_m_record;
-    ssize_t bits_per_d_record;
-    ssize_t bits_per_l_record;
+    size_t position_m = 0;
+    size_t position_d = 0;
+    size_t position_l = 0;
+    size_t bits_per_m_record;
+    size_t bits_per_d_record;
+    size_t bits_per_l_record;
 
     MeasureRecordReaderFormatDets(FILE *in, size_t n_measurements, size_t n_detection_events = 0, size_t n_logical_observables = 0);
 
@@ -160,8 +161,8 @@ struct MeasureRecordReaderFormatDets : MeasureRecordReader {
     char current_result_type() override;
 
   private:
-    ssize_t& position();
-    ssize_t& bits_per_record();
+    size_t& position();
+    size_t& bits_per_record();
 
     void update_next_shot();
 };

--- a/src/io/measure_record_reader.h
+++ b/src/io/measure_record_reader.h
@@ -61,9 +61,6 @@ struct MeasureRecordReader {
     /// and read_bytes() returns no data. Note that records in file formats HITS and DETS never end.
     virtual bool is_end_of_record() = 0;
 
-    /// Returns true when there are no more results of the current result type in the current record.
-    //virtual bool is_end_of_result_type();
-
     /// Used to obtain the DETS format prefix character (M for measurement, D for detector, L for logical
     /// observable). Readers of other formats always return 'M'.
     virtual char current_result_type();

--- a/src/io/measure_record_reader.h
+++ b/src/io/measure_record_reader.h
@@ -160,8 +160,8 @@ struct MeasureRecordReaderFormatDets : MeasureRecordReader {
     char current_result_type() override;
 
    private:
-    size_t &position();
-    size_t &bits_per_record();
+    uint64_t &position();
+    uint64_t &bits_per_record();
 
     void update_next_shot();
 };

--- a/src/io/measure_record_reader.h
+++ b/src/io/measure_record_reader.h
@@ -36,7 +36,15 @@ struct MeasureRecordReader {
     ssize_t bits_per_record;
 
     /// Creates a MeasureRecordReader that reads measurement records in the given format from the given FILE*.
-    static std::unique_ptr<MeasureRecordReader> make(FILE *in, SampleFormat input_format, size_t bits_per_record);
+    /// Record size must be specified upfront. The DETS format supports three different types of records
+    /// and size of each is specified independently. All other formats support one type of record. It is
+    /// an error to specify non-zero size of detection event records or logical observable records unless
+    /// the input format is DETS.
+    static std::unique_ptr<MeasureRecordReader> make(FILE *in,
+                                                     SampleFormat input_format,
+                                                     size_t n_measurements,
+                                                     size_t n_detection_events = 0,
+                                                     size_t n_logical_observables = 0);
 
     MeasureRecordReader(size_t bits_per_record);
     virtual ~MeasureRecordReader() = default;
@@ -125,8 +133,10 @@ struct MeasureRecordReaderFormatDets : MeasureRecordReader {
     char result_type = 'M';
     int separator = '\n';
     ssize_t next_shot = -1;
+    ssize_t next_d_shot = -1;
+    ssize_t next_l_shot = -1;
 
-    MeasureRecordReaderFormatDets(FILE *in, size_t bits_per_record);
+    MeasureRecordReaderFormatDets(FILE *in, size_t n_measurements, size_t n_detection_events = 0, size_t n_logical_observables = 0);
 
     bool read_bit() override;
     bool next_record() override;

--- a/src/io/measure_record_reader.h
+++ b/src/io/measure_record_reader.h
@@ -119,9 +119,9 @@ struct MeasureRecordReaderFormatR8 : MeasureRecordReader {
 struct MeasureRecordReaderFormatDets : MeasureRecordReader {
     FILE *in;
     char result_type = 'M';
-    char separator;
-    size_t next_shot;
-    uint64_t position = 0;
+    char separator = '\n';
+    size_t next_shot = 0;
+    uint64_t position = 1;
     size_t bits_returned = 0;
     const size_t max_bits;
 
@@ -132,7 +132,7 @@ struct MeasureRecordReaderFormatDets : MeasureRecordReader {
     bool is_end_of_file() override;
     char current_result_type() override;
   private:
-    void read_next_shot();
+    void maybe_read_next_shot();
 };
 
 }  // namespace stim_internal

--- a/src/io/measure_record_reader.test.cc
+++ b/src/io/measure_record_reader.test.cc
@@ -39,7 +39,7 @@ TEST(MeasureRecordReader, Format01) {
     // We'll read the data like this:  |-0xF8-|0|-0xF8-|1|
     FILE *tmp = tmpfile_with_contents("000111110000111111\n");
     ASSERT_NE(tmp, nullptr);
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_01);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_01, 18);
     ASSERT_FALSE(reader->is_end_of_record());
     // bits 0..7 == 0xF8
     uint8_t bytes[]{0};
@@ -59,7 +59,7 @@ TEST(MeasureRecordReader, Format01) {
 TEST(MeasureRecordReader, FormatB8) {
     FILE *tmp = tmpfile_with_contents("\xF8\xF0\x03");
     ASSERT_NE(tmp, nullptr);
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_B8);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_B8, 18);
     ASSERT_FALSE(reader->is_end_of_record());
     // bits 0..7 == 0xF8
     uint8_t bytes[]{0};
@@ -73,18 +73,13 @@ TEST(MeasureRecordReader, FormatB8) {
     ASSERT_EQ(0xF8, bytes[0]);
     // bit 17 == 1
     ASSERT_TRUE(reader->read_bit());
-    // bits 18..24 == 0
-    for (int i = 0; i < 6; ++i) {
-        ASSERT_FALSE(reader->is_end_of_record());
-        ASSERT_FALSE(reader->read_bit());
-    }
     ASSERT_TRUE(reader->is_end_of_record());
 }
 
 TEST(MeasureRecordReader, FormatHits) {
     FILE *tmp = tmpfile_with_contents("3,4,5,6,7,12,13,14,15,16,17\n");
     ASSERT_NE(tmp, nullptr);
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_HITS);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_HITS, 18);
     ASSERT_FALSE(reader->is_end_of_record());
     // bits 0..7 == 0xF8
     uint8_t bytes[]{0};
@@ -98,21 +93,14 @@ TEST(MeasureRecordReader, FormatHits) {
     ASSERT_EQ(0xF8, bytes[0]);
     // bit 17 == 1
     ASSERT_TRUE(reader->read_bit());
-    ASSERT_FALSE(reader->is_end_of_record());
-    // bit 18 == 0
-    ASSERT_FALSE(reader->read_bit());
-    // bits 19..26 == 0
-    bytes[0] = 0xFF;
-    ASSERT_EQ(8, reader->read_bytes(bytes));
-    ASSERT_EQ(0, bytes[0]);
-    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->is_end_of_record());
 }
 
 TEST(MeasureRecordReader, FormatR8) {
     char tmp_data[]{3, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0};
     FILE *tmp = tmpfile_with_contents(std::string(std::begin(tmp_data), std::end(tmp_data)));
     ASSERT_NE(tmp, nullptr);
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_R8);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_R8, 18);
     ASSERT_FALSE(reader->is_end_of_record());
     // bits 0..7 == 0xF8
     uint8_t bytes[]{0};
@@ -132,7 +120,7 @@ TEST(MeasureRecordReader, FormatR8) {
 TEST(MeasureRecordReader, FormatR8_LongGap) {
     FILE *tmp = tmpfile_with_contents("\xFF\xFF\x02\x20");
     ASSERT_NE(tmp, nullptr);
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_R8);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_R8, 8 * 64 + 4 * 32 + 1);
     ASSERT_FALSE(reader->is_end_of_record());
     uint8_t bytes[]{1, 2, 3, 4, 5, 6, 7, 8};
     for (int i = 0; i < 8; ++i) {
@@ -153,7 +141,7 @@ TEST(MeasureRecordReader, FormatR8_LongGap) {
 
 TEST(MeasureRecordReader, FormatDets) {
     FILE *tmp = tmpfile_with_contents("shot D3 D4 D5 D6 D7 D12 D13 D14 D15 D16 L1\n");
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, 17 + 2);
     ASSERT_FALSE(reader->is_end_of_record());
 
     // Detection events:
@@ -176,14 +164,7 @@ TEST(MeasureRecordReader, FormatDets) {
     // bit 1 == 1
     ASSERT_TRUE(reader->read_bit());
 
-    ASSERT_FALSE(reader->is_end_of_record());
-
-    // bit 2 == 0
-    ASSERT_FALSE(reader->read_bit());
-    // bits 3..10 == 0
-    bytes[0] = 0xFF;
-    ASSERT_EQ(8, reader->read_bytes(bytes));
-    ASSERT_EQ(0, bytes[0]);
+    ASSERT_TRUE(reader->is_end_of_record());
 }
 
 FILE *write_records(ConstPointerRange<uint8_t> data, SampleFormat format) {
@@ -194,8 +175,8 @@ FILE *write_records(ConstPointerRange<uint8_t> data, SampleFormat format) {
     return tmp;
 }
 
-size_t read_records_as_bytes(FILE *in, PointerRange<uint8_t> buf, SampleFormat format) {
-    auto reader = MeasureRecordReader::make(in, format);
+size_t read_records_as_bytes(FILE *in, PointerRange<uint8_t> buf, SampleFormat format, size_t bits_per_record) {
+    auto reader = MeasureRecordReader::make(in, format, bits_per_record);
     return reader->read_bytes(buf);
 }
 
@@ -206,7 +187,7 @@ TEST(MeasureRecordReader, Format01_WriteRead) {
     memset(dst, 0, num_bytes);
     FILE *tmp = write_records({src, src + num_bytes}, SAMPLE_FORMAT_01);
     rewind(tmp);
-    ASSERT_EQ(num_bytes * 8, read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_01));
+    ASSERT_EQ(num_bytes * 8 - 1, read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_01, 8 * num_bytes - 1));
     for (size_t i = 0; i < num_bytes; ++i) {
         ASSERT_EQ(src[i], dst[i]);
     }
@@ -219,7 +200,7 @@ TEST(MeasureRecordReader, FormatB8_WriteRead) {
     memset(dst, 0, num_bytes);
     FILE *tmp = write_records({src, src + num_bytes}, SAMPLE_FORMAT_B8);
     rewind(tmp);
-    ASSERT_EQ(num_bytes * 8, read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_B8));
+    ASSERT_EQ(num_bytes * 8 - 1, read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_B8, 8 * num_bytes - 1));
     for (size_t i = 0; i < num_bytes; ++i) {
         ASSERT_EQ(src[i], dst[i]);
     }
@@ -232,7 +213,7 @@ TEST(MeasureRecordReader, FormatR8_WriteRead) {
     memset(dst, 0, num_bytes);
     FILE *tmp = write_records({src, src + num_bytes}, SAMPLE_FORMAT_R8);
     rewind(tmp);
-    ASSERT_EQ(num_bytes * 8, read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_R8));
+    ASSERT_EQ(num_bytes * 8 - 1, read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_R8, 8 * num_bytes - 1));
     for (size_t i = 0; i < num_bytes; ++i) {
         ASSERT_EQ(src[i], dst[i]);
     }
@@ -245,7 +226,7 @@ TEST(MeasureRecordReader, FormatHits_WriteRead) {
     memset(dst, 0, num_bytes);
     FILE *tmp = write_records({src, src + num_bytes}, SAMPLE_FORMAT_HITS);
     rewind(tmp);
-    ASSERT_EQ(num_bytes * 8, read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_HITS));
+    ASSERT_EQ(num_bytes * 8 - 1, read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_HITS, 8 * num_bytes - 1));
     for (size_t i = 0; i < num_bytes; ++i) {
         ASSERT_EQ(src[i], dst[i]);
     }
@@ -258,58 +239,60 @@ TEST(MeasureRecordReader, FormatDets_WriteRead) {
     memset(dst, 0, num_bytes);
     FILE *tmp = write_records({src, src + num_bytes}, SAMPLE_FORMAT_DETS);
     rewind(tmp);
-    ASSERT_EQ(num_bytes * 8, read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_DETS));
+    ASSERT_EQ(num_bytes * 8 - 1, read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_DETS, 8 * num_bytes - 1));
     for (size_t i = 0; i < num_bytes; ++i) {
         ASSERT_EQ(src[i], dst[i]);
     }
 }
 
 TEST(MeasureRecordReader, Format01_MultipleRecords) {
-    FILE *tmp = tmpfile_with_contents("111011001\n01\n1");
+    FILE *tmp = tmpfile_with_contents("111011001\n01000000\n101100011");
     ASSERT_NE(tmp, nullptr);
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_01);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_01, 9);
     ASSERT_FALSE(reader->is_end_of_record());
-    // first record (9 bits)
+    // first record
     uint8_t bytes[]{0};
     ASSERT_EQ(8, reader->read_bytes(bytes));
     ASSERT_EQ(0x37, bytes[0]);
     ASSERT_FALSE(reader->is_end_of_record());
     ASSERT_TRUE(reader->read_bit());
     ASSERT_TRUE(reader->is_end_of_record());
-    // second_record (2 bits)
+    // second_record
     ASSERT_TRUE(reader->next_record());
     ASSERT_FALSE(reader->read_bit());
     ASSERT_TRUE(reader->read_bit());
-    ASSERT_TRUE(reader->is_end_of_record());
-    // third record (1 bit)
+    ASSERT_FALSE(reader->read_bit());
+    ASSERT_FALSE(reader->is_end_of_record());
+    // third record
     ASSERT_TRUE(reader->next_record());
     bytes[0] = 0;
-    ASSERT_EQ(1, reader->read_bytes(bytes));
-    ASSERT_EQ(1, bytes[0]);
+    ASSERT_EQ(8, reader->read_bytes(bytes));
+    ASSERT_EQ(0x8D, bytes[0]);
+    ASSERT_TRUE(reader->read_bit());
     ASSERT_TRUE(reader->is_end_of_record());
     // no more records
     ASSERT_FALSE(reader->next_record());
 }
 
 TEST(MeasureRecordReader, Format01_MultipleShortRecords) {
-    FILE *tmp = tmpfile_with_contents("1\n01\n1\n");
+    FILE *tmp = tmpfile_with_contents("10\n01\n10\n");
     ASSERT_NE(tmp, nullptr);
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_01);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_01, 2);
     ASSERT_FALSE(reader->is_end_of_record());
-    // first record (1 bit)
+    // first record
     uint8_t bytes[]{0};
-    ASSERT_EQ(1, reader->read_bytes(bytes));
+    ASSERT_EQ(2, reader->read_bytes(bytes));
     ASSERT_EQ(1, bytes[0]);
     ASSERT_TRUE(reader->is_end_of_record());
-    // second_record (2 bits)
+    // second_record
     ASSERT_TRUE(reader->next_record());
     ASSERT_FALSE(reader->read_bit());
     ASSERT_TRUE(reader->read_bit());
     ASSERT_TRUE(reader->is_end_of_record());
-    // third record (1 bit)
+    // third record
     ASSERT_TRUE(reader->next_record());
     bytes[0] = 0;
-    ASSERT_EQ(1, reader->read_bytes(bytes));
+    ASSERT_EQ(2, reader->read_bytes(bytes));
     ASSERT_EQ(1, bytes[0]);
     ASSERT_TRUE(reader->is_end_of_record());
     // no more records
@@ -319,26 +302,28 @@ TEST(MeasureRecordReader, Format01_MultipleShortRecords) {
 TEST(MeasureRecordReader, FormatHits_MultipleRecords) {
     FILE *tmp = tmpfile_with_contents("0,1,2,4,5,8\n1\n0\n");
     ASSERT_NE(tmp, nullptr);
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_HITS);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_HITS, 9);
     ASSERT_FALSE(reader->is_end_of_record());
-    // first record (9 bits)
+    // first record
     uint8_t bytes[]{0};
     ASSERT_EQ(8, reader->read_bytes(bytes));
     ASSERT_EQ(0x37, bytes[0]);
     ASSERT_FALSE(reader->is_end_of_record());
     ASSERT_TRUE(reader->read_bit());
-    ASSERT_FALSE(reader->is_end_of_record());
-    // second_record (2 bits)
+    ASSERT_TRUE(reader->is_end_of_record());
+    // second_record
     ASSERT_TRUE(reader->next_record());
     ASSERT_FALSE(reader->read_bit());
     ASSERT_TRUE(reader->read_bit());
+    ASSERT_FALSE(reader->read_bit());
     ASSERT_FALSE(reader->is_end_of_record());
-    // third record (1 bit)
+    // third record
     ASSERT_TRUE(reader->next_record());
     bytes[0] = 0;
     ASSERT_EQ(8, reader->read_bytes(bytes));
     ASSERT_EQ(1, bytes[0]);
-    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->read_bit());
+    ASSERT_TRUE(reader->is_end_of_record());
     // no more records
     ASSERT_FALSE(reader->next_record());
 }
@@ -346,30 +331,30 @@ TEST(MeasureRecordReader, FormatHits_MultipleRecords) {
 TEST(MeasureRecordReader, FormatHits_MultipleShortRecords) {
     FILE *tmp = tmpfile_with_contents("0\n1\n0\n\n");
     ASSERT_NE(tmp, nullptr);
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_HITS);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_HITS, 2);
     ASSERT_FALSE(reader->is_end_of_record());
-    // first record (1 bit)
+    // first record
     uint8_t bytes[]{0};
-    ASSERT_EQ(8, reader->read_bytes(bytes));
+    ASSERT_EQ(2, reader->read_bytes(bytes));
     ASSERT_EQ(1, bytes[0]);
-    ASSERT_FALSE(reader->is_end_of_record());
-    // second_record (2 bits)
+    ASSERT_TRUE(reader->is_end_of_record());
+    // second_record
     ASSERT_TRUE(reader->next_record());
     ASSERT_FALSE(reader->read_bit());
     ASSERT_TRUE(reader->read_bit());
-    ASSERT_FALSE(reader->is_end_of_record());
-    // third record (1 bit)
+    ASSERT_TRUE(reader->is_end_of_record());
+    // third record
     ASSERT_TRUE(reader->next_record());
     bytes[0] = 0;
-    ASSERT_EQ(8, reader->read_bytes(bytes));
+    ASSERT_EQ(2, reader->read_bytes(bytes));
     ASSERT_EQ(1, bytes[0]);
-    ASSERT_FALSE(reader->is_end_of_record());
-    // fourth record (0 bits)
+    ASSERT_TRUE(reader->is_end_of_record());
+    // fourth record
     ASSERT_TRUE(reader->next_record());
     bytes[0] = 0xFF;
-    ASSERT_EQ(8, reader->read_bytes(bytes));
+    ASSERT_EQ(2, reader->read_bytes(bytes));
     ASSERT_EQ(0, bytes[0]);
-    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->is_end_of_record());
     // no more records
     ASSERT_FALSE(reader->next_record());
 }
@@ -377,14 +362,14 @@ TEST(MeasureRecordReader, FormatHits_MultipleShortRecords) {
 TEST(MeasureRecordReader, FormatDets_MultipleRecords) {
     FILE *tmp = tmpfile_with_contents("shot M0 M1 M2 M4 M5 M8\nshot M1\nshot M0\n");
     ASSERT_NE(tmp, nullptr);
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, 9);
     ASSERT_FALSE(reader->is_end_of_record());
     // first record
     uint8_t bytes[]{0};
     ASSERT_EQ(8, reader->read_bytes(bytes));
     ASSERT_EQ(0x37, bytes[0]);
     ASSERT_TRUE(reader->read_bit());
-    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->is_end_of_record());
     // second_record
     ASSERT_TRUE(reader->next_record());
     ASSERT_FALSE(reader->read_bit());
@@ -395,7 +380,8 @@ TEST(MeasureRecordReader, FormatDets_MultipleRecords) {
     bytes[0] = 0;
     ASSERT_EQ(8, reader->read_bytes(bytes));
     ASSERT_EQ(1, bytes[0]);
-    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->read_bit());
+    ASSERT_TRUE(reader->is_end_of_record());
     // no more recocrds
     ASSERT_FALSE(reader->next_record());
 }
@@ -403,30 +389,30 @@ TEST(MeasureRecordReader, FormatDets_MultipleRecords) {
 TEST(MeasureRecordReader, FormatDets_MultipleShortRecords) {
     FILE *tmp = tmpfile_with_contents("shot M0\nshot M1\nshot M0\nshot\n");
     ASSERT_NE(tmp, nullptr);
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, 2);
     ASSERT_FALSE(reader->is_end_of_record());
     // first record
     uint8_t bytes[]{0};
-    ASSERT_EQ(8, reader->read_bytes(bytes));
+    ASSERT_EQ(2, reader->read_bytes(bytes));
     ASSERT_EQ(1, bytes[0]);
-    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->is_end_of_record());
     // second_record
     ASSERT_TRUE(reader->next_record());
     ASSERT_FALSE(reader->read_bit());
     ASSERT_TRUE(reader->read_bit());
-    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->is_end_of_record());
     // third record
     ASSERT_TRUE(reader->next_record());
     bytes[0] = 0;
-    ASSERT_EQ(8, reader->read_bytes(bytes));
+    ASSERT_EQ(2, reader->read_bytes(bytes));
     ASSERT_EQ(1, bytes[0]);
-    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->is_end_of_record());
     // fourth record (0 bits)
     ASSERT_TRUE(reader->next_record());
     bytes[0] = 0xFF;
-    ASSERT_EQ(8, reader->read_bytes(bytes));
+    ASSERT_EQ(2, reader->read_bytes(bytes));
     ASSERT_EQ(0, bytes[0]);
-    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->is_end_of_record());
     // no more recocrds
     ASSERT_FALSE(reader->next_record());
 }
@@ -434,7 +420,7 @@ TEST(MeasureRecordReader, FormatDets_MultipleShortRecords) {
 TEST(MeasureRecordReader, Format01_InvalidInput) {
     FILE *tmp = tmpfile_with_contents("012\n");
     ASSERT_NE(tmp, nullptr);
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_01);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_01, 3);
     ASSERT_FALSE(reader->read_bit());
     ASSERT_TRUE(reader->read_bit());
     ASSERT_THROW({ reader->read_bit(); }, std::runtime_error);
@@ -443,7 +429,7 @@ TEST(MeasureRecordReader, Format01_InvalidInput) {
 TEST(MeasureRecordReader, FormatHits_InvalidInput) {
     FILE *tmp = tmpfile_with_contents("1,1\n");
     ASSERT_NE(tmp, nullptr);
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_HITS);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_HITS, 3);
     ASSERT_FALSE(reader->read_bit());
     ASSERT_TRUE(reader->read_bit());
     ASSERT_THROW({ reader->read_bit(); }, std::runtime_error);
@@ -452,5 +438,5 @@ TEST(MeasureRecordReader, FormatHits_InvalidInput) {
 TEST(MeasureRecordReader, FormatDets_InvalidInput) {
     FILE *tmp = tmpfile_with_contents("D2\n");
     ASSERT_NE(tmp, nullptr);
-    ASSERT_THROW({ MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS); }, std::runtime_error);
+    ASSERT_THROW({ MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, 3); }, std::runtime_error);
 }

--- a/src/io/measure_record_reader.test.cc
+++ b/src/io/measure_record_reader.test.cc
@@ -245,6 +245,126 @@ TEST(MeasureRecordReader, FormatDets_WriteRead) {
     }
 }
 
+TEST(MeasureRecordReader, Format01_WriteRead_MultipleRecords) {
+    uint8_t record1[]{0x12, 0xAB, 0x00, 0xFF, 0x75};
+    uint8_t record2[]{0x80, 0xFF, 0x01, 0x56, 0x57};
+    uint8_t record3[]{0x2F, 0x08, 0xF0, 0x1C, 0x60};
+    constexpr size_t num_bytes = sizeof(record1) / sizeof(uint8_t);
+    constexpr size_t bits_per_record = 8 * num_bytes - 1;
+
+    FILE *tmp = tmpfile();
+    auto writer = MeasureRecordWriter::make(tmp, SAMPLE_FORMAT_01);
+    writer->write_bytes({record1, record1 + num_bytes});
+    writer->write_end();
+    writer->write_bytes({record2, record2 + num_bytes});
+    writer->write_end();
+    writer->write_bytes({record3, record3 + num_bytes});
+    writer->write_end();
+
+    rewind(tmp);
+
+    uint8_t buf[num_bytes];
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_01, bits_per_record);
+
+    memset(buf, 0, num_bytes);
+    ASSERT_EQ(bits_per_record, reader->read_bytes({buf, buf + num_bytes}));
+    for (size_t i = 0; i < num_bytes; ++i) ASSERT_EQ(buf[i], record1[i]);
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->next_record());
+
+    memset(buf, 0, num_bytes);
+    ASSERT_EQ(bits_per_record, reader->read_bytes({buf, buf + num_bytes}));
+    for (size_t i = 0; i < num_bytes; ++i) ASSERT_EQ(buf[i], record2[i]);
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->next_record());
+
+    memset(buf, 0, num_bytes);
+    ASSERT_EQ(bits_per_record, reader->read_bytes({buf, buf + num_bytes}));
+    for (size_t i = 0; i < num_bytes; ++i) ASSERT_EQ(buf[i], record3[i]);
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->next_record());
+}
+
+TEST(MeasureRecordReader, FormatHits_WriteRead_MultipleRecords) {
+    uint8_t record1[]{0x12, 0xAB, 0x00, 0xFF, 0x75};
+    uint8_t record2[]{0x80, 0xFF, 0x01, 0x56, 0x57};
+    uint8_t record3[]{0x2F, 0x08, 0xF0, 0x1C, 0x60};
+    constexpr size_t num_bytes = sizeof(record1) / sizeof(uint8_t);
+    constexpr size_t bits_per_record = 8 * num_bytes - 1;
+
+    FILE *tmp = tmpfile();
+    auto writer = MeasureRecordWriter::make(tmp, SAMPLE_FORMAT_HITS);
+    writer->write_bytes({record1, record1 + num_bytes});
+    writer->write_end();
+    writer->write_bytes({record2, record2 + num_bytes});
+    writer->write_end();
+    writer->write_bytes({record3, record3 + num_bytes});
+    writer->write_end();
+
+    rewind(tmp);
+
+    uint8_t buf[num_bytes];
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_HITS, bits_per_record);
+
+    memset(buf, 0, num_bytes);
+    ASSERT_EQ(bits_per_record, reader->read_bytes({buf, buf + num_bytes}));
+    for (size_t i = 0; i < num_bytes; ++i) ASSERT_EQ(buf[i], record1[i]);
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->next_record());
+
+    memset(buf, 0, num_bytes);
+    ASSERT_EQ(bits_per_record, reader->read_bytes({buf, buf + num_bytes}));
+    for (size_t i = 0; i < num_bytes; ++i) ASSERT_EQ(buf[i], record2[i]);
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->next_record());
+
+    memset(buf, 0, num_bytes);
+    ASSERT_EQ(bits_per_record, reader->read_bytes({buf, buf + num_bytes}));
+    for (size_t i = 0; i < num_bytes; ++i) ASSERT_EQ(buf[i], record3[i]);
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->next_record());
+}
+
+TEST(MeasureRecordReader, FormatDets_WriteRead_MultipleRecords) {
+    uint8_t record1[]{0x12, 0xAB, 0x00, 0xFF, 0x75};
+    uint8_t record2[]{0x80, 0xFF, 0x01, 0x56, 0x57};
+    uint8_t record3[]{0x2F, 0x08, 0xF0, 0x1C, 0x60};
+    constexpr size_t num_bytes = sizeof(record1) / sizeof(uint8_t);
+    constexpr size_t bits_per_record = 8 * num_bytes - 1;
+
+    FILE *tmp = tmpfile();
+    auto writer = MeasureRecordWriter::make(tmp, SAMPLE_FORMAT_DETS);
+    writer->write_bytes({record1, record1 + num_bytes});
+    writer->write_end();
+    writer->write_bytes({record2, record2 + num_bytes});
+    writer->write_end();
+    writer->write_bytes({record3, record3 + num_bytes});
+    writer->write_end();
+
+    rewind(tmp);
+
+    uint8_t buf[num_bytes];
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, bits_per_record);
+
+    memset(buf, 0, num_bytes);
+    ASSERT_EQ(bits_per_record, reader->read_bytes({buf, buf + num_bytes}));
+    for (size_t i = 0; i < num_bytes; ++i) ASSERT_EQ(buf[i], record1[i]);
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->next_record());
+
+    memset(buf, 0, num_bytes);
+    ASSERT_EQ(bits_per_record, reader->read_bytes({buf, buf + num_bytes}));
+    for (size_t i = 0; i < num_bytes; ++i) ASSERT_EQ(buf[i], record2[i]);
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->next_record());
+
+    memset(buf, 0, num_bytes);
+    ASSERT_EQ(bits_per_record, reader->read_bytes({buf, buf + num_bytes}));
+    for (size_t i = 0; i < num_bytes; ++i) ASSERT_EQ(buf[i], record3[i]);
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->next_record());
+}
+
 TEST(MeasureRecordReader, Format01_MultipleRecords) {
     FILE *tmp = tmpfile_with_contents("111011001\n01000000\n101100011");
     ASSERT_NE(tmp, nullptr);

--- a/src/io/measure_record_reader.test.cc
+++ b/src/io/measure_record_reader.test.cc
@@ -15,16 +15,16 @@
  */
 
 #include "measure_record_reader.h"
-#include "measure_record_writer.h"
 
 #include "gtest/gtest.h"
 
 #include "../test_util.test.h"
+#include "measure_record_writer.h"
 
 using namespace stim_internal;
 
-FILE* tmpfile_with_contents(const std::string &contents) {
-    FILE* tmp = tmpfile();
+FILE *tmpfile_with_contents(const std::string &contents) {
+    FILE *tmp = tmpfile();
     size_t written = fwrite(contents.c_str(), 1, contents.size(), tmp);
     if (written != contents.size()) {
         int en = errno;
@@ -35,8 +35,8 @@ FILE* tmpfile_with_contents(const std::string &contents) {
     return tmp;
 }
 
-bool maybe_consume_keyword(FILE *in, const std::string& keyword, int &next);
-bool read_uint64(FILE* in, uint64_t &value, int &next);
+bool maybe_consume_keyword(FILE *in, const std::string &keyword, int &next);
+bool read_uint64(FILE *in, uint64_t &value, int &next);
 
 TEST(maybe_consume_keyword, FoundKeyword) {
     int next = 0;
@@ -231,7 +231,8 @@ TEST(MeasureRecordReader, Format01_WriteRead) {
     memset(dst, 0, num_bytes);
     FILE *tmp = write_records({src, src + num_bytes}, SAMPLE_FORMAT_01);
     rewind(tmp);
-    ASSERT_EQ(num_bytes * 8 - 1, read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_01, 8 * num_bytes - 1));
+    ASSERT_EQ(
+        num_bytes * 8 - 1, read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_01, 8 * num_bytes - 1));
     for (size_t i = 0; i < num_bytes; ++i) {
         ASSERT_EQ(src[i], dst[i]);
     }
@@ -244,7 +245,8 @@ TEST(MeasureRecordReader, FormatB8_WriteRead) {
     memset(dst, 0, num_bytes);
     FILE *tmp = write_records({src, src + num_bytes}, SAMPLE_FORMAT_B8);
     rewind(tmp);
-    ASSERT_EQ(num_bytes * 8 - 1, read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_B8, 8 * num_bytes - 1));
+    ASSERT_EQ(
+        num_bytes * 8 - 1, read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_B8, 8 * num_bytes - 1));
     for (size_t i = 0; i < num_bytes; ++i) {
         ASSERT_EQ(src[i], dst[i]);
     }
@@ -257,7 +259,8 @@ TEST(MeasureRecordReader, FormatR8_WriteRead) {
     memset(dst, 0, num_bytes);
     FILE *tmp = write_records({src, src + num_bytes}, SAMPLE_FORMAT_R8);
     rewind(tmp);
-    ASSERT_EQ(num_bytes * 8 - 1, read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_R8, 8 * num_bytes - 1));
+    ASSERT_EQ(
+        num_bytes * 8 - 1, read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_R8, 8 * num_bytes - 1));
     for (size_t i = 0; i < num_bytes; ++i) {
         ASSERT_EQ(src[i], dst[i]);
     }
@@ -270,7 +273,8 @@ TEST(MeasureRecordReader, FormatHits_WriteRead) {
     memset(dst, 0, num_bytes);
     FILE *tmp = write_records({src, src + num_bytes}, SAMPLE_FORMAT_HITS);
     rewind(tmp);
-    ASSERT_EQ(num_bytes * 8 - 1, read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_HITS, 8 * num_bytes - 1));
+    ASSERT_EQ(
+        num_bytes * 8 - 1, read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_HITS, 8 * num_bytes - 1));
     for (size_t i = 0; i < num_bytes; ++i) {
         ASSERT_EQ(src[i], dst[i]);
     }
@@ -283,7 +287,8 @@ TEST(MeasureRecordReader, FormatDets_WriteRead) {
     memset(dst, 0, num_bytes);
     FILE *tmp = write_records({src, src + num_bytes}, SAMPLE_FORMAT_DETS);
     rewind(tmp);
-    ASSERT_EQ(num_bytes * 8 - 1, read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_DETS, 8 * num_bytes - 1));
+    ASSERT_EQ(
+        num_bytes * 8 - 1, read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_DETS, 8 * num_bytes - 1));
     for (size_t i = 0; i < num_bytes; ++i) {
         ASSERT_EQ(src[i], dst[i]);
     }
@@ -312,19 +317,22 @@ TEST(MeasureRecordReader, Format01_WriteRead_MultipleRecords) {
 
     memset(buf, 0, num_bytes);
     ASSERT_EQ(bits_per_record, reader->read_bytes({buf, buf + num_bytes}));
-    for (size_t i = 0; i < num_bytes; ++i) ASSERT_EQ(buf[i], record1[i]);
+    for (size_t i = 0; i < num_bytes; ++i)
+        ASSERT_EQ(buf[i], record1[i]);
     ASSERT_TRUE(reader->is_end_of_record());
     ASSERT_TRUE(reader->next_record());
 
     memset(buf, 0, num_bytes);
     ASSERT_EQ(bits_per_record, reader->read_bytes({buf, buf + num_bytes}));
-    for (size_t i = 0; i < num_bytes; ++i) ASSERT_EQ(buf[i], record2[i]);
+    for (size_t i = 0; i < num_bytes; ++i)
+        ASSERT_EQ(buf[i], record2[i]);
     ASSERT_TRUE(reader->is_end_of_record());
     ASSERT_TRUE(reader->next_record());
 
     memset(buf, 0, num_bytes);
     ASSERT_EQ(bits_per_record, reader->read_bytes({buf, buf + num_bytes}));
-    for (size_t i = 0; i < num_bytes; ++i) ASSERT_EQ(buf[i], record3[i]);
+    for (size_t i = 0; i < num_bytes; ++i)
+        ASSERT_EQ(buf[i], record3[i]);
     ASSERT_TRUE(reader->is_end_of_record());
     ASSERT_FALSE(reader->next_record());
 }
@@ -352,19 +360,22 @@ TEST(MeasureRecordReader, FormatHits_WriteRead_MultipleRecords) {
 
     memset(buf, 0, num_bytes);
     ASSERT_EQ(bits_per_record, reader->read_bytes({buf, buf + num_bytes}));
-    for (size_t i = 0; i < num_bytes; ++i) ASSERT_EQ(buf[i], record1[i]);
+    for (size_t i = 0; i < num_bytes; ++i)
+        ASSERT_EQ(buf[i], record1[i]);
     ASSERT_TRUE(reader->is_end_of_record());
     ASSERT_TRUE(reader->next_record());
 
     memset(buf, 0, num_bytes);
     ASSERT_EQ(bits_per_record, reader->read_bytes({buf, buf + num_bytes}));
-    for (size_t i = 0; i < num_bytes; ++i) ASSERT_EQ(buf[i], record2[i]);
+    for (size_t i = 0; i < num_bytes; ++i)
+        ASSERT_EQ(buf[i], record2[i]);
     ASSERT_TRUE(reader->is_end_of_record());
     ASSERT_TRUE(reader->next_record());
 
     memset(buf, 0, num_bytes);
     ASSERT_EQ(bits_per_record, reader->read_bytes({buf, buf + num_bytes}));
-    for (size_t i = 0; i < num_bytes; ++i) ASSERT_EQ(buf[i], record3[i]);
+    for (size_t i = 0; i < num_bytes; ++i)
+        ASSERT_EQ(buf[i], record3[i]);
     ASSERT_TRUE(reader->is_end_of_record());
     ASSERT_FALSE(reader->next_record());
 }
@@ -392,19 +403,22 @@ TEST(MeasureRecordReader, FormatDets_WriteRead_MultipleRecords) {
 
     memset(buf, 0, num_bytes);
     ASSERT_EQ(bits_per_record, reader->read_bytes({buf, buf + num_bytes}));
-    for (size_t i = 0; i < num_bytes; ++i) ASSERT_EQ(buf[i], record1[i]);
+    for (size_t i = 0; i < num_bytes; ++i)
+        ASSERT_EQ(buf[i], record1[i]);
     ASSERT_TRUE(reader->is_end_of_record());
     ASSERT_TRUE(reader->next_record());
 
     memset(buf, 0, num_bytes);
     ASSERT_EQ(bits_per_record, reader->read_bytes({buf, buf + num_bytes}));
-    for (size_t i = 0; i < num_bytes; ++i) ASSERT_EQ(buf[i], record2[i]);
+    for (size_t i = 0; i < num_bytes; ++i)
+        ASSERT_EQ(buf[i], record2[i]);
     ASSERT_TRUE(reader->is_end_of_record());
     ASSERT_TRUE(reader->next_record());
 
     memset(buf, 0, num_bytes);
     ASSERT_EQ(bits_per_record, reader->read_bytes({buf, buf + num_bytes}));
-    for (size_t i = 0; i < num_bytes; ++i) ASSERT_EQ(buf[i], record3[i]);
+    for (size_t i = 0; i < num_bytes; ++i)
+        ASSERT_EQ(buf[i], record3[i]);
     ASSERT_TRUE(reader->is_end_of_record());
     ASSERT_FALSE(reader->next_record());
 }
@@ -680,4 +694,3 @@ TEST(MeasureRecordReader, FormatDets_InvalidInput) {
     ASSERT_NE(tmp, nullptr);
     ASSERT_THROW({ MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, 3); }, std::runtime_error);
 }
-

--- a/src/io/measure_record_reader.test.cc
+++ b/src/io/measure_record_reader.test.cc
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "measure_record_reader.h"
+#include "measure_record_writer.h"
+
+#include "gtest/gtest.h"
+
+#include "../test_util.test.h"
+
+using namespace stim_internal;
+
+FILE* tmpfile_with_contents(const std::string &contents) {
+    FILE* tmp = tmpfile();
+    size_t written = fwrite(contents.c_str(), 1, contents.size(), tmp);
+    if (written != contents.size()) {
+        int en = errno;
+        std::cerr << "Failed to write to tmpfile: " << strerror(en) << std::endl;
+        return nullptr;
+    }
+    rewind(tmp);
+    return tmp;
+}
+
+TEST(MeasureRecordReader, Format01) {
+    // We'll read the data like this:  |-0xF8-|0|-0xF8-|1|
+    FILE *tmp = tmpfile_with_contents("000111110000111111\n");
+    ASSERT_NE(tmp, nullptr);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_01);
+    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    // bits 0..7 == 0xF8
+    uint8_t bytes[]{0};
+    reader->read_bytes(bytes);
+    ASSERT_EQ(0xF8, bytes[0]);
+    // bit 8 == 0
+    ASSERT_FALSE(reader->read_bit());
+    // bits 9..16 == 0xF8
+    bytes[0] = 0;
+    reader->read_bytes(bytes);
+    ASSERT_EQ(0xF8, bytes[0]);
+    // bit 17 == 1
+    ASSERT_TRUE(reader->read_bit());
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->is_end_of_file());
+}
+
+TEST(MeasureRecordReader, FormatB8) {
+    FILE *tmp = tmpfile_with_contents("\xF8\xF0\x03");
+    ASSERT_NE(tmp, nullptr);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_B8);
+    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    // bits 0..7 == 0xF8
+    uint8_t bytes[]{0};
+    reader->read_bytes(bytes);
+    ASSERT_EQ(0xF8, bytes[0]);
+    // bit 8 == 0
+    ASSERT_FALSE(reader->read_bit());
+    // bits 9..16 == 0xF8
+    bytes[0] = 0;
+    reader->read_bytes(bytes);
+    ASSERT_EQ(0xF8, bytes[0]);
+    // bit 17 == 1
+    ASSERT_TRUE(reader->read_bit());
+    // bits 18..24 == 0
+    for (int i = 0; i < 6; ++i) {
+        ASSERT_FALSE(reader->is_end_of_record());
+        ASSERT_FALSE(reader->is_end_of_file());
+        ASSERT_FALSE(reader->read_bit());
+    }
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->is_end_of_file());
+}
+
+TEST(MeasureRecordReader, FormatHits) {
+    FILE *tmp = tmpfile_with_contents("3,4,5,6,7,12,13,14,15,16,17\n");
+    ASSERT_NE(tmp, nullptr);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_HITS, 18);
+    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    // bits 0..7 == 0xF8
+    uint8_t bytes[]{0};
+    reader->read_bytes(bytes);
+    ASSERT_EQ(0xF8, bytes[0]);
+    // bit 8 == 0
+    ASSERT_FALSE(reader->read_bit());
+    // bits 9..16 == 0xF8
+    bytes[0] = 0;
+    reader->read_bytes(bytes);
+    ASSERT_EQ(0xF8, bytes[0]);
+    // bit 17 == 1
+    ASSERT_TRUE(reader->read_bit());
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->is_end_of_file());
+}
+
+TEST(MeasureRecordReader, FormatR8) {
+    char tmp_data[]{3, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0};
+    FILE *tmp = tmpfile_with_contents(std::string(std::begin(tmp_data), std::end(tmp_data)));
+    ASSERT_NE(tmp, nullptr);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_R8);
+    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    // bits 0..7 == 0xF8
+    uint8_t bytes[]{0};
+    reader->read_bytes(bytes);
+    ASSERT_EQ(0xF8, bytes[0]);
+    // bit 8 == 0
+    ASSERT_FALSE(reader->read_bit());
+    // bits 9..16 == 0xF8
+    bytes[0] = 0;
+    reader->read_bytes(bytes);
+    ASSERT_EQ(0xF8, bytes[0]);
+    // bit 17 == 1
+    ASSERT_TRUE(reader->read_bit());
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->is_end_of_file());
+}
+
+TEST(MeasureRecordReader, FormatR8_LongGap) {
+    FILE *tmp = tmpfile_with_contents("\xFF\xFF\x02\x20");
+    ASSERT_NE(tmp, nullptr);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_R8);
+    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    uint8_t bytes[]{1, 2, 3, 4, 5, 6, 7, 8};
+    for (int i = 0; i < 8; ++i) {
+        reader->read_bytes({bytes, bytes + 8});
+        for (int j = 0; j < 8; ++j) {
+            ASSERT_EQ(0, bytes[j]);
+            bytes[j] = 123;
+        }
+    }
+    ASSERT_TRUE(reader->read_bit());
+    reader->read_bytes({bytes, bytes + 4});
+    ASSERT_EQ(0, bytes[0]);
+    ASSERT_EQ(0, bytes[1]);
+    ASSERT_EQ(0, bytes[2]);
+    ASSERT_EQ(0, bytes[3]);
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->is_end_of_file());
+}
+
+TEST(MeasureRecordReader, FormatDets) {
+    FILE *tmp = tmpfile_with_contents("shot D3 D4 D5 D6 D7 D12 D13 D14 D15 D16 L1\n");
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS);
+    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+
+    // Detection events:
+    // bits 0..7 == 0xF8
+    uint8_t bytes[]{0};
+    reader->read_bytes(bytes);
+    ASSERT_EQ(0xF8, bytes[0]);
+    ASSERT_EQ(reader->current_result_type(), 'D');
+    // bit 8 == 0
+    ASSERT_FALSE(reader->read_bit());
+    // bits 9..16 == 0xF8
+    bytes[0] = 0;
+    reader->read_bytes(bytes);
+    ASSERT_EQ(0xF8, bytes[0]);
+
+    // Logical observables:
+    // bit 0 == 0
+    ASSERT_FALSE(reader->read_bit());
+    ASSERT_EQ(reader->current_result_type(), 'L');
+    // bit 1 == 1
+    ASSERT_TRUE(reader->read_bit());
+
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->is_end_of_file());
+}
+
+FILE *write_records(ConstPointerRange<uint8_t> data, SampleFormat format) {
+    FILE *tmp = tmpfile();
+    auto writer = MeasureRecordWriter::make(tmp, format);
+    writer->write_bytes(data);
+    writer->write_end();
+    return tmp;
+}
+
+size_t read_records_as_bytes(FILE *in, PointerRange<uint8_t> buf, SampleFormat format, size_t num_bits) {
+    auto reader = MeasureRecordReader::make(in, format, num_bits);
+    return reader->read_bytes(buf);
+}
+
+TEST(MeasureRecordReader, Format01_WriteRead) {
+    uint8_t src[]{0, 1, 2, 3, 4, 0xFF, 0xBF, 0xFE, 80, 0, 0, 1, 20};
+    constexpr size_t num_bytes = sizeof(src) / sizeof(uint8_t);
+    uint8_t dst[num_bytes];
+    memset(dst, 0, num_bytes);
+    FILE *tmp = write_records({src, src + num_bytes}, SAMPLE_FORMAT_01);
+    rewind(tmp);
+    read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_01, num_bytes * 8);
+    for (size_t i = 0; i < num_bytes; ++i) {
+        ASSERT_EQ(src[i], dst[i]);
+    }
+}
+
+TEST(MeasureRecordReader, FormatB8_WriteRead) {
+    uint8_t src[]{0, 1, 2, 3, 4, 0xFF, 0xBF, 0xFE, 80, 0, 0, 1, 20};
+    constexpr size_t num_bytes = sizeof(src) / sizeof(uint8_t);
+    uint8_t dst[num_bytes];
+    memset(dst, 0, num_bytes);
+    FILE *tmp = write_records({src, src + num_bytes}, SAMPLE_FORMAT_B8);
+    rewind(tmp);
+    read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_B8, num_bytes * 8);
+    for (size_t i = 0; i < num_bytes; ++i) {
+        ASSERT_EQ(src[i], dst[i]);
+    }
+}
+
+TEST(MeasureRecordReader, FormatR8_WriteRead) {
+    uint8_t src[]{0, 1, 2, 3, 4, 0xFF, 0xBF, 0xFE, 80, 0, 0, 1, 20};
+    constexpr size_t num_bytes = sizeof(src) / sizeof(uint8_t);
+    uint8_t dst[num_bytes];
+    memset(dst, 0, num_bytes);
+    FILE *tmp = write_records({src, src + num_bytes}, SAMPLE_FORMAT_R8);
+    rewind(tmp);
+    read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_R8, num_bytes * 8);
+    for (size_t i = 0; i < num_bytes; ++i) {
+        ASSERT_EQ(src[i], dst[i]);
+    }
+}
+
+TEST(MeasureRecordReader, FormatHits_WriteRead) {
+    uint8_t src[]{0, 1, 2, 3, 4, 0xFF, 0xBF, 0xFE, 80, 0, 0, 1, 20};
+    constexpr size_t num_bytes = sizeof(src) / sizeof(uint8_t);
+    uint8_t dst[num_bytes];
+    memset(dst, 0, num_bytes);
+    FILE *tmp = write_records({src, src + num_bytes}, SAMPLE_FORMAT_HITS);
+    rewind(tmp);
+    read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_HITS, num_bytes * 8);
+    for (size_t i = 0; i < num_bytes; ++i) {
+        ASSERT_EQ(src[i], dst[i]);
+    }
+}
+
+TEST(MeasureRecordReader, FormatDets_WriteRead) {
+    uint8_t src[]{0, 1, 2, 3, 4, 0xFF, 0xBF, 0xFE, 80, 0, 0, 1, 20};
+    constexpr size_t num_bytes = sizeof(src) / sizeof(uint8_t);
+    uint8_t dst[num_bytes];
+    memset(dst, 0, num_bytes);
+    FILE *tmp = write_records({src, src + num_bytes}, SAMPLE_FORMAT_DETS);
+    rewind(tmp);
+    read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_DETS, num_bytes * 8);
+    for (size_t i = 0; i < num_bytes; ++i) {
+        ASSERT_EQ(src[i], dst[i]);
+    }
+}
+
+// TODO: add tests for num_bits, including off byte boundaries

--- a/src/io/measure_record_reader.test.cc
+++ b/src/io/measure_record_reader.test.cc
@@ -44,13 +44,13 @@ TEST(MeasureRecordReader, Format01) {
     ASSERT_FALSE(reader->is_end_of_file());
     // bits 0..7 == 0xF8
     uint8_t bytes[]{0};
-    reader->read_bytes(bytes);
+    ASSERT_EQ(8, reader->read_bytes(bytes));
     ASSERT_EQ(0xF8, bytes[0]);
     // bit 8 == 0
     ASSERT_FALSE(reader->read_bit());
     // bits 9..16 == 0xF8
     bytes[0] = 0;
-    reader->read_bytes(bytes);
+    ASSERT_EQ(8, reader->read_bytes(bytes));
     ASSERT_EQ(0xF8, bytes[0]);
     // bit 17 == 1
     ASSERT_TRUE(reader->read_bit());
@@ -66,13 +66,13 @@ TEST(MeasureRecordReader, FormatB8) {
     ASSERT_FALSE(reader->is_end_of_file());
     // bits 0..7 == 0xF8
     uint8_t bytes[]{0};
-    reader->read_bytes(bytes);
+    ASSERT_EQ(8, reader->read_bytes(bytes));
     ASSERT_EQ(0xF8, bytes[0]);
     // bit 8 == 0
     ASSERT_FALSE(reader->read_bit());
     // bits 9..16 == 0xF8
     bytes[0] = 0;
-    reader->read_bytes(bytes);
+    ASSERT_EQ(8, reader->read_bytes(bytes));
     ASSERT_EQ(0xF8, bytes[0]);
     // bit 17 == 1
     ASSERT_TRUE(reader->read_bit());
@@ -94,13 +94,13 @@ TEST(MeasureRecordReader, FormatHits) {
     ASSERT_FALSE(reader->is_end_of_file());
     // bits 0..7 == 0xF8
     uint8_t bytes[]{0};
-    reader->read_bytes(bytes);
+    ASSERT_EQ(8, reader->read_bytes(bytes));
     ASSERT_EQ(0xF8, bytes[0]);
     // bit 8 == 0
     ASSERT_FALSE(reader->read_bit());
     // bits 9..16 == 0xF8
     bytes[0] = 0;
-    reader->read_bytes(bytes);
+    ASSERT_EQ(8, reader->read_bytes(bytes));
     ASSERT_EQ(0xF8, bytes[0]);
     // bit 17 == 1
     ASSERT_TRUE(reader->read_bit());
@@ -117,13 +117,13 @@ TEST(MeasureRecordReader, FormatR8) {
     ASSERT_FALSE(reader->is_end_of_file());
     // bits 0..7 == 0xF8
     uint8_t bytes[]{0};
-    reader->read_bytes(bytes);
+    ASSERT_EQ(8, reader->read_bytes(bytes));
     ASSERT_EQ(0xF8, bytes[0]);
     // bit 8 == 0
     ASSERT_FALSE(reader->read_bit());
     // bits 9..16 == 0xF8
     bytes[0] = 0;
-    reader->read_bytes(bytes);
+    ASSERT_EQ(8, reader->read_bytes(bytes));
     ASSERT_EQ(0xF8, bytes[0]);
     // bit 17 == 1
     ASSERT_TRUE(reader->read_bit());
@@ -139,14 +139,14 @@ TEST(MeasureRecordReader, FormatR8_LongGap) {
     ASSERT_FALSE(reader->is_end_of_file());
     uint8_t bytes[]{1, 2, 3, 4, 5, 6, 7, 8};
     for (int i = 0; i < 8; ++i) {
-        reader->read_bytes({bytes, bytes + 8});
+        ASSERT_EQ(64, reader->read_bytes({bytes, bytes + 8}));
         for (int j = 0; j < 8; ++j) {
             ASSERT_EQ(0, bytes[j]);
             bytes[j] = 123;
         }
     }
     ASSERT_TRUE(reader->read_bit());
-    reader->read_bytes({bytes, bytes + 4});
+    ASSERT_EQ(32, reader->read_bytes({bytes, bytes + 4}));
     ASSERT_EQ(0, bytes[0]);
     ASSERT_EQ(0, bytes[1]);
     ASSERT_EQ(0, bytes[2]);
@@ -157,21 +157,21 @@ TEST(MeasureRecordReader, FormatR8_LongGap) {
 
 TEST(MeasureRecordReader, FormatDets) {
     FILE *tmp = tmpfile_with_contents("shot D3 D4 D5 D6 D7 D12 D13 D14 D15 D16 L1\n");
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, 19);
     ASSERT_FALSE(reader->is_end_of_record());
     ASSERT_FALSE(reader->is_end_of_file());
 
     // Detection events:
     // bits 0..7 == 0xF8
     uint8_t bytes[]{0};
-    reader->read_bytes(bytes);
+    ASSERT_EQ(8, reader->read_bytes(bytes));
     ASSERT_EQ(0xF8, bytes[0]);
     ASSERT_EQ(reader->current_result_type(), 'D');
     // bit 8 == 0
     ASSERT_FALSE(reader->read_bit());
     // bits 9..16 == 0xF8
     bytes[0] = 0;
-    reader->read_bytes(bytes);
+    ASSERT_EQ(8, reader->read_bytes(bytes));
     ASSERT_EQ(0xF8, bytes[0]);
 
     // Logical observables:
@@ -205,7 +205,7 @@ TEST(MeasureRecordReader, Format01_WriteRead) {
     memset(dst, 0, num_bytes);
     FILE *tmp = write_records({src, src + num_bytes}, SAMPLE_FORMAT_01);
     rewind(tmp);
-    read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_01, num_bytes * 8);
+    ASSERT_EQ(num_bytes * 8, read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_01, num_bytes * 8));
     for (size_t i = 0; i < num_bytes; ++i) {
         ASSERT_EQ(src[i], dst[i]);
     }
@@ -218,7 +218,7 @@ TEST(MeasureRecordReader, FormatB8_WriteRead) {
     memset(dst, 0, num_bytes);
     FILE *tmp = write_records({src, src + num_bytes}, SAMPLE_FORMAT_B8);
     rewind(tmp);
-    read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_B8, num_bytes * 8);
+    ASSERT_EQ(num_bytes * 8, read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_B8, num_bytes * 8));
     for (size_t i = 0; i < num_bytes; ++i) {
         ASSERT_EQ(src[i], dst[i]);
     }
@@ -231,7 +231,7 @@ TEST(MeasureRecordReader, FormatR8_WriteRead) {
     memset(dst, 0, num_bytes);
     FILE *tmp = write_records({src, src + num_bytes}, SAMPLE_FORMAT_R8);
     rewind(tmp);
-    read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_R8, num_bytes * 8);
+    ASSERT_EQ(num_bytes * 8, read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_R8, num_bytes * 8));
     for (size_t i = 0; i < num_bytes; ++i) {
         ASSERT_EQ(src[i], dst[i]);
     }
@@ -244,7 +244,7 @@ TEST(MeasureRecordReader, FormatHits_WriteRead) {
     memset(dst, 0, num_bytes);
     FILE *tmp = write_records({src, src + num_bytes}, SAMPLE_FORMAT_HITS);
     rewind(tmp);
-    read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_HITS, num_bytes * 8);
+    ASSERT_EQ(num_bytes * 8, read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_HITS, num_bytes * 8));
     for (size_t i = 0; i < num_bytes; ++i) {
         ASSERT_EQ(src[i], dst[i]);
     }
@@ -257,10 +257,242 @@ TEST(MeasureRecordReader, FormatDets_WriteRead) {
     memset(dst, 0, num_bytes);
     FILE *tmp = write_records({src, src + num_bytes}, SAMPLE_FORMAT_DETS);
     rewind(tmp);
-    read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_DETS, num_bytes * 8);
+    // TODO: Use max_bits for record size rather than overall size
+    ASSERT_EQ(101, read_records_as_bytes(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_DETS, num_bytes * 8));
     for (size_t i = 0; i < num_bytes; ++i) {
         ASSERT_EQ(src[i], dst[i]);
     }
 }
 
-// TODO: add tests for num_bits, including off byte boundaries
+TEST(MeasureRecordReader, Format01_MultipleRecords) {
+    FILE *tmp = tmpfile_with_contents("111011001\n01\n1");
+    ASSERT_NE(tmp, nullptr);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_01);
+    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    // first record (9 bits)
+    uint8_t bytes[]{0};
+    ASSERT_EQ(8, reader->read_bytes(bytes));
+    ASSERT_EQ(0x37, bytes[0]);
+    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    ASSERT_TRUE(reader->read_bit());
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    // second_record (2 bits)
+    ASSERT_FALSE(reader->read_bit());
+    ASSERT_TRUE(reader->read_bit());
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    // third record (1 bit)
+    bytes[0] = 0;
+    ASSERT_EQ(1, reader->read_bytes(bytes));
+    ASSERT_EQ(1, bytes[0]);
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->is_end_of_file());
+}
+
+TEST(MeasureRecordReader, Format01_MultipleShortRecords) {
+    FILE *tmp = tmpfile_with_contents("1\n01\n1\n");
+    ASSERT_NE(tmp, nullptr);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_01);
+    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    // first record (1 bit)
+    uint8_t bytes[]{0};
+    ASSERT_EQ(1, reader->read_bytes(bytes));
+    ASSERT_EQ(1, bytes[0]);
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    // second_record (2 bits)
+    ASSERT_FALSE(reader->read_bit());
+    ASSERT_TRUE(reader->read_bit());
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    // third record (1 bit)
+    bytes[0] = 0;
+    ASSERT_EQ(1, reader->read_bytes(bytes));
+    ASSERT_EQ(1, bytes[0]);
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->is_end_of_file());
+}
+
+TEST(MeasureRecordReader, FormatDets_MultipleRecords) {
+    FILE *tmp = tmpfile_with_contents("shot M0 M1 M2 M4 M5 M8\nshot M1\nshot M0\n");
+    ASSERT_NE(tmp, nullptr);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS);
+    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    // first record
+    uint8_t bytes[]{0};
+    ASSERT_EQ(8, reader->read_bytes(bytes));
+    ASSERT_EQ(0x37, bytes[0]);
+    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    ASSERT_TRUE(reader->read_bit());
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    // second_record
+    ASSERT_FALSE(reader->read_bit());
+    ASSERT_TRUE(reader->read_bit());
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    // third record
+    bytes[0] = 0;
+    ASSERT_EQ(1, reader->read_bytes(bytes));
+    ASSERT_EQ(1, bytes[0]);
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->is_end_of_file());
+}
+
+TEST(MeasureRecordReader, FormatDets_MultipleShortRecords) {
+    FILE *tmp = tmpfile_with_contents("shot M0\nshot M1\nshot M0\n");
+    ASSERT_NE(tmp, nullptr);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS);
+    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    // first record
+    uint8_t bytes[]{0};
+    ASSERT_EQ(1, reader->read_bytes(bytes));
+    ASSERT_EQ(1, bytes[0]);
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    // second_record
+    ASSERT_FALSE(reader->read_bit());
+    ASSERT_TRUE(reader->read_bit());
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    // third record
+    bytes[0] = 0;
+    ASSERT_EQ(1, reader->read_bytes(bytes));
+    ASSERT_EQ(1, bytes[0]);
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->is_end_of_file());
+}
+
+TEST(MeasureRecordReader, Format01_Limit_ReadBytes) {
+    FILE *tmp = tmpfile_with_contents("01111111\n");
+    ASSERT_NE(tmp, nullptr);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_01, 5);
+    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    uint8_t bytes[]{0};
+    ASSERT_EQ(5, reader->read_bytes(bytes));
+    ASSERT_EQ(0x1E, bytes[0]);
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->is_end_of_file());
+}
+
+TEST(MeasureRecordReader, FormatB8_Limit_ReadBytes) {
+    FILE *tmp = tmpfile_with_contents("\xFE");
+    ASSERT_NE(tmp, nullptr);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_B8, 5);
+    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    uint8_t bytes[]{0};
+    ASSERT_EQ(5, reader->read_bytes(bytes));
+    ASSERT_EQ(0x1E, bytes[0]);
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->is_end_of_file());
+}
+
+TEST(MeasureRecordReader, FormatHits_Limit_ReadBytes) {
+    FILE *tmp = tmpfile_with_contents("1,2,3,4,5,6,7\n");
+    ASSERT_NE(tmp, nullptr);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_HITS, 5);
+    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    uint8_t bytes[]{0};
+    ASSERT_EQ(5, reader->read_bytes(bytes));
+    ASSERT_EQ(0x1E, bytes[0]);
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->is_end_of_file());
+}
+
+TEST(MeasureRecordReader, FormatR8_Limit_ReadBytes) {
+    char tmp_data[]{1, 0, 0, 0, 0, 0, 0, 0};
+    FILE *tmp = tmpfile_with_contents(std::string(std::begin(tmp_data), std::end(tmp_data)));
+    ASSERT_NE(tmp, nullptr);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_R8, 5);
+    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    uint8_t bytes[]{0};
+    ASSERT_EQ(5, reader->read_bytes(bytes));
+    ASSERT_EQ(0x1E, bytes[0]);
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->is_end_of_file());
+}
+
+TEST(MeasureRecordReader, FormatDets_Limit_ReadBytes) {
+    FILE *tmp = tmpfile_with_contents("shot M1 M2 M3 M4 M5 M6 M7\n");
+    ASSERT_NE(tmp, nullptr);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, 5);
+    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    uint8_t bytes[]{0};
+    ASSERT_EQ(5, reader->read_bytes(bytes));
+    ASSERT_EQ(0x1E, bytes[0]);
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->is_end_of_file());
+}
+
+TEST(MeasureRecordReader, Format01_Limit_ReadBits) {
+    FILE *tmp = tmpfile_with_contents("01111111\n");
+    ASSERT_NE(tmp, nullptr);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_01, 2);
+    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    ASSERT_FALSE(reader->read_bit());
+    ASSERT_TRUE(reader->read_bit());
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->is_end_of_file());
+}
+
+TEST(MeasureRecordReader, FormatB8_Limit_ReadBits) {
+    FILE *tmp = tmpfile_with_contents("\xFE");
+    ASSERT_NE(tmp, nullptr);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_B8, 2);
+    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    ASSERT_FALSE(reader->read_bit());
+    ASSERT_TRUE(reader->read_bit());
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->is_end_of_file());
+}
+
+TEST(MeasureRecordReader, FormatHits_Limit_ReadBits) {
+    FILE *tmp = tmpfile_with_contents("1,2,3,4,5,6,7\n");
+    ASSERT_NE(tmp, nullptr);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_HITS, 2);
+    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    ASSERT_FALSE(reader->read_bit());
+    ASSERT_TRUE(reader->read_bit());
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->is_end_of_file());
+}
+
+TEST(MeasureRecordReader, FormatR8_Limit_ReadBits) {
+    char tmp_data[]{1, 0, 0, 0, 0, 0, 0, 0};
+    FILE *tmp = tmpfile_with_contents(std::string(std::begin(tmp_data), std::end(tmp_data)));
+    ASSERT_NE(tmp, nullptr);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_R8, 2);
+    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    ASSERT_FALSE(reader->read_bit());
+    ASSERT_TRUE(reader->read_bit());
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->is_end_of_file());
+}
+
+TEST(MeasureRecordReader, FormatDets_Limit_ReadBits) {
+    FILE *tmp = tmpfile_with_contents("shot M1 M2 M3 M4 M5 M6 M7\n");
+    ASSERT_NE(tmp, nullptr);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, 2);
+    ASSERT_FALSE(reader->is_end_of_record());
+    ASSERT_FALSE(reader->is_end_of_file());
+    ASSERT_FALSE(reader->read_bit());
+    ASSERT_TRUE(reader->read_bit());
+    ASSERT_TRUE(reader->is_end_of_record());
+    ASSERT_TRUE(reader->is_end_of_file());
+}

--- a/src/io/measure_record_reader.test.cc
+++ b/src/io/measure_record_reader.test.cc
@@ -141,7 +141,7 @@ TEST(MeasureRecordReader, FormatR8_LongGap) {
 
 TEST(MeasureRecordReader, FormatDets) {
     FILE *tmp = tmpfile_with_contents("shot D3 D4 D5 D6 D7 D12 D13 D14 D15 D16 L1\n");
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, 17 + 2);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, 0, 17, 2);
     ASSERT_FALSE(reader->is_end_of_record());
 
     // Detection events:
@@ -417,7 +417,7 @@ TEST(MeasureRecordReader, FormatDets_MultipleShortRecords) {
     ASSERT_FALSE(reader->next_record());
 }
 
-TEST(MeasureRecordReader, FormatDets_MultipleResultTypes) {
+TEST(MeasureRecordReader, FormatDets_MultipleResultTypes_D0L0) {
     FILE *tmp = tmpfile_with_contents("shot D0 D3 D5 L1 L2\n");
     ASSERT_NE(tmp, nullptr);
     auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, 0, 7, 4);
@@ -432,6 +432,63 @@ TEST(MeasureRecordReader, FormatDets_MultipleResultTypes) {
     ASSERT_EQ('L', reader->current_result_type());
     ASSERT_EQ(4, reader->read_bytes(bytes));
     ASSERT_EQ(6, bytes[0]);
+
+    ASSERT_FALSE(reader->next_record());
+}
+
+TEST(MeasureRecordReader, FormatDets_MultipleResultTypes_D1L0) {
+    FILE *tmp = tmpfile_with_contents("shot D0 D3 D5 D6 L1 L2\n");
+    ASSERT_NE(tmp, nullptr);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, 0, 7, 4);
+    ASSERT_FALSE(reader->is_end_of_record());
+    // Detection events
+    uint8_t bytes[]{0};
+    ASSERT_EQ('D', reader->current_result_type());
+    ASSERT_EQ(7, reader->read_bytes(bytes));
+    ASSERT_EQ(0x69, bytes[0]);
+    // Logiacl observables
+    bytes[0] = 0;
+    ASSERT_EQ('L', reader->current_result_type());
+    ASSERT_EQ(4, reader->read_bytes(bytes));
+    ASSERT_EQ(6, bytes[0]);
+
+    ASSERT_FALSE(reader->next_record());
+}
+
+TEST(MeasureRecordReader, FormatDets_MultipleResultTypes_D0L1) {
+    FILE *tmp = tmpfile_with_contents("shot D0 D3 D5 L0 L1 L2\n");
+    ASSERT_NE(tmp, nullptr);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, 0, 7, 4);
+    ASSERT_FALSE(reader->is_end_of_record());
+    // Detection events
+    uint8_t bytes[]{0};
+    ASSERT_EQ('D', reader->current_result_type());
+    ASSERT_EQ(7, reader->read_bytes(bytes));
+    ASSERT_EQ(0x29, bytes[0]);
+    // Logiacl observables
+    bytes[0] = 0;
+    ASSERT_EQ('L', reader->current_result_type());
+    ASSERT_EQ(4, reader->read_bytes(bytes));
+    ASSERT_EQ(7, bytes[0]);
+
+    ASSERT_FALSE(reader->next_record());
+}
+
+TEST(MeasureRecordReader, FormatDets_MultipleResultTypes_D1L1) {
+    FILE *tmp = tmpfile_with_contents("shot D0 D3 D5 D6 L0 L1 L2\n");
+    ASSERT_NE(tmp, nullptr);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, 0, 7, 4);
+    ASSERT_FALSE(reader->is_end_of_record());
+    // Detection events
+    uint8_t bytes[]{0};
+    ASSERT_EQ('D', reader->current_result_type());
+    ASSERT_EQ(7, reader->read_bytes(bytes));
+    ASSERT_EQ(0x69, bytes[0]);
+    // Logiacl observables
+    bytes[0] = 0;
+    ASSERT_EQ('L', reader->current_result_type());
+    ASSERT_EQ(4, reader->read_bytes(bytes));
+    ASSERT_EQ(7, bytes[0]);
 
     ASSERT_FALSE(reader->next_record());
 }

--- a/src/io/measure_record_reader.test.cc
+++ b/src/io/measure_record_reader.test.cc
@@ -417,6 +417,25 @@ TEST(MeasureRecordReader, FormatDets_MultipleShortRecords) {
     ASSERT_FALSE(reader->next_record());
 }
 
+TEST(MeasureRecordReader, FormatDets_MultipleResultTypes) {
+    FILE *tmp = tmpfile_with_contents("shot D0 D3 D5 L1 L2\n");
+    ASSERT_NE(tmp, nullptr);
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, 0, 7, 4);
+    ASSERT_FALSE(reader->is_end_of_record());
+    // Detection events
+    uint8_t bytes[]{0};
+    ASSERT_EQ('D', reader->current_result_type());
+    ASSERT_EQ(7, reader->read_bytes(bytes));
+    ASSERT_EQ(0x29, bytes[0]);
+    // Logiacl observables
+    bytes[0] = 0;
+    ASSERT_EQ('L', reader->current_result_type());
+    ASSERT_EQ(4, reader->read_bytes(bytes));
+    ASSERT_EQ(6, bytes[0]);
+
+    ASSERT_FALSE(reader->next_record());
+}
+
 TEST(MeasureRecordReader, Format01_InvalidInput) {
     FILE *tmp = tmpfile_with_contents("012\n");
     ASSERT_NE(tmp, nullptr);

--- a/src/io/measure_record_writer.h
+++ b/src/io/measure_record_writer.h
@@ -36,7 +36,7 @@ struct MeasureRecordWriter {
     virtual void write_bit(bool b) = 0;
     /// Writes (or buffers) multiple measurement results.
     virtual void write_bytes(ConstPointerRange<uint8_t> data);
-    /// Flushes all buffered measurement results and writes any end-of-result markers that are needed (e.g. a newline).
+    /// Flushes all buffered measurement results and writes any end-of-record markers that are needed (e.g. a newline).
     virtual void write_end() = 0;
     /// Used to control the DETS format prefix character (M for measurement, D for detector, L for logical observable).
     ///


### PR DESCRIPTION
The API is simple, but supports rather varied file formats (one vs many measure records per file, known vs unknown record length) in a consistent way.

Tests fall into three groups: counterparts to tests for writers, write-read-compare tests and additional tests for multi-record file formats.

Follow-ups:
* benchmarking tests for the readers,
* integration with `MeasureRecord`,
* support for PTB64 file format,
* read counterpart to `write_table_data`,
* possible refactoring of `write_table_data` to fit it into `MeasureRecordWriters` and similar for the read side (contingent on a fix for the performance regression this is causing).