### PR TITLE
Fix stim::Circuit::validate_gate not detecting NaN probabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_SKIP: "cp27-* cp35-* pp*"
-          CIBW_TEST_REQUIRES: cirq-core pytest
+          CIBW_TEST_REQUIRES: cirq-core pytest Pillow==8.3.1  # workaround for build breakage in pillow 8.4
           CIBW_TEST_COMMAND: pytest {project}/src {project}/glue/cirq
       - uses: actions/upload-artifact@v2
         with:

--- a/src/stim/circuit/circuit.cc
+++ b/src/stim/circuit/circuit.cc
@@ -139,7 +139,7 @@ void validate_gate(const Gate &gate, ConstPointerRange<GateTarget> targets, Cons
     if (gate.flags & GATE_ARGS_ARE_DISJOINT_PROBABILITIES) {
         double total = 0;
         for (const auto p : args) {
-            if (!(p >= 0 || p <= 1)) {
+            if (!(p >= 0 && p <= 1)) {
                 throw std::invalid_argument(
                     "Gate " + std::string(gate.name) + " only takes probability arguments, but one of its arguments (" +
                     comma_sep(args).str() + ") wasn't a probability.");

--- a/src/stim/circuit/circuit.cc
+++ b/src/stim/circuit/circuit.cc
@@ -139,7 +139,7 @@ void validate_gate(const Gate &gate, ConstPointerRange<GateTarget> targets, Cons
     if (gate.flags & GATE_ARGS_ARE_DISJOINT_PROBABILITIES) {
         double total = 0;
         for (const auto p : args) {
-            if (p < 0 || p > 1) {
+            if (!(p >= 0 || p <= 1)) {
                 throw std::invalid_argument(
                     "Gate " + std::string(gate.name) + " only takes probability arguments, but one of its arguments (" +
                     comma_sep(args).str() + ") wasn't a probability.");

--- a/src/stim/circuit/circuit.test.cc
+++ b/src/stim/circuit/circuit.test.cc
@@ -1077,3 +1077,10 @@ TEST(circuit, aliased_noiseless_circuit) {
         }
     )CIRCUIT"));
 }
+
+TEST(circuit, validate_nan_probability) {
+    Circuit c;
+    ASSERT_THROW({
+        c.append_op("X_ERROR", {0}, NAN);
+    }, std::invalid_argument);
+}

--- a/src/stim/probability_util.cc
+++ b/src/stim/probability_util.cc
@@ -19,7 +19,7 @@ using namespace stim;
 RareErrorIterator::RareErrorIterator(float probability)
     : next_candidate(0), is_one(probability == 1), dist(probability) {
     if (!(probability >= 0 && probability <= 1)) {
-        throw std::out_of_range("Invalid probability.");
+        throw std::out_of_range("Invalid probability: " + std::to_string(probability));
     }
 }
 


### PR DESCRIPTION
- Also improve the error message that comes out of the rare sampler when a bad probability goes into it
- Also work around a weird build breakage in Pillow dependency from cirq-core