### PR TITLE
Squash five issues

### DIFF
--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -507,7 +507,7 @@
 >     ...     stim.target_logical_observable_id(13)
 >     ... ])
 >     >>> print(repr(m))
->     stim.DetectorErrorMode('''
+>     stim.DetectorErrorModel('''
 >         error(0.25) L13
 >     ''')
 > ```
@@ -535,7 +535,7 @@
 >     ...     stim.target_relative_detector_id(13)
 >     ... ])
 >     >>> print(repr(m))
->     stim.DetectorErrorMode('''
+>     stim.DetectorErrorModel('''
 >         error(0.25) D13
 >     ''')
 > ```
@@ -553,7 +553,7 @@
 >     ...     stim.target_relative_detector_id(2),
 >     ... ])
 >     >>> print(repr(m))
->     stim.DetectorErrorMode('''
+>     stim.DetectorErrorModel('''
 >         error(0.25) D1 ^ D2
 >     ''')
 > ```
@@ -595,10 +595,12 @@
 >     >>> c2 = stim.Circuit('''
 >     ...    M 0 1 2
 >     ... ''')
->     >>> print(c1 + c2)
->     X 0
->     Y 1 2
->     M 0 1 2
+>     >>> c1 + c2
+>     stim.Circuit('''
+>         X 0
+>         Y 1 2
+>         M 0 1 2
+>     ''')
 > ```
 
 ### `stim.Circuit.__eq__(self, arg0: stim.Circuit) -> bool`<a name="stim.Circuit.__eq__"></a>
@@ -656,10 +658,12 @@
 >     ...    M 0 1 2
 >     ... ''')
 >     >>> c1 += c2
->     >>> print(c1)
->     X 0
->     Y 1 2
->     M 0 1 2
+>     >>> print(repr(c1))
+>     stim.Circuit('''
+>         X 0
+>         Y 1 2
+>         M 0 1 2
+>     ''')
 > ```
 
 ### `stim.Circuit.__imul__(self, repetitions: int) -> stim.Circuit`<a name="stim.Circuit.__imul__"></a>
@@ -679,11 +683,13 @@
 >     ...    Y 1 2
 >     ... ''')
 >     >>> c *= 3
->     >>> print(c)
->     REPEAT 3 {
->         X 0
->         Y 1 2
->     }
+>     >>> print(repr(c))
+>     stim.Circuit('''
+>         REPEAT 3 {
+>             X 0
+>             Y 1 2
+>         }
+>     ''')
 > ```
 
 ### `stim.Circuit.__init__(self, stim_program_text: str = '') -> None`<a name="stim.Circuit.__init__"></a>
@@ -746,11 +752,13 @@
 >     ...    X 0
 >     ...    Y 1 2
 >     ... ''')
->     >>> print(c * 3)
->     REPEAT 3 {
->         X 0
->         Y 1 2
->     }
+>     >>> c * 3
+>     stim.Circuit('''
+>         REPEAT 3 {
+>             X 0
+>             Y 1 2
+>         }
+>     ''')
 > ```
 
 ### `stim.Circuit.__ne__(self, arg0: stim.Circuit) -> bool`<a name="stim.Circuit.__ne__"></a>
@@ -779,11 +787,13 @@
 >     ...    X 0
 >     ...    Y 1 2
 >     ... ''')
->     >>> print(3 * c)
->     REPEAT 3 {
->         X 0
->         Y 1 2
->     }
+>     >>> 3 * c
+>     stim.Circuit('''
+>         REPEAT 3 {
+>             X 0
+>             Y 1 2
+>         }
+>     ''')
 > ```
 
 ### `stim.Circuit.__str__(self) -> str`<a name="stim.Circuit.__str__"></a>
@@ -828,13 +838,15 @@
 >     >>> c.append_operation("CNOT", [stim.target_rec(-1), 0])
 >     >>> c.append_operation("X_ERROR", [0], 0.125)
 >     >>> c.append_operation("CORRELATED_ERROR", [stim.target_x(0), stim.target_y(2)], 0.25)
->     >>> print(c)
->     X 0
->     H 0 1
->     M 0 !1
->     CX rec[-1] 0
->     X_ERROR(0.125) 0
->     E(0.25) X0 Y2
+>     >>> print(repr(c))
+>     stim.Circuit('''
+>         X 0
+>         H 0 1
+>         M 0 !1
+>         CX rec[-1] 0
+>         X_ERROR(0.125) 0
+>         E(0.25) X0 Y2
+>     ''')
 > 
 > Args:
 >     name: The name of the operation's gate (e.g. "H" or "M" or "CNOT").
@@ -1973,7 +1985,7 @@
 >     ...     stim.DemTarget.logical_observable_id(13)
 >     ... ])
 >     >>> print(repr(m))
->     stim.DetectorErrorMode('''
+>     stim.DetectorErrorModel('''
 >         error(0.25) L13
 >     ''')
 > ```
@@ -1995,7 +2007,7 @@
 >     ...     stim.DemTarget.relative_detector_id(13)
 >     ... ])
 >     >>> print(repr(m))
->     stim.DetectorErrorMode('''
+>     stim.DetectorErrorModel('''
 >         error(0.25) D13
 >     ''')
 > ```
@@ -2013,7 +2025,7 @@
 >     ...     stim.DemTarget.relative_detector_id(2),
 >     ... ])
 >     >>> print(repr(m))
->     stim.DetectorErrorMode('''
+>     stim.DetectorErrorModel('''
 >         error(0.25) D1 ^ D2
 >     ''')
 > ```
@@ -2040,7 +2052,7 @@
 >     >>> m1 = stim.DetectorErrorModel('''
 >     ...    error(0.125) D0
 >     ... ''')
->     >>> m2 = stim.Circuit('''
+>     >>> m2 = stim.DetectorErrorModel('''
 >     ...    error(0.25) D1
 >     ... ''')
 >     >>> m1 + m2
@@ -2069,7 +2081,7 @@
 >     >>> model = stim.DetectorErrorModel('''
 >     ...    error(0.125) D0
 >     ...    error(0.125) D1 L1
->     ...    REPEAT 100 {
+>     ...    repeat 100 {
 >     ...        error(0.125) D1 D2
 >     ...        shift_detectors 1
 >     ...    }
@@ -2101,7 +2113,7 @@
 >     >>> m1 = stim.DetectorErrorModel('''
 >     ...    error(0.125) D0
 >     ... ''')
->     >>> m2 = stim.Circuit('''
+>     >>> m2 = stim.DetectorErrorModel('''
 >     ...    error(0.25) D1
 >     ... ''')
 >     >>> m1 += m2
@@ -2130,7 +2142,7 @@
 >     ... ''')
 >     >>> m *= 3
 >     >>> print(m)
->     REPEAT 3 {
+>     repeat 3 {
 >         error(0.25) D0
 >         shift_detectors 1
 >     }
@@ -2169,7 +2181,7 @@
 >     ... '''))
 >     3
 >     >>> len(stim.DetectorErrorModel('''
->     ...    REPEAT 100 {
+>     ...    repeat 100 {
 >     ...        error(0.1) D0 D1
 >     ...        error(0.1) D1 D2
 >     ...    }
@@ -2179,13 +2191,13 @@
 
 ### `stim.DetectorErrorModel.__mul__(self, repetitions: int) -> stim.DetectorErrorModel`<a name="stim.DetectorErrorModel.__mul__"></a>
 > ```
-> Returns a detector error model with a REPEAT block containing the current model's instructions.
+> Returns a detector error model with a repeat block containing the current model's instructions.
 > 
 > Special case: if the repetition count is 0, an empty model is returned.
-> Special case: if the repetition count is 1, an equal model with no REPEAT block is returned.
+> Special case: if the repetition count is 1, an equal model with no repeat block is returned.
 > 
 > Args:
->     repetitions: The number of times the REPEAT block should repeat.
+>     repetitions: The number of times the repeat block should repeat.
 > 
 > Examples:
 >     >>> import stim
@@ -2195,7 +2207,7 @@
 >     ... ''')
 >     >>> m * 3
 >     stim.DetectorErrorModel('''
->         REPEAT 3 {
+>         repeat 3 {
 >             error(0.25) D0
 >             shift_detectors 1
 >         }
@@ -2214,13 +2226,13 @@
 
 ### `stim.DetectorErrorModel.__rmul__(self, repetitions: int) -> stim.DetectorErrorModel`<a name="stim.DetectorErrorModel.__rmul__"></a>
 > ```
-> Returns a detector error model with a REPEAT block containing the current model's instructions.
+> Returns a detector error model with a repeat block containing the current model's instructions.
 > 
 > Special case: if the repetition count is 0, an empty model is returned.
-> Special case: if the repetition count is 1, an equal model with no REPEAT block is returned.
+> Special case: if the repetition count is 1, an equal model with no repeat block is returned.
 > 
 > Args:
->     repetitions: The number of times the REPEAT block should repeat.
+>     repetitions: The number of times the repeat block should repeat.
 > 
 > Examples:
 >     >>> import stim
@@ -2230,7 +2242,7 @@
 >     ... ''')
 >     >>> 3 * m
 >     stim.DetectorErrorModel('''
->         REPEAT 3 {
+>         repeat 3 {
 >             error(0.25) D0
 >             shift_detectors 1
 >         }
@@ -2267,14 +2279,14 @@
 >     ...     stim.DemTarget.logical_observable_id(3),
 >     ... ])
 >     >>> print(repr(m))
->     stim.DetectorErrorMode('''
+>     stim.DetectorErrorModel('''
 >         error(0.125) D1
 >         error(0.25) D1 ^ D2 L3
 >     ''')
 > 
 >     >>> m.append("shift_detectors", (1, 2, 3), [5])
 >     >>> print(repr(m))
->     stim.DetectorErrorMode('''
+>     stim.DetectorErrorModel('''
 >         error(0.125) D1
 >         error(0.25) D1 ^ D2 L3
 >         shift_detectors(1, 2, 3) 5
@@ -2284,7 +2296,7 @@
 >     >>> m.append(m[0])
 >     >>> m.append(m[-2])
 >     >>> print(repr(m))
->     stim.DetectorErrorMode('''
+>     stim.DetectorErrorModel('''
 >         error(0.125) D1
 >         error(0.25) D1 ^ D2 L3
 >         shift_detectors(1, 2, 3) 5
@@ -2328,22 +2340,22 @@
 >     >>> base.approx_equals(base, atol=0)
 >     True
 > 
->     >>> base.approx_equals(stim.Circuit('''
+>     >>> base.approx_equals(stim.DetectorErrorModel('''
 >     ...    error(0.101) D0 D1
 >     ... '''), atol=0)
 >     False
 > 
->     >>> base.approx_equals(stim.Circuit('''
+>     >>> base.approx_equals(stim.DetectorErrorModel('''
 >     ...    error(0.101) D0 D1
 >     ... '''), atol=0.0001)
 >     False
 > 
->     >>> base.approx_equals(stim.Circuit('''
+>     >>> base.approx_equals(stim.DetectorErrorModel('''
 >     ...    error(0.101) D0 D1
 >     ... '''), atol=0.01)
 >     True
 > 
->     >>> base.approx_equals(stim.Circuit('''
+>     >>> base.approx_equals(stim.DetectorErrorModel('''
 >     ...    error(0.099) D0 D1 L0 L1 L2 L3 L4
 >     ... '''), atol=9999)
 >     False
@@ -2422,8 +2434,8 @@
 > 
 >     >>> stim.DetectorErrorModel('''
 >     ...     error(0.125) D0
->     ...     REPEAT 100 {
->     ...         REPEAT 5 {
+>     ...     repeat 100 {
+>     ...         repeat 5 {
 >     ...             error(0.25) D1
 >     ...         }
 >     ...     }

--- a/glue/python/generate_api_reference.py
+++ b/glue/python/generate_api_reference.py
@@ -37,6 +37,8 @@ keep = {
 skip = {
     "__builtins__",
     "__cached__",
+    "__getstate__",
+    "__setstate__",
     "__path__",
     "__class__",
     "__delattr__",

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -1079,4 +1079,13 @@ void pybind_circuit(pybind11::module &m) {
                 False
         )DOC")
             .data());
+
+    c.def(pybind11::pickle(
+        [](const Circuit &self) -> pybind11::str {
+            return self.str();
+        },
+        [](const pybind11::str &text) {
+            return Circuit(pybind11::cast<std::string>(text).data());
+        }
+    ));
 }

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -456,10 +456,12 @@ void pybind_circuit(pybind11::module &m) {
                 >>> c2 = stim.Circuit('''
                 ...    M 0 1 2
                 ... ''')
-                >>> print(c1 + c2)
-                X 0
-                Y 1 2
-                M 0 1 2
+                >>> c1 + c2
+                stim.Circuit('''
+                    X 0
+                    Y 1 2
+                    M 0 1 2
+                ''')
         )DOC")
             .data());
 
@@ -480,10 +482,12 @@ void pybind_circuit(pybind11::module &m) {
                 ...    M 0 1 2
                 ... ''')
                 >>> c1 += c2
-                >>> print(c1)
-                X 0
-                Y 1 2
-                M 0 1 2
+                >>> print(repr(c1))
+                stim.Circuit('''
+                    X 0
+                    Y 1 2
+                    M 0 1 2
+                ''')
         )DOC")
             .data());
 
@@ -507,11 +511,13 @@ void pybind_circuit(pybind11::module &m) {
                 ...    Y 1 2
                 ... ''')
                 >>> c *= 3
-                >>> print(c)
-                REPEAT 3 {
-                    X 0
-                    Y 1 2
-                }
+                >>> print(repr(c))
+                stim.Circuit('''
+                    REPEAT 3 {
+                        X 0
+                        Y 1 2
+                    }
+                ''')
         )DOC")
             .data());
 
@@ -534,11 +540,13 @@ void pybind_circuit(pybind11::module &m) {
                 ...    X 0
                 ...    Y 1 2
                 ... ''')
-                >>> print(c * 3)
-                REPEAT 3 {
-                    X 0
-                    Y 1 2
-                }
+                >>> c * 3
+                stim.Circuit('''
+                    REPEAT 3 {
+                        X 0
+                        Y 1 2
+                    }
+                ''')
         )DOC")
             .data());
 
@@ -561,11 +569,13 @@ void pybind_circuit(pybind11::module &m) {
                 ...    X 0
                 ...    Y 1 2
                 ... ''')
-                >>> print(3 * c)
-                REPEAT 3 {
-                    X 0
-                    Y 1 2
-                }
+                >>> 3 * c
+                stim.Circuit('''
+                    REPEAT 3 {
+                        X 0
+                        Y 1 2
+                    }
+                ''')
         )DOC")
             .data());
 
@@ -639,13 +649,15 @@ void pybind_circuit(pybind11::module &m) {
                 >>> c.append_operation("CNOT", [stim.target_rec(-1), 0])
                 >>> c.append_operation("X_ERROR", [0], 0.125)
                 >>> c.append_operation("CORRELATED_ERROR", [stim.target_x(0), stim.target_y(2)], 0.25)
-                >>> print(c)
-                X 0
-                H 0 1
-                M 0 !1
-                CX rec[-1] 0
-                X_ERROR(0.125) 0
-                E(0.25) X0 Y2
+                >>> print(repr(c))
+                stim.Circuit('''
+                    X 0
+                    H 0 1
+                    M 0 !1
+                    CX rec[-1] 0
+                    X_ERROR(0.125) 0
+                    E(0.25) X0 Y2
+                ''')
 
             Args:
                 name: The name of the operation's gate (e.g. "H" or "M" or "CNOT").

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -360,30 +360,6 @@ void pybind_circuit(pybind11::module &m) {
             .data());
 
     c.def(
-        "__iadd__",
-        &Circuit::operator+=,
-        pybind11::arg("second"),
-        clean_doc_string(u8R"DOC(
-            Appends a circuit into the receiving circuit (mutating it).
-
-            Examples:
-                >>> import stim
-                >>> c1 = stim.Circuit('''
-                ...    X 0
-                ...    Y 1 2
-                ... ''')
-                >>> c2 = stim.Circuit('''
-                ...    M 0 1 2
-                ... ''')
-                >>> c1 += c2
-                >>> print(c1)
-                X 0
-                Y 1 2
-                M 0 1 2
-        )DOC")
-            .data());
-
-    c.def(
         "flattened_operations",
         [](Circuit &self) {
             pybind11::list result;
@@ -481,6 +457,30 @@ void pybind_circuit(pybind11::module &m) {
                 ...    M 0 1 2
                 ... ''')
                 >>> print(c1 + c2)
+                X 0
+                Y 1 2
+                M 0 1 2
+        )DOC")
+            .data());
+
+    c.def(
+        "__iadd__",
+        &Circuit::operator+=,
+        pybind11::arg("second"),
+        clean_doc_string(u8R"DOC(
+            Appends a circuit into the receiving circuit (mutating it).
+
+            Examples:
+                >>> import stim
+                >>> c1 = stim.Circuit('''
+                ...    X 0
+                ...    Y 1 2
+                ... ''')
+                >>> c2 = stim.Circuit('''
+                ...    M 0 1 2
+                ... ''')
+                >>> c1 += c2
+                >>> print(c1)
                 X 0
                 Y 1 2
                 M 0 1 2
@@ -621,7 +621,7 @@ void pybind_circuit(pybind11::module &m) {
                 throw std::invalid_argument(
                     "First argument of append_operation must be a str (a gate name), "
                     "a stim.CircuitInstruction, "
-                    "or a stim.Circuit");
+                    "or a stim.CircuitRepeatBlock");
             }
         },
         pybind11::arg("name"),

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -1015,4 +1015,68 @@ void pybind_circuit(pybind11::module &m) {
                 ''')
         )DOC")
             .data());
+
+    c.def(
+        "approx_equals",
+        [](const Circuit &self, const pybind11::object &obj, double atol) -> bool {
+            try {
+                return self.approx_equals(pybind11::cast<Circuit>(obj), atol);
+            } catch (const pybind11::cast_error &ex) {
+                return false;
+            }
+        },
+        pybind11::arg("other"),
+        pybind11::kw_only(),
+        pybind11::arg("atol"),
+        clean_doc_string(u8R"DOC(
+            Checks if a circuit is approximately equal to another circuit.
+
+            Two circuits are approximately equal if they are equal up to slight perturbations of instruction arguments
+            such as probabilities. For example `X_ERROR(0.100) 0` is approximately equal to `X_ERROR(0.099)` within an
+            absolute tolerance of 0.002. All other details of the circuits (such as the ordering of instructions and
+            targets) must be exactly the same.
+
+            Args:
+                other: The circuit, or other object, to compare to this one.
+                atol: The absolute error tolerance. The maximum amount each probability may have been perturbed by.
+
+            Returns:
+                True if the given object is a circuit approximately equal up to the receiving circuit up to the given
+                tolerance, otherwise False.
+
+            Examples:
+                >>> import stim
+                >>> base = stim.Circuit('''
+                ...    X_ERROR(0.099) 0 1 2
+                ...    M 0 1 2
+                ... ''')
+
+                >>> base.approx_equals(base, atol=0)
+                True
+
+                >>> base.approx_equals(stim.Circuit('''
+                ...    X_ERROR(0.101) 0 1 2
+                ...    M 0 1 2
+                ... '''), atol=0)
+                False
+
+                >>> base.approx_equals(stim.Circuit('''
+                ...    X_ERROR(0.101) 0 1 2
+                ...    M 0 1 2
+                ... '''), atol=0.0001)
+                False
+
+                >>> base.approx_equals(stim.Circuit('''
+                ...    X_ERROR(0.101) 0 1 2
+                ...    M 0 1 2
+                ... '''), atol=0.01)
+                True
+
+                >>> base.approx_equals(stim.Circuit('''
+                ...    DEPOLARIZE1(0.099) 0 1 2
+                ...    MRX 0 1 2
+                ... '''), atol=9999)
+                False
+        )DOC")
+            .data());
 }

--- a/src/stim/circuit/circuit_pybind_test.py
+++ b/src/stim/circuit/circuit_pybind_test.py
@@ -577,3 +577,17 @@ def test_approx_equals():
 
     assert not base.approx_equals(object(), atol=999)
     assert not base.approx_equals(stim.PauliString("XYZ"), atol=999)
+
+
+def test_pickle():
+    import pickle
+
+    t = stim.Circuit("""
+        H 0
+        REPEAT 100 {
+            M 0
+            CNOT rec[-1] 2
+        }
+    """)
+    a = pickle.dumps(t)
+    assert pickle.loads(a) == t

--- a/src/stim/circuit/circuit_pybind_test.py
+++ b/src/stim/circuit/circuit_pybind_test.py
@@ -565,3 +565,15 @@ def test_circuit_detector_sampling_seeded():
     s3 = c.compile_detector_sampler(seed=6).sample(256)
     assert np.array_equal(s1, s2)
     assert not np.array_equal(s1, s3)
+
+
+def test_approx_equals():
+    base = stim.Circuit("X_ERROR(0.099) 0")
+    assert not base.approx_equals(stim.Circuit("X_ERROR(0.101) 0"), atol=0)
+    assert not base.approx_equals(stim.Circuit("X_ERROR(0.101) 0"), atol=0.00001)
+    assert base.approx_equals(stim.Circuit("X_ERROR(0.101) 0"), atol=0.01)
+    assert base.approx_equals(stim.Circuit("X_ERROR(0.101) 0"), atol=999)
+    assert not base.approx_equals(stim.Circuit("DEPOLARIZE1(0.101) 0"), atol=999)
+
+    assert not base.approx_equals(object(), atol=999)
+    assert not base.approx_equals(stim.PauliString("XYZ"), atol=999)

--- a/src/stim/dem/detector_error_model.cc
+++ b/src/stim/dem/detector_error_model.cc
@@ -232,37 +232,29 @@ void DemInstruction::validate() const {
 }
 
 void DetectorErrorModel::append_error_instruction(double probability, ConstPointerRange<DemTarget> targets) {
-    ConstPointerRange<double> args = {&probability};
-    DemInstruction{args, targets, DEM_ERROR}.validate();
-    auto stored_targets = target_buf.take_copy(targets);
-    auto stored_args = arg_buf.take_copy(args);
-    instructions.push_back(DemInstruction{stored_args, stored_targets, DEM_ERROR});
+    append_dem_instruction(DemInstruction{&probability, targets, DEM_ERROR});
 }
 
 void DetectorErrorModel::append_shift_detectors_instruction(
     ConstPointerRange<double> coord_shift, uint64_t detector_shift) {
     DemTarget shift{detector_shift};
-    ConstPointerRange<DemTarget> targets = {&shift};
-    DemInstruction{coord_shift, targets, DEM_SHIFT_DETECTORS}.validate();
-
-    auto stored_targets = target_buf.take_copy(targets);
-    auto stored_args = arg_buf.take_copy(coord_shift);
-    instructions.push_back(DemInstruction{stored_args, stored_targets, DEM_SHIFT_DETECTORS});
+    append_dem_instruction(DemInstruction{coord_shift, &shift, DEM_SHIFT_DETECTORS});
 }
 
 void DetectorErrorModel::append_detector_instruction(ConstPointerRange<double> coords, DemTarget target) {
-    ConstPointerRange<DemTarget> targets = {&target};
-    DemInstruction{coords, targets, DEM_DETECTOR}.validate();
-    auto stored_targets = target_buf.take_copy(targets);
-    auto stored_args = arg_buf.take_copy(coords);
-    instructions.push_back(DemInstruction{stored_args, stored_targets, DEM_DETECTOR});
+    append_dem_instruction(DemInstruction{coords, &target, DEM_DETECTOR});
 }
 
 void DetectorErrorModel::append_logical_observable_instruction(DemTarget target) {
-    ConstPointerRange<DemTarget> targets = {&target};
-    DemInstruction{{}, targets, DEM_LOGICAL_OBSERVABLE}.validate();
-    auto stored_targets = target_buf.take_copy(targets);
-    instructions.push_back(DemInstruction{{}, stored_targets, DEM_LOGICAL_OBSERVABLE});
+    append_dem_instruction(DemInstruction{{}, &target, DEM_LOGICAL_OBSERVABLE});
+}
+
+void DetectorErrorModel::append_dem_instruction(const DemInstruction &instruction) {
+    assert(instruction.type != DEM_REPEAT_BLOCK);
+    instruction.validate();
+    auto stored_targets = target_buf.take_copy(instruction.target_data);
+    auto stored_args = arg_buf.take_copy(instruction.arg_data);
+    instructions.push_back(DemInstruction{stored_args, stored_targets, instruction.type});
 }
 
 void DetectorErrorModel::append_repeat_block(uint64_t repeat_count, DetectorErrorModel &&body) {
@@ -665,4 +657,42 @@ DetectorErrorModel DetectorErrorModel::py_get_slice(int64_t start, int64_t step,
         }
     }
     return result;
+}
+
+DetectorErrorModel DetectorErrorModel::operator*(size_t repetitions) const {
+    DetectorErrorModel copy = *this;
+    copy *= repetitions;
+    return copy;
+}
+
+DetectorErrorModel &DetectorErrorModel::operator*=(size_t repetitions) {
+    if (repetitions == 0) {
+        clear();
+    }
+    if (repetitions <= 1) {
+        return *this;
+    }
+    DetectorErrorModel other = std::move(*this);
+    clear();
+    append_repeat_block(repetitions, std::move(other));
+    return *this;
+}
+
+DetectorErrorModel DetectorErrorModel::operator+(const DetectorErrorModel &other) const {
+    DetectorErrorModel result = *this;
+    result += other;
+    return result;
+}
+
+DetectorErrorModel &DetectorErrorModel::operator+=(const DetectorErrorModel &other) {
+    for (auto &e : other.instructions) {
+        if (e.type == DEM_REPEAT_BLOCK) {
+            uint64_t repeat_count = e.target_data[0].data;
+            const DetectorErrorModel &block = other.blocks[e.target_data[1].data];
+            append_repeat_block(repeat_count, block);
+        } else {
+            append_dem_instruction(e);
+        }
+    }
+    return *this;
 }

--- a/src/stim/dem/detector_error_model.cc
+++ b/src/stim/dem/detector_error_model.cc
@@ -712,6 +712,11 @@ DetectorErrorModel DetectorErrorModel::operator+(const DetectorErrorModel &other
 }
 
 DetectorErrorModel &DetectorErrorModel::operator+=(const DetectorErrorModel &other) {
+    if (&other == this) {
+        instructions.insert(instructions.end(), instructions.begin(), instructions.end());
+        return *this;
+    }
+
     for (auto &e : other.instructions) {
         if (e.type == DEM_REPEAT_BLOCK) {
             uint64_t repeat_count = e.target_data[0].data;

--- a/src/stim/dem/detector_error_model.cc
+++ b/src/stim/dem/detector_error_model.cc
@@ -616,6 +616,33 @@ uint64_t DetectorErrorModel::count_detectors() const {
     return max_num;
 }
 
+uint64_t DetectorErrorModel::count_errors() const {
+    uint64_t total = 0;
+    for (const auto &e : instructions) {
+        switch (e.type) {
+            case DEM_LOGICAL_OBSERVABLE:
+                break;
+            case DEM_SHIFT_DETECTORS:
+                break;
+            case DEM_REPEAT_BLOCK: {
+                auto &block = blocks[e.target_data[1].data];
+                auto n = block.count_errors();
+                auto reps = e.target_data[0].data;
+                total += n * reps;
+                break;
+            }
+            case DEM_DETECTOR:
+                break;
+            case DEM_ERROR:
+                total++;
+                break;
+            default:
+                throw std::invalid_argument("Instruction type not implemented in count_errors: " + e.str());
+        }
+    }
+    return total;
+}
+
 uint64_t DetectorErrorModel::count_observables() const {
     uint64_t max_num = 0;
     for (const auto &e : instructions) {

--- a/src/stim/dem/detector_error_model.h
+++ b/src/stim/dem/detector_error_model.h
@@ -122,6 +122,7 @@ struct DetectorErrorModel {
     uint64_t total_detector_shift() const;
     uint64_t count_detectors() const;
     uint64_t count_observables() const;
+    uint64_t count_errors() const;
 
     void clear();
 

--- a/src/stim/dem/detector_error_model.h
+++ b/src/stim/dem/detector_error_model.h
@@ -89,6 +89,12 @@ struct DetectorErrorModel {
     /// Move assignment.
     DetectorErrorModel &operator=(DetectorErrorModel &&other) noexcept;
 
+    DetectorErrorModel &operator*=(size_t repetitions);
+    DetectorErrorModel operator*(size_t repetitions) const;
+    DetectorErrorModel operator+(const DetectorErrorModel &other) const;
+    DetectorErrorModel &operator+=(const DetectorErrorModel &other);
+
+    void append_dem_instruction(const DemInstruction &instruction);
     void append_error_instruction(double probability, ConstPointerRange<DemTarget> targets);
     void append_shift_detectors_instruction(ConstPointerRange<double> coord_shift, uint64_t detector_shift);
     void append_detector_instruction(ConstPointerRange<double> coords, DemTarget target);

--- a/src/stim/dem/detector_error_model.pybind.cc
+++ b/src/stim/dem/detector_error_model.pybind.cc
@@ -330,7 +330,6 @@ void pybind_detector_error_model(pybind11::module &m) {
         )DOC")
             .data());
 
-
     c.def(
         "approx_equals",
         [](const DetectorErrorModel &self, const pybind11::object &obj, double atol) -> bool {
@@ -639,4 +638,13 @@ void pybind_detector_error_model(pybind11::module &m) {
                 ''')
         )DOC")
             .data());
+
+    c.def(pybind11::pickle(
+        [](const DetectorErrorModel &self) -> pybind11::str {
+            return self.str();
+        },
+        [](const pybind11::str &text) -> DetectorErrorModel {
+            return DetectorErrorModel(pybind11::cast<std::string>(text).data());
+        }
+    ));
 }

--- a/src/stim/dem/detector_error_model.pybind.cc
+++ b/src/stim/dem/detector_error_model.pybind.cc
@@ -297,4 +297,64 @@ void pybind_detector_error_model(pybind11::module &m) {
                 ''')
         )DOC")
             .data());
+
+
+    c.def(
+        "approx_equals",
+        [](const DetectorErrorModel &self, const pybind11::object &obj, double atol) -> bool {
+            try {
+                return self.approx_equals(pybind11::cast<DetectorErrorModel>(obj), atol);
+            } catch (const pybind11::cast_error &ex) {
+                return false;
+            }
+        },
+        pybind11::arg("other"),
+        pybind11::kw_only(),
+        pybind11::arg("atol"),
+        clean_doc_string(u8R"DOC(
+            Checks if a detector error model is approximately equal to another detector error model.
+
+            Two detector error model are approximately equal if they are equal up to slight perturbations of instruction
+            arguments such as probabilities. For example `error(0.100) D0` is approximately equal to `error(0.099) D0`
+            within an absolute tolerance of 0.002. All other details of the models (such as the ordering of errors and
+            their targets) must be exactly the same.
+
+            Args:
+                other: The detector error model, or other object, to compare to this one.
+                atol: The absolute error tolerance. The maximum amount each probability may have been perturbed by.
+
+            Returns:
+                True if the given object is a detector error model approximately equal up to the receiving circuit up to
+                the given tolerance, otherwise False.
+
+            Examples:
+                >>> import stim
+                >>> base = stim.DetectorErrorModel('''
+                ...    error(0.099) D0 D1
+                ... ''')
+
+                >>> base.approx_equals(base, atol=0)
+                True
+
+                >>> base.approx_equals(stim.Circuit('''
+                ...    error(0.101) D0 D1
+                ... '''), atol=0)
+                False
+
+                >>> base.approx_equals(stim.Circuit('''
+                ...    error(0.101) D0 D1
+                ... '''), atol=0.0001)
+                False
+
+                >>> base.approx_equals(stim.Circuit('''
+                ...    error(0.101) D0 D1
+                ... '''), atol=0.01)
+                True
+
+                >>> base.approx_equals(stim.Circuit('''
+                ...    error(0.099) D0 D1 L0 L1 L2 L3 L4
+                ... '''), atol=9999)
+                False
+        )DOC")
+            .data());
 }

--- a/src/stim/dem/detector_error_model.pybind.cc
+++ b/src/stim/dem/detector_error_model.pybind.cc
@@ -163,6 +163,30 @@ void pybind_detector_error_model(pybind11::module &m) {
             .data());
 
     c.def_property_readonly(
+        "num_errors",
+        &DetectorErrorModel::count_errors,
+        clean_doc_string(u8R"DOC(
+            Counts the number of errors (e.g. `error(0.1) D0`) in the error model.
+
+            Error instructions inside repeat blocks count once per repetition.
+            Redundant errors with the same targets count as separate errors.
+
+            Examples:
+                >>> import stim
+
+                >>> stim.DetectorErrorModel('''
+                ...     error(0.125) D0
+                ...     REPEAT 100 {
+                ...         REPEAT 5 {
+                ...             error(0.25) D1
+                ...         }
+                ...     }
+                ... ''').num_errors
+                501
+        )DOC")
+            .data());
+
+    c.def_property_readonly(
         "num_observables",
         &DetectorErrorModel::count_observables,
         clean_doc_string(u8R"DOC(

--- a/src/stim/dem/detector_error_model.pybind.cc
+++ b/src/stim/dem/detector_error_model.pybind.cc
@@ -176,8 +176,8 @@ void pybind_detector_error_model(pybind11::module &m) {
 
                 >>> stim.DetectorErrorModel('''
                 ...     error(0.125) D0
-                ...     REPEAT 100 {
-                ...         REPEAT 5 {
+                ...     repeat 100 {
+                ...         repeat 5 {
                 ...             error(0.25) D1
                 ...         }
                 ...     }
@@ -288,7 +288,7 @@ void pybind_detector_error_model(pybind11::module &m) {
                 ... '''))
                 3
                 >>> len(stim.DetectorErrorModel('''
-                ...    REPEAT 100 {
+                ...    repeat 100 {
                 ...        error(0.1) D0 D1
                 ...        error(0.1) D1 D2
                 ...    }
@@ -330,7 +330,7 @@ void pybind_detector_error_model(pybind11::module &m) {
                 >>> model = stim.DetectorErrorModel('''
                 ...    error(0.125) D0
                 ...    error(0.125) D1 L1
-                ...    REPEAT 100 {
+                ...    repeat 100 {
                 ...        error(0.125) D1 D2
                 ...        shift_detectors 1
                 ...    }
@@ -391,22 +391,22 @@ void pybind_detector_error_model(pybind11::module &m) {
                 >>> base.approx_equals(base, atol=0)
                 True
 
-                >>> base.approx_equals(stim.Circuit('''
+                >>> base.approx_equals(stim.DetectorErrorModel('''
                 ...    error(0.101) D0 D1
                 ... '''), atol=0)
                 False
 
-                >>> base.approx_equals(stim.Circuit('''
+                >>> base.approx_equals(stim.DetectorErrorModel('''
                 ...    error(0.101) D0 D1
                 ... '''), atol=0.0001)
                 False
 
-                >>> base.approx_equals(stim.Circuit('''
+                >>> base.approx_equals(stim.DetectorErrorModel('''
                 ...    error(0.101) D0 D1
                 ... '''), atol=0.01)
                 True
 
-                >>> base.approx_equals(stim.Circuit('''
+                >>> base.approx_equals(stim.DetectorErrorModel('''
                 ...    error(0.099) D0 D1 L0 L1 L2 L3 L4
                 ... '''), atol=9999)
                 False
@@ -494,14 +494,14 @@ void pybind_detector_error_model(pybind11::module &m) {
                 ...     stim.DemTarget.logical_observable_id(3),
                 ... ])
                 >>> print(repr(m))
-                stim.DetectorErrorMode('''
+                stim.DetectorErrorModel('''
                     error(0.125) D1
                     error(0.25) D1 ^ D2 L3
                 ''')
 
                 >>> m.append("shift_detectors", (1, 2, 3), [5])
                 >>> print(repr(m))
-                stim.DetectorErrorMode('''
+                stim.DetectorErrorModel('''
                     error(0.125) D1
                     error(0.25) D1 ^ D2 L3
                     shift_detectors(1, 2, 3) 5
@@ -511,7 +511,7 @@ void pybind_detector_error_model(pybind11::module &m) {
                 >>> m.append(m[0])
                 >>> m.append(m[-2])
                 >>> print(repr(m))
-                stim.DetectorErrorMode('''
+                stim.DetectorErrorModel('''
                     error(0.125) D1
                     error(0.25) D1 ^ D2 L3
                     shift_detectors(1, 2, 3) 5
@@ -551,7 +551,7 @@ void pybind_detector_error_model(pybind11::module &m) {
                 ... ''')
                 >>> m *= 3
                 >>> print(m)
-                REPEAT 3 {
+                repeat 3 {
                     error(0.25) D0
                     shift_detectors 1
                 }
@@ -570,7 +570,7 @@ void pybind_detector_error_model(pybind11::module &m) {
                 >>> m1 = stim.DetectorErrorModel('''
                 ...    error(0.125) D0
                 ... ''')
-                >>> m2 = stim.Circuit('''
+                >>> m2 = stim.DetectorErrorModel('''
                 ...    error(0.25) D1
                 ... ''')
                 >>> m1 + m2
@@ -593,7 +593,7 @@ void pybind_detector_error_model(pybind11::module &m) {
                 >>> m1 = stim.DetectorErrorModel('''
                 ...    error(0.125) D0
                 ... ''')
-                >>> m2 = stim.Circuit('''
+                >>> m2 = stim.DetectorErrorModel('''
                 ...    error(0.25) D1
                 ... ''')
                 >>> m1 += m2
@@ -610,13 +610,13 @@ void pybind_detector_error_model(pybind11::module &m) {
         &DetectorErrorModel::operator*,
         pybind11::arg("repetitions"),
         clean_doc_string(u8R"DOC(
-            Returns a detector error model with a REPEAT block containing the current model's instructions.
+            Returns a detector error model with a repeat block containing the current model's instructions.
 
             Special case: if the repetition count is 0, an empty model is returned.
-            Special case: if the repetition count is 1, an equal model with no REPEAT block is returned.
+            Special case: if the repetition count is 1, an equal model with no repeat block is returned.
 
             Args:
-                repetitions: The number of times the REPEAT block should repeat.
+                repetitions: The number of times the repeat block should repeat.
 
             Examples:
                 >>> import stim
@@ -626,7 +626,7 @@ void pybind_detector_error_model(pybind11::module &m) {
                 ... ''')
                 >>> m * 3
                 stim.DetectorErrorModel('''
-                    REPEAT 3 {
+                    repeat 3 {
                         error(0.25) D0
                         shift_detectors 1
                     }
@@ -639,13 +639,13 @@ void pybind_detector_error_model(pybind11::module &m) {
         &DetectorErrorModel::operator*,
         pybind11::arg("repetitions"),
         clean_doc_string(u8R"DOC(
-            Returns a detector error model with a REPEAT block containing the current model's instructions.
+            Returns a detector error model with a repeat block containing the current model's instructions.
 
             Special case: if the repetition count is 0, an empty model is returned.
-            Special case: if the repetition count is 1, an equal model with no REPEAT block is returned.
+            Special case: if the repetition count is 1, an equal model with no repeat block is returned.
 
             Args:
-                repetitions: The number of times the REPEAT block should repeat.
+                repetitions: The number of times the repeat block should repeat.
 
             Examples:
                 >>> import stim
@@ -655,7 +655,7 @@ void pybind_detector_error_model(pybind11::module &m) {
                 ... ''')
                 >>> 3 * m
                 stim.DetectorErrorModel('''
-                    REPEAT 3 {
+                    repeat 3 {
                         error(0.25) D0
                         shift_detectors 1
                     }

--- a/src/stim/dem/detector_error_model.pybind.cc
+++ b/src/stim/dem/detector_error_model.pybind.cc
@@ -32,6 +32,38 @@ std::string detector_error_model_repr(const DetectorErrorModel &self) {
     return ss.str();
 }
 
+std::vector<double> python_arg_to_instruction_arguments(const pybind11::object &arg) {
+    if (arg.is(pybind11::none())) {
+        return {};
+    }
+    try {
+        return {pybind11::cast<double>(arg)};
+    } catch (const pybind11::cast_error &ex) {
+    }
+    try {
+        return pybind11::cast<std::vector<double>>(arg);
+    } catch (const pybind11::cast_error &ex) {
+    }
+    throw std::invalid_argument("parens_arguments must be None, a double, or a list of doubles.");
+}
+
+DemInstructionType non_block_instruction_name_to_enum(const std::string &name) {
+    std::string low;
+    for (char c : name) {
+        low.push_back(tolower(c));
+    }
+    if (low == "error") {
+        return DemInstructionType::DEM_ERROR;
+    } else if (low == "shift_detectors") {
+        return DemInstructionType::DEM_SHIFT_DETECTORS;
+    } else if (low == "detector") {
+        return DemInstructionType::DEM_DETECTOR;
+    } else if (low == "logical_observable") {
+        return DemInstructionType::DEM_LOGICAL_OBSERVABLE;
+    }
+    throw std::invalid_argument("Not a non-block detector error model instruction name: " + name);
+}
+
 void pybind_detector_error_model(pybind11::module &m) {
     auto c = pybind11::class_<DetectorErrorModel>(
         m,
@@ -355,6 +387,256 @@ void pybind_detector_error_model(pybind11::module &m) {
                 ...    error(0.099) D0 D1 L0 L1 L2 L3 L4
                 ... '''), atol=9999)
                 False
+        )DOC")
+            .data());
+
+    c.def(
+        "append",
+        [](DetectorErrorModel &self,
+           const pybind11::object &instruction,
+           const pybind11::object &parens_arguments,
+           const std::vector<pybind11::object> &targets) {
+
+            bool is_name = pybind11::isinstance<pybind11::str>(instruction);
+            if (!is_name && (!targets.empty() || !parens_arguments.is_none())) {
+                throw std::invalid_argument(
+                    "Can't specify `parens_arguments` or `targets` when instruction is a "
+                    "stim.DemInstruction (instead of an instruction name).");
+            }
+            if (is_name && (targets.empty() || parens_arguments.is_none())) {
+                throw std::invalid_argument(
+                    "Must specify `parens_arguments` and `targets` when instruction is an instruction name.");
+            }
+
+            if (is_name) {
+                auto name = pybind11::cast<std::string>(instruction);
+                auto type = non_block_instruction_name_to_enum(name);
+                auto conv_args = python_arg_to_instruction_arguments(parens_arguments);
+                std::vector<DemTarget> conv_targets;
+                for (const auto &e : targets) {
+                    try {
+                        if (type == DemInstructionType::DEM_SHIFT_DETECTORS) {
+                            conv_targets.push_back(DemTarget{pybind11::cast<uint64_t>(e)});
+                        } else {
+                            conv_targets.push_back(DemTarget{pybind11::cast<ExposedDemTarget>(e).data});
+                        }
+                    } catch (pybind11::cast_error &ex) {
+                        auto str = pybind11::cast<std::string>(pybind11::str(e));
+                        throw std::invalid_argument("Bad target '" + str + "' for instruction '" + name + "'.");
+                    }
+                }
+
+                self.append_dem_instruction(DemInstruction{
+                    conv_args,
+                    conv_targets,
+                    type,
+                });
+            } else if (pybind11::isinstance<ExposedDemInstruction>(instruction)) {
+                const ExposedDemInstruction &exp = pybind11::cast<ExposedDemInstruction>(instruction);
+                self.append_dem_instruction(DemInstruction{exp.arguments, exp.targets, exp.type});
+            } else if (pybind11::isinstance<ExposedDemRepeatBlock>(instruction)) {
+                const ExposedDemRepeatBlock &block = pybind11::cast<ExposedDemRepeatBlock>(instruction);
+                self.append_repeat_block(block.repeat_count, block.body);
+            } else {
+                throw std::invalid_argument(
+                    "First argument to stim.DetectorErrorModel.append must be a str (an instruction name), "
+                    "a stim.DemInstruction, "
+                    "or a stim.DemRepeatBlock");
+            }
+        },
+        pybind11::arg("instruction"),
+        pybind11::arg("parens_arguments") = pybind11::none(),
+        pybind11::arg("targets") = pybind11::make_tuple(),
+        clean_doc_string(u8R"DOC(
+            Appends an instruction to the detector error model.
+
+            Args:
+                instruction: Either the name of an instruction, a stim.DemInstruction, or a stim.DemRepeatBlock.
+                    The `parens_arguments` and `targets` arguments are given if and only if the instruction is a name.
+                parens_arguments: Numeric values parameterizing the instruction. The numbers inside parentheses in a
+                    detector error model file (eg. the `0.25` in `error(0.25) D0`). This argument can be given either
+                    a list of doubles, or a single double (which will be implicitly wrapped into a list).
+                targets: The instruction targets, such as the `D0` in `error(0.25) D0`.
+
+            Examples:
+                >>> import stim
+                >>> m = stim.DetectorErrorModel()
+                >>> m.append("error", 0.125, [
+                ...     stim.DemTarget.relative_detector_id(1),
+                ... ])
+                >>> m.append("error", 0.25, [
+                ...     stim.DemTarget.relative_detector_id(1),
+                ...     stim.DemTarget.separator(),
+                ...     stim.DemTarget.relative_detector_id(2),
+                ...     stim.DemTarget.logical_observable_id(3),
+                ... ])
+                >>> print(repr(m))
+                stim.DetectorErrorMode('''
+                    error(0.125) D1
+                    error(0.25) D1 ^ D2 L3
+                ''')
+
+                >>> m.append("shift_detectors", (1, 2, 3), [5])
+                >>> print(repr(m))
+                stim.DetectorErrorMode('''
+                    error(0.125) D1
+                    error(0.25) D1 ^ D2 L3
+                    shift_detectors(1, 2, 3) 5
+                ''')
+
+                >>> m += m * 3
+                >>> m.append(m[0])
+                >>> m.append(m[-2])
+                >>> print(repr(m))
+                stim.DetectorErrorMode('''
+                    error(0.125) D1
+                    error(0.25) D1 ^ D2 L3
+                    shift_detectors(1, 2, 3) 5
+                    repeat 3 {
+                        error(0.125) D1
+                        error(0.25) D1 ^ D2 L3
+                        shift_detectors(1, 2, 3) 5
+                    }
+                    error(0.125) D1
+                    repeat 3 {
+                        error(0.125) D1
+                        error(0.25) D1 ^ D2 L3
+                        shift_detectors(1, 2, 3) 5
+                    }
+                ''')
+        )DOC")
+            .data());
+
+    c.def(
+        "__imul__",
+        &DetectorErrorModel::operator*=,
+        pybind11::arg("repetitions"),
+        clean_doc_string(u8R"DOC(
+            Mutates the detector error model by putting its contents into a repeat block.
+
+            Special case: if the repetition count is 0, the model is cleared.
+            Special case: if the repetition count is 1, nothing happens.
+
+            Args:
+                repetitions: The number of times the repeat block should repeat.
+
+            Examples:
+                >>> import stim
+                >>> m = stim.DetectorErrorModel('''
+                ...    error(0.25) D0
+                ...    shift_detectors 1
+                ... ''')
+                >>> m *= 3
+                >>> print(m)
+                REPEAT 3 {
+                    error(0.25) D0
+                    shift_detectors 1
+                }
+        )DOC")
+            .data());
+
+    c.def(
+        "__add__",
+        &DetectorErrorModel::operator+,
+        pybind11::arg("second"),
+        clean_doc_string(u8R"DOC(
+            Creates a detector error model by appending two models.
+
+            Examples:
+                >>> import stim
+                >>> m1 = stim.DetectorErrorModel('''
+                ...    error(0.125) D0
+                ... ''')
+                >>> m2 = stim.Circuit('''
+                ...    error(0.25) D1
+                ... ''')
+                >>> m1 + m2
+                stim.DetectorErrorModel('''
+                    error(0.125) D0
+                    error(0.25) D1
+                ''')
+        )DOC")
+            .data());
+
+    c.def(
+        "__iadd__",
+        &DetectorErrorModel::operator+=,
+        pybind11::arg("second"),
+        clean_doc_string(u8R"DOC(
+            Appends a detector error model into the receiving model (mutating it).
+
+            Examples:
+                >>> import stim
+                >>> m1 = stim.DetectorErrorModel('''
+                ...    error(0.125) D0
+                ... ''')
+                >>> m2 = stim.Circuit('''
+                ...    error(0.25) D1
+                ... ''')
+                >>> m1 += m2
+                >>> print(repr(m1))
+                stim.DetectorErrorModel('''
+                    error(0.125) D0
+                    error(0.25) D1
+                ''')
+        )DOC")
+            .data());
+
+    c.def(
+        "__mul__",
+        &DetectorErrorModel::operator*,
+        pybind11::arg("repetitions"),
+        clean_doc_string(u8R"DOC(
+            Returns a detector error model with a REPEAT block containing the current model's instructions.
+
+            Special case: if the repetition count is 0, an empty model is returned.
+            Special case: if the repetition count is 1, an equal model with no REPEAT block is returned.
+
+            Args:
+                repetitions: The number of times the REPEAT block should repeat.
+
+            Examples:
+                >>> import stim
+                >>> m = stim.DetectorErrorModel('''
+                ...    error(0.25) D0
+                ...    shift_detectors 1
+                ... ''')
+                >>> m * 3
+                stim.DetectorErrorModel('''
+                    REPEAT 3 {
+                        error(0.25) D0
+                        shift_detectors 1
+                    }
+                ''')
+        )DOC")
+            .data());
+
+    c.def(
+        "__rmul__",
+        &DetectorErrorModel::operator*,
+        pybind11::arg("repetitions"),
+        clean_doc_string(u8R"DOC(
+            Returns a detector error model with a REPEAT block containing the current model's instructions.
+
+            Special case: if the repetition count is 0, an empty model is returned.
+            Special case: if the repetition count is 1, an equal model with no REPEAT block is returned.
+
+            Args:
+                repetitions: The number of times the REPEAT block should repeat.
+
+            Examples:
+                >>> import stim
+                >>> m = stim.DetectorErrorModel('''
+                ...    error(0.25) D0
+                ...    shift_detectors 1
+                ... ''')
+                >>> 3 * m
+                stim.DetectorErrorModel('''
+                    REPEAT 3 {
+                        error(0.25) D0
+                        shift_detectors 1
+                    }
+                ''')
         )DOC")
             .data());
 }

--- a/src/stim/dem/detector_error_model.test.cc
+++ b/src/stim/dem/detector_error_model.test.cc
@@ -482,3 +482,122 @@ TEST(detector_error_model, py_get_slice) {
     d2.clear();
     ASSERT_EQ(d, d3);
 }
+
+TEST(detector_error_model, mul) {
+    DetectorErrorModel original(R"MODEL(
+        error(0.25) D0
+        REPEAT 999 {
+            error(0.25) D1
+        }
+    )MODEL");
+    DetectorErrorModel d = original;
+    ASSERT_EQ(d * 3, DetectorErrorModel(R"MODEL(
+        REPEAT 3 {
+            error(0.25) D0
+            REPEAT 999 {
+                error(0.25) D1
+            }
+        }
+    )MODEL"));
+    ASSERT_EQ(d * 1, d);
+    ASSERT_EQ(d * 0, DetectorErrorModel());
+    ASSERT_EQ(d, original);
+}
+
+TEST(detector_error_model, imul) {
+    DetectorErrorModel original(R"MODEL(
+        error(0.25) D0
+        REPEAT 999 {
+            error(0.25) D1
+        }
+    )MODEL");
+    DetectorErrorModel d = original;
+    d *= 3;
+    ASSERT_EQ(d, DetectorErrorModel(R"MODEL(
+        REPEAT 3 {
+            error(0.25) D0
+            REPEAT 999 {
+                error(0.25) D1
+            }
+        }
+    )MODEL"));
+    d = original;
+    d *= 1;
+    ASSERT_EQ(d, original);
+    d = original;
+    d *= 0;
+    ASSERT_EQ(d, DetectorErrorModel());
+}
+
+TEST(detector_error_model, add) {
+    DetectorErrorModel a(R"MODEL(
+        error(0.25) D0
+        REPEAT 999 {
+            error(0.25) D1
+        }
+    )MODEL");
+    DetectorErrorModel b(R"MODEL(
+        error(0.125) D1
+        REPEAT 2 {
+            REPEAT 3 {
+                error(0.125) D1
+            }
+        }
+    )MODEL");
+
+    ASSERT_EQ(a + b, DetectorErrorModel(R"MODEL(
+        error(0.25) D0
+        REPEAT 999 {
+            error(0.25) D1
+        }
+        error(0.125) D1
+        REPEAT 2 {
+            REPEAT 3 {
+                error(0.125) D1
+            }
+        }
+    )MODEL"));
+
+    ASSERT_EQ(a + DetectorErrorModel(), a);
+    ASSERT_EQ(DetectorErrorModel() + a, a);
+    ASSERT_EQ(b + DetectorErrorModel(), b);
+    ASSERT_EQ(DetectorErrorModel() + b, b);
+    ASSERT_EQ(DetectorErrorModel() + DetectorErrorModel(), DetectorErrorModel());
+}
+
+TEST(detector_error_model, iadd) {
+    DetectorErrorModel a(R"MODEL(
+        error(0.25) D0
+        REPEAT 999 {
+            error(0.25) D1
+        }
+    )MODEL");
+    DetectorErrorModel b(R"MODEL(
+        error(0.125) D1
+        REPEAT 2 {
+            REPEAT 3 {
+                error(0.125) D1
+            }
+        }
+    )MODEL");
+
+    a += b;
+    ASSERT_EQ(a, DetectorErrorModel(R"MODEL(
+        error(0.25) D0
+        REPEAT 999 {
+            error(0.25) D1
+        }
+        error(0.125) D1
+        REPEAT 2 {
+            REPEAT 3 {
+                error(0.125) D1
+            }
+        }
+    )MODEL"));
+
+    DetectorErrorModel original = b;
+    b += DetectorErrorModel();
+    ASSERT_EQ(b, original);
+    b += a;
+    ASSERT_NE(b, original);
+}

--- a/src/stim/dem/detector_error_model.test.cc
+++ b/src/stim/dem/detector_error_model.test.cc
@@ -600,4 +600,10 @@ TEST(detector_error_model, iadd) {
     ASSERT_EQ(b, original);
     b += a;
     ASSERT_NE(b, original);
+
+    // Aliased.
+    a = original;
+    a += a;
+    a = DetectorErrorModel(a.str().data()); // Remove memory deduplication, because it affects equality.
+    ASSERT_EQ(a, original + original);
 }

--- a/src/stim/dem/detector_error_model_pybind_test.py
+++ b/src/stim/dem/detector_error_model_pybind_test.py
@@ -171,3 +171,16 @@ def test_append_bad():
         m.append(m[0], 0.125, [])
     with pytest.raises(ValueError, match="Can't specify.*instruction is a"):
         m.append(m[-1], 0.125, [])
+
+
+def test_pickle():
+    import pickle
+
+    t = stim.DetectorErrorModel("""
+        repeat 100 {
+            error(0.25) D0 L1
+            shift_detectors(1, 2) 3
+        }
+    """)
+    a = pickle.dumps(t)
+    assert pickle.loads(a) == t

--- a/src/stim/dem/detector_error_model_pybind_test.py
+++ b/src/stim/dem/detector_error_model_pybind_test.py
@@ -184,3 +184,23 @@ def test_pickle():
     """)
     a = pickle.dumps(t)
     assert pickle.loads(a) == t
+
+
+def test_count_errors():
+    assert stim.DetectorErrorModel().num_errors == 0
+
+    assert stim.DetectorErrorModel("""
+        logical_observable L100
+        detector D100
+        shift_detectors(100, 100, 100) 100
+        error(0.125) D100
+    """).num_errors == 1
+
+    assert stim.DetectorErrorModel("""
+        error(0.125) D0
+        REPEAT 100 {
+            REPEAT 5 {
+                error(0.25) D1
+            }
+        }
+    """).num_errors == 501

--- a/src/stim/dem/detector_error_model_pybind_test.py
+++ b/src/stim/dem/detector_error_model_pybind_test.py
@@ -97,3 +97,15 @@ def test_repr():
     assert eval(repr(v), {"stim": stim}) == v
     v = stim.DetectorErrorModel("error(0.125) D0 D1")
     assert eval(repr(v), {"stim": stim}) == v
+
+
+def test_approx_equals():
+    base = stim.DetectorErrorModel("error(0.099) D0")
+    assert not base.approx_equals(stim.DetectorErrorModel("error(0.101) D0"), atol=0)
+    assert not base.approx_equals(stim.DetectorErrorModel("error(0.101) D0"), atol=0.00001)
+    assert base.approx_equals(stim.DetectorErrorModel("error(0.101) D0"), atol=0.01)
+    assert base.approx_equals(stim.DetectorErrorModel("error(0.101) D0"), atol=999)
+    assert not base.approx_equals(stim.DetectorErrorModel("error(0.101) D0 D1"), atol=999)
+
+    assert not base.approx_equals(object(), atol=999)
+    assert not base.approx_equals(stim.PauliString("XYZ"), atol=999)

--- a/src/stim/dem/detector_error_model_target.pybind.cc
+++ b/src/stim/dem/detector_error_model_target.pybind.cc
@@ -46,7 +46,7 @@ void pybind_detector_error_model_target(pybind11::module &m) {
                 ...     stim.target_relative_detector_id(13)
                 ... ])
                 >>> print(repr(m))
-                stim.DetectorErrorMode('''
+                stim.DetectorErrorModel('''
                     error(0.25) D13
                 ''')
         )DOC")
@@ -72,7 +72,7 @@ void pybind_detector_error_model_target(pybind11::module &m) {
                 ...     stim.target_logical_observable_id(13)
                 ... ])
                 >>> print(repr(m))
-                stim.DetectorErrorMode('''
+                stim.DetectorErrorModel('''
                     error(0.25) L13
                 ''')
         )DOC")
@@ -93,7 +93,7 @@ void pybind_detector_error_model_target(pybind11::module &m) {
                 ...     stim.target_relative_detector_id(2),
                 ... ])
                 >>> print(repr(m))
-                stim.DetectorErrorMode('''
+                stim.DetectorErrorModel('''
                     error(0.25) D1 ^ D2
                 ''')
         )DOC")
@@ -122,7 +122,7 @@ void pybind_detector_error_model_target(pybind11::module &m) {
                 ...     stim.DemTarget.relative_detector_id(13)
                 ... ])
                 >>> print(repr(m))
-                stim.DetectorErrorMode('''
+                stim.DetectorErrorModel('''
                     error(0.25) D13
                 ''')
         )DOC")
@@ -148,7 +148,7 @@ void pybind_detector_error_model_target(pybind11::module &m) {
                 ...     stim.DemTarget.logical_observable_id(13)
                 ... ])
                 >>> print(repr(m))
-                stim.DetectorErrorMode('''
+                stim.DetectorErrorModel('''
                     error(0.25) L13
                 ''')
         )DOC")
@@ -169,7 +169,7 @@ void pybind_detector_error_model_target(pybind11::module &m) {
                 ...     stim.DemTarget.relative_detector_id(2),
                 ... ])
                 >>> print(repr(m))
-                stim.DetectorErrorMode('''
+                stim.DetectorErrorModel('''
                     error(0.25) D1 ^ D2
                 ''')
         )DOC")

--- a/src/stim/dem/detector_error_model_target.pybind.cc
+++ b/src/stim/dem/detector_error_model_target.pybind.cc
@@ -38,6 +38,17 @@ void pybind_detector_error_model_target(pybind11::module &m) {
 
             Returns:
                 The relative detector target.
+
+            Examples:
+                >>> import stim
+                >>> m = stim.DetectorErrorModel()
+                >>> m.append("error", 0.25, [
+                ...     stim.target_relative_detector_id(13)
+                ... ])
+                >>> print(repr(m))
+                stim.DetectorErrorMode('''
+                    error(0.25) D13
+                ''')
         )DOC")
             .data());
 
@@ -53,6 +64,17 @@ void pybind_detector_error_model_target(pybind11::module &m) {
 
             Returns:
                 The logical observable target.
+
+            Examples:
+                >>> import stim
+                >>> m = stim.DetectorErrorModel()
+                >>> m.append("error", 0.25, [
+                ...     stim.target_logical_observable_id(13)
+                ... ])
+                >>> print(repr(m))
+                stim.DetectorErrorMode('''
+                    error(0.25) L13
+                ''')
         )DOC")
             .data());
 
@@ -61,11 +83,97 @@ void pybind_detector_error_model_target(pybind11::module &m) {
         &ExposedDemTarget::separator,
         clean_doc_string(u8R"DOC(
             Returns a target separator (e.g. "^" in a .dem file).
+
+            Examples:
+                >>> import stim
+                >>> m = stim.DetectorErrorModel()
+                >>> m.append("error", 0.25, [
+                ...     stim.target_relative_detector_id(1),
+                ...     stim.target_separator(),
+                ...     stim.target_relative_detector_id(2),
+                ... ])
+                >>> print(repr(m))
+                stim.DetectorErrorMode('''
+                    error(0.25) D1 ^ D2
+                ''')
         )DOC")
             .data());
 
     c.def(pybind11::self == pybind11::self, "Determines if two `stim.DemTarget`s are identical.");
     c.def(pybind11::self != pybind11::self, "Determines if two `stim.DemTarget`s are different.");
+
+    c.def_static(
+        "relative_detector_id",
+        &ExposedDemTarget::relative_detector_id,
+        pybind11::arg("index"),
+        clean_doc_string(u8R"DOC(
+            Returns a relative detector id (e.g. "D5" in a .dem file).
+
+            Args:
+                index: The index of the detector, relative to the current detector offset.
+
+            Returns:
+                The relative detector target.
+
+            Examples:
+                >>> import stim
+                >>> m = stim.DetectorErrorModel()
+                >>> m.append("error", 0.25, [
+                ...     stim.DemTarget.relative_detector_id(13)
+                ... ])
+                >>> print(repr(m))
+                stim.DetectorErrorMode('''
+                    error(0.25) D13
+                ''')
+        )DOC")
+            .data());
+
+    c.def_static(
+        "logical_observable_id",
+        &ExposedDemTarget::observable_id,
+        pybind11::arg("index"),
+        clean_doc_string(u8R"DOC(
+            Returns a logical observable id identifying a frame change (e.g. "L5" in a .dem file).
+
+            Args:
+                index: The index of the observable.
+
+            Returns:
+                The logical observable target.
+
+            Examples:
+                >>> import stim
+                >>> m = stim.DetectorErrorModel()
+                >>> m.append("error", 0.25, [
+                ...     stim.DemTarget.logical_observable_id(13)
+                ... ])
+                >>> print(repr(m))
+                stim.DetectorErrorMode('''
+                    error(0.25) L13
+                ''')
+        )DOC")
+            .data());
+
+    c.def_static(
+        "separator",
+        &ExposedDemTarget::separator,
+        clean_doc_string(u8R"DOC(
+            Returns a target separator (e.g. "^" in a .dem file).
+
+            Examples:
+                >>> import stim
+                >>> m = stim.DetectorErrorModel()
+                >>> m.append("error", 0.25, [
+                ...     stim.DemTarget.relative_detector_id(1),
+                ...     stim.DemTarget.separator(),
+                ...     stim.DemTarget.relative_detector_id(2),
+                ... ])
+                >>> print(repr(m))
+                stim.DetectorErrorMode('''
+                    error(0.25) D1 ^ D2
+                ''')
+        )DOC")
+            .data());
 
     c.def(
         "__repr__",

--- a/src/stim/dem/detector_error_model_target_pybind_test.py
+++ b/src/stim/dem/detector_error_model_target_pybind_test.py
@@ -61,3 +61,9 @@ def test_repr():
     assert eval(repr(v), {"stim": stim}) == v
     v = stim.target_separator()
     assert eval(repr(v), {"stim": stim}) == v
+
+
+def test_static_constructors():
+    assert stim.DemTarget.relative_detectorr_id(5) == stim.target_relative_detector_id(5)
+    assert stim.DemTarget.logical_observable_id(5) == stim.target_logical_observable_id(5)
+    assert stim.DemTarget.separator(5) == stim.target_separator(5)

--- a/src/stim/dem/detector_error_model_target_pybind_test.py
+++ b/src/stim/dem/detector_error_model_target_pybind_test.py
@@ -64,6 +64,6 @@ def test_repr():
 
 
 def test_static_constructors():
-    assert stim.DemTarget.relative_detectorr_id(5) == stim.target_relative_detector_id(5)
+    assert stim.DemTarget.relative_detector_id(5) == stim.target_relative_detector_id(5)
     assert stim.DemTarget.logical_observable_id(5) == stim.target_logical_observable_id(5)
-    assert stim.DemTarget.separator(5) == stim.target_separator(5)
+    assert stim.DemTarget.separator() == stim.target_separator()

--- a/src/stim/simulators/measurements_to_detection_events.h
+++ b/src/stim/simulators/measurements_to_detection_events.h
@@ -37,14 +37,8 @@ namespace stim {
 /// Args:
 ///     measurements_in: The file to read measurement data from.
 ///     input_format: The format of the measurement data in the file.
-///     optional_initial_error_frames_in: An optional file containing initial error frame data. Each record in the file
-///         should have a size equal to the number of qubits in the circuit. The first record is the X bits for the
-///         first shot's error frame, the second record is the Z bits for that frame, then the next two records are the
-///         X and Z bits for the next frame, and etc. These initial error frames are propagated through the circuit, and
-///         any measurements flipped by the propagated errors are also flipped in the read measurement data before
-///         computing detector/observable flips.
-///     initial_error_frames_in_format: The format of the records in the error frame file. Ignored when
-///         optional_initial_error_frames_in == nullptr.
+///     optional_sweep_bits_in: An optional file containing sweep data for each shot in the measurements file.
+///     sweep_bits_in_format: The format of the sweep data file. Ignored when optional_sweep_bits_in == nullptr.
 ///     results_out: The file to write detection event data to.
 ///     output_format: The format to use when writing the detection event data.
 ///     circuit: The circuit that the measurement data corresponds to, with DETECTOR and OBSERVABLE_INCLUDE annotations
@@ -90,6 +84,10 @@ void stream_measurements_to_detection_events_helper(
 ///     sweep_bits__minor_shot_index: Per-shot configuration data controlling operations like `CNOT sweep[0] 1`.
 ///         Major axis: sweep bit index.
 ///         Minor axis: shot index.
+///
+///         To not specify sweep data, set the major axis length of sweep_bits__minor_shot_index to 0 (the minor axis
+///         length must still match the number of shots). The major axis can also be partially truncated. Sweep bits
+///         beyond that length default to False.
 ///     circuit: The circuit that the measurement data corresponds to, with DETECTOR and OBSERVABLE_INCLUDE annotations
 ///         indicating how to perform the conversion.
 ///     append_observables: Whether or not to include observable flip data in the detection event data.
@@ -107,7 +105,7 @@ simd_bit_table measurements_to_detection_events(
     bool append_observables,
     bool skip_reference_sample);
 /// A variant of `stim::measurements_to_detection_events` with derived values passed in, not recomputed.
-void measurements_to_detection_events_helper(
+    void measurements_to_detection_events_helper(
     const simd_bit_table &measurements__minor_shot_index,
     const simd_bit_table &sweep_bits__minor_shot_index,
     simd_bit_table &out_detection_results__minor_shot_index,

--- a/src/stim/simulators/measurements_to_detection_events.pybind.cc
+++ b/src/stim/simulators/measurements_to_detection_events.pybind.cc
@@ -313,7 +313,7 @@ void pybind_compiled_measurements_to_detection_events_converter_methods(
                 measurements: A numpy array containing measurement data:
                     dtype=bool8
                     shape=(num_shots, circuit.num_measurements)
-                sweep_bits_filepath: A numpy array containing sweep data for `sweep[k]` controls in the circuit:
+                sweep_bits: A numpy array containing sweep data for `sweep[k]` controls in the circuit:
                     dtype=bool8
                     shape=(num_shots, circuit.num_sweep_bits)
                     Defaults to None (all sweep bits False).

--- a/src/stim/stabilizers/pauli_string.pybind.h
+++ b/src/stim/stabilizers/pauli_string.pybind.h
@@ -27,6 +27,7 @@ struct PyPauliString {
     PyPauliString(const stim::PauliStringRef val, bool imag = false);
     PyPauliString(stim::PauliString &&val, bool imag = false);
 
+    static PyPauliString from_text(const char *c);
     std::complex<float> get_phase() const;
 
     PyPauliString operator+(const PyPauliString &rhs) const;

--- a/src/stim/stabilizers/pauli_string_pybind_test.py
+++ b/src/stim/stabilizers/pauli_string_pybind_test.py
@@ -460,3 +460,15 @@ def test_commutes_different_lengths():
     assert not x1000.commutes(z1)
     assert not x1.commutes(z1000)
     assert not z1000.commutes(x1)
+
+
+def test_pickle():
+    import pickle
+
+    t = stim.PauliString.random(4)
+    a = pickle.dumps(t)
+    assert pickle.loads(a) == t
+
+    t = stim.PauliString("i_XYZ")
+    a = pickle.dumps(t)
+    assert pickle.loads(a) == t

--- a/src/stim/stabilizers/tableau_pybind_test.py
+++ b/src/stim/stabilizers/tableau_pybind_test.py
@@ -674,3 +674,10 @@ def test_inverse():
             stim.PauliString("+ZZ_"),
         ],
     )
+
+
+def test_pickle():
+    import pickle
+    t = stim.Tableau.random(4)
+    a = pickle.dumps(t)
+    assert pickle.loads(a) == t


### PR DESCRIPTION
- Add `stim.DetectorErrorModel.num_errors`
- Add `stim.{Circuit,DetectorErrorModel}.approx_equals`
- Add `*,+,*=,+=` to `stim.DetectorErrorModel`
- Add `stim.DetectorErrorModel.append`
- Add static factory methods to `stim.DemTarget`
- Make `stim.{Circuit,PauliString,Tableau,DetectorErrorModel}` pickleable

Fixes https://github.com/quantumlib/Stim/issues/116
Fixes https://github.com/quantumlib/Stim/issues/160
Fixes https://github.com/quantumlib/Stim/issues/161
Fixes https://github.com/quantumlib/Stim/issues/162
Fixes https://github.com/quantumlib/Stim/issues/163

