### PR TITLE
Add support for bulk reading of measurement data

### DIFF
--- a/src/stim/circuit/circuit_instruction.pybind.h
+++ b/src/stim/circuit/circuit_instruction.pybind.h
@@ -30,8 +30,7 @@ struct CircuitInstruction {
 
     CircuitInstruction(
         const char *name, const std::vector<pybind11::object> &targets, const std::vector<double> &gate_args);
-    CircuitInstruction(
-        const stim::Gate &gate, std::vector<stim::GateTarget> targets, std::vector<double> gate_args);
+    CircuitInstruction(const stim::Gate &gate, std::vector<stim::GateTarget> targets, std::vector<double> gate_args);
 
     std::string name() const;
     std::vector<stim::GateTarget> targets_copy() const;

--- a/src/stim/io/measure_record_reader.cc
+++ b/src/stim/io/measure_record_reader.cc
@@ -399,7 +399,7 @@ void MeasureRecordReaderFormatR8::buffer_data() {
         int t = getc(in);
         if (t == EOF) {
             throw std::invalid_argument(
-                "r8 data ended too early. "
+                "r8 data ended too early.  "
                 "The extracted data ended in a 1, but there was no corresponding 0x00 terminator byte for the expected "
                 "'fake encoded 1 just after the end of the data' before the input ended.");
         } else if (t != 0) {

--- a/src/stim/io/measure_record_reader.cc
+++ b/src/stim/io/measure_record_reader.cc
@@ -399,7 +399,7 @@ void MeasureRecordReaderFormatR8::buffer_data() {
         int t = getc(in);
         if (t == EOF) {
             throw std::invalid_argument(
-                "r8 data ended too early.  "
+                "r8 data ended too early. "
                 "The extracted data ended in a 1, but there was no corresponding 0x00 terminator byte for the expected "
                 "'fake encoded 1 just after the end of the data' before the input ended.");
         } else if (t != 0) {

--- a/src/stim/io/measure_record_reader.cc
+++ b/src/stim/io/measure_record_reader.cc
@@ -17,7 +17,6 @@
 #include "stim/io/measure_record_reader.h"
 
 #include <algorithm>
-#include <limits.h>
 
 using namespace stim;
 
@@ -49,9 +48,8 @@ bool read_uint64(FILE *in, uint64_t &value, int &next) {
     }
 
     value = 0;
-    uint64_t prev_value = 0;
     while (isdigit(next)) {
-        prev_value = value;
+        uint64_t prev_value = value;
         value *= 10;
         value += next - '0';
         if (value < prev_value) {
@@ -60,6 +58,32 @@ bool read_uint64(FILE *in, uint64_t &value, int &next) {
         next = getc(in);
     }
     return true;
+}
+
+size_t MeasureRecordReader::read_records_into(simd_bit_table &out, bool major_index_is_shot_index, size_t max_shots) {
+    if (!major_index_is_shot_index) {
+        simd_bit_table buf(out.num_minor_bits_padded(), out.num_major_bits_padded());
+        size_t r = read_records_into(buf, true, max_shots);
+        buf.transpose_into(out);
+        return r;
+    }
+
+    size_t rec = 0;
+    max_shots = std::min(max_shots, out.num_major_bits_padded());
+    while (rec < max_shots) {
+        size_t n = read_bytes({out[rec].u8, out[rec].u8 + out[rec].num_u8_padded()});
+        if (n == 0) {
+            break;
+        }
+        if (!is_end_of_record()) {
+            throw std::invalid_argument("Failed to read data. A shot contained more bits than expected.");
+        }
+        rec++;
+        if (!next_record()) {
+            break;
+        }
+    }
+    return rec;
 }
 
 std::unique_ptr<MeasureRecordReader> MeasureRecordReader::make(
@@ -201,8 +225,16 @@ bool MeasureRecordReaderFormatB8::read_bit() {
 }
 
 bool MeasureRecordReaderFormatB8::next_record() {
+    while (!is_end_of_record()) {
+        read_bit();
+    }
     position = 0;
-    return false;
+    int i = fgetc(in);
+    if (i == EOF) {
+        return false;
+    }
+    ungetc(i, in);
+    return true;
 }
 
 bool MeasureRecordReaderFormatB8::is_end_of_record() {
@@ -282,25 +314,22 @@ void MeasureRecordReaderFormatHits::update_next_hit() {
 
 MeasureRecordReaderFormatR8::MeasureRecordReaderFormatR8(FILE *in, size_t bits_per_record)
     : in(in), bits_per_record(bits_per_record) {
-    update_run_length();
-    run_length_1s = 0;
 }
 
 size_t MeasureRecordReaderFormatR8::read_bytes(PointerRange<uint8_t> data) {
-    if (position >= bits_per_record) {
-        return 0;
-    }
     size_t n = 0;
     for (uint8_t &b : data) {
-        if (run_length_0s >= generated_0s + 8 && bits_per_record >= position + 8) {
-            b = 0;
+        b = 0;
+        if (buffered_0s >= 8) {
             position += 8;
-            generated_0s += 8;
+            buffered_0s -= 8;
             n += 8;
             continue;
         }
-        b = 0;
         for (size_t k = 0; k < 8; k++) {
+            if (!buffered_0s && !buffered_1s && !have_seen_terminal_1) {
+                buffer_data();
+            }
             if (is_end_of_record()) {
                 return n;
             }
@@ -312,63 +341,71 @@ size_t MeasureRecordReaderFormatR8::read_bytes(PointerRange<uint8_t> data) {
 }
 
 bool MeasureRecordReaderFormatR8::read_bit() {
-    if (position >= bits_per_record) {
-        throw std::out_of_range("Attempt to read past end-of-record");
+    if (!buffered_0s && !buffered_1s) {
+        buffer_data();
     }
-    if (generated_1s < run_length_1s) {
-        ++generated_1s;
-        ++position;
-        return true;
-    }
-    if (generated_0s < run_length_0s) {
-        ++generated_0s;
-        ++position;
+    if (buffered_0s) {
+        buffered_0s--;
+        position++;
         return false;
-    }
-    if (!update_run_length()) {
-        throw std::out_of_range("Attempt to read past end-of-file");
-    } else {
-        ++generated_1s;
-        ++position;
+    } else if (buffered_1s) {
+        buffered_1s--;
+        position++;
         return true;
+    } else {
+        throw std::invalid_argument("Read past end-of-record.");
     }
 }
 
 bool MeasureRecordReaderFormatR8::next_record() {
+    while (!is_end_of_record()) {
+        read_bit();
+    }
     position = 0;
-    return false;
+    have_seen_terminal_1 = false;
+    int i = fgetc(in);
+    if (i == EOF) {
+        return false;
+    }
+    ungetc(i, in);
+    return true;
 }
 
 bool MeasureRecordReaderFormatR8::is_end_of_record() {
-    if (position >= bits_per_record) {
-        return true;
-    }
-    if (generated_0s < run_length_0s) {
-        return false;
-    }
-    if (generated_1s < run_length_1s) {
-        return false;
-    }
-    return !update_run_length();
+    return position == bits_per_record && have_seen_terminal_1;
 }
 
-bool MeasureRecordReaderFormatR8::update_run_length() {
-    int r = getc(in);
-    if (r == EOF) {
-        return false;
+void MeasureRecordReaderFormatR8::buffer_data() {
+    assert(buffered_0s == 0);
+    assert(buffered_1s == 0);
+    if (is_end_of_record()) {
+        throw std::invalid_argument("Attempted to read past end-of-record.");
     }
-    run_length_0s = 0;
-    while (r == 0xFF) {
-        run_length_0s += 0xFF;
+
+    // Count zeroes until a one is found.
+    int r;
+    do {
         r = getc(in);
+        if (r == EOF) {
+            throw std::invalid_argument("r8 data hit end-of-file without seeing a 1 encoded at end of data.");
+        }
+        buffered_0s += r;
+    } while (r == 0xFF);
+    buffered_1s = 1;
+
+    // Check if the 1 is the one at end of data.
+    size_t total_data = position + buffered_0s + buffered_1s;
+    if (total_data == bits_per_record) {
+        if (getc(in) != 0) {
+            throw std::invalid_argument("r8 data ending in an encoded 1 didn't include a 0x00 byte encoding the extra 1 at end of data.");
+        }
+        have_seen_terminal_1 = true;
+    } else if (total_data == bits_per_record + 1) {
+        have_seen_terminal_1 = true;
+        buffered_1s = 0;
+    } else if (total_data > bits_per_record + 1) {
+        throw std::invalid_argument("r8 data encoded a jump past the expected end of encoded data.");
     }
-    if (r > 0) {
-        run_length_0s += r;
-    }
-    run_length_1s = 1;
-    generated_0s = 0;
-    generated_1s = 0;
-    return true;
 }
 
 /// DETS format

--- a/src/stim/io/measure_record_reader.h
+++ b/src/stim/io/measure_record_reader.h
@@ -52,7 +52,7 @@ struct MeasureRecordReader {
     /// Reads multiple measurement results. Returns the number of results read. If no results are available,
     /// zero is returned. Read terminates when data is filled up or when the current record ends. Note that
     /// records encoded in HITS and DETS file formats never end.
-    virtual size_t read_bytes(PointerRange<uint8_t> buf);
+    virtual size_t read_bits_into_bytes(PointerRange<uint8_t> out_buffer);
 
     /// Reads entire records into the given bit table.
     ///
@@ -83,7 +83,7 @@ struct MeasureRecordReader {
     virtual bool next_record() = 0;
 
     /// Returns true when the current record has ended. Beyond this point read_bit() throws an exception
-    /// and read_bytes() returns no data. Note that records in file formats HITS and DETS never end.
+    /// and read_bits_into_bytes() returns no data. Note that records in file formats HITS and DETS never end.
     virtual bool is_end_of_record() = 0;
 
     /// Used to obtain the DETS format prefix character (M for measurement, D for detector, L for logical
@@ -113,7 +113,7 @@ struct MeasureRecordReaderFormatB8 : MeasureRecordReader {
 
     MeasureRecordReaderFormatB8(FILE *in, size_t bits_per_record);
 
-    size_t read_bytes(PointerRange<uint8_t> data) override;
+    size_t read_bits_into_bytes(PointerRange<uint8_t> out_buffer) override;
     bool read_bit() override;
     bool next_record() override;
     bool is_end_of_record() override;
@@ -150,7 +150,7 @@ struct MeasureRecordReaderFormatR8 : MeasureRecordReader {
 
     MeasureRecordReaderFormatR8(FILE *in, size_t bits_per_record);
 
-    size_t read_bytes(PointerRange<uint8_t> data) override;
+    size_t read_bits_into_bytes(PointerRange<uint8_t> out_buffer) override;
     bool read_bit() override;
     bool next_record() override;
     bool is_end_of_record() override;

--- a/src/stim/io/measure_record_writer.cc
+++ b/src/stim/io/measure_record_writer.cc
@@ -42,6 +42,14 @@ std::unique_ptr<MeasureRecordWriter> MeasureRecordWriter::make(FILE *out, Sample
 void MeasureRecordWriter::begin_result_type(char result_type) {
 }
 
+void MeasureRecordWriter::write_bits(uint8_t *data, size_t num_bits) {
+    size_t num_bytes = num_bits >> 3;
+    write_bytes({data, data + num_bytes});
+    for (size_t b = 0; b < (num_bits & 7); b++) {
+        write_bit((data[num_bytes] >> b) & 1);
+    }
+}
+
 void MeasureRecordWriter::write_bytes(ConstPointerRange<uint8_t> data) {
     for (uint8_t b : data) {
         for (size_t k = 0; k < 8; k++) {

--- a/src/stim/io/measure_record_writer.h
+++ b/src/stim/io/measure_record_writer.h
@@ -39,6 +39,8 @@ struct MeasureRecordWriter {
     virtual void write_bytes(ConstPointerRange<uint8_t> data);
     /// Flushes all buffered measurement results and writes any end-of-record markers that are needed (e.g. a newline).
     virtual void write_end() = 0;
+    /// Writes (or buffers) multiple measurement results.
+    virtual void write_bits(uint8_t *data, size_t num_bits);
     /// Used to control the DETS format prefix character (M for measurement, D for detector, L for logical observable).
     ///
     /// Setting this is understood to reset the "result index" back to 0 so that e.g. listing logical observables after

--- a/src/stim/io/measure_record_writer.test.cc
+++ b/src/stim/io/measure_record_writer.test.cc
@@ -376,3 +376,57 @@ TEST(MeasureRecordWriter, write_table_data_large) {
             "\0\0\0\0\0\0\0\0",
             8 * 100));
 }
+
+TEST(MeasureRecordWriter, write_bits_01_a) {
+    FILE *f = tmpfile();
+    uint8_t data[]{0x0, 0xFF};
+    auto writer = MeasureRecordWriter::make(f, SampleFormat::SAMPLE_FORMAT_01);
+    writer->write_bits(&data[0], 11);
+    writer->write_end();
+    ASSERT_EQ(rewind_read_all(f), "00000000111\n");
+}
+
+TEST(MeasureRecordWriter, write_bits_01_b) {
+    FILE *f = tmpfile();
+    uint8_t data[] {0xFF, 0x0};
+    auto writer = MeasureRecordWriter::make(f, SampleFormat::SAMPLE_FORMAT_01);
+    writer->write_bits(&data[0], 11);
+    writer->write_end();
+    ASSERT_EQ(rewind_read_all(f), "11111111000\n");
+}
+
+TEST(MeasureRecordWriter, write_bits_b8_a) {
+    FILE *f = tmpfile();
+    uint8_t data[]{0x0, 0xFF};
+    auto writer = MeasureRecordWriter::make(f, SampleFormat::SAMPLE_FORMAT_B8);
+    writer->write_bits(&data[0], 11);
+    writer->write_end();
+    ASSERT_EQ(rewind_read_all(f), std::string("\x00\x07", 2));
+}
+
+TEST(MeasureRecordWriter, write_bits_b8_b) {
+    FILE *f = tmpfile();
+    uint8_t data[] {0xFF, 0x0};
+    auto writer = MeasureRecordWriter::make(f, SampleFormat::SAMPLE_FORMAT_B8);
+    writer->write_bits(&data[0], 11);
+    writer->write_end();
+    ASSERT_EQ(rewind_read_all(f), std::string("\xFF\x00", 2));
+}
+
+TEST(MeasureRecordWriter, write_bits_r8_a) {
+    FILE *f = tmpfile();
+    uint8_t data[]{0x0, 0xFF};
+    auto writer = MeasureRecordWriter::make(f, SampleFormat::SAMPLE_FORMAT_R8);
+    writer->write_bits(&data[0], 11);
+    writer->write_end();
+    ASSERT_EQ(rewind_read_all(f), std::string("\x08\x00\x00\x00", 4));
+}
+
+TEST(MeasureRecordWriter, write_bits_r8_b) {
+    FILE *f = tmpfile();
+    uint8_t data[] {0xFF, 0x0};
+    auto writer = MeasureRecordWriter::make(f, SampleFormat::SAMPLE_FORMAT_R8);
+    writer->write_bits(&data[0], 11);
+    writer->write_end();
+    ASSERT_EQ(rewind_read_all(f), std::string("\x00\x00\x00\x00\x00\x00\x00\x00\x03", 9));
+}


### PR DESCRIPTION
- Add MeasureRecordWriter::write_bits
- Add MeasureRecordReader::read_records_into
- Fix MeasureRecordReaderFormat{R8,B8}::next_record not reading to end of current record, and also unconditionally reporting failure
- Combine `MeasureRecordReaderFormatR8::{run_length,generated}_{0s,1s}` into `buffered_{0s,1s}`
- Fix MeasureRecordReaderFormatR8 not explicitly checking for and tracking the terminal 1 bit
- Rename `read_bytes` to `read_bits_into_bytes`