### PR TITLE
Add 'skip_reference_sample' pybind option and do some general cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,7 @@ jobs:
       - run: cmake .
       - run: make stim
       - run: diff doc/gates.md <(out/stim --help gates_markdown)
+      - run: diff doc/result_formats.md <(out/stim --help formats_markdown)
   test_pybind:
     runs-on: ubuntu-16.04
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ set(SOURCE_FILES_NO_MAIN
         src/circuit/gate_data_swaps.cc
         src/circuit/gate_target.cc
         src/dem/detector_error_model.cc
-        src/gate_help.cc
+        src/help.cc
         src/gen/circuit_gen_main.cc
         src/gen/circuit_gen_params.cc
         src/gen/gen_color_code.cc
@@ -58,7 +58,8 @@ set(SOURCE_FILES_NO_MAIN
         src/io/measure_record.cc
         src/io/measure_record_reader.cc
         src/io/measure_record_writer.cc
-        src/main_helper.cc
+        src/io/stim_data_formats.cc
+        src/main_namespaced.cc
         src/probability_util.cc
         src/simd/bit_ref.cc
         src/simd/simd_bit_table.cc
@@ -95,7 +96,7 @@ set(TEST_FILES
         src/io/measure_record_batch_writer.test.cc
         src/io/measure_record_reader.test.cc
         src/io/measure_record_writer.test.cc
-        src/main_helper.test.cc
+        src/main_namespaced.test.cc
         src/probability_util.test.cc
         src/simd/bit_ref.test.cc
         src/simd/fixed_cap_vector.test.cc
@@ -123,7 +124,7 @@ set(BENCHMARK_FILES
         src/benchmark_util.perf.cc
         src/circuit/circuit.perf.cc
         src/circuit/gate_data.perf.cc
-        src/main.perf.cc
+        src/main_namespaced.perf.cc
         src/probability_util.perf.cc
         src/simd/simd_bit_table.perf.cc
         src/simd/simd_bits.perf.cc

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ all operated on simultaneously by individual CPU instructions.
 
 Circuits can be input using the [stim circuit file format (.stim)](doc/file_format_stim_circuit.md).
 
-Samples can be output using [a variety of text and binary formats](doc/usage_command_line.md#out_format).
+Samples can be output using [a variety of text and binary formats](doc/result_formats.md).
 
 Error models can be output using the [detector error model file format (.dem)](doc/file_format_dem_detector_error_model.md).
 

--- a/doc/result_formats.md
+++ b/doc/result_formats.md
@@ -1,0 +1,423 @@
+# Result formats supported by Stim
+
+- [01](#01)
+- [b8](#b8)
+- [dets](#dets)
+- [hits](#hits)
+- [ptb64](#ptb64)
+- [r8](#r8)
+
+- <a name="01"></a>**`01`**
+    
+    A human readable format that stores shots as lines of '0' and '1' characters.
+    
+    The data from each shot is terminated by a newline character '\n'. Each character in the line is a '0' (indicating
+    False) or a '1' (indicating True) corresponding to a measurement result (or a detector result) from a circuit.
+    
+    This is the default format used when saving to files.
+    
+    Example:
+    
+        >>> with tempfile.NamedTemporaryFile() as t:
+        ...     stim.Circuit("""
+        ...         X 1
+        ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
+        ...     """).compile_sampler().sample_write(shots=10, filepath=t.name, format="01")
+        ...     with open(t.name) as f:
+        ...         print(f.read())
+        00001111001101
+        00001111001101
+        00001111001101
+        00001111001101
+        00001111001101
+        00001111001101
+        00001111001101
+        00001111001101
+        00001111001101
+        00001111001101
+    
+    - Sample parsing code (python):
+    
+        ```python
+        from typing import List
+        
+        def parse_01(data: str) -> List[List[bool]]:
+            shots = []
+            for line in data.split('\n'):
+                shot = []
+                for c in line:
+                    assert c in '01'
+                    shot.append(c == '1')
+                shots.append(shot)
+            return shots
+        ```
+        
+    - Sample saving code (python):
+    
+        ```python
+        from typing import List
+        
+        def save_01(shots: List[List[bool]]) -> str:
+            output = ""
+            for shot in shots:
+                for sample in shot:
+                    output += '1' if sample else '0'
+                output += "\n"
+            return output
+        ```
+        
+    
+- <a name="b8"></a>**`b8`**
+    
+    A binary format that stores shots as bit-packed bytes.
+    
+    Each shot is stored into ceil(n / 8) bytes, where n is the number of bits in the shot. Effectively, each shot is padded
+    up to a multiple of 8 by appending False bits, so that shots always start on a byte boundary. Bits are packed into bytes
+    in significance order (the 1s bit is the first bit, the 2s bit is the second, the 4s bit is the third, and so forth
+    until the 128s bit which is the eighth bit).
+    
+    This format requires the reader to know the number of bits in each shot.
+    
+    Example:
+    
+        >>> with tempfile.NamedTemporaryFile() as t:
+        ...     stim.Circuit("""
+        ...         X 1
+        ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
+        ...     """).compile_sampler().sample_write(shots=10, filepath=t.name, format="01")
+        ...     with open(t.name, 'rb') as f:
+        ...         print(' '.join(hex(e)[2:] for e in f.read()))
+        f0 2c f0 2c f0 2c f0 2c f0 2c f0 2c f0 2c f0 2c f0 2c f0 2c
+    
+    - Sample parsing code (python):
+    
+        ```python
+        from typing import List
+        
+        def parse_b8(data: bytes, bits_per_shot: int) -> List[List[bool]]:
+            shots = []
+            bytes_per_shot = (bits_per_shot + 7) // 8
+            for offset in range(0, len(data), bytes_per_shot):
+                shot = []
+                for k in range(bits_per_shot):
+                    byte = data[offset + k // 8]
+                    bit = (byte >> (k % 8)) % 2 == 1
+                    shot.append(bit)
+                shots.append(shot)
+            return shots
+        ```
+        
+    - Sample saving code (python):
+    
+        ```python
+        from typing import List
+        
+        def save_b8(shots: List[List[bool]]) -> bytes:
+            output = b""
+            bytes_per_shot = (len(shot) + 7) // 8
+            for shot in shots:
+                v = 0
+                for b in reversed(shot):
+                    v <<= 1
+                    v += b
+                output += v.to_bytes(bytes_per_shot, 'little')
+            return output
+        ```
+        
+    
+- <a name="dets"></a>**`dets`**
+    
+    A human readable format that stores shots as lines starting with 'shot' and space-separated prefixed values like 'D5'.
+    
+    The data from each shot is started with the text 'shot' and terminated by a newline character '\n'. The rest of the
+    line is a series of integers, separated by spaces and prefixed by a single letter. The prefix letter indicates the type
+    of value ('M' for measurement, 'D' for detector, and 'L' for logical observable). The integer indicates the index of the
+    value. For example, "D1 D3 L0" indicates detectors 1 and 3 fired, and logical observable 0 was flipped.
+    
+    This format requires the reader to know the number of measurements/detectors/observables in each shot, if the reader
+    wants to produce vectors of bits instead of sets.
+    
+    Example:
+    
+        >>> with tempfile.NamedTemporaryFile() as t:
+        ...     stim.Circuit("""
+        ...         X 1
+        ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1 0 1
+        ...     """).compile_sampler().sample_write(shots=3, filepath=t.name, format="dets")
+        ...     with open(t.name) as f:
+        ...         print(f.read())
+        shot M4 M5 M6 M7 M10 M11 M13 M15
+        shot M4 M5 M6 M7 M10 M11 M13 M15
+        shot M4 M5 M6 M7 M10 M11 M13 M15
+    
+        >>> with tempfile.NamedTemporaryFile() as t:
+        ...     stim.Circuit("""
+        ...         X_ERROR(1) 1
+        ...         M 0 1 2
+        ...         DETECTOR rec[-1]
+        ...         DETECTOR rec[-2]
+        ...         DETECTOR rec[-3]
+        ...         OBSERVABLE_INCLUDE(5) rec[-2]
+        ...     """).compile_detector_sampler().sample_write(shots=2, filepath=t.name, format="dets", append_observables=True)
+        ...     with open(t.name) as f:
+        ...         print(f.read())
+        shot D1 L5
+        shot D1 L5
+    
+    - Sample parsing code (python):
+    
+        ```python
+        from typing import List
+        
+        def parse_dets(data: str, num_detectors: int, num_observables: int) -> List[List[bool]]:
+            shots = []
+            for line in data.split('\n'):
+                if not line:
+                    continue
+                assert line.startswith('shot')
+                line = line[4:].strip()
+        
+                shot = [False] * (num_detectors + num_observables)
+                for term in line.split(' '):
+                    c = term[0]
+                    v = int(term[1:])
+                    if c == 'D':
+                        assert 0 <= v < num_detectors
+                        shot[v] = True
+                    elif c == 'L':
+                        assert 0 <= v < num_observables
+                        shot[num_detectors + v] = True
+                    else:
+                        raise NotImplementedError(c)
+                shots.append(shot)
+            return shots
+        ```
+        
+    - Sample saving code (python):
+    
+        ```python
+        from typing import List
+        
+        def save_dets(shots: List[List[bool]], num_detectors: int, num_observables: int):
+            output = ""
+            for shot in shots:
+                assert len(shot) == num_detectors + num_observables
+                detectors = shot[:num_detectors]
+                observables = shot[num_detectors:]
+                output += "shot"
+                for k in range(num_detectors):
+                    if shot[k]:
+                        output += " D" + str(k)
+                for k in range(num_observables):
+                    if shot[num_detectors + k]:
+                        output += " L" + str(k)
+                output += "\n"
+            return output
+        ```
+        
+    
+- <a name="hits"></a>**`hits`**
+    
+    A human readable format that stores shots as a comma-separated list of integers indicating which bits were true.
+    
+    The data from each shot is terminated by a newline character '\n'. The line is a series of non-negative integers
+    separated by commas, with each integer indicating a bit from the shot that was true.
+    
+    This format requires the reader to know the number of bits in each shot (if they want to get a list instead of a set).
+    
+    This format is useful in contexts where the number of set bits is expected to be low, e.g. when sampling detection
+    events.
+    
+    Example:
+    
+        >>> with tempfile.NamedTemporaryFile() as t:
+        ...     stim.Circuit("""
+        ...         X 1
+        ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1 0 1
+        ...     """).compile_sampler().sample_write(shots=10, filepath=t.name, format="hits")
+        ...     with open(t.name) as f:
+        ...         print(f.read())
+        4,5,6,7,10,11,13
+        4,5,6,7,10,11,13
+        4,5,6,7,10,11,13
+        4,5,6,7,10,11,13
+        4,5,6,7,10,11,13
+        4,5,6,7,10,11,13
+        4,5,6,7,10,11,13
+        4,5,6,7,10,11,13
+        4,5,6,7,10,11,13
+        4,5,6,7,10,11,13
+    
+    - Sample parsing code (python):
+    
+        ```python
+        from typing import List
+        
+        def parse_hits(data: str, bits_per_shot: int) -> List[List[bool]]:
+            shots = []
+            for line in data.split('\n'):
+                shot = [False] * bits_per_shot
+                for term in line.split(','):
+                    shot[int(term)] = True
+                shots.append(shot)
+            return shots
+        ```
+        
+    - Sample saving code (python):
+    
+        ```python
+        from typing import List
+        
+        def save_hits(shots: List[List[bool]]) -> str:
+            output = ""
+            for shot in shots:
+                hits = [index for index, bit in enumerate(shot) if bit]
+                output += ','.join(hits) + '\n'
+            return output
+        ```
+        
+    
+- <a name="ptb64"></a>**`ptb64`**
+    
+    A binary format that stores shots as partially transposed bit-packed data.
+    
+    Each 64 bit word (8 bytes) of the data contains bits from the same measurement result across 64 separate shots. The next
+    8 bytes contain bits for the next measurement result from the 64 separate shots. This continues until the 8 bytes
+    containing the bits from the last measurement result, and then starts over again with data from the next 64 shots (if
+    there are more).
+    
+    The shots are stored by byte order then significant order. The first shot's data goes into the least significant bit of
+    the first byte of each 8 byte group. When the number of shots is not a multiple of 64, the bits corresponding to the
+    missing shots are always zero.
+    
+    This format requires the reader to know the number of bits in each shot.
+    This format requires the reader to know the number of shots that were taken.
+    
+    This format is generally more tedious to work with, but useful for achieving good performance on data processing tasks
+    where it is possible to parallelize across shots using SIMD instructions.
+    
+    Example:
+    
+        >>> with tempfile.NamedTemporaryFile() as t:
+        ...     stim.Circuit("""
+        ...         X 1
+        ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1 0 1
+        ...     """).compile_sampler().sample_write(shots=10, filepath=t.name, format="ptb64")
+        ...     with open(t.name, 'rb') as f:
+        ...         print(' '.join(hex(e)[2:] for e in f.read()))
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ff 3 0 0 0 0 0 0
+    
+    - Sample parsing code (python):
+    
+        ```python
+        from typing import List
+        
+        def parse_ptb64(data: bytes, bits_per_shot: int, num_shots: int) -> List[List[bool]]:
+            result = [[False] * bits_per_shot for _ in range(num_shots)]
+            group_byte_stride = bits_per_shot * 8
+            for shot_offset in range(num_shots):
+                shot_group = shot_offset // 64
+                shot_stripe = shot_offset % 64
+                for bit_index in range(bits_per_shot):
+                    byte_offset = group_byte_stride*shot_group + bit_index * 8 + shot_stripe // 8
+                    bit = (data[byte_offset] >> (shot_stripe % 8)) % 2 == 1
+                    result[shot_offset][measure_index] = bit
+            return result
+        ```
+        
+    - Sample saving code (python):
+    
+        ```python
+        from typing import List
+        
+        def print_ptb64(shots: List[List[bool]]):
+            output = b""
+            for shot_offset in range(0, len(shots), 64):
+                bits_per_shot = len(shots[0])
+                for measure_index in range(bits_per_shot):
+                    v = 0
+                    for k in reversed(range(64)):
+                        v <<= 1
+                        v += shots[shot_offset + k][measure_index]
+                    output += v.to_bytes(bytes_per_shot, 'little')
+            return output
+        ```
+        
+    
+- <a name="r8"></a>**`r8`**
+    
+    A binary format that stores shots as the length of runs between 1s.
+    
+    Each byte in the data indicates how many False bits there are before the next True bit. The maximum byte value (255) is
+    special; it indicates to include 255 False bits but not follow them by a True bit. A shot always has a terminating True
+    bit appended to it before encoding. Decoding of the shot ends (and the next shot begin) when this True bit just past the
+    end of the shot data is reached.
+    
+    This format requires the reader to know the number of bits in each shot.
+    
+    This format is useful in contexts where the number of set bits is expected to be low, e.g. when sampling detection
+    events.
+    
+    Example:
+    
+        >>> with tempfile.NamedTemporaryFile() as t:
+        ...     stim.Circuit("""
+        ...         X 1
+        ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1 0 1
+        ...     """).compile_sampler().sample_write(shots=10, filepath=t.name, format="01")
+        ...     with open(t.name, 'rb') as f:
+        ...         print(' '.join(hex(e)[2:] for e in f.read()))
+        4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0
+    
+        >>> with tempfile.NamedTemporaryFile() as t:
+        ...     stim.Circuit("""
+        ...         X 1
+        ...         M 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        ...     """).compile_sampler().sample_write(shots=10, filepath=t.name, format="01")
+        ...     with open(t.name, 'rb') as f:
+        ...         print(' '.join(hex(e)[2:] for e in f.read()))
+        9 1f 9 1f 9 1f 9 1f 9 1f 9 1f 9 1f 9 1f 9 1f 9 1f
+    
+    - Sample parsing code (python):
+    
+        ```python
+        from typing import List
+        
+        def parse_r8(data: bytes, bits_per_shot: int) -> List[List[bool]]:
+            shots = []
+            shot = []
+            for byte in data:
+                shot += [False] * byte
+                if byte != 255:
+                    shot.append(True)
+                if len(shot) > bits_per_shot:
+                    assert len(shot) == bits_per_shot + 1 and shot[-1]
+                    shot.pop()
+                    shots.append(shot)
+                    shot = []
+            assert len(shot) == 0
+            return shots
+        ```
+        
+    - Sample saving code (python):
+    
+        ```python
+        from typing import List
+        
+        def save_r8(shots: List[List[bool]]) -> bytes:
+            output = ""
+            for shot in shots:
+                gap = 0
+                for b in shot + [True]:
+                    if b:
+                        while gap >= 255:
+                            gap -= 255
+                            output += (255).to_bytes(1, 'big')
+                        output += gap.to_bytes(1, 'big')
+                        gap = 0
+                    else:
+                        gap += 1
+            return output
+        ```
+        
+    

--- a/glue/javascript/circuit.js.cc
+++ b/glue/javascript/circuit.js.cc
@@ -43,7 +43,7 @@ bool ExposedCircuit::isEqualTo(const ExposedCircuit &other) const {
 }
 
 void emscripten_bind_circuit() {
-    auto &&c = emscripten::class_<ExposedCircuit>("Circuit");
+    auto c = emscripten::class_<ExposedCircuit>("Circuit");
     c.constructor();
     c.constructor<const std::string &>();
     c.function("toString", &ExposedCircuit::toString);

--- a/glue/javascript/pauli_string.js.cc
+++ b/glue/javascript/pauli_string.js.cc
@@ -72,7 +72,7 @@ int8_t ExposedPauliString::getSign() const {
 }
 
 void emscripten_bind_pauli_string() {
-    auto &&c = emscripten::class_<ExposedPauliString>("PauliString");
+    auto c = emscripten::class_<ExposedPauliString>("PauliString");
     c.constructor<const emscripten::val &>();
     c.class_function("random", &ExposedPauliString::random);
     c.function("neg", &ExposedPauliString::neg);

--- a/glue/javascript/tableau.js.cc
+++ b/glue/javascript/tableau.js.cc
@@ -98,7 +98,7 @@ bool ExposedTableau::isEqualTo(const ExposedTableau &other) const {
 }
 
 void emscripten_bind_tableau() {
-    auto &&c = emscripten::class_<ExposedTableau>("Tableau");
+    auto c = emscripten::class_<ExposedTableau>("Tableau");
     c.constructor<int>();
     c.class_function("random", &ExposedTableau::random);
     c.class_function("from_named_gate", &ExposedTableau::from_named_gate);

--- a/glue/javascript/tableau_simulator.js.cc
+++ b/glue/javascript/tableau_simulator.js.cc
@@ -136,7 +136,7 @@ ExposedTableauSimulator ExposedTableauSimulator::copy() const {
 }
 
 void emscripten_bind_tableau_simulator() {
-    auto &&c = emscripten::class_<ExposedTableauSimulator>("TableauSimulator");
+    auto c = emscripten::class_<ExposedTableauSimulator>("TableauSimulator");
     c.constructor();
     c.function("current_inverse_tableau", &ExposedTableauSimulator::current_inverse_tableau);
     c.function("set_inverse_tableau", &ExposedTableauSimulator::set_inverse_tableau);

--- a/glue/python/generate_api_reference.py
+++ b/glue/python/generate_api_reference.py
@@ -34,6 +34,8 @@ keep = {
     "__hash__",
 }
 skip = {
+    "_UNSTABLE_raw_gate_data",
+    "_UNSTABLE_raw_format_data",
     "__class__",
     "__delattr__",
     "__dir__",

--- a/src/circuit/circuit.h
+++ b/src/circuit/circuit.h
@@ -37,51 +37,6 @@ uint64_t op_data_rep_count(const OperationData &data);
 uint64_t add_saturate(uint64_t a, uint64_t b);
 uint64_t mul_saturate(uint64_t a, uint64_t b);
 
-enum SampleFormat {
-    /// Human readable format.
-    ///
-    /// For each shot:
-    ///     For each measurement:
-    ///         Output '0' if false, '1' if true
-    ///     Output '\n'
-    SAMPLE_FORMAT_01,
-
-    /// Binary format.
-    ///
-    /// For each shot:
-    ///     For each group of 8 measurement (padded with 0s if needed):
-    ///         Output a bit packed byte (least significant bit of byte has first measurement)
-    SAMPLE_FORMAT_B8,
-
-    /// Transposed binary format.
-    ///
-    /// For each measurement:
-    ///     For each group of 64 shots (padded with 0s if needed):
-    ///         Output bit packed bytes (least significant bit of first byte has first shot)
-    SAMPLE_FORMAT_PTB64,
-
-    /// Human readable compressed format.
-    ///
-    /// For each shot:
-    ///     For each measurement_index where the measurement result was 1:
-    ///         Output decimal(measurement_index)
-    SAMPLE_FORMAT_HITS,
-
-    /// Binary run-length format.
-    ///
-    /// For each shot:
-    ///     Append a one to the shot
-    ///     For each run length d of zeros between ones (including runs of length 0):
-    ///         Output [0x255] * (d // 255) + [d % 255]
-    SAMPLE_FORMAT_R8,
-
-    /// Specific to detection event data.
-    ///
-    /// For each shot:
-    ///     Output "shot" + " D#" for each detector that fired + " L#" for each observable that was inverted + "\n".
-    SAMPLE_FORMAT_DETS,
-};
-
 /// The data that describes how a gate is being applied to qubits (or other targets).
 ///
 /// This struct is not self-sufficient. It points into data stored elsewhere (e.g. in a Circuit's jagged_data).

--- a/src/circuit/circuit_gate_target.pybind.cc
+++ b/src/circuit/circuit_gate_target.pybind.cc
@@ -33,7 +33,7 @@ GateTarget obj_to_gate_target(const pybind11::object &obj) {
 }
 
 void pybind_circuit_gate_target(pybind11::module &m) {
-    auto &&c = pybind11::class_<GateTarget>(
+    auto c = pybind11::class_<GateTarget>(
         m,
         "GateTarget",
         clean_doc_string(u8R"DOC(

--- a/src/circuit/circuit_instruction.pybind.cc
+++ b/src/circuit/circuit_instruction.pybind.cc
@@ -80,7 +80,7 @@ std::vector<double> CircuitInstruction::gate_args_copy() const {
 }
 
 void pybind_circuit_instruction(pybind11::module &m) {
-    auto &&c = pybind11::class_<CircuitInstruction>(
+    auto c = pybind11::class_<CircuitInstruction>(
         m,
         "CircuitInstruction",
         clean_doc_string(u8R"DOC(

--- a/src/circuit/circuit_repeat_block.pybind.cc
+++ b/src/circuit/circuit_repeat_block.pybind.cc
@@ -42,7 +42,7 @@ std::string CircuitRepeatBlock::repr() const {
 }
 
 void pybind_circuit_repeat_block(pybind11::module &m) {
-    auto &&c = pybind11::class_<CircuitRepeatBlock>(
+    auto c = pybind11::class_<CircuitRepeatBlock>(
         m,
         "CircuitRepeatBlock",
         clean_doc_string(u8R"DOC(

--- a/src/dem/detector_error_model.pybind.cc
+++ b/src/dem/detector_error_model.pybind.cc
@@ -33,7 +33,7 @@ std::string detector_error_model_repr(const DetectorErrorModel &self) {
 }
 
 void pybind_detector_error_model(pybind11::module &m) {
-    auto &&c = pybind11::class_<DetectorErrorModel>(
+    auto c = pybind11::class_<DetectorErrorModel>(
         m,
         "DetectorErrorModel",
         clean_doc_string(u8R"DOC(

--- a/src/dem/detector_error_model_instruction.pybind.cc
+++ b/src/dem/detector_error_model_instruction.pybind.cc
@@ -83,7 +83,7 @@ std::vector<double> ExposedDemInstruction::args_copy() const {
 }
 
 void pybind_detector_error_model_instruction(pybind11::module &m) {
-    auto &&c = pybind11::class_<ExposedDemInstruction>(
+    auto c = pybind11::class_<ExposedDemInstruction>(
         m,
         "DemInstruction",
         clean_doc_string(u8R"DOC(

--- a/src/dem/detector_error_model_repeat_block.pybind.cc
+++ b/src/dem/detector_error_model_repeat_block.pybind.cc
@@ -21,7 +21,7 @@
 using namespace stim_internal;
 
 void pybind_detector_error_model_repeat_block(pybind11::module &m) {
-    auto &&c = pybind11::class_<ExposedDemRepeatBlock>(
+    auto c = pybind11::class_<ExposedDemRepeatBlock>(
         m,
         "DemRepeatBlock",
         clean_doc_string(u8R"DOC(

--- a/src/dem/detector_error_model_target.pybind.cc
+++ b/src/dem/detector_error_model_target.pybind.cc
@@ -20,7 +20,7 @@
 using namespace stim_internal;
 
 void pybind_detector_error_model_target(pybind11::module &m) {
-    auto &&c = pybind11::class_<ExposedDemTarget>(
+    auto c = pybind11::class_<ExposedDemTarget>(
         m, "DemTarget", "An instruction target from a detector error model (.dem) file.");
 
     m.def(

--- a/src/help.cc
+++ b/src/help.cc
@@ -12,18 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "gate_help.h"
+#include "help.h"
 
 #include <algorithm>
 #include <cstring>
 #include <iostream>
 #include <map>
 #include <set>
+#include <sstream>
 
 #include "arg_parse.h"
+#include "circuit/gate_data.h"
+#include "io/stim_data_formats.h"
 #include "stabilizers/tableau.h"
 
 using namespace stim_internal;
+
+std::string upper(const std::string &val) {
+    std::string copy = val;
+    for (char &c : copy) {
+        c = toupper(c);
+    }
+    return copy;
+}
 
 struct Acc {
     std::string settled;
@@ -299,7 +310,66 @@ std::string generate_per_gate_help_markdown(const Gate &alt_gate, int indent, bo
     return out.settled;
 }
 
-std::map<std::string, std::string> stim_internal::generate_gate_help_markdown() {
+std::string generate_per_format_markdown(const FileFormatData &format_data, int indent, bool anchor) {
+    Acc out;
+    out.indent = indent;
+    if (anchor) {
+        out << "<a name=\"" << format_data.name << "\"></a>";
+    }
+    out << "**`" << format_data.name << "`**\n";
+    out << format_data.help;
+    out << "\n";
+
+    out << "- Sample parsing code (python):\n";
+    out.change_indent(+4);
+    out << "```python";
+    out << format_data.help_python_parse;
+    out << "```\n";
+    out.change_indent(-4);
+
+    out << "- Sample saving code (python):\n";
+    out.change_indent(+4);
+    out << "```python";
+    out << format_data.help_python_save;
+    out << "```\n";
+    out.change_indent(-4);
+
+    out.flush();
+    return out.settled;
+}
+
+std::map<std::string, std::string> generate_format_help_markdown() {
+    std::map<std::string, std::string> result;
+
+    std::stringstream all;
+    all << "Result data formats supported by Stim\n";
+    all << "=====================================\n";
+    for (const auto &kv : format_name_to_enum_map) {
+        all << kv.first << "\n";
+    }
+    result[std::string("FORMATS")] = all.str();
+
+    for (const auto &kv : format_name_to_enum_map) {
+        result[upper(kv.first)] = generate_per_format_markdown(kv.second, 0, false);
+    }
+
+    all.str("");
+    all << R"MARKDOWN(# Result formats supported by Stim
+
+)MARKDOWN";
+    for (const auto &kv : format_name_to_enum_map) {
+        all << "- [" << kv.first << "](#" << kv.first << ")\n";
+    }
+    all << "\n";
+    for (const auto &kv : format_name_to_enum_map) {
+        all << "- " << generate_per_format_markdown(kv.second, 4, true) << "\n";
+    }
+    result[std::string("FORMATS_MARKDOWN")] = all.str();
+
+    return result;
+}
+
+std::map<std::string, std::string> generate_gate_help_markdown() {
     std::map<std::string, std::string> result;
     for (const auto &g : GATE_DATA.gates()) {
         result[g.name] = generate_per_gate_help_markdown(g, 0, false);
@@ -350,7 +420,7 @@ Interactive measurement sampling mode:
 
 Bulk measurement sampling mode:
     stim --sample[=#shots] \
-         [--frame0] \
+         [--skip_reference_sample] \
          [--out_format=01|b8|ptb64|r8|hits|dets] \
          [--in=file] \
          [--out=file]
@@ -391,15 +461,16 @@ M 0 1 2
 
 int stim_internal::main_help(int argc, const char **argv) {
     const char *help = require_find_argument("--help", argc, argv);
-    auto m = generate_gate_help_markdown();
-    auto key = std::string(help);
-    for (auto &c : key) {
-        c = toupper(c);
-    }
-    auto p = m.find(key);
-    if (p == m.end()) {
-        std::cerr << "Unrecognized help topic '" << help << "'.\n";
-        return EXIT_FAILURE;
+    auto m1 = generate_gate_help_markdown();
+    auto m2 = generate_format_help_markdown();
+    auto key = upper(help);
+    auto p = m1.find(key);
+    if (p == m1.end()) {
+        p = m2.find(key);
+        if (p == m2.end()) {
+            std::cerr << "Unrecognized help topic '" << help << "'.\n";
+            return EXIT_FAILURE;
+        }
     }
 
     std::cout << p->second;

--- a/src/help.h
+++ b/src/help.h
@@ -14,17 +14,14 @@
  * limitations under the License.
  */
 
-#ifndef STIM_GATE_HELP_H
-#define STIM_GATE_HELP_H
+#ifndef STIM_HELP_H
+#define STIM_HELP_H
 
 #include <map>
 #include <string>
 
-#include "circuit/gate_data.h"
-
 namespace stim_internal {
 
-std::map<std::string, std::string> generate_gate_help_markdown();
 int main_help(int argc, const char **argv);
 
 }  // namespace stim_internal

--- a/src/include/stim.h
+++ b/src/include/stim.h
@@ -17,6 +17,8 @@
 #ifndef STIM_H
 #define STIM_H
 
+#include "../arg_parse.h"
+#include "../benchmark_util.h"
 #include "../circuit/circuit.h"
 #include "../circuit/gate_data.h"
 #include "../circuit/gate_target.h"
@@ -26,12 +28,19 @@
 #include "../gen/gen_color_code.h"
 #include "../gen/gen_rep_code.h"
 #include "../gen/gen_surface_code.h"
+#include "../help.h"
 #include "../io/measure_record.h"
 #include "../io/measure_record_batch.h"
 #include "../io/measure_record_batch_writer.h"
+#include "../io/measure_record_reader.h"
 #include "../io/measure_record_writer.h"
+#include "../io/stim_data_formats.h"
+#include "../main_namespaced.h"
 #include "../probability_util.h"
 #include "../simd/bit_ref.h"
+#include "../simd/fixed_cap_vector.h"
+#include "../simd/monotonic_buffer.h"
+#include "../simd/pointer_range.h"
 #include "../simd/simd_bit_table.h"
 #include "../simd/simd_bits.h"
 #include "../simd/simd_bits_range_ref.h"
@@ -47,6 +56,7 @@
 #include "../stabilizers/pauli_string_ref.h"
 #include "../stabilizers/tableau.h"
 #include "../stabilizers/tableau_transposed_raii.h"
+#include "../str_util.h"
 
 namespace stim {
 using Circuit = stim_internal::Circuit;

--- a/src/io/measure_record_reader.h
+++ b/src/io/measure_record_reader.h
@@ -22,6 +22,7 @@
 #include "../circuit/circuit.h"
 #include "../simd/pointer_range.h"
 #include "../simd/simd_bit_table.h"
+#include "stim_data_formats.h"
 
 namespace stim_internal {
 

--- a/src/io/measure_record_writer.h
+++ b/src/io/measure_record_writer.h
@@ -22,6 +22,7 @@
 #include "../circuit/circuit.h"
 #include "../simd/pointer_range.h"
 #include "../simd/simd_bit_table.h"
+#include "stim_data_formats.h"
 
 namespace stim_internal {
 

--- a/src/io/stim_data_formats.cc
+++ b/src/io/stim_data_formats.cc
@@ -18,14 +18,16 @@ This is the default format used when saving to files.
 
 Example:
 
+    >>> import pathlib
     >>> import stim
     >>> import tempfile
-    >>> with tempfile.NamedTemporaryFile() as t:
+    >>> with tempfile.TemporaryDirectory() as d:
+    ...     path = str(pathlib.Path(d) / "tmp.dat")
     ...     stim.Circuit("""
     ...         X 1
     ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
-    ...     """).compile_sampler().sample_write(shots=10, filepath=t.name, format="01")
-    ...     with open(t.name) as f:
+    ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="01")
+    ...     with open(path) as f:
     ...         print(f.read().strip())
     00001111001101
     00001111001101
@@ -84,14 +86,16 @@ This format requires the reader to know the number of bits in each shot.
 
 Example:
 
+    >>> import pathlib
     >>> import stim
     >>> import tempfile
-    >>> with tempfile.NamedTemporaryFile() as t:
+    >>> with tempfile.TemporaryDirectory() as d:
+    ...     path = str(pathlib.Path(d) / "tmp.dat")
     ...     stim.Circuit("""
     ...         X 1
     ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
-    ...     """).compile_sampler().sample_write(shots=10, filepath=t.name, format="b8")
-    ...     with open(t.name, 'rb') as f:
+    ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="b8")
+    ...     with open(path, 'rb') as f:
     ...         print(' '.join(hex(e)[2:] for e in f.read()))
     f0 2c f0 2c f0 2c f0 2c f0 2c f0 2c f0 2c f0 2c f0 2c f0 2c
 )HELP",
@@ -152,14 +156,16 @@ where it is possible to parallelize across shots using SIMD instructions.
 
 Example:
 
+    >>> import pathlib
     >>> import stim
     >>> import tempfile
-    >>> with tempfile.NamedTemporaryFile() as t:
+    >>> with tempfile.TemporaryDirectory() as d:
+    ...     path = str(pathlib.Path(d) / "tmp.dat")
     ...     stim.Circuit("""
     ...         X 1
     ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
-    ...     """).compile_sampler().sample_write(shots=10, filepath=t.name, format="ptb64")
-    ...     with open(t.name, 'rb') as f:
+    ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="ptb64")
+    ...     with open(path, 'rb') as f:
     ...         print(' '.join(hex(e)[2:] for e in f.read()))
     0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ff 3 0 0 0 0 0 0
 )HELP",
@@ -216,14 +222,16 @@ events.
 
 Example:
 
+    >>> import pathlib
     >>> import stim
     >>> import tempfile
-    >>> with tempfile.NamedTemporaryFile() as t:
+    >>> with tempfile.TemporaryDirectory() as d:
+    ...     path = str(pathlib.Path(d) / "tmp.dat")
     ...     stim.Circuit("""
     ...         X 1
     ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
-    ...     """).compile_sampler().sample_write(shots=10, filepath=t.name, format="hits")
-    ...     with open(t.name) as f:
+    ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="hits")
+    ...     with open(path) as f:
     ...         print(f.read().strip())
     4,5,6,7,10,11,13
     4,5,6,7,10,11,13
@@ -283,23 +291,26 @@ events.
 
 Example:
 
+    >>> import pathlib
     >>> import stim
     >>> import tempfile
-    >>> with tempfile.NamedTemporaryFile() as t:
+    >>> with tempfile.TemporaryDirectory() as d:
+    ...     path = str(pathlib.Path(d) / "tmp.dat")
     ...     stim.Circuit("""
     ...         X 1
     ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
-    ...     """).compile_sampler().sample_write(shots=10, filepath=t.name, format="r8")
-    ...     with open(t.name, 'rb') as f:
+    ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="r8")
+    ...     with open(path, 'rb') as f:
     ...         print(' '.join(hex(e)[2:] for e in f.read()))
     4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0
 
-    >>> with tempfile.NamedTemporaryFile() as t:
+    >>> with tempfile.TemporaryDirectory() as d:
+    ...     path = str(pathlib.Path(d) / "tmp.dat")
     ...     stim.Circuit("""
     ...         X 1
     ...         M 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
-    ...     """).compile_sampler().sample_write(shots=10, filepath=t.name, format="r8")
-    ...     with open(t.name, 'rb') as f:
+    ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="r8")
+    ...     with open(path, 'rb') as f:
     ...         print(' '.join(hex(e)[2:] for e in f.read()))
     9 1f 9 1f 9 1f 9 1f 9 1f 9 1f 9 1f 9 1f 9 1f 9 1f
 )HELP",
@@ -360,20 +371,23 @@ wants to produce vectors of bits instead of sets.
 
 Example:
 
+    >>> import pathlib
     >>> import stim
     >>> import tempfile
-    >>> with tempfile.NamedTemporaryFile() as t:
+    >>> with tempfile.TemporaryDirectory() as d:
+    ...     path = str(pathlib.Path(d) / "tmp.dat")
     ...     stim.Circuit("""
     ...         X 1
     ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1 0 1
-    ...     """).compile_sampler().sample_write(shots=3, filepath=t.name, format="dets")
-    ...     with open(t.name) as f:
+    ...     """).compile_sampler().sample_write(shots=3, filepath=path, format="dets")
+    ...     with open(path) as f:
     ...         print(f.read().strip())
     shot M4 M5 M6 M7 M10 M11 M13 M15
     shot M4 M5 M6 M7 M10 M11 M13 M15
     shot M4 M5 M6 M7 M10 M11 M13 M15
 
-    >>> with tempfile.NamedTemporaryFile() as t:
+    >>> with tempfile.TemporaryDirectory() as d:
+    ...     path = str(pathlib.Path(d) / "tmp.dat")
     ...     stim.Circuit("""
     ...         X_ERROR(1) 1
     ...         M 0 1 2
@@ -381,8 +395,8 @@ Example:
     ...         DETECTOR rec[-2]
     ...         DETECTOR rec[-3]
     ...         OBSERVABLE_INCLUDE(5) rec[-2]
-    ...     """).compile_detector_sampler().sample_write(shots=2, filepath=t.name, format="dets", append_observables=True)
-    ...     with open(t.name) as f:
+    ...     """).compile_detector_sampler().sample_write(shots=2, filepath=path, format="dets", append_observables=True)
+    ...     with open(path) as f:
     ...         print(f.read().strip())
     shot D1 L5
     shot D1 L5

--- a/src/io/stim_data_formats.cc
+++ b/src/io/stim_data_formats.cc
@@ -1,0 +1,438 @@
+#include "stim_data_formats.h"
+
+using namespace stim_internal;
+
+extern const std::map<std::string, stim_internal::FileFormatData> stim_internal::format_name_to_enum_map{
+    {
+        "01",
+        FileFormatData{
+            "01",
+            SAMPLE_FORMAT_01,
+            R"HELP(
+A human readable format that stores shots as lines of '0' and '1' characters.
+
+The data from each shot is terminated by a newline character '\n'. Each character in the line is a '0' (indicating
+False) or a '1' (indicating True) corresponding to a measurement result (or a detector result) from a circuit.
+
+This is the default format used when saving to files.
+
+Example:
+
+    >>> import stim
+    >>> import tempfile
+    >>> with tempfile.NamedTemporaryFile() as t:
+    ...     stim.Circuit("""
+    ...         X 1
+    ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
+    ...     """).compile_sampler().sample_write(shots=10, filepath=t.name, format="01")
+    ...     with open(t.name) as f:
+    ...         print(f.read().strip())
+    00001111001101
+    00001111001101
+    00001111001101
+    00001111001101
+    00001111001101
+    00001111001101
+    00001111001101
+    00001111001101
+    00001111001101
+    00001111001101
+)HELP",
+            R"PYTHON(
+from typing import List
+
+def save_01(shots: List[List[bool]]) -> str:
+    output = ""
+    for shot in shots:
+        for sample in shot:
+            output += '1' if sample else '0'
+        output += "\n"
+    return output
+)PYTHON",
+            R"PYTHON(
+from typing import List
+
+def parse_01(data: str) -> List[List[bool]]:
+    shots = []
+    for line in data.split('\n'):
+        if not line:
+            continue
+        shot = []
+        for c in line:
+            assert c in '01'
+            shot.append(c == '1')
+        shots.append(shot)
+    return shots
+)PYTHON",
+        },
+    },
+
+    {
+        "b8",
+        FileFormatData{
+            "b8",
+            SAMPLE_FORMAT_B8,
+            R"HELP(
+A binary format that stores shots as bit-packed bytes.
+
+Each shot is stored into ceil(n / 8) bytes, where n is the number of bits in the shot. Effectively, each shot is padded
+up to a multiple of 8 by appending False bits, so that shots always start on a byte boundary. Bits are packed into bytes
+in significance order (the 1s bit is the first bit, the 2s bit is the second, the 4s bit is the third, and so forth
+until the 128s bit which is the eighth bit).
+
+This format requires the reader to know the number of bits in each shot.
+
+Example:
+
+    >>> import stim
+    >>> import tempfile
+    >>> with tempfile.NamedTemporaryFile() as t:
+    ...     stim.Circuit("""
+    ...         X 1
+    ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
+    ...     """).compile_sampler().sample_write(shots=10, filepath=t.name, format="b8")
+    ...     with open(t.name, 'rb') as f:
+    ...         print(' '.join(hex(e)[2:] for e in f.read()))
+    f0 2c f0 2c f0 2c f0 2c f0 2c f0 2c f0 2c f0 2c f0 2c f0 2c
+)HELP",
+            R"PYTHON(
+from typing import List
+
+def save_b8(shots: List[List[bool]]) -> bytes:
+    output = b""
+    for shot in shots:
+        bytes_per_shot = (len(shot) + 7) // 8
+        v = 0
+        for b in reversed(shot):
+            v <<= 1
+            v += b
+        output += v.to_bytes(bytes_per_shot, 'little')
+    return output
+)PYTHON",
+            R"PYTHON(
+from typing import List
+
+def parse_b8(data: bytes, bits_per_shot: int) -> List[List[bool]]:
+    shots = []
+    bytes_per_shot = (bits_per_shot + 7) // 8
+    for offset in range(0, len(data), bytes_per_shot):
+        shot = []
+        for k in range(bits_per_shot):
+            byte = data[offset + k // 8]
+            bit = (byte >> (k % 8)) % 2 == 1
+            shot.append(bit)
+        shots.append(shot)
+    return shots
+)PYTHON",
+        },
+    },
+
+    {
+        "ptb64",
+        FileFormatData{
+            "ptb64",
+            SAMPLE_FORMAT_PTB64,
+            R"HELP(
+A binary format that stores shots as partially transposed bit-packed data.
+
+Each 64 bit word (8 bytes) of the data contains bits from the same measurement result across 64 separate shots. The next
+8 bytes contain bits for the next measurement result from the 64 separate shots. This continues until the 8 bytes
+containing the bits from the last measurement result, and then starts over again with data from the next 64 shots (if
+there are more).
+
+The shots are stored by byte order then significant order. The first shot's data goes into the least significant bit of
+the first byte of each 8 byte group. When the number of shots is not a multiple of 64, the bits corresponding to the
+missing shots are always zero.
+
+This format requires the reader to know the number of bits in each shot.
+This format requires the reader to know the number of shots that were taken.
+
+This format is generally more tedious to work with, but useful for achieving good performance on data processing tasks
+where it is possible to parallelize across shots using SIMD instructions.
+
+Example:
+
+    >>> import stim
+    >>> import tempfile
+    >>> with tempfile.NamedTemporaryFile() as t:
+    ...     stim.Circuit("""
+    ...         X 1
+    ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
+    ...     """).compile_sampler().sample_write(shots=10, filepath=t.name, format="ptb64")
+    ...     with open(t.name, 'rb') as f:
+    ...         print(' '.join(hex(e)[2:] for e in f.read()))
+    0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ff 3 0 0 0 0 0 0
+)HELP",
+            R"PYTHON(
+from typing import List
+
+def save_ptb64(shots: List[List[bool]]):
+    output = b""
+    for shot_offset in range(0, len(shots), 64):
+        bits_per_shot = len(shots[0])
+        for measure_index in range(bits_per_shot):
+            v = 0
+            for k in reversed(range(min(64, len(shots) - shot_offset))):
+                v <<= 1
+                v += shots[shot_offset + k][measure_index]
+            output += v.to_bytes(8, 'little')
+    return output
+)PYTHON",
+            R"PYTHON(
+from typing import List
+
+def parse_ptb64(data: bytes, bits_per_shot: int, num_shots: int) -> List[List[bool]]:
+    result = [[False] * bits_per_shot for _ in range(num_shots)]
+    group_byte_stride = bits_per_shot * 8
+    for shot_offset in range(num_shots):
+        shot_group = shot_offset // 64
+        shot_stripe = shot_offset % 64
+        for measure_index in range(bits_per_shot):
+            byte_offset = group_byte_stride*shot_group + measure_index * 8 + shot_stripe // 8
+            bit = (data[byte_offset] >> (shot_stripe % 8)) % 2 == 1
+            result[shot_offset][measure_index] = bit
+    return result
+)PYTHON",
+        },
+    },
+
+    {
+        "hits",
+        FileFormatData{
+            "hits",
+            SAMPLE_FORMAT_HITS,
+            R"HELP(
+A human readable format that stores shots as a comma-separated list of integers indicating which bits were true.
+
+The data from each shot is terminated by a newline character '\n'. The line is a series of non-negative integers
+separated by commas, with each integer indicating a bit from the shot that was true.
+
+This format requires the reader to know the number of bits in each shot (if they want to get a list instead of a set).
+This format requires the reader to know how many trailing newlines, that don't correspond to shots with no hit, are in
+the text data.
+
+This format is useful in contexts where the number of set bits is expected to be low, e.g. when sampling detection
+events.
+
+Example:
+
+    >>> import stim
+    >>> import tempfile
+    >>> with tempfile.NamedTemporaryFile() as t:
+    ...     stim.Circuit("""
+    ...         X 1
+    ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
+    ...     """).compile_sampler().sample_write(shots=10, filepath=t.name, format="hits")
+    ...     with open(t.name) as f:
+    ...         print(f.read().strip())
+    4,5,6,7,10,11,13
+    4,5,6,7,10,11,13
+    4,5,6,7,10,11,13
+    4,5,6,7,10,11,13
+    4,5,6,7,10,11,13
+    4,5,6,7,10,11,13
+    4,5,6,7,10,11,13
+    4,5,6,7,10,11,13
+    4,5,6,7,10,11,13
+    4,5,6,7,10,11,13
+)HELP",
+            R"PYTHON(
+from typing import List
+
+def save_hits(shots: List[List[bool]]) -> str:
+    output = ""
+    for shot in shots:
+        output += ",".join(str(index) for index, bit in enumerate(shot) if bit) + "\n"
+    return output
+)PYTHON",
+            R"PYTHON(
+from typing import List
+
+def parse_hits(data: str, bits_per_shot: int) -> List[List[bool]]:
+    shots = []
+    if data.endswith('\n'):
+        data = data[:-1]
+    for line in data.split('\n'):
+        shot = [False] * bits_per_shot
+        if line:
+            for term in line.split(','):
+                shot[int(term)] = True
+        shots.append(shot)
+    return shots
+)PYTHON",
+        },
+    },
+
+    {
+        "r8",
+        FileFormatData{
+            "r8",
+            SAMPLE_FORMAT_R8,
+            R"HELP(
+A binary format that stores shots as the length of runs between 1s.
+
+Each byte in the data indicates how many False bits there are before the next True bit. The maximum byte value (255) is
+special; it indicates to include 255 False bits but not follow them by a True bit. A shot always has a terminating True
+bit appended to it before encoding. Decoding of the shot ends (and the next shot begin) when this True bit just past the
+end of the shot data is reached.
+
+This format requires the reader to know the number of bits in each shot.
+
+This format is useful in contexts where the number of set bits is expected to be low, e.g. when sampling detection
+events.
+
+Example:
+
+    >>> import stim
+    >>> import tempfile
+    >>> with tempfile.NamedTemporaryFile() as t:
+    ...     stim.Circuit("""
+    ...         X 1
+    ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
+    ...     """).compile_sampler().sample_write(shots=10, filepath=t.name, format="r8")
+    ...     with open(t.name, 'rb') as f:
+    ...         print(' '.join(hex(e)[2:] for e in f.read()))
+    4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0
+
+    >>> with tempfile.NamedTemporaryFile() as t:
+    ...     stim.Circuit("""
+    ...         X 1
+    ...         M 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+    ...     """).compile_sampler().sample_write(shots=10, filepath=t.name, format="r8")
+    ...     with open(t.name, 'rb') as f:
+    ...         print(' '.join(hex(e)[2:] for e in f.read()))
+    9 1f 9 1f 9 1f 9 1f 9 1f 9 1f 9 1f 9 1f 9 1f 9 1f
+)HELP",
+            R"PYTHON(
+from typing import List
+
+def save_r8(shots: List[List[bool]]) -> bytes:
+    output = b""
+    for shot in shots:
+        gap = 0
+        for b in shot + [True]:
+            if b:
+                while gap >= 255:
+                    gap -= 255
+                    output += (255).to_bytes(1, 'big')
+                output += gap.to_bytes(1, 'big')
+                gap = 0
+            else:
+                gap += 1
+    return output
+)PYTHON",
+            R"PYTHON(
+from typing import List
+
+def parse_r8(data: bytes, bits_per_shot: int) -> List[List[bool]]:
+    shots = []
+    shot = []
+    for byte in data:
+        shot += [False] * byte
+        if byte != 255:
+            shot.append(True)
+        if len(shot) > bits_per_shot:
+            assert len(shot) == bits_per_shot + 1 and shot[-1]
+            shot.pop()
+            shots.append(shot)
+            shot = []
+    assert len(shot) == 0
+    return shots
+)PYTHON",
+        },
+    },
+
+    {
+        "dets",
+        FileFormatData{
+            "dets",
+            SAMPLE_FORMAT_DETS,
+            R"HELP(
+A human readable format that stores shots as lines starting with 'shot' and space-separated prefixed values like 'D5'.
+
+The data from each shot is started with the text 'shot' and terminated by a newline character '\n'. The rest of the
+line is a series of integers, separated by spaces and prefixed by a single letter. The prefix letter indicates the type
+of value ('M' for measurement, 'D' for detector, and 'L' for logical observable). The integer indicates the index of the
+value. For example, "D1 D3 L0" indicates detectors 1 and 3 fired, and logical observable 0 was flipped.
+
+This format requires the reader to know the number of measurements/detectors/observables in each shot, if the reader
+wants to produce vectors of bits instead of sets.
+
+Example:
+
+    >>> import stim
+    >>> import tempfile
+    >>> with tempfile.NamedTemporaryFile() as t:
+    ...     stim.Circuit("""
+    ...         X 1
+    ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1 0 1
+    ...     """).compile_sampler().sample_write(shots=3, filepath=t.name, format="dets")
+    ...     with open(t.name) as f:
+    ...         print(f.read().strip())
+    shot M4 M5 M6 M7 M10 M11 M13 M15
+    shot M4 M5 M6 M7 M10 M11 M13 M15
+    shot M4 M5 M6 M7 M10 M11 M13 M15
+
+    >>> with tempfile.NamedTemporaryFile() as t:
+    ...     stim.Circuit("""
+    ...         X_ERROR(1) 1
+    ...         M 0 1 2
+    ...         DETECTOR rec[-1]
+    ...         DETECTOR rec[-2]
+    ...         DETECTOR rec[-3]
+    ...         OBSERVABLE_INCLUDE(5) rec[-2]
+    ...     """).compile_detector_sampler().sample_write(shots=2, filepath=t.name, format="dets", append_observables=True)
+    ...     with open(t.name) as f:
+    ...         print(f.read().strip())
+    shot D1 L5
+    shot D1 L5
+)HELP",
+            R"PYTHON(
+from typing import List
+
+def save_dets(shots: List[List[bool]], num_detectors: int, num_observables: int):
+    output = ""
+    for shot in shots:
+        assert len(shot) == num_detectors + num_observables
+        detectors = shot[:num_detectors]
+        observables = shot[num_detectors:]
+        output += "shot"
+        for k in range(num_detectors):
+            if shot[k]:
+                output += " D" + str(k)
+        for k in range(num_observables):
+            if shot[num_detectors + k]:
+                output += " L" + str(k)
+        output += "\n"
+    return output
+)PYTHON",
+            R"PYTHON(
+from typing import List
+
+def parse_dets(data: str, num_detectors: int, num_observables: int) -> List[List[bool]]:
+    shots = []
+    for line in data.split('\n'):
+        if not line.strip():
+            continue
+        assert line.startswith('shot')
+        line = line[4:].strip()
+
+        shot = [False] * (num_detectors + num_observables)
+        if line:
+            for term in line.split(' '):
+                c = term[0]
+                v = int(term[1:])
+                if c == 'D':
+                    assert 0 <= v < num_detectors
+                    shot[v] = True
+                elif c == 'L':
+                    assert 0 <= v < num_observables
+                    shot[num_detectors + v] = True
+                else:
+                    raise NotImplementedError(c)
+        shots.append(shot)
+    return shots
+)PYTHON",
+        },
+    },
+};

--- a/src/io/stim_data_formats.h
+++ b/src/io/stim_data_formats.h
@@ -1,0 +1,30 @@
+#ifndef STIM_DATA_FORMATS_H
+#define STIM_DATA_FORMATS_H
+
+#include <map>
+#include <string>
+
+namespace stim_internal {
+
+enum SampleFormat {
+    SAMPLE_FORMAT_01,
+    SAMPLE_FORMAT_B8,
+    SAMPLE_FORMAT_PTB64,
+    SAMPLE_FORMAT_HITS,
+    SAMPLE_FORMAT_R8,
+    SAMPLE_FORMAT_DETS,
+};
+
+struct FileFormatData {
+    const char *name;
+    SampleFormat id;
+    const char *help;
+    const char *help_python_save;
+    const char *help_python_parse;
+};
+
+extern const std::map<std::string, FileFormatData> format_name_to_enum_map;
+
+}  // namespace stim_internal
+
+#endif

--- a/src/main.cc
+++ b/src/main.cc
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "main_helper.h"
+#include "main_namespaced.h"
 
 using namespace stim_internal;
 
 int main(int argc, const char **argv) {
-    return main_helper(argc, argv);
+    return stim_internal::main(argc, argv);
 }

--- a/src/main_namespaced.h
+++ b/src/main_namespaced.h
@@ -17,15 +17,11 @@
 #ifndef STIM_MAIN_HELPER_H
 #define STIM_MAIN_HELPER_H
 
-#include "arg_parse.h"
-#include "probability_util.h"
-#include "simulators/frame_simulator.h"
-#include "simulators/tableau_simulator.h"
-
 namespace stim_internal {
 
-int main_helper(int argc, const char **argv);
+/// Stim's main method (in a namespace; not the global entrypoint main!).
+int main(int argc, const char **argv);
 
-}
+}  // namespace stim_internal
 
 #endif

--- a/src/main_namespaced.perf.cc
+++ b/src/main_namespaced.perf.cc
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "main_namespaced.h"
+
 #include "benchmark_util.h"
-#include "main_helper.h"
 #include "simulators/detection_simulator.h"
+#include "simulators/frame_simulator.h"
+#include "simulators/tableau_simulator.h"
 
 using namespace stim_internal;
 

--- a/src/py/base.pybind.cc
+++ b/src/py/base.pybind.cc
@@ -97,19 +97,14 @@ bool normalize_index_or_slice(
 }
 
 SampleFormat format_to_enum(const std::string &format) {
-    if (format == "01") {
-        return SAMPLE_FORMAT_01;
-    } else if (format == "hits") {
-        return SAMPLE_FORMAT_HITS;
-    } else if (format == "b8") {
-        return SAMPLE_FORMAT_B8;
-    } else if (format == "r8") {
-        return SAMPLE_FORMAT_R8;
-    } else if (format == "dets") {
-        return SAMPLE_FORMAT_DETS;
-    } else if (format == "ptb64") {
-        return SAMPLE_FORMAT_PTB64;
-    } else {
-        throw std::invalid_argument("Unrecognized format. Expected '01', 'hits', 'b8', 'r8', 'dets', or 'ptb64'.");
+    auto found_format = format_name_to_enum_map.find(format);
+    if (found_format == format_name_to_enum_map.end()) {
+        std::stringstream msg;
+        msg << "Unrecognized output format: '" << format << "'. Recognized formats are:\n";
+        for (const auto &kv : format_name_to_enum_map) {
+            msg << "    " << kv.first << "\n";
+        }
+        throw std::invalid_argument(msg.str());
     }
+    return found_format->second.id;
 }

--- a/src/py/base.pybind.h
+++ b/src/py/base.pybind.h
@@ -22,6 +22,7 @@
 #include <random>
 
 #include "../circuit/circuit.h"
+#include "../io/stim_data_formats.h"
 
 std::mt19937_64 &PYBIND_SHARED_RNG();
 std::string clean_doc_string(const char *c);

--- a/src/py/compiled_detector_sampler.pybind.cc
+++ b/src/py/compiled_detector_sampler.pybind.cc
@@ -77,6 +77,9 @@ void CompiledDetectorSampler::sample_write(
     bool append_observables) {
     auto f = format_to_enum(format);
     FILE *out = fopen(filepath.data(), "w");
+    if (out == nullptr) {
+        throw std::invalid_argument("Failed to open '" + filepath + "' to write.");
+    }
     detector_samples_out(circuit, num_samples, prepend_observables, append_observables, out, f, PYBIND_SHARED_RNG());
     fclose(out);
 }
@@ -90,7 +93,7 @@ std::string CompiledDetectorSampler::repr() const {
 }
 
 void pybind_compiled_detector_sampler(pybind11::module &m) {
-    auto &&c = pybind11::class_<CompiledDetectorSampler>(
+    auto c = pybind11::class_<CompiledDetectorSampler>(
         m, "CompiledDetectorSampler", "An analyzed stabilizer circuit whose detection events can be sampled quickly.");
 
     c.def(pybind11::init<Circuit>());

--- a/src/py/compiled_measurement_sampler.pybind.h
+++ b/src/py/compiled_measurement_sampler.pybind.h
@@ -22,16 +22,18 @@
 #include "../circuit/circuit.h"
 #include "../simd/simd_bits.h"
 
-void pybind_compiled_measurement_sampler(pybind11::module &m);
-
 struct CompiledMeasurementSampler {
     const stim_internal::simd_bits ref;
     const stim_internal::Circuit circuit;
-    CompiledMeasurementSampler(stim_internal::Circuit circuit);
+    const bool skip_reference_sample;
+    CompiledMeasurementSampler(stim_internal::Circuit circuit, bool skip_reference_sample);
     pybind11::array_t<uint8_t> sample(size_t num_samples);
     pybind11::array_t<uint8_t> sample_bit_packed(size_t num_samples);
     void sample_write(size_t num_samples, const std::string &filepath, const std::string &format);
     std::string repr() const;
 };
+
+pybind11::class_<CompiledMeasurementSampler> pybind_compiled_measurement_sampler_class(pybind11::module &m);
+void pybind_compiled_measurement_sampler_methods(pybind11::class_<CompiledMeasurementSampler> &c);
 
 #endif

--- a/src/py/compiled_measurement_sampler_pybind_test.py
+++ b/src/py/compiled_measurement_sampler_pybind_test.py
@@ -85,3 +85,44 @@ def test_sample_write():
         c.compile_sampler().sample_write(5, filepath=path, format='01')
         with open(path, 'r') as f:
             assert f.readlines() == ['1000110\n'] * 5
+
+
+def test_skip_reference_sample():
+    np.testing.assert_array_equal(
+        stim.Circuit("X 0\nM 0").compile_sampler().sample(1),
+        [[True]],
+    )
+    np.testing.assert_array_equal(
+        stim.Circuit("X 0\nM 0").compile_sampler(skip_reference_sample=False).sample(1),
+        [[True]],
+    )
+    np.testing.assert_array_equal(
+        stim.Circuit("X 0\nM 0").compile_sampler(skip_reference_sample=True).sample(1),
+        [[False]],
+    )
+    np.testing.assert_array_equal(
+        stim.Circuit("X_ERROR(1) 0\nM 0").compile_sampler(skip_reference_sample=False).sample(1),
+        [[True]],
+    )
+    np.testing.assert_array_equal(
+        stim.Circuit("X_ERROR(1) 0\nM 0").compile_sampler(skip_reference_sample=True).sample(1),
+        [[True]],
+    )
+
+
+def test_repr():
+    assert repr(stim.Circuit("""
+        X 0
+        M 0
+    """).compile_sampler()) == """stim.CompiledMeasurementSampler(stim.Circuit('''
+    X 0
+    M 0
+'''))"""
+
+    assert repr(stim.Circuit("""
+        X 0
+        M 0
+    """).compile_sampler(skip_reference_sample=True)) == """stim.CompiledMeasurementSampler(stim.Circuit('''
+    X 0
+    M 0
+'''), skip_reference_sample=True)"""

--- a/src/py/stim_pybind_test.py
+++ b/src/py/stim_pybind_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import doctest
+import importlib
+import types
 
 import stim
 import re
@@ -27,3 +30,63 @@ def test_targets():
     assert stim.target_inv(5) & 0xFFFF == 5
     assert stim.target_rec(-5) & 0xFFFF == 5
     assert isinstance(stim.target_combiner(), stim.GateTarget)
+
+
+def test_gate_data():
+    data = stim._UNSTABLE_raw_gate_data()
+    assert len(data) >= 69
+    assert data["CX"]["name"] == "CX"
+    assert data["X"]["unitary_matrix"] == [[0, 1], [1, 0]]
+
+
+def test_format_data():
+    format_data = stim._UNSTABLE_raw_format_data()
+    assert len(format_data) >= 6
+
+    # Check that example code has needed imports.
+    for k, v in format_data.items():
+        exec(v["parse_example"], {}, {})
+        exec(v["save_example"], {}, {})
+
+    # Collect sample methods.
+    ctx = {}
+    for k, v in format_data.items():
+        exec(v["parse_example"], {}, ctx)
+        exec(v["save_example"], {}, ctx)
+
+    # Manually test example save/parse methods.
+    data = [[0, 1, 1, 0], [0, 0, 0, 0]]
+    saved = "0110\n0000\n"
+    assert ctx["save_01"](data) == saved
+    assert ctx["parse_01"](saved) == data
+
+    saved = b"\x01\x00\x01\x04"
+    assert ctx["save_r8"](data) == saved
+    assert ctx["parse_r8"](saved, bits_per_shot=4) == data
+
+    saved = b"\x06\x00"
+    assert ctx["save_b8"](data) == saved
+    assert ctx["parse_b8"](saved, bits_per_shot=4) == data
+
+    saved = "1,2\n\n"
+    assert ctx["save_hits"](data) == saved
+    assert ctx["parse_hits"](saved, bits_per_shot=4) == data
+
+    saved = "shot D1 L0\nshot\n"
+    assert ctx["save_dets"](data, num_detectors=2, num_observables=2) == saved
+    assert ctx["parse_dets"](saved, num_detectors=2, num_observables=2) == data
+
+    saved = (b"\x00\x00\x00\x00\x00\x00\x00\x00"
+             b"\x01\x00\x00\x00\x00\x00\x00\x00"
+             b"\x01\x00\x00\x00\x00\x00\x00\x00"
+             b"\x00\x00\x00\x00\x00\x00\x00\x00")
+    assert ctx["save_ptb64"](data) == saved
+    assert ctx["parse_ptb64"](saved, bits_per_shot=4, num_shots=2) == data
+
+    # Check that python examples in help strings are correct.
+    for k, v in format_data.items():
+        mod = types.ModuleType('stim_test_fake')
+        mod.f = lambda: 5
+        mod.__test__ = {"f": mod.f}
+        mod.f.__doc__ = v["help"]
+        assert doctest.testmod(mod).failed == 0, k

--- a/src/simulators/detection_simulator.h
+++ b/src/simulators/detection_simulator.h
@@ -20,6 +20,7 @@
 #include <random>
 
 #include "../circuit/circuit.h"
+#include "../io/stim_data_formats.h"
 #include "../simd/simd_bit_table.h"
 
 namespace stim_internal {

--- a/src/simulators/tableau_simulator.pybind.cc
+++ b/src/simulators/tableau_simulator.pybind.cc
@@ -67,7 +67,7 @@ TempViewableData args_to_target_pairs(TableauSimulator &self, const pybind11::ar
 }
 
 void pybind_tableau_simulator(pybind11::module &m) {
-    auto &&c = pybind11::class_<TableauSimulator>(
+    auto c = pybind11::class_<TableauSimulator>(
         m,
         "TableauSimulator",
         clean_doc_string(u8R"DOC(

--- a/src/stabilizers/pauli_string.pybind.cc
+++ b/src/stabilizers/pauli_string.pybind.cc
@@ -198,7 +198,7 @@ std::string PyPauliString::str() const {
 }
 
 void pybind_pauli_string(pybind11::module &m) {
-    auto &&c = pybind11::class_<PyPauliString>(
+    auto c = pybind11::class_<PyPauliString>(
         m,
         "PauliString",
         clean_doc_string(u8R"DOC(

--- a/src/stabilizers/tableau.pybind.cc
+++ b/src/stabilizers/tableau.pybind.cc
@@ -23,7 +23,7 @@
 using namespace stim_internal;
 
 void pybind_tableau(pybind11::module &m) {
-    auto &&c = pybind11::class_<Tableau>(
+    auto c = pybind11::class_<Tableau>(
         m,
         "Tableau",
         clean_doc_string(u8R"DOC(


### PR DESCRIPTION
- Drop r-value ref usage when declaring pybind classes
- Add skip_reference_sample option to CompiledMeasurementSampler
- Deprecate `--frame0` in favor of `--skip_reference_sample`
- Rename main_helper to stim_internal::main
- Add io/stim_data_formats.{h,cc} for format data
- Switch from exit(EXIT_FAILURE) to throw std::invalid_argument in arg_parse.cc
- Add doc/result_formats.md
- Add unit testing of example format data methods
- Add format entries to command line documentation

Fixes https://github.com/quantumlib/Stim/issues/135