### PR TITLE
Add better-performance read-entire-record methods

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ set(SOURCE_FILES_NO_MAIN
         src/stim/io/measure_record_reader.cc
         src/stim/io/measure_record_writer.cc
         src/stim/io/stim_data_formats.cc
+        src/stim/io/sparse_shot.cc
         src/stim/main_namespaced.cc
         src/stim/mem/bit_ref.cc
         src/stim/mem/simd_bit_table.cc
@@ -98,6 +99,7 @@ set(TEST_FILES
         src/stim/io/measure_record_batch_writer.test.cc
         src/stim/io/measure_record_reader.test.cc
         src/stim/io/measure_record_writer.test.cc
+        src/stim/io/sparse_shot.test.cc
         src/stim/main_namespaced.test.cc
         src/stim/mem/bit_ref.test.cc
         src/stim/mem/fixed_cap_vector.test.cc
@@ -127,6 +129,7 @@ set(BENCHMARK_FILES
         src/stim/benchmark_util.perf.cc
         src/stim/circuit/circuit.perf.cc
         src/stim/circuit/gate_data.perf.cc
+        src/stim/io/measure_record_reader.perf.cc
         src/stim/main_namespaced.perf.cc
         src/stim/mem/simd_bit_table.perf.cc
         src/stim/mem/simd_bits.perf.cc

--- a/src/stim/io/measure_record_reader.h
+++ b/src/stim/io/measure_record_reader.h
@@ -19,12 +19,18 @@
 
 #include <memory>
 
+#include "sparse_shot.h"
 #include "stim/circuit/circuit.h"
 #include "stim/io/stim_data_formats.h"
 #include "stim/mem/pointer_range.h"
 #include "stim/mem/simd_bit_table.h"
 
 namespace stim {
+
+// Returns true if an integer value is found at current position. Returns false otherwise.
+// Uses two output variables: value to return the integer value read and next for the next
+// character or EOF.
+bool read_uint64(FILE *in, uint64_t &value, int &next, bool include_next = false);
 
 /// Handles reading measurement data from the outside world.
 ///
@@ -33,6 +39,12 @@ namespace stim {
 /// HITS and DETS encode any number of records. Record size in bits is fixed for each file and the client
 /// must specify it upfront.
 struct MeasureRecordReader {
+    size_t num_measurements;
+    size_t num_detectors;
+    size_t num_observables;
+    size_t bits_per_record() const;
+    MeasureRecordReader(size_t num_measurements, size_t num_detectors, size_t num_observables);
+
     /// Creates a MeasureRecordReader that reads measurement records in the given format from the given FILE*.
     /// Record size must be specified upfront. The DETS format supports three different types of records
     /// and size of each is specified independently. All other formats support one type of record. It is
@@ -41,9 +53,9 @@ struct MeasureRecordReader {
     static std::unique_ptr<MeasureRecordReader> make(
         FILE *in,
         SampleFormat input_format,
-        size_t n_measurements,
-        size_t n_detection_events = 0,
-        size_t n_logical_observables = 0);
+        size_t num_measurements,
+        size_t num_detectors = 0,
+        size_t num_observables = 0);
     virtual ~MeasureRecordReader() = default;
 
     /// Reads and returns one measurement result. If no result is available, exception is thrown.
@@ -93,53 +105,172 @@ struct MeasureRecordReader {
     /// Returns true when the current record has ended. Beyond this point read_bit() throws an exception
     /// and read_bits_into_bytes() returns no data. Note that records in file formats HITS and DETS never end.
     virtual bool is_end_of_record() = 0;
+
+    /// Reads an entire record from start to finish, returning False if there are no more records.
+    /// The data from the record is bit packed into a simd_bits.
+    ///
+    /// Args:
+    ///     dirty_out_buffer: The simd-compatible buffer to write the data to. The buffer is not required to be zero'd.
+    ///
+    /// Returns:
+    ///     True: The record was read successfully.
+    ///     False: End of file. There were no more records. No record was read.
+    ///
+    /// Throws:
+    ///     std::invalid_argument: A record was only partially read.
+    virtual bool start_and_read_entire_record(simd_bits_range_ref dirty_out_buffer) = 0;
+
+    /// Reads an entire record from start to finish, returning False if there are no more records.
+    /// The data from the record is stored as sparse indices-of-ones data.
+    ///
+    /// When reading detection event data with observables appended, the observable data goes into the `mask` field
+    /// of the output. Note that this method requires that there be at most 32 observables.
+    ///
+    /// Args:
+    ///     cleared_out: A cleared SparseShot struct to write data into.
+    ///
+    /// Returns:
+    ///     True: The record was read successfully.
+    ///     False: End of file. There were no more records. No record was read.
+    ///
+    /// Throws:
+    ///     std::invalid_argument: A record was only partially read.
+    virtual bool start_and_read_entire_record(SparseShot &cleared_out) = 0;
+
+   protected:
+    void move_obs_in_shots_to_mask_assuming_sorted(SparseShot &shot);
 };
 
 struct MeasureRecordReaderFormat01 : MeasureRecordReader {
     FILE *in;
     int payload;
     size_t position;
-    size_t bits_per_record;
 
-    MeasureRecordReaderFormat01(FILE *in, size_t bits_per_record);
+    MeasureRecordReaderFormat01(FILE *in, size_t num_measurements, size_t num_detectors, size_t num_observables);
 
     bool read_bit() override;
     bool next_record() override;
     bool start_record() override;
     bool is_end_of_record() override;
+    bool start_and_read_entire_record(simd_bits_range_ref dirty_out_buffer) override;
+    bool start_and_read_entire_record(SparseShot &cleared_out) override;
+
+   private:
+    template <typename SAW0, typename SAW1>
+    bool start_and_read_entire_record_helper(SAW0 saw0, SAW1 saw1) {
+        size_t n = bits_per_record();
+        for (size_t k = 0; k < n; k++) {
+            int b = getc(in);
+            switch (b) {
+                case '0':
+                    saw0(k);
+                    break;
+                case '1':
+                    saw1(k);
+                    break;
+                case EOF:
+                    if (k == 0) {
+                        return false;
+                    }
+                    // intentional fall through.
+                case '\n':
+                    throw std::invalid_argument(
+                        "01 data ended in middle of record at byte position " + std::to_string(k) +
+                        ".\nExpected bits per record was " + std::to_string(n) + ".");
+                default:
+                    throw std::invalid_argument("Unexpected character in 01 format data: '" + std::to_string(b) + "'.");
+            }
+        }
+        if (getc(in) != '\n') {
+            throw std::invalid_argument("01 data didn't end with a newline after the expected data length of '" + std::to_string(n) + "'.");
+        }
+        return true;
+    }
 };
 
 struct MeasureRecordReaderFormatB8 : MeasureRecordReader {
     FILE *in;
-    size_t bits_per_record;
     int payload;
     uint8_t bits_available;
     size_t position;
 
-    MeasureRecordReaderFormatB8(FILE *in, size_t bits_per_record);
+    MeasureRecordReaderFormatB8(FILE *in, size_t num_measurements, size_t num_detectors, size_t num_observables);
 
     size_t read_bits_into_bytes(PointerRange<uint8_t> out_buffer) override;
     bool read_bit() override;
     bool next_record() override;
     bool start_record() override;
     bool is_end_of_record() override;
+    bool start_and_read_entire_record(simd_bits_range_ref dirty_out_buffer) override;
+    bool start_and_read_entire_record(SparseShot &cleared_out) override;
 
    private:
     void maybe_update_payload();
+
+    template <typename HANDLE_BYTE>
+    bool start_and_read_entire_record_helper(HANDLE_BYTE handle_byte) {
+        size_t n = bits_per_record();
+        size_t nb = (n + 7) >> 3;
+        for (size_t k = 0; k < nb; k++) {
+            int b = getc(in);
+            if (b == EOF) {
+                if (k == 0) {
+                    return false;
+                }
+                throw std::invalid_argument(
+                    "b8 data ended in middle of record at byte position " + std::to_string(k) +
+                    ".\n"
+                    "Expected bytes per record was " +
+                    std::to_string(nb) + " (" + std::to_string(n) + " bits padded).");
+            }
+            handle_byte(k, (uint8_t)b);
+        }
+        return true;
+    }
 };
 
 struct MeasureRecordReaderFormatHits : MeasureRecordReader {
     FILE *in;
-    uint64_t bits_per_record;
     simd_bits buffer;
     size_t position_in_buffer;
 
-    MeasureRecordReaderFormatHits(FILE *in, size_t bits_per_record);
+    MeasureRecordReaderFormatHits(FILE *in, size_t num_measurements, size_t num_detectors, size_t num_observables);
 
     bool read_bit() override;
     bool next_record() override;
     bool start_record() override;
     bool is_end_of_record() override;
+    bool start_and_read_entire_record(simd_bits_range_ref dirty_out_buffer) override;
+    bool start_and_read_entire_record(SparseShot &cleared_out) override;
+
+   private:
+    template <typename HANDLE_HIT>
+    bool start_and_read_entire_record_helper(HANDLE_HIT handle_hit) {
+        bool first = true;
+        while (true) {
+            int next_char;
+            uint64_t value;
+            if (!read_uint64(in, value, next_char, false)) {
+                if (first && next_char == EOF) {
+                    return false;
+                }
+                if (first && next_char == '\n') {
+                    return true;
+                }
+                throw std::invalid_argument(
+                    "HITS data wasn't comma-separated integers terminated by a newline.");
+            }
+            handle_hit(value);
+            first = false;
+            if (next_char == '\n') {
+                return true;
+            }
+            if (next_char != ',') {
+                throw std::invalid_argument(
+                    "HITS data wasn't comma-separated integers terminated by a newline.");
+            }
+        }
+    }
 };
 
 struct MeasureRecordReaderFormatR8 : MeasureRecordReader {
@@ -148,9 +279,8 @@ struct MeasureRecordReaderFormatR8 : MeasureRecordReader {
     bool have_seen_terminal_1 = false;
     size_t buffered_0s = 0;
     size_t buffered_1s = 0;
-    size_t bits_per_record;
 
-    MeasureRecordReaderFormatR8(FILE *in, size_t bits_per_record);
+    MeasureRecordReaderFormatR8(FILE *in, size_t num_measurements, size_t num_detectors, size_t num_observables);
 
     size_t read_bits_into_bytes(PointerRange<uint8_t> out_buffer) override;
     bool read_bit() override;
@@ -158,25 +288,112 @@ struct MeasureRecordReaderFormatR8 : MeasureRecordReader {
     bool start_record() override;
     bool is_end_of_record() override;
 
+    bool start_and_read_entire_record(simd_bits_range_ref dirty_out_buffer) override;
+    bool start_and_read_entire_record(SparseShot &cleared_out) override;
+
    private:
     bool maybe_buffer_data();
+    template <typename HANDLE_HIT>
+    bool start_and_read_entire_record_helper(HANDLE_HIT handle_hit) {
+        int next_char = getc(in);
+        if (next_char == EOF) {
+            return false;
+        }
+
+        size_t n = bits_per_record();
+        size_t pos = 0;
+        while (true) {
+            pos += next_char;
+            if (next_char != 255) {
+                if (pos < n) {
+                    handle_hit(pos);
+                    pos++;
+                } else if (pos == n) {
+                    return true;
+                } else {
+                    throw std::invalid_argument("r8 data jumped past expected end of encoded data. Expected to decode " + std::to_string(bits_per_record()) + " bits.");
+                }
+            }
+            next_char = getc(in);
+            if (next_char == EOF) {
+                throw std::invalid_argument("End of file before end of r8 data. Expected to decode " + std::to_string(bits_per_record()) + " bits.");
+            }
+        }
+    }
 };
 
 struct MeasureRecordReaderFormatDets : MeasureRecordReader {
     FILE *in;
     simd_bits buffer;
     size_t position_in_buffer;
-    uint64_t m_bits_per_record;
-    uint64_t d_bits_per_record;
-    uint64_t l_bits_per_record;
 
     MeasureRecordReaderFormatDets(
-        FILE *in, size_t n_measurements, size_t n_detection_events = 0, size_t n_logical_observables = 0);
+        FILE *in, size_t num_measurements, size_t num_detectors = 0, size_t num_observables = 0);
 
     bool read_bit() override;
     bool next_record() override;
     bool start_record() override;
     bool is_end_of_record() override;
+    bool start_and_read_entire_record(simd_bits_range_ref dirty_out_buffer) override;
+    bool start_and_read_entire_record(SparseShot &cleared_out) override;
+
+   private:
+    template <typename HANDLE_HIT>
+    bool start_and_read_entire_record_helper(HANDLE_HIT handle_hit) {
+        // Read "shot" prefix, or notice end of data. Ignore indentation and spacing.
+        while (true) {
+            int next_char = getc(in);
+            if (next_char == ' ' || next_char == '\n' || next_char == '\t') {
+                continue;
+            }
+            if (next_char == EOF) {
+                return false;
+            }
+            if (next_char != 's' || getc(in) != 'h' || getc(in) != 'o' || getc(in) != 't') {
+                throw std::invalid_argument("DETS data didn't start with 'shot'");
+            }
+            break;
+        }
+
+        // Read prefixed integers until end of line.
+        int next_char = getc(in);
+        while (true) {
+            if (next_char == '\n' || next_char == EOF) {
+                return true;
+            }
+            if (next_char != ' ') {
+                throw std::invalid_argument("DETS data wasn't single-space-separated with no trailing spaces.");
+            }
+            next_char = getc(in);
+            uint64_t offset;
+            uint64_t length;
+            if (next_char == 'M') {
+                offset = 0;
+                length = num_measurements;
+            } else if (next_char == 'D') {
+                offset = num_measurements;
+                length = num_detectors;
+            } else if (next_char == 'L') {
+                offset = num_measurements + num_detectors;
+                length = num_observables;
+            } else {
+                throw std::invalid_argument("Unrecognized DETS prefix. Expected M or D or L not '" + std::to_string(next_char) + "'");
+            }
+            char prefix = next_char;
+
+            uint64_t value;
+            if (!read_uint64(in, value, next_char, false)) {
+                throw std::invalid_argument("DETS data had a value prefix (M or D or L) not followed by an integer.");
+            }
+            if (value >= length) {
+                std::stringstream msg;
+                msg << "DETS data had a value that larger than expected. ";
+                msg << "Got " << prefix << value << " but expected length of " << prefix << " space to be " << length << ".";
+                throw std::invalid_argument(msg.str());
+            }
+            handle_hit(offset + value);
+        }
+    }
 };
 
 }  // namespace stim

--- a/src/stim/io/measure_record_reader.perf.cc
+++ b/src/stim/io/measure_record_reader.perf.cc
@@ -1,0 +1,130 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "stim/io/measure_record_reader.h"
+#include "stim/io/measure_record_writer.h"
+#include "stim/probability_util.h"
+
+#include "stim/benchmark_util.perf.h"
+
+using namespace stim;
+
+template <size_t n, size_t denom, SampleFormat format>
+void dense_reader_benchmark(double goal_micros) {
+    double p = 1 / (double)denom;
+    FILE *f = tmpfile();
+    {
+        auto writer = MeasureRecordWriter::make(f, format);
+        simd_bits data(n);
+        std::mt19937_64 rng(0);
+        biased_randomize_bits(p, data.u64, data.u64 + (n >> 6), rng);
+        writer->write_bytes({data.u8, data.u8 + (n >> 3)});
+        writer->write_end();
+    }
+
+    auto reader = MeasureRecordReader::make(f, format, n, 0, 0);
+    simd_bits buffer(n);
+    benchmark_go([&]() {
+        rewind(f);
+        reader->start_and_read_entire_record(buffer);
+    })
+        .goal_micros(goal_micros)
+        .show_rate("Bits", n);
+    if (!buffer.not_zero()) {
+        std::cerr << "data dependence!\n";
+    }
+    fclose(f);
+}
+
+template <size_t n, size_t denom, SampleFormat format>
+void sparse_reader_benchmark(double goal_micros) {
+    double p = 1 / (double)denom;
+    FILE *f = tmpfile();
+    {
+        auto writer = MeasureRecordWriter::make(f, format);
+        simd_bits data(n);
+        std::mt19937_64 rng(0);
+        biased_randomize_bits(p, data.u64, data.u64 + (n >> 6), rng);
+        writer->write_bytes({data.u8, data.u8 + (n >> 3)});
+        writer->write_end();
+    }
+
+    auto reader = MeasureRecordReader::make(f, format, n, 0, 0);
+    SparseShot buffer;
+    buffer.hits.reserve((size_t)ceil(n * p * 1.1));
+    benchmark_go([&]() {
+        rewind(f);
+        buffer.clear();
+        reader->start_and_read_entire_record(buffer);
+    })
+        .goal_micros(goal_micros)
+        .show_rate("Pops", n * p);
+    if (buffer.hits.empty()) {
+        std::cerr << "data dependence!\n";
+    }
+    fclose(f);
+}
+
+BENCHMARK(read_01_dense_per10) {
+    dense_reader_benchmark<10000, 10, SAMPLE_FORMAT_01>(80);
+}
+BENCHMARK(read_01_sparse_per10) {
+    sparse_reader_benchmark<10000, 10, SAMPLE_FORMAT_01>(57);
+}
+
+BENCHMARK(read_b8_dense_per10) {
+    dense_reader_benchmark<10000, 10, SAMPLE_FORMAT_B8>(5.6);
+}
+BENCHMARK(read_b8_sparse_per10) {
+    sparse_reader_benchmark<10000, 10, SAMPLE_FORMAT_B8>(8);
+}
+
+BENCHMARK(read_hits_dense_per10) {
+    dense_reader_benchmark<10000, 10, SAMPLE_FORMAT_HITS>(22);
+}
+BENCHMARK(read_hits_dense_per100) {
+    dense_reader_benchmark<10000, 100, SAMPLE_FORMAT_HITS>(2.8);
+}
+BENCHMARK(read_hits_sparse_per10) {
+    sparse_reader_benchmark<10000, 10, SAMPLE_FORMAT_HITS>(25);
+}
+BENCHMARK(read_hits_sparse_per100) {
+    sparse_reader_benchmark<10000, 100, SAMPLE_FORMAT_HITS>(3.4);
+}
+
+BENCHMARK(read_dets_dense_per10) {
+    dense_reader_benchmark<10000, 10, SAMPLE_FORMAT_DETS>(30);
+}
+BENCHMARK(read_dets_dense_per100) {
+    dense_reader_benchmark<10000, 100, SAMPLE_FORMAT_DETS>(3.6);
+}
+BENCHMARK(read_dets_sparse_per10) {
+    sparse_reader_benchmark<10000, 10, SAMPLE_FORMAT_DETS>(33);
+}
+BENCHMARK(read_dets_sparse_per100) {
+    sparse_reader_benchmark<10000, 100, SAMPLE_FORMAT_DETS>(3.6);
+}
+
+BENCHMARK(read_r8_dense_per10) {
+    dense_reader_benchmark<10000, 10, SAMPLE_FORMAT_R8>(6.3);
+}
+BENCHMARK(read_r8_dense_per100) {
+    dense_reader_benchmark<10000, 100, SAMPLE_FORMAT_R8>(1.3);
+}
+BENCHMARK(read_r8_sparse_per10) {
+    sparse_reader_benchmark<10000, 10, SAMPLE_FORMAT_R8>(4.4);
+}
+BENCHMARK(read_r8_sparse_per100) {
+    sparse_reader_benchmark<10000, 100, SAMPLE_FORMAT_R8>(1.0);
+}

--- a/src/stim/io/sparse_shot.cc
+++ b/src/stim/io/sparse_shot.cc
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "stim/io/sparse_shot.h"
+
+#include <sstream>
+#include <stim/str_util.h>
+
+using namespace stim;
+
+SparseShot::SparseShot(): hits(), obs_mask(0) {
+}
+SparseShot::SparseShot(std::vector<uint64_t> hits, uint32_t obs_mask): hits(hits), obs_mask(obs_mask) {
+}
+
+void SparseShot::clear() {
+    hits.clear();
+    obs_mask = 0;
+}
+
+bool SparseShot::operator==(const SparseShot &other) const {
+    return hits == other.hits && obs_mask == other.obs_mask;
+}
+
+bool SparseShot::operator!=(const SparseShot &other) const {
+    return !(*this == other);
+}
+
+std::string SparseShot::str() const {
+    std::stringstream ss;
+    ss << *this;
+    return ss.str();
+}
+
+std::ostream &stim::operator<<(std::ostream &out, const SparseShot &v) {
+    return out << "SparseShot{{" << comma_sep(v.hits) << "}, " << v.obs_mask << "}";
+}

--- a/src/stim/io/sparse_shot.h
+++ b/src/stim/io/sparse_shot.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _STIM_IO_SPARSE_SHOT_H
+#define _STIM_IO_SPARSE_SHOT_H
+
+#include <string>
+#include <vector>
+
+namespace stim {
+
+struct SparseShot {
+    /// Indices of non-zero bits.
+    std::vector<uint64_t> hits;
+
+    /// When reading detection event data with observables appended, the observables go into this mask.
+    /// The observable with index k goes into the 1<<k bit.
+    uint32_t obs_mask;
+
+    SparseShot();
+    SparseShot(std::vector<uint64_t> hits, uint32_t obs_mask = 0);
+
+    void clear();
+    bool operator==(const SparseShot &other) const;
+    bool operator!=(const SparseShot &other) const;
+    std::string str() const;
+};
+std::ostream &operator<<(std::ostream &out, const SparseShot &v);
+
+}  // namespace stim
+
+#endif

--- a/src/stim/io/sparse_shot.test.cc
+++ b/src/stim/io/sparse_shot.test.cc
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "stim/io/sparse_shot.h"
+
+#include "gtest/gtest.h"
+#include "stim/test_util.test.h"
+
+using namespace stim;
+
+TEST(sparse_shot, equality) {
+    ASSERT_TRUE((SparseShot{}) == (SparseShot{}));
+    ASSERT_FALSE((SparseShot{}) != (SparseShot{}));
+    ASSERT_TRUE((SparseShot{}) != (SparseShot{{2}, 0}));
+    ASSERT_FALSE((SparseShot{}) == (SparseShot{{2}, 0}));
+
+    ASSERT_EQ((SparseShot{{1, 2, 3}, 4}), (SparseShot{{1, 2, 3}, 4}));
+    ASSERT_NE((SparseShot{{1, 2, 3}, 4}), (SparseShot{{1, 2, 3}, 5}));
+    ASSERT_NE((SparseShot{{1, 2, 3}, 4}), (SparseShot{{1, 2, 4}, 4}));
+    ASSERT_NE((SparseShot{{1, 2, 3}, 4}), (SparseShot{{1, 2}, 4}));
+}
+
+TEST(sparse_shot, str) {
+    ASSERT_EQ((SparseShot{{1, 2, 3}, 4}.str()), "SparseShot{{1, 2, 3}, 4}");
+}

--- a/src/stim/main_namespaced.cc
+++ b/src/stim/main_namespaced.cc
@@ -50,6 +50,9 @@ int main_mode_detect(int argc, const char **argv) {
         argv);
     const auto &out_format = find_enum_argument("--out_format", "01", format_name_to_enum_map, argc, argv);
     bool prepend_observables = find_bool_argument("--prepend_observables", argc, argv);
+    if (prepend_observables) {
+        std::cerr << "[DEPRECATION] Avoid using `--prepend_observables`. Data readers assume observables are appended, not prepended.\n";
+    }
     bool append_observables = find_bool_argument("--append_observables", argc, argv);
     uint64_t num_shots =
         find_argument("--shots", argc, argv)    ? (uint64_t)find_int64_argument("--shots", 1, 0, INT64_MAX, argc, argv)

--- a/src/stim/main_namespaced.test.cc
+++ b/src/stim/main_namespaced.test.cc
@@ -50,7 +50,7 @@ std::string execute(std::vector<const char *> flags, const char *std_in_content)
     std::string out = testing::internal::GetCapturedStdout();
     std::string err = testing::internal::GetCapturedStderr();
     if (!err.empty()) {
-        return "[stderr=" + err + "]";
+        return out + "[stderr=" + err + "]";
     }
     if (result != EXIT_SUCCESS) {
         return "[exit code != EXIT_SUCCESS]";
@@ -594,6 +594,8 @@ OBSERVABLE_INCLUDE(0) rec[-2] rec[-1]
             )input")),
         trim(R"output(
 0000
+[stderr=[DEPRECATION] Avoid using `--prepend_observables`. Data readers assume observables are appended, not prepended.
+]
             )output"));
 
     ASSERT_EQ(
@@ -612,6 +614,8 @@ OBSERVABLE_INCLUDE(0) rec[-2]
             )input")),
         trim(R"output(
 1000
+[stderr=[DEPRECATION] Avoid using `--prepend_observables`. Data readers assume observables are appended, not prepended.
+]
             )output"));
 
     ASSERT_EQ(

--- a/src/stim/mem/simd_bit_table.cc
+++ b/src/stim/mem/simd_bit_table.cc
@@ -24,11 +24,11 @@
 using namespace stim;
 
 simd_bit_table::simd_bit_table(size_t min_bits_major, size_t min_bits_minor)
-    : num_simd_words_major(simd_bits::min_bits_to_num_simd_words(min_bits_major)),
-      num_simd_words_minor(simd_bits::min_bits_to_num_simd_words(min_bits_minor)),
+    : num_simd_words_major(min_bits_to_num_simd_words(min_bits_major)),
+      num_simd_words_minor(min_bits_to_num_simd_words(min_bits_minor)),
       data(
-          simd_bits::min_bits_to_num_bits_padded(min_bits_minor) *
-          simd_bits::min_bits_to_num_bits_padded(min_bits_major)) {
+          min_bits_to_num_bits_padded(min_bits_minor) *
+          min_bits_to_num_bits_padded(min_bits_major)) {
 }
 
 simd_bit_table simd_bit_table::identity(size_t n) {

--- a/src/stim/mem/simd_bits.cc
+++ b/src/stim/mem/simd_bits.cc
@@ -23,24 +23,15 @@
 
 using namespace stim;
 
-size_t simd_bits::min_bits_to_num_bits_padded(size_t min_bits) {
-    constexpr size_t mask = sizeof(simd_word) * 8 - 1;
-    return (min_bits + mask) & ~mask;
-}
-
-size_t simd_bits::min_bits_to_num_simd_words(size_t min_bits) {
-    return (min_bits_to_num_bits_padded(min_bits) / sizeof(simd_word)) >> 3;
-}
-
 uint64_t *malloc_aligned_padded_zeroed(size_t min_bits) {
-    size_t num_u8 = simd_bits::min_bits_to_num_bits_padded(min_bits) >> 3;
+    size_t num_u8 = min_bits_to_num_bits_padded(min_bits) >> 3;
     void *result = simd_word::aligned_malloc(num_u8);
     memset(result, 0, num_u8);
     return (uint64_t *)result;
 }
 
 simd_bits::simd_bits(size_t min_bits)
-    : num_simd_words(simd_bits::min_bits_to_num_simd_words(min_bits)), u64(malloc_aligned_padded_zeroed(min_bits)) {
+    : num_simd_words(min_bits_to_num_simd_words(min_bits)), u64(malloc_aligned_padded_zeroed(min_bits)) {
 }
 
 simd_bits::simd_bits(const simd_bits &other)

--- a/src/stim/mem/simd_bits.h
+++ b/src/stim/mem/simd_bits.h
@@ -44,8 +44,6 @@ struct simd_bits {
         uint64_t *u64;
         simd_word *ptr_simd;
     };
-    static size_t min_bits_to_num_simd_words(size_t min_bits);
-    static size_t min_bits_to_num_bits_padded(size_t min_bits);
 
     /// Constructs a zero-initialized simd_bits with at least the given number of bits.
     explicit simd_bits(size_t min_bits);
@@ -90,6 +88,10 @@ struct simd_bits {
     /// Returns a reference to a sub-range of the bits in this simd_bits.
     inline simd_bits_range_ref word_range_ref(size_t word_offset, size_t sub_num_simd_words) {
         return simd_bits_range_ref(ptr_simd + word_offset, sub_num_simd_words);
+    }
+    /// Returns a reference to a sub-range of the bits at the start of this simd_bits.
+    inline simd_bits_range_ref prefix_ref(size_t unpadded_bit_length) {
+        return simd_bits_range_ref(ptr_simd, min_bits_to_num_simd_words(unpadded_bit_length));
     }
     /// Returns a const reference to a sub-range of the bits in this simd_bits.
     inline const simd_bits_range_ref word_range_ref(size_t word_offset, size_t sub_num_simd_words) const {

--- a/src/stim/mem/simd_bits.test.cc
+++ b/src/stim/mem/simd_bits.test.cc
@@ -64,7 +64,7 @@ TEST(simd_bits, aliased_editing_and_bit_refs) {
 }
 
 TEST(simd_util, min_bits_to_num_bits_padded) {
-    const auto &f = &simd_bits::min_bits_to_num_bits_padded;
+    const auto &f = &min_bits_to_num_bits_padded;
     if (sizeof(simd_word) == 256 / 8) {
         ASSERT_EQ(f(0), 0);
         ASSERT_EQ(f(1), 256);
@@ -288,4 +288,14 @@ TEST(simd_bits, popcnt) {
     data.u64[8] = 0xFFFFFFFFFFFFFFFFULL;
     ASSERT_EQ(data.popcnt(), 66);
     ASSERT_EQ(simd_bits(0).popcnt(), 0);
+}
+
+TEST(simd_bits, prefix_ref) {
+    simd_bits data(1024);
+    auto prefix = data.prefix_ref(257);
+    ASSERT_TRUE(prefix.num_bits_padded() >= 257);
+    ASSERT_TRUE(prefix.num_bits_padded() < 1024);
+    ASSERT_FALSE(data[0]);
+    prefix[0] = true;
+    ASSERT_TRUE(data[0]);
 }

--- a/src/stim/mem/simd_bits_range_ref.h
+++ b/src/stim/mem/simd_bits_range_ref.h
@@ -26,6 +26,14 @@
 
 namespace stim {
 
+constexpr size_t min_bits_to_num_bits_padded(size_t min_bits) {
+    return (min_bits + (sizeof(simd_word) * 8 - 1)) & ~(sizeof(simd_word) * 8 - 1);
+}
+
+constexpr size_t min_bits_to_num_simd_words(size_t min_bits) {
+    return (min_bits_to_num_bits_padded(min_bits) / sizeof(simd_word)) >> 3;
+}
+
 /// A reference to a range of bits that support SIMD operations (e.g. they are aligned and padded correctly).
 ///
 /// Conceptually behaves the same as a reference like `int &`, as opposed to a pointer like `int *`. For example, the
@@ -73,6 +81,10 @@ struct simd_bits_range_ref {
     /// Returns a const reference to a given bit within the referenced range.
     inline const bit_ref operator[](size_t k) const {
         return bit_ref(u8, k);
+    }
+    /// Returns a reference to a sub-range of the bits at the start of this simd_bits.
+    inline simd_bits_range_ref prefix_ref(size_t unpadded_bit_length) {
+        return simd_bits_range_ref(ptr_simd, min_bits_to_num_simd_words(unpadded_bit_length));
     }
     /// Returns a reference to a sub-range of the bits in the referenced range.
     inline simd_bits_range_ref word_range_ref(size_t word_offset, size_t sub_num_simd_words) {

--- a/src/stim/mem/simd_bits_range_ref.test.cc
+++ b/src/stim/mem/simd_bits_range_ref.test.cc
@@ -271,3 +271,14 @@ TEST(simd_bits_range_ref, intersects) {
     ASSERT_EQ(data.intersects(other), true);
     ASSERT_EQ(ref.intersects(other), true);
 }
+
+TEST(simd_bits_range_ref, prefix_ref) {
+    simd_bits data(1024);
+    simd_bits_range_ref ref(data);
+    auto prefix = ref.prefix_ref(257);
+    ASSERT_TRUE(prefix.num_bits_padded() >= 257);
+    ASSERT_TRUE(prefix.num_bits_padded() < 1024);
+    ASSERT_FALSE(data[0]);
+    prefix[0] = true;
+    ASSERT_TRUE(data[0]);
+}


### PR DESCRIPTION
- Add a dense (into bit packed memory) and sparse (into vector of hits) variants
- Add SparseShot struct for reading sparse data
- Fix various readers not knowing about the expected layout of data they were reading
- Add benchmarks for read performance
- Add deprecation warning to `--prepend_observables`
- Add prefix_ref method to simd_bits
- Move simd-bit-sizing methods into stim:: namespace

```
[....................*....................]  80 us (vs  80 us) (120 MBits/s) read_01_dense_per10
[....................*....................]  51 us (vs  57 us) ( 19 MPops/s) read_01_sparse_per10
[....................*....................] 5.0 us (vs 5.6 us) (1.9 GBits/s) read_b8_dense_per10
[....................*....................] 7.8 us (vs 8.0 us) (120 MPops/s) read_b8_sparse_per10
[....................*....................]  22 us (vs  22 us) (430 MBits/s) read_hits_dense_per10
[....................*....................] 2.7 us (vs 2.8 us) (3.5 GBits/s) read_hits_dense_per100
[....................*....................]  22 us (vs  25 us) ( 44 MPops/s) read_hits_sparse_per10
[....................|*...................] 2.6 us (vs 3.4 us) ( 37 MPops/s) read_hits_sparse_per100
[....................*....................]  30 us (vs  30 us) (320 MBits/s) read_dets_dense_per10
[....................*....................] 3.6 us (vs 3.6 us) (2.7 GBits/s) read_dets_dense_per100
[....................|*...................]  27 us (vs  33 us) ( 36 MPops/s) read_dets_sparse_per10
[....................*....................] 3.2 us (vs 3.6 us) ( 30 MPops/s) read_dets_sparse_per100
[...................*|....................] 7.1 us (vs 6.3 us) (1.4 GBits/s) read_r8_dense_per10
[....................*....................] 1.2 us (vs 1.3 us) (7.9 GBits/s) read_r8_dense_per100
[....................*....................] 4.6 us (vs 4.4 us) (210 MPops/s) read_r8_sparse_per10
[....................*....................] 1.0 us (vs 1.0 us) ( 93 MPops/s) read_r8_sparse_per100
```