### PR TITLE
Fix dependency on cirq

### DIFF
--- a/glue/cirq/setup.py
+++ b/glue/cirq/setup.py
@@ -32,6 +32,6 @@ setup(
     long_description_content_type='text/markdown',
     python_requires='>=3.6.0',
     data_files=['README.md'],
-    install_requires=['stim', 'cirq'],
+    install_requires=['stim', 'cirq-core'],
     tests_require=['pytest', 'python3-distutils'],
 )


### PR DESCRIPTION
- cirq is now a meta-package that pulls in all cirq
    packages including cirq-google, cirq-ionq, cirq-rigetti, etc.
- Change dependency to cirq-core to only pull in necessary components.