### PR TITLE
Add the ability to seed samplers when creating them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-10.15]
+        os: [ubuntu-latest, windows-2019, macOS-10.15]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -43,14 +43,14 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
   run_main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - run: cmake .
     - run: make stim
     - run: echo -e "H 0 \n CNOT 0 1 \n M 0 1" | out/stim --sample
   build_lib:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - run: cmake .
@@ -67,7 +67,7 @@ jobs:
       - run: MSBuild.exe stim_benchmark.vcxproj /p:Configuration=Release /p:OutDir=msbuild_out /p:O=2
       - run: msbuild_out/stim_benchmark.exe
   benchmark:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         simd_width: [64, 128, 256]
@@ -77,7 +77,7 @@ jobs:
     - run: make stim_benchmark
     - run: out/stim_benchmark
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         simd_width: [64, 128, 256]
@@ -94,7 +94,7 @@ jobs:
     - run: make stim_test
     - run: out/stim_test
   test_o3:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - run: |
@@ -108,7 +108,7 @@ jobs:
     - run: make stim_test_o3
     - run: out/stim_test_o3
   test_generated_docs_are_fresh:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
@@ -123,7 +123,7 @@ jobs:
       - run: diff doc/result_formats.md <(out/stim help formats_markdown)
       - run: diff doc/usage_command_line.md <(out/stim help flags_markdown)
   test_pybind:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
@@ -135,7 +135,7 @@ jobs:
       - run: pytest src
       - run: python -c "import stim; import doctest; assert doctest.testmod(stim).failed == 0"
   test_stimcirq:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
@@ -148,7 +148,7 @@ jobs:
       - run: pytest glue/cirq
       - run: python -c "import stimcirq; import doctest; assert doctest.testmod(stimcirq).failed == 0"
   test_stimzx:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -1292,9 +1292,9 @@
 > Examples:
 >     >>> import stim
 >     >>> c = stim.Circuit('''
->     ...    H 2
->     ...    CNOT 2 3
->     ...    X_ERROR(1.0) 2
+>     ...    H 0
+>     ...    CNOT 0 1
+>     ...    X_ERROR(1.0) 0
 >     ...    M 0 1
 >     ...    DETECTOR rec[-1] rec[-2]
 >     ... ''')

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -44,6 +44,7 @@
     - [`stim.CircuitRepeatBlock.body_copy`](#stim.CircuitRepeatBlock.body_copy)
     - [`stim.CircuitRepeatBlock.repeat_count`](#stim.CircuitRepeatBlock.repeat_count)
 - [`stim.CompiledDetectorSampler`](#stim.CompiledDetectorSampler)
+    - [`stim.CompiledDetectorSampler.__init__`](#stim.CompiledDetectorSampler.__init__)
     - [`stim.CompiledDetectorSampler.__repr__`](#stim.CompiledDetectorSampler.__repr__)
     - [`stim.CompiledDetectorSampler.sample`](#stim.CompiledDetectorSampler.sample)
     - [`stim.CompiledDetectorSampler.sample_bit_packed`](#stim.CompiledDetectorSampler.sample_bit_packed)
@@ -796,9 +797,30 @@
 >     stim.Circuit()
 > ```
 
-### `stim.Circuit.compile_detector_sampler(self) -> stim.CompiledDetectorSampler`<a name="stim.Circuit.compile_detector_sampler"></a>
+### `stim.Circuit.compile_detector_sampler(self, *, seed: object = None) -> stim.CompiledDetectorSampler`<a name="stim.Circuit.compile_detector_sampler"></a>
 > ```
 > Returns a CompiledDetectorSampler, which can quickly batch sample detection events, for the circuit.
+> 
+> Args:
+>     seed: PARTIALLY determines simulation results by deterministically seeding the random number generator.
+>         Must be None or an integer in range(2**64).
+> 
+>         Defaults to None. When set to None, a prng seeded by system entropy is used.
+> 
+>         When set to an integer, making the exact same series calls on the exact same machine with the exact
+>         same version of Stim will produce the exact same simulation results.
+> 
+>         CAUTION: simulation results *WILL NOT* be consistent between versions of Stim. This restriction is
+>         present to make it possible to have future optimizations to the random sampling, and is enforced by
+>         introducing intentional differences in the seeding strategy from version to version.
+> 
+>         CAUTION: simulation results *MAY NOT* be consistent across machines that differ in the width of
+>         supported SIMD instructions. For example, using the same seed on a machine that supports AVX
+>         instructions and one that only supports SSE instructions may produce different simulation results.
+> 
+>         CAUTION: simulation results *MAY NOT* be consistent if you vary how many shots are taken. For
+>         example, taking 10 shots and then 90 shots will give different results from taking 100 shots in one
+>         call.
 > 
 > Examples:
 >     >>> import stim
@@ -813,7 +835,7 @@
 >     array([[0]], dtype=uint8)
 > ```
 
-### `stim.Circuit.compile_sampler(self, *, skip_reference_sample: bool = False) -> stim.CompiledMeasurementSampler`<a name="stim.Circuit.compile_sampler"></a>
+### `stim.Circuit.compile_sampler(self, *, skip_reference_sample: bool = False, seed: object = None) -> stim.CompiledMeasurementSampler`<a name="stim.Circuit.compile_sampler"></a>
 > ```
 > Returns a CompiledMeasurementSampler, which can quickly batch sample measurements, for the circuit.
 > 
@@ -830,6 +852,25 @@
 >         other. Computing the reference sample is the most time consuming and memory intensive part of
 >         simulating the circuit, so promising that the simulator can safely skip that step is an effective
 >         optimization.
+>     seed: PARTIALLY determines simulation results by deterministically seeding the random number generator.
+>         Must be None or an integer in range(2**64).
+> 
+>         Defaults to None. When set to None, a prng seeded by system entropy is used.
+> 
+>         When set to an integer, making the exact same series calls on the exact same machine with the exact
+>         same version of Stim will produce the exact same simulation results.
+> 
+>         CAUTION: simulation results *WILL NOT* be consistent between versions of Stim. This restriction is
+>         present to make it possible to have future optimizations to the random sampling, and is enforced by
+>         introducing intentional differences in the seeding strategy from version to version.
+> 
+>         CAUTION: simulation results *MAY NOT* be consistent across machines that differ in the width of
+>         supported SIMD instructions. For example, using the same seed on a machine that supports AVX
+>         instructions and one that only supports SSE instructions may produce different simulation results.
+> 
+>         CAUTION: simulation results *MAY NOT* be consistent if you vary how many shots are taken. For
+>         example, taking 10 shots and then 90 shots will give different results from taking 100 shots in one
+>         call.
 > 
 > Examples:
 >     >>> import stim
@@ -1219,6 +1260,49 @@
 >     5
 > ```
 
+### `stim.CompiledDetectorSampler.__init__(self, circuit: stim.Circuit, *, seed: object = None) -> None`<a name="stim.CompiledDetectorSampler.__init__"></a>
+> ```
+> Creates a detector sampler, which can sample the detectors (and optionally observables) in a circuit.
+> 
+> Args:
+>     circuit: The circuit to sample from.
+>     seed: PARTIALLY determines simulation results by deterministically seeding the random number generator.
+>         Must be None or an integer in range(2**64).
+> 
+>         Defaults to None. When set to None, a prng seeded by system entropy is used.
+> 
+>         When set to an integer, making the exact same series calls on the exact same machine with the exact
+>         same version of Stim will produce the exact same simulation results.
+> 
+>         CAUTION: simulation results *WILL NOT* be consistent between versions of Stim. This restriction is
+>         present to make it possible to have future optimizations to the random sampling, and is enforced by
+>         introducing intentional differences in the seeding strategy from version to version.
+> 
+>         CAUTION: simulation results *MAY NOT* be consistent across machines that differ in the width of
+>         supported SIMD instructions. For example, using the same seed on a machine that supports AVX
+>         instructions and one that only supports SSE instructions may produce different simulation results.
+> 
+>         CAUTION: simulation results *MAY NOT* be consistent if you vary how many shots are taken. For
+>         example, taking 10 shots and then 90 shots will give different results from taking 100 shots in one
+>         call.
+> 
+> Returns:
+>     An initialized stim.CompiledDetectorSampler.
+> 
+> Examples:
+>     >>> import stim
+>     >>> c = stim.Circuit('''
+>     ...    H 2
+>     ...    CNOT 2 3
+>     ...    X_ERROR(1.0) 2
+>     ...    M 0 1
+>     ...    DETECTOR rec[-1] rec[-2]
+>     ... ''')
+>     >>> s = c.compile_detector_sampler()
+>     >>> s.sample(shots=1)
+>     array([[1]], dtype=uint8)
+> ```
+
 ### `stim.CompiledDetectorSampler.__repr__(self) -> str`<a name="stim.CompiledDetectorSampler.__repr__"></a>
 > ```
 > Returns text that is a valid python expression evaluating to an equivalent `stim.CompiledDetectorSampler`.
@@ -1300,7 +1384,7 @@
 >     None.
 > ```
 
-### `stim.CompiledMeasurementSampler.__init__(self, circuit: stim.Circuit, *, skip_reference_sample: bool = False) -> None`<a name="stim.CompiledMeasurementSampler.__init__"></a>
+### `stim.CompiledMeasurementSampler.__init__(self, circuit: stim.Circuit, *, skip_reference_sample: bool = False, seed: object = None) -> None`<a name="stim.CompiledMeasurementSampler.__init__"></a>
 > ```
 > Creates a measurement sampler for the given circuit.
 > 
@@ -1322,6 +1406,25 @@
 >         other. Computing the reference sample is the most time consuming and memory intensive part of
 >         simulating the circuit, so promising that the simulator can safely skip that step is an effective
 >         optimization.
+>     seed: PARTIALLY determines simulation results by deterministically seeding the random number generator.
+>         Must be None or an integer in range(2**64).
+> 
+>         Defaults to None. When set to None, a prng seeded by system entropy is used.
+> 
+>         When set to an integer, making the exact same series calls on the exact same machine with the exact
+>         same version of Stim will produce the exact same simulation results.
+> 
+>         CAUTION: simulation results *WILL NOT* be consistent between versions of Stim. This restriction is
+>         present to make it possible to have future optimizations to the random sampling, and is enforced by
+>         introducing intentional differences in the seeding strategy from version to version.
+> 
+>         CAUTION: simulation results *MAY NOT* be consistent across machines that differ in the width of
+>         supported SIMD instructions. For example, using the same seed on a machine that supports AVX
+>         instructions and one that only supports SSE instructions may produce different simulation results.
+> 
+>         CAUTION: simulation results *MAY NOT* be consistent if you vary how many shots are taken. For
+>         example, taking 10 shots and then 90 shots will give different results from taking 100 shots in one
+>         call.
 > 
 > Returns:
 >     A numpy array with `dtype=uint8` and `shape=(shots, num_measurements)`.

--- a/doc/usage_command_line.md
+++ b/doc/usage_command_line.md
@@ -154,6 +154,7 @@ error(0.003344519141621982161) D1
     - [--in](#--in)
 - **(mode)** [stim detect](#detect)
     - [--out_format](#--out_format)
+    - [--seed](#--seed)
     - [--append_observables](#--append_observables)
     - [--in](#--in)
     - [--out](#--out)
@@ -179,6 +180,7 @@ error(0.003344519141621982161) D1
 - **(mode)** [stim repl](#repl)
 - **(mode)** [stim sample](#sample)
     - [--out_format](#--out_format)
+    - [--seed](#--seed)
     - [--in](#--in)
     - [--out](#--out)
     - [--skip_reference_sample](#--skip_reference_sample)
@@ -317,6 +319,7 @@ error(0.003344519141621982161) D1
     
     Flags used with this mode:
         - [--out_format](#--out_format)
+        - [--seed](#--seed)
         - [--append_observables](#--append_observables)
         - [--in](#--in)
         - [--out](#--out)
@@ -510,6 +513,7 @@ error(0.003344519141621982161) D1
     
     Flags used with this mode:
         - [--out_format](#--out_format)
+        - [--seed](#--seed)
         - [--in](#--in)
         - [--out](#--out)
         - [--skip_reference_sample](#--skip_reference_sample)
@@ -708,6 +712,29 @@ error(0.003344519141621982161) D1
     
     The number of rounds must be an integer between 1 and a quintillion (10^18). Different codes/tasks may place additional
     constraints on the number of rounds (e.g. enough rounds to have measured all the stabilizers at least once).
+    
+    
+- <a name="--seed"></a>**`--seed`**
+    Make simulation results PARTIALLY deterministic.
+    
+    When not set, the random number generator is seeded with external system entropy.
+    
+    When set to an integer, using the exact same other flags on the exact same machine with the exact
+    same version of Stim will produce the exact same simulation results.
+    The integer must be a non-negative 64 bit signed integer.
+    
+    CAUTION: simulation results *WILL NOT* be consistent between versions of Stim. This restriction is
+    present to make it possible to have future optimizations to the random sampling, and is enforced by
+    introducing intentional differences in the seeding strategy from version to version.
+    
+    CAUTION: simulation results *MAY NOT* be consistent across machines. For example, using the same
+    seed on a machine that supports AVX instructions and one that only supports SSE instructions may
+    produce different simulation results.
+    
+    CAUTION: simulation results *MAY NOT* be consistent if you vary other flags and modes. For example,
+    `--skip_reference_sample` may result in fewer calls the to the random number generator before reported
+    sampling begins. More generally, using the same seed for `stim sample` and `stim detect` will not
+    result in detection events corresponding to the measurement results.
     
     
 - <a name="--shots"></a>**`--shots`**

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -178,11 +178,10 @@ void pybind_circuit(pybind11::module &m) {
 
     c.def(
         "compile_sampler",
-        [](const Circuit &self, bool skip_reference_sample) {
-            return CompiledMeasurementSampler(self, skip_reference_sample);
-        },
+        &py_init_compiled_sampler,
         pybind11::kw_only(),
         pybind11::arg("skip_reference_sample") = false,
+        pybind11::arg("seed") = pybind11::none(),
         clean_doc_string(u8R"DOC(
             Returns a CompiledMeasurementSampler, which can quickly batch sample measurements, for the circuit.
 
@@ -199,6 +198,25 @@ void pybind_circuit(pybind11::module &m) {
                     other. Computing the reference sample is the most time consuming and memory intensive part of
                     simulating the circuit, so promising that the simulator can safely skip that step is an effective
                     optimization.
+                seed: PARTIALLY determines simulation results by deterministically seeding the random number generator.
+                    Must be None or an integer in range(2**64).
+
+                    Defaults to None. When set to None, a prng seeded by system entropy is used.
+
+                    When set to an integer, making the exact same series calls on the exact same machine with the exact
+                    same version of Stim will produce the exact same simulation results.
+
+                    CAUTION: simulation results *WILL NOT* be consistent between versions of Stim. This restriction is
+                    present to make it possible to have future optimizations to the random sampling, and is enforced by
+                    introducing intentional differences in the seeding strategy from version to version.
+
+                    CAUTION: simulation results *MAY NOT* be consistent across machines that differ in the width of
+                    supported SIMD instructions. For example, using the same seed on a machine that supports AVX
+                    instructions and one that only supports SSE instructions may produce different simulation results.
+
+                    CAUTION: simulation results *MAY NOT* be consistent if you vary how many shots are taken. For
+                    example, taking 10 shots and then 90 shots will give different results from taking 100 shots in one
+                    call.
 
             Examples:
                 >>> import stim
@@ -214,11 +232,32 @@ void pybind_circuit(pybind11::module &m) {
 
     c.def(
         "compile_detector_sampler",
-        [](Circuit &self) {
-            return CompiledDetectorSampler(self);
-        },
+        &py_init_compiled_detector_sampler,
+        pybind11::kw_only(),
+        pybind11::arg("seed") = pybind11::none(),
         clean_doc_string(u8R"DOC(
             Returns a CompiledDetectorSampler, which can quickly batch sample detection events, for the circuit.
+
+            Args:
+                seed: PARTIALLY determines simulation results by deterministically seeding the random number generator.
+                    Must be None or an integer in range(2**64).
+
+                    Defaults to None. When set to None, a prng seeded by system entropy is used.
+
+                    When set to an integer, making the exact same series calls on the exact same machine with the exact
+                    same version of Stim will produce the exact same simulation results.
+
+                    CAUTION: simulation results *WILL NOT* be consistent between versions of Stim. This restriction is
+                    present to make it possible to have future optimizations to the random sampling, and is enforced by
+                    introducing intentional differences in the seeding strategy from version to version.
+
+                    CAUTION: simulation results *MAY NOT* be consistent across machines that differ in the width of
+                    supported SIMD instructions. For example, using the same seed on a machine that supports AVX
+                    instructions and one that only supports SSE instructions may produce different simulation results.
+
+                    CAUTION: simulation results *MAY NOT* be consistent if you vary how many shots are taken. For
+                    example, taking 10 shots and then 90 shots will give different results from taking 100 shots in one
+                    call.
 
             Examples:
                 >>> import stim

--- a/src/stim/circuit/circuit_pybind_test.py
+++ b/src/stim/circuit/circuit_pybind_test.py
@@ -514,3 +514,54 @@ def test_append_instructions_and_blocks():
 
     with pytest.raises(ValueError, match="repeat 0"):
         c.append_operation(stim.CircuitRepeatBlock(0, stim.Circuit("H 1")))
+
+
+def test_circuit_measurement_sampling_seeded():
+    c = stim.Circuit("""
+        H 0
+        M 0
+    """)
+    with pytest.raises(ValueError, match="seed"):
+        c.compile_sampler(seed=-1)
+    with pytest.raises(ValueError, match="seed"):
+        c.compile_sampler(seed=object())
+
+    s1 = c.compile_sampler().sample(256)
+    s2 = c.compile_sampler().sample(256)
+    assert not np.array_equal(s1, s2)
+
+    s1 = c.compile_sampler(seed=None).sample(256)
+    s2 = c.compile_sampler(seed=None).sample(256)
+    assert not np.array_equal(s1, s2)
+
+    s1 = c.compile_sampler(seed=5).sample(256)
+    s2 = c.compile_sampler(seed=5).sample(256)
+    s3 = c.compile_sampler(seed=6).sample(256)
+    assert np.array_equal(s1, s2)
+    assert not np.array_equal(s1, s3)
+
+
+def test_circuit_detector_sampling_seeded():
+    c = stim.Circuit("""
+        X_ERROR(0.5) 0
+        M 0
+        DETECTOR rec[-1]
+    """)
+    with pytest.raises(ValueError, match="seed"):
+        c.compile_detector_sampler(seed=-1)
+    with pytest.raises(ValueError, match="seed"):
+        c.compile_detector_sampler(seed=object())
+
+    s1 = c.compile_detector_sampler().sample(256)
+    s2 = c.compile_detector_sampler().sample(256)
+    assert not np.array_equal(s1, s2)
+
+    s1 = c.compile_detector_sampler(seed=None).sample(256)
+    s2 = c.compile_detector_sampler(seed=None).sample(256)
+    assert not np.array_equal(s1, s2)
+
+    s1 = c.compile_detector_sampler(seed=5).sample(256)
+    s2 = c.compile_detector_sampler(seed=5).sample(256)
+    s3 = c.compile_detector_sampler(seed=6).sample(256)
+    assert np.array_equal(s1, s2)
+    assert not np.array_equal(s1, s3)

--- a/src/stim/help.cc
+++ b/src/stim/help.cc
@@ -126,7 +126,7 @@ stdout: The sample data.
     shot M2 M3 M5
     ```
 )PARAGRAPH",
-        {"--out_format", "--in", "--out", "--skip_reference_sample", "--shots"},
+        {"--out_format", "--seed", "--in", "--out", "--skip_reference_sample", "--shots"},
     };
 
     modes["m2d"] = CommandLineSingleModeData{
@@ -271,7 +271,7 @@ See also: `stim help DETECTOR` and `stim help OBSERVABLE_INCLUDE`.
     shot D2 D3
     ```
 )PARAGRAPH",
-        {"--out_format", "--append_observables", "--in", "--out", "--shots"}};
+        {"--out_format", "--seed", "--append_observables", "--in", "--out", "--shots"}};
 
     flags["--append_observables"] = R"PARAGRAPH(Treat observables as extra detectors at the end of the circuit.
 
@@ -280,7 +280,29 @@ be reported as if they were detectors. For example, if there are 100 detectors a
 the output will contain 110 detectors and the last 10 are the observables. A notable exception to the "observables are
 just extra detectors" behavior of this flag is that, when using `out_format=dets`, the observables are distinguished
 from detectors by being named e.g. `L0` through `L9` instead of `D100` through `D109`.
-)PARAGRAPH",
+)PARAGRAPH";
+
+    flags["--seed"] = R"PARAGRAPH(Make simulation results PARTIALLY deterministic.
+
+When not set, the random number generator is seeded with external system entropy.
+
+When set to an integer, using the exact same other flags on the exact same machine with the exact
+same version of Stim will produce the exact same simulation results.
+The integer must be a non-negative 64 bit signed integer.
+
+CAUTION: simulation results *WILL NOT* be consistent between versions of Stim. This restriction is
+present to make it possible to have future optimizations to the random sampling, and is enforced by
+introducing intentional differences in the seeding strategy from version to version.
+
+CAUTION: simulation results *MAY NOT* be consistent across machines. For example, using the same
+seed on a machine that supports AVX instructions and one that only supports SSE instructions may
+produce different simulation results.
+
+CAUTION: simulation results *MAY NOT* be consistent if you vary other flags and modes. For example,
+`--skip_reference_sample` may result in fewer calls the to the random number generator before reported
+sampling begins. More generally, using the same seed for `stim sample` and `stim detect` will not
+result in detection events corresponding to the measurement results.
+)PARAGRAPH";
 
     modes["analyze_errors"] = CommandLineSingleModeData{
         "Converts a circuit into a detector error model.",

--- a/src/stim/main_namespaced.cc
+++ b/src/stim/main_namespaced.cc
@@ -37,7 +37,14 @@ std::mt19937_64 optionally_seeded_rng(int argc, const char **argv) {
 
 int main_mode_detect(int argc, const char **argv) {
     check_for_unknown_arguments(
-        {"--detect", "--seed", "--shots", "--prepend_observables", "--append_observables", "--out_format", "--out", "--in"},
+        {"--detect",
+         "--seed",
+         "--shots",
+         "--prepend_observables",
+         "--append_observables",
+         "--out_format",
+         "--out",
+         "--in"},
         "detect",
         argc,
         argv);

--- a/src/stim/main_namespaced.test.cc
+++ b/src/stim/main_namespaced.test.cc
@@ -824,3 +824,73 @@ shot D0
 shot D0 D1
             )output"));
 }
+
+TEST(main, seeded_sampling) {
+    ASSERT_EQ(
+        execute({"sample", "--shots=256", "--seed 5"}, R"input(
+                H 0
+                M 0
+            )input"),
+        execute({"sample", "--shots=256", "--seed 5"}, R"input(
+                H 0
+                M 0
+            )input"));
+
+    ASSERT_NE(
+        execute({"sample", "--shots=256"}, R"input(
+                H 0
+                M 0
+            )input"),
+        execute({"sample", "--shots=256"}, R"input(
+                H 0
+                M 0
+            )input"));
+
+    ASSERT_NE(
+        execute({"sample", "--shots=256", "--seed 5"}, R"input(
+                H 0
+                M 0
+            )input"),
+        execute({"sample", "--shots=256", "--seed 6"}, R"input(
+                H 0
+                M 0
+            )input"));
+}
+
+TEST(main, seeded_detecting) {
+    ASSERT_EQ(
+        execute({"detect", "--shots=256", "--seed 5"}, R"input(
+                X_ERROR(0.5) 0
+                M 0
+                DETECTOR rec[-1]
+            )input"),
+        execute({"detect", "--shots=256", "--seed 5"}, R"input(
+                X_ERROR(0.5) 0
+                M 0
+                DETECTOR rec[-1]
+            )input"));
+
+    ASSERT_NE(
+        execute({"detect", "--shots=256"}, R"input(
+                X_ERROR(0.5) 0
+                M 0
+                DETECTOR rec[-1]
+            )input"),
+        execute({"detect", "--shots=256"}, R"input(
+                X_ERROR(0.5) 0
+                M 0
+                DETECTOR rec[-1]
+            )input"));
+
+    ASSERT_NE(
+        execute({"detect", "--shots=256", "--seed 5"}, R"input(
+                X_ERROR(0.5) 0
+                M 0
+                DETECTOR rec[-1]
+            )input"),
+        execute({"detect", "--shots=256", "--seed 6"}, R"input(
+                X_ERROR(0.5) 0
+                M 0
+                DETECTOR rec[-1]
+            )input"));
+}

--- a/src/stim/py/base.pybind.cc
+++ b/src/stim/py/base.pybind.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "stim/py/base.pybind.h"
+
 #include <memory>
 
 #include "stim/probability_util.h"

--- a/src/stim/py/base.pybind.cc
+++ b/src/stim/py/base.pybind.cc
@@ -13,20 +13,31 @@
 // limitations under the License.
 
 #include "stim/py/base.pybind.h"
+#include <memory>
 
 #include "stim/probability_util.h"
 
 using namespace stim;
 
-static bool shared_rng_initialized;
-static std::mt19937_64 shared_rng;
+static std::shared_ptr<std::mt19937_64> shared_rng;
 
-std::mt19937_64 &PYBIND_SHARED_RNG() {
-    if (!shared_rng_initialized) {
-        shared_rng = externally_seeded_rng();
-        shared_rng_initialized = true;
+// Change this number from version to version.
+constexpr uint64_t INTENTIONAL_VERSION_SEED_INCOMPATIBILITY = 0xDEADBEEF1234ULL;
+
+std::shared_ptr<std::mt19937_64> PYBIND_SHARED_RNG(const pybind11::object &seed) {
+    if (seed.is(pybind11::none())) {
+        if (!shared_rng) {
+            shared_rng = std::make_shared<std::mt19937_64>(std::move(externally_seeded_rng()));
+        }
+        return shared_rng;
     }
-    return shared_rng;
+
+    try {
+        uint64_t s = pybind11::cast<uint64_t>(seed) ^ INTENTIONAL_VERSION_SEED_INCOMPATIBILITY;
+        return std::make_shared<std::mt19937_64>(s);
+    } catch (const pybind11::cast_error &) {
+        throw std::invalid_argument("Expected seed to be None or a 64 bit unsigned integer.");
+    }
 }
 
 std::string clean_doc_string(const char *c) {

--- a/src/stim/py/base.pybind.h
+++ b/src/stim/py/base.pybind.h
@@ -24,7 +24,7 @@
 #include "stim/circuit/circuit.h"
 #include "stim/io/stim_data_formats.h"
 
-std::mt19937_64 &PYBIND_SHARED_RNG();
+std::shared_ptr<std::mt19937_64> PYBIND_SHARED_RNG(const pybind11::object &seed);
 std::string clean_doc_string(const char *c);
 stim::SampleFormat format_to_enum(const std::string &format);
 bool normalize_index_or_slice(

--- a/src/stim/py/compiled_detector_sampler.pybind.cc
+++ b/src/stim/py/compiled_detector_sampler.pybind.cc
@@ -22,13 +22,13 @@
 
 using namespace stim;
 
-CompiledDetectorSampler::CompiledDetectorSampler(Circuit circuit) : dets_obs(circuit), circuit(std::move(circuit)) {
+CompiledDetectorSampler::CompiledDetectorSampler(Circuit circuit, std::shared_ptr<std::mt19937_64> prng) : dets_obs(circuit), circuit(std::move(circuit)), prng(prng) {
 }
 
 pybind11::array_t<uint8_t> CompiledDetectorSampler::sample(
     size_t num_shots, bool prepend_observables, bool append_observables) {
     auto sample =
-        detector_samples(circuit, dets_obs, num_shots, prepend_observables, append_observables, PYBIND_SHARED_RNG())
+        detector_samples(circuit, dets_obs, num_shots, prepend_observables, append_observables, *prng)
             .transposed();
 
     const simd_bits &flat = sample.data;
@@ -56,7 +56,7 @@ pybind11::array_t<uint8_t> CompiledDetectorSampler::sample(
 pybind11::array_t<uint8_t> CompiledDetectorSampler::sample_bit_packed(
     size_t num_shots, bool prepend_observables, bool append_observables) {
     auto sample =
-        detector_samples(circuit, dets_obs, num_shots, prepend_observables, append_observables, PYBIND_SHARED_RNG())
+        detector_samples(circuit, dets_obs, num_shots, prepend_observables, append_observables, *prng)
             .transposed();
     size_t n = dets_obs.detectors.size() + dets_obs.observables.size() * (prepend_observables + append_observables);
 
@@ -80,7 +80,7 @@ void CompiledDetectorSampler::sample_write(
     if (out == nullptr) {
         throw std::invalid_argument("Failed to open '" + filepath + "' to write.");
     }
-    detector_samples_out(circuit, num_samples, prepend_observables, append_observables, out, f, PYBIND_SHARED_RNG());
+    detector_samples_out(circuit, num_samples, prepend_observables, append_observables, out, f, *prng);
     fclose(out);
 }
 
@@ -92,11 +92,61 @@ std::string CompiledDetectorSampler::repr() const {
     return result.str();
 }
 
+CompiledDetectorSampler py_init_compiled_detector_sampler(const Circuit &circuit, const pybind11::object &seed) {
+    return CompiledDetectorSampler(circuit, PYBIND_SHARED_RNG(seed));
+}
+
 void pybind_compiled_detector_sampler(pybind11::module &m) {
     auto c = pybind11::class_<CompiledDetectorSampler>(
         m, "CompiledDetectorSampler", "An analyzed stabilizer circuit whose detection events can be sampled quickly.");
 
-    c.def(pybind11::init<Circuit>());
+    c.def(
+        pybind11::init(&py_init_compiled_detector_sampler),
+        pybind11::arg("circuit"),
+        pybind11::kw_only(),
+        pybind11::arg("seed") = pybind11::none(),
+        clean_doc_string(u8R"DOC(
+            Creates a detector sampler, which can sample the detectors (and optionally observables) in a circuit.
+
+            Args:
+                circuit: The circuit to sample from.
+                seed: PARTIALLY determines simulation results by deterministically seeding the random number generator.
+                    Must be None or an integer in range(2**64).
+
+                    Defaults to None. When set to None, a prng seeded by system entropy is used.
+
+                    When set to an integer, making the exact same series calls on the exact same machine with the exact
+                    same version of Stim will produce the exact same simulation results.
+
+                    CAUTION: simulation results *WILL NOT* be consistent between versions of Stim. This restriction is
+                    present to make it possible to have future optimizations to the random sampling, and is enforced by
+                    introducing intentional differences in the seeding strategy from version to version.
+
+                    CAUTION: simulation results *MAY NOT* be consistent across machines that differ in the width of
+                    supported SIMD instructions. For example, using the same seed on a machine that supports AVX
+                    instructions and one that only supports SSE instructions may produce different simulation results.
+
+                    CAUTION: simulation results *MAY NOT* be consistent if you vary how many shots are taken. For
+                    example, taking 10 shots and then 90 shots will give different results from taking 100 shots in one
+                    call.
+
+            Returns:
+                An initialized stim.CompiledDetectorSampler.
+
+            Examples:
+                >>> import stim
+                >>> c = stim.Circuit('''
+                ...    H 2
+                ...    CNOT 2 3
+                ...    X_ERROR(1.0) 2
+                ...    M 0 1
+                ...    DETECTOR rec[-1] rec[-2]
+                ... ''')
+                >>> s = c.compile_detector_sampler()
+                >>> s.sample(shots=1)
+                array([[1]], dtype=uint8)
+        )DOC")
+            .data());
 
     c.def(
         "sample",

--- a/src/stim/py/compiled_detector_sampler.pybind.cc
+++ b/src/stim/py/compiled_detector_sampler.pybind.cc
@@ -138,9 +138,9 @@ void pybind_compiled_detector_sampler_methods(pybind11::class_<CompiledDetectorS
             Examples:
                 >>> import stim
                 >>> c = stim.Circuit('''
-                ...    H 2
-                ...    CNOT 2 3
-                ...    X_ERROR(1.0) 2
+                ...    H 0
+                ...    CNOT 0 1
+                ...    X_ERROR(1.0) 0
                 ...    M 0 1
                 ...    DETECTOR rec[-1] rec[-2]
                 ... ''')

--- a/src/stim/py/compiled_detector_sampler.pybind.cc
+++ b/src/stim/py/compiled_detector_sampler.pybind.cc
@@ -96,10 +96,12 @@ CompiledDetectorSampler py_init_compiled_detector_sampler(const Circuit &circuit
     return CompiledDetectorSampler(circuit, PYBIND_SHARED_RNG(seed));
 }
 
-void pybind_compiled_detector_sampler(pybind11::module &m) {
-    auto c = pybind11::class_<CompiledDetectorSampler>(
+pybind11::class_<CompiledDetectorSampler> pybind_compiled_detector_sampler_class(pybind11::module &m) {
+    return pybind11::class_<CompiledDetectorSampler>(
         m, "CompiledDetectorSampler", "An analyzed stabilizer circuit whose detection events can be sampled quickly.");
+}
 
+void pybind_compiled_detector_sampler_methods(pybind11::class_<CompiledDetectorSampler> &c) {
     c.def(
         pybind11::init(&py_init_compiled_detector_sampler),
         pybind11::arg("circuit"),

--- a/src/stim/py/compiled_detector_sampler.pybind.cc
+++ b/src/stim/py/compiled_detector_sampler.pybind.cc
@@ -22,14 +22,14 @@
 
 using namespace stim;
 
-CompiledDetectorSampler::CompiledDetectorSampler(Circuit circuit, std::shared_ptr<std::mt19937_64> prng) : dets_obs(circuit), circuit(std::move(circuit)), prng(prng) {
+CompiledDetectorSampler::CompiledDetectorSampler(Circuit circuit, std::shared_ptr<std::mt19937_64> prng)
+    : dets_obs(circuit), circuit(std::move(circuit)), prng(prng) {
 }
 
 pybind11::array_t<uint8_t> CompiledDetectorSampler::sample(
     size_t num_shots, bool prepend_observables, bool append_observables) {
     auto sample =
-        detector_samples(circuit, dets_obs, num_shots, prepend_observables, append_observables, *prng)
-            .transposed();
+        detector_samples(circuit, dets_obs, num_shots, prepend_observables, append_observables, *prng).transposed();
 
     const simd_bits &flat = sample.data;
     std::vector<uint8_t> bytes;
@@ -56,8 +56,7 @@ pybind11::array_t<uint8_t> CompiledDetectorSampler::sample(
 pybind11::array_t<uint8_t> CompiledDetectorSampler::sample_bit_packed(
     size_t num_shots, bool prepend_observables, bool append_observables) {
     auto sample =
-        detector_samples(circuit, dets_obs, num_shots, prepend_observables, append_observables, *prng)
-            .transposed();
+        detector_samples(circuit, dets_obs, num_shots, prepend_observables, append_observables, *prng).transposed();
     size_t n = dets_obs.detectors.size() + dets_obs.observables.size() * (prepend_observables + append_observables);
 
     void *ptr = sample.data.u8;

--- a/src/stim/py/compiled_detector_sampler.pybind.h
+++ b/src/stim/py/compiled_detector_sampler.pybind.h
@@ -27,7 +27,11 @@ void pybind_compiled_detector_sampler(pybind11::module &m);
 struct CompiledDetectorSampler {
     const stim::DetectorsAndObservables dets_obs;
     const stim::Circuit circuit;
-    CompiledDetectorSampler(stim::Circuit circuit);
+    std::shared_ptr<std::mt19937_64> prng;
+    CompiledDetectorSampler() = delete;
+    CompiledDetectorSampler(const CompiledDetectorSampler &) = delete;
+    CompiledDetectorSampler(CompiledDetectorSampler &&) = default;
+    CompiledDetectorSampler(stim::Circuit circuit, std::shared_ptr<std::mt19937_64> prng);
     pybind11::array_t<uint8_t> sample(size_t num_shots, bool prepend_observables, bool append_observables);
     pybind11::array_t<uint8_t> sample_bit_packed(size_t num_shots, bool prepend_observables, bool append_observables);
     void sample_write(
@@ -38,5 +42,7 @@ struct CompiledDetectorSampler {
         bool append_observables);
     std::string repr() const;
 };
+
+CompiledDetectorSampler py_init_compiled_detector_sampler(const stim::Circuit &circuit, const pybind11::object &seed);
 
 #endif

--- a/src/stim/py/compiled_detector_sampler.pybind.h
+++ b/src/stim/py/compiled_detector_sampler.pybind.h
@@ -22,8 +22,6 @@
 #include "stim/circuit/circuit.h"
 #include "stim/mem/simd_bits.h"
 
-void pybind_compiled_detector_sampler(pybind11::module &m);
-
 struct CompiledDetectorSampler {
     const stim::DetectorsAndObservables dets_obs;
     const stim::Circuit circuit;
@@ -43,6 +41,8 @@ struct CompiledDetectorSampler {
     std::string repr() const;
 };
 
+pybind11::class_<CompiledDetectorSampler> pybind_compiled_detector_sampler_class(pybind11::module &m);
+void pybind_compiled_detector_sampler_methods(pybind11::class_<CompiledDetectorSampler> &c);
 CompiledDetectorSampler py_init_compiled_detector_sampler(const stim::Circuit &circuit, const pybind11::object &seed);
 
 #endif

--- a/src/stim/py/compiled_measurement_sampler.pybind.cc
+++ b/src/stim/py/compiled_measurement_sampler.pybind.cc
@@ -22,11 +22,9 @@
 
 using namespace stim;
 
-CompiledMeasurementSampler::CompiledMeasurementSampler(simd_bits ref_sample, Circuit circuit, bool skip_reference_sample, std::shared_ptr<std::mt19937_64> prng)
-    : ref_sample(ref_sample),
-      circuit(circuit),
-      skip_reference_sample(skip_reference_sample),
-      prng(prng) {
+CompiledMeasurementSampler::CompiledMeasurementSampler(
+    simd_bits ref_sample, Circuit circuit, bool skip_reference_sample, std::shared_ptr<std::mt19937_64> prng)
+    : ref_sample(ref_sample), circuit(circuit), skip_reference_sample(skip_reference_sample), prng(prng) {
 }
 
 pybind11::array_t<uint8_t> CompiledMeasurementSampler::sample(size_t num_samples) {
@@ -91,10 +89,10 @@ pybind11::class_<CompiledMeasurementSampler> pybind_compiled_measurement_sampler
         m, "CompiledMeasurementSampler", "An analyzed stabilizer circuit whose measurements can be sampled quickly.");
 }
 
-CompiledMeasurementSampler py_init_compiled_sampler(const Circuit &circuit, bool skip_reference_sample, const pybind11::object &seed) {
-    simd_bits ref_sample = skip_reference_sample
-                         ? simd_bits(circuit.count_measurements())
-                         : TableauSimulator::reference_sample_circuit(circuit);
+CompiledMeasurementSampler py_init_compiled_sampler(
+    const Circuit &circuit, bool skip_reference_sample, const pybind11::object &seed) {
+    simd_bits ref_sample = skip_reference_sample ? simd_bits(circuit.count_measurements())
+                                                 : TableauSimulator::reference_sample_circuit(circuit);
     return CompiledMeasurementSampler(ref_sample, circuit, skip_reference_sample, PYBIND_SHARED_RNG(seed));
 }
 

--- a/src/stim/py/compiled_measurement_sampler.pybind.cc
+++ b/src/stim/py/compiled_measurement_sampler.pybind.cc
@@ -22,15 +22,15 @@
 
 using namespace stim;
 
-CompiledMeasurementSampler::CompiledMeasurementSampler(Circuit circuit, bool skip_reference_sample)
-    : ref(skip_reference_sample ? simd_bits(circuit.count_measurements())
-                                : TableauSimulator::reference_sample_circuit(circuit)),
+CompiledMeasurementSampler::CompiledMeasurementSampler(simd_bits ref_sample, Circuit circuit, bool skip_reference_sample, std::shared_ptr<std::mt19937_64> prng)
+    : ref_sample(ref_sample),
       circuit(circuit),
-      skip_reference_sample(skip_reference_sample) {
+      skip_reference_sample(skip_reference_sample),
+      prng(prng) {
 }
 
 pybind11::array_t<uint8_t> CompiledMeasurementSampler::sample(size_t num_samples) {
-    auto sample = FrameSimulator::sample(circuit, ref, num_samples, PYBIND_SHARED_RNG());
+    auto sample = FrameSimulator::sample(circuit, ref_sample, num_samples, *prng);
 
     const simd_bits &flat = sample.data;
     std::vector<uint8_t> bytes;
@@ -53,7 +53,7 @@ pybind11::array_t<uint8_t> CompiledMeasurementSampler::sample(size_t num_samples
 }
 
 pybind11::array_t<uint8_t> CompiledMeasurementSampler::sample_bit_packed(size_t num_samples) {
-    auto sample = FrameSimulator::sample(circuit, ref, num_samples, PYBIND_SHARED_RNG());
+    auto sample = FrameSimulator::sample(circuit, ref_sample, num_samples, *prng);
 
     void *ptr = sample.data.u8;
     ssize_t itemsize = sizeof(uint8_t);
@@ -71,7 +71,7 @@ void CompiledMeasurementSampler::sample_write(
     if (out == nullptr) {
         throw std::invalid_argument("Failed to open '" + filepath + "' to write.");
     }
-    FrameSimulator::sample_out(circuit, ref, num_samples, out, f, PYBIND_SHARED_RNG());
+    FrameSimulator::sample_out(circuit, ref_sample, num_samples, out, f, *prng);
     fclose(out);
 }
 
@@ -91,12 +91,20 @@ pybind11::class_<CompiledMeasurementSampler> pybind_compiled_measurement_sampler
         m, "CompiledMeasurementSampler", "An analyzed stabilizer circuit whose measurements can be sampled quickly.");
 }
 
+CompiledMeasurementSampler py_init_compiled_sampler(const Circuit &circuit, bool skip_reference_sample, const pybind11::object &seed) {
+    simd_bits ref_sample = skip_reference_sample
+                         ? simd_bits(circuit.count_measurements())
+                         : TableauSimulator::reference_sample_circuit(circuit);
+    return CompiledMeasurementSampler(ref_sample, circuit, skip_reference_sample, PYBIND_SHARED_RNG(seed));
+}
+
 void pybind_compiled_measurement_sampler_methods(pybind11::class_<CompiledMeasurementSampler> &c) {
     c.def(
-        pybind11::init<Circuit, bool>(),
+        pybind11::init(&py_init_compiled_sampler),
         pybind11::arg("circuit"),
         pybind11::kw_only(),
         pybind11::arg("skip_reference_sample") = false,
+        pybind11::arg("seed") = pybind11::none(),
         clean_doc_string(u8R"DOC(
             Creates a measurement sampler for the given circuit.
 
@@ -118,6 +126,25 @@ void pybind_compiled_measurement_sampler_methods(pybind11::class_<CompiledMeasur
                     other. Computing the reference sample is the most time consuming and memory intensive part of
                     simulating the circuit, so promising that the simulator can safely skip that step is an effective
                     optimization.
+                seed: PARTIALLY determines simulation results by deterministically seeding the random number generator.
+                    Must be None or an integer in range(2**64).
+
+                    Defaults to None. When set to None, a prng seeded by system entropy is used.
+
+                    When set to an integer, making the exact same series calls on the exact same machine with the exact
+                    same version of Stim will produce the exact same simulation results.
+
+                    CAUTION: simulation results *WILL NOT* be consistent between versions of Stim. This restriction is
+                    present to make it possible to have future optimizations to the random sampling, and is enforced by
+                    introducing intentional differences in the seeding strategy from version to version.
+
+                    CAUTION: simulation results *MAY NOT* be consistent across machines that differ in the width of
+                    supported SIMD instructions. For example, using the same seed on a machine that supports AVX
+                    instructions and one that only supports SSE instructions may produce different simulation results.
+
+                    CAUTION: simulation results *MAY NOT* be consistent if you vary how many shots are taken. For
+                    example, taking 10 shots and then 90 shots will give different results from taking 100 shots in one
+                    call.
 
             Returns:
                 A numpy array with `dtype=uint8` and `shape=(shots, num_measurements)`.

--- a/src/stim/py/compiled_measurement_sampler.pybind.h
+++ b/src/stim/py/compiled_measurement_sampler.pybind.h
@@ -30,7 +30,11 @@ struct CompiledMeasurementSampler {
     CompiledMeasurementSampler() = delete;
     CompiledMeasurementSampler(const CompiledMeasurementSampler &) = delete;
     CompiledMeasurementSampler(CompiledMeasurementSampler &&) = default;
-    CompiledMeasurementSampler(stim::simd_bits ref_sample, stim::Circuit circuit, bool skip_reference_sample, std::shared_ptr<std::mt19937_64> prng);
+    CompiledMeasurementSampler(
+        stim::simd_bits ref_sample,
+        stim::Circuit circuit,
+        bool skip_reference_sample,
+        std::shared_ptr<std::mt19937_64> prng);
     pybind11::array_t<uint8_t> sample(size_t num_samples);
     pybind11::array_t<uint8_t> sample_bit_packed(size_t num_samples);
     void sample_write(size_t num_samples, const std::string &filepath, const std::string &format);
@@ -39,6 +43,7 @@ struct CompiledMeasurementSampler {
 
 pybind11::class_<CompiledMeasurementSampler> pybind_compiled_measurement_sampler_class(pybind11::module &m);
 void pybind_compiled_measurement_sampler_methods(pybind11::class_<CompiledMeasurementSampler> &c);
-CompiledMeasurementSampler py_init_compiled_sampler(const stim::Circuit &circuit, bool skip_reference_sample, const pybind11::object &seed);
+CompiledMeasurementSampler py_init_compiled_sampler(
+    const stim::Circuit &circuit, bool skip_reference_sample, const pybind11::object &seed);
 
 #endif

--- a/src/stim/py/compiled_measurement_sampler.pybind.h
+++ b/src/stim/py/compiled_measurement_sampler.pybind.h
@@ -23,10 +23,14 @@
 #include "stim/mem/simd_bits.h"
 
 struct CompiledMeasurementSampler {
-    const stim::simd_bits ref;
+    const stim::simd_bits ref_sample;
     const stim::Circuit circuit;
     const bool skip_reference_sample;
-    CompiledMeasurementSampler(stim::Circuit circuit, bool skip_reference_sample);
+    std::shared_ptr<std::mt19937_64> prng;
+    CompiledMeasurementSampler() = delete;
+    CompiledMeasurementSampler(const CompiledMeasurementSampler &) = delete;
+    CompiledMeasurementSampler(CompiledMeasurementSampler &&) = default;
+    CompiledMeasurementSampler(stim::simd_bits ref_sample, stim::Circuit circuit, bool skip_reference_sample, std::shared_ptr<std::mt19937_64> prng);
     pybind11::array_t<uint8_t> sample(size_t num_samples);
     pybind11::array_t<uint8_t> sample_bit_packed(size_t num_samples);
     void sample_write(size_t num_samples, const std::string &filepath, const std::string &format);
@@ -35,5 +39,6 @@ struct CompiledMeasurementSampler {
 
 pybind11::class_<CompiledMeasurementSampler> pybind_compiled_measurement_sampler_class(pybind11::module &m);
 void pybind_compiled_measurement_sampler_methods(pybind11::class_<CompiledMeasurementSampler> &c);
+CompiledMeasurementSampler py_init_compiled_sampler(const stim::Circuit &circuit, bool skip_reference_sample, const pybind11::object &seed);
 
 #endif

--- a/src/stim/py/stim.pybind.cc
+++ b/src/stim/py/stim.pybind.cc
@@ -111,9 +111,11 @@ PYBIND11_MODULE(stim, m) {
     // described as `stim::DetectorErrorModel` instead of `stim.DetectorErrorModel`.
 
     pybind_detector_error_model(m);
-    pybind_compiled_detector_sampler(m);
+
+    auto c0 = pybind_compiled_detector_sampler_class(m);
     auto c1 = pybind_compiled_measurement_sampler_class(m);
     pybind_circuit(m);
+    pybind_compiled_detector_sampler_methods(c0);
     pybind_compiled_measurement_sampler_methods(c1);
     pybind_pauli_string(m);
     pybind_tableau(m);

--- a/src/stim/simulators/tableau_simulator.pybind.cc
+++ b/src/stim/simulators/tableau_simulator.pybind.cc
@@ -31,7 +31,9 @@ struct TempViewableData {
 };
 
 TableauSimulator create_tableau_simulator() {
-    return TableauSimulator(PYBIND_SHARED_RNG(), 0);
+    std::shared_ptr<std::mt19937_64> rng = PYBIND_SHARED_RNG(pybind11::none());
+    // Note: there is a global shared_ptr to the unseeded rng so it won't deallocate.
+    return TableauSimulator(*rng, 0);
 }
 
 TempViewableData args_to_targets(TableauSimulator &self, const pybind11::args &args) {

--- a/src/stim/stabilizers/pauli_string.pybind.cc
+++ b/src/stim/stabilizers/pauli_string.pybind.cc
@@ -339,8 +339,8 @@ void pybind_pauli_string(pybind11::module &m) {
     c.def_static(
         "random",
         [](size_t num_qubits, bool allow_imaginary) {
-            auto &rng = PYBIND_SHARED_RNG();
-            return PyPauliString(PauliString::random(num_qubits, rng), allow_imaginary ? (rng() & 1) : false);
+            std::shared_ptr<std::mt19937_64> rng = PYBIND_SHARED_RNG(pybind11::none());
+            return PyPauliString(PauliString::random(num_qubits, *rng), allow_imaginary ? ((*rng)() & 1) : false);
         },
         pybind11::arg("num_qubits"),
         pybind11::kw_only(),

--- a/src/stim/stabilizers/tableau.pybind.cc
+++ b/src/stim/stabilizers/tableau.pybind.cc
@@ -85,7 +85,7 @@ void pybind_tableau(pybind11::module &m) {
     c.def_static(
         "random",
         [](size_t num_qubits) {
-            return Tableau::random(num_qubits, PYBIND_SHARED_RNG());
+            return Tableau::random(num_qubits, *PYBIND_SHARED_RNG(pybind11::none()));
         },
         pybind11::arg("num_qubits"),
         clean_doc_string(u8R"DOC(


### PR DESCRIPTION
- Refactor PYBIND_SHARED_RNG to take an object argument that determines whether system entropy or manual seeding is used
- Add keyworkd-only seed argument to stim.Circuit.compile{_detector}_sampler()
- Add keyworkd-only seed argument to constructors of stim.CompiledCircuit{Detector}Sampler
- Add `--seed` option to `stim sample` and `stim detect` command line modes

Fixes https://github.com/quantumlib/Stim/issues/143