### PR TITLE
feat: add Nix/flake setup to Stim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ venv/*
 .venv/*
 **/LastTest.log
 *.so
+result
+result*
+*.drv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,64 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1634851050,
+        "narHash": "sha256-N83GlSGPJJdcqhUxSCS/WwW5pksYf3VP1M13cDRTSVA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c91f3de5adaf1de973b797ef7485e441a65b8935",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1635165013,
+        "narHash": "sha256-o/BdVjNwcB6jOmzZjOH703BesSkkS5O7ej3xhyO8hAY=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "5b9e0ff9d3b551234b4f3eb3983744fa354b17f1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1635702959,
+        "narHash": "sha256-ZKxX9DjJJGJqq20pE4dIj1G4ssCLVXXRFerM6lNuF0k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e544ee88fa4590df75e221e645a03fe157a99e5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,9 @@
               allPyStims = mapAttrs (_: mkPyStim) (listToAttrs pyOuts);
             in
             flake-utils.lib.flattenTree (allPyStims // {
-              stim = pkgs.callPackage ./stim.nix { };
+              stim-avx2 = pkgs.callPackage ./stim.nix { avx2Support = true; sseSupport = false; };
+              stim-sse = pkgs.callPackage ./stim.nix { avx2Support = false; sseSupport = true; };
+              stim = pkgs.callPackage ./stim.nix { }
             });
 
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,73 @@
+{
+  description = "A fast stabilizer circuit simulator";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    gitignore = {
+      url = "github:hercules-ci/gitignore.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, flake-utils, gitignore, nixpkgs }:
+    let
+      inherit (nixpkgs.lib) attrValues last listToAttrs mapAttrs nameValuePair replaceStrings;
+      pyVersions = [ "3.7" "3.8" "3.9" "3.10" ];
+      pyNixVersions = map (replaceStrings [ "." ] [ "" ]) pyVersions;
+      pyLatest = "python${last pyNixVersions}";
+    in
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          pkgs = import nixpkgs { inherit system; overlays = [ gitignore.overlay ]; };
+        in
+        {
+          defaultPackage = pkgs.linkFarmFromDrvs "stim" (attrValues self.packages.${system});
+
+          packages =
+            let
+              pyVersionToInterpreter = ver:
+                nameValuePair "pystim-python${ver}" pkgs."python${ver}";
+              pyOuts = map pyVersionToInterpreter pyNixVersions;
+              mkPyStim = python: python.pkgs.callPackage ./pystim.nix { };
+              allPyStims = mapAttrs (_: mkPyStim) (listToAttrs pyOuts);
+            in
+            flake-utils.lib.flattenTree (allPyStims // {
+              stim = pkgs.callPackage ./stim.nix { };
+            });
+
+
+          devShell = pkgs.mkShell {
+            inputsFrom = [
+              self.packages.${system}.stim
+              self.packages.${system}."pystim-${pyLatest}"
+            ];
+
+            nativeBuildInputs = with pkgs; [
+              nix-linter
+              nixpkgs-fmt
+              pyright
+            ];
+          };
+        }) // {
+      overlay =
+        final: prev:
+        let
+          gitignoreSource = (gitignore.overlay final prev).gitignoreSource;
+          mkPyOverlay = ver:
+            let
+              py = prev."python${ver}";
+              packageOverrides = pyFinal: _: {
+                pystim = pyFinal.callPackage ./pystim.nix { inherit gitignoreSource; };
+              };
+              pyOverride = py.override { inherit packageOverrides; };
+            in
+            nameValuePair "python${ver}" pyOverride;
+          pyOverlays = listToAttrs (map mkPyOverlay pyNixVersions);
+        in
+        {
+          stim = final.callPackage ./stim.nix { inherit gitignoreSource; };
+        } // pyOverlays;
+    };
+}

--- a/pystim.nix
+++ b/pystim.nix
@@ -4,7 +4,6 @@
 , numpy
 , pybind11
 , pytestCheckHook
-, networkx
 }:
 let
   simdFlags =
@@ -30,12 +29,9 @@ buildPythonPackage {
 
   pythonImportsCheck = [ "stim" ];
 
-  checkInputs = [ pytestCheckHook networkx ];
+  checkInputs = [ pytestCheckHook ];
 
   disabledTestPaths = [
-    # requires cirq, which isn't in nixpkgs
-    "glue/cirq/stimcirq/_cirq_to_stim_test.py"
-    "glue/cirq/stimcirq/_stim_sampler_test.py"
-    "glue/cirq/stimcirq/_stim_to_cirq_test.py"
+    "glue/*"
   ];
 }

--- a/pystim.nix
+++ b/pystim.nix
@@ -1,0 +1,41 @@
+{ buildPythonPackage
+, stdenv
+, gitignoreSource
+, numpy
+, pybind11
+, pytestCheckHook
+, networkx
+}:
+let
+  simdFlags =
+    if stdenv.targetPlatform.avx2Support
+    then "'-mavx2', '-msse2'"
+    else if stdenv.targetPlatform.isx86_64
+    then "'-mno-avx2', '-msse2'"
+    else "'-mno-avx2', '-mno-sse2'";
+in
+buildPythonPackage {
+  pname = "Stim";
+  version = "1.7.dev1";
+
+  src = gitignoreSource ./.;
+
+  postPatch = ''
+    sed -i setup.py -e "s/'-march=native'/${simdFlags}/"
+  '';
+
+  nativeBuildInputs = [ pybind11 ];
+
+  propagatedBuildInputs = [ numpy ];
+
+  pythonImportsCheck = [ "stim" ];
+
+  checkInputs = [ pytestCheckHook networkx ];
+
+  disabledTestPaths = [
+    # requires cirq, which isn't in nixpkgs
+    "glue/cirq/stimcirq/_cirq_to_stim_test.py"
+    "glue/cirq/stimcirq/_stim_sampler_test.py"
+    "glue/cirq/stimcirq/_stim_to_cirq_test.py"
+  ];
+}

--- a/stim.nix
+++ b/stim.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, cmake
+, gitignoreSource
+, avx2Support ? stdenv.targetPlatform.avx2Support
+, sseSupport ? stdenv.targetPlatform.isx86_64
+}:
+stdenv.mkDerivation {
+  pname = "Stim";
+  version = "1.7.dev1";
+
+  src = gitignoreSource ./.;
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags =
+    if avx2Support
+    then [ "-DSIMD_WIDTH=256" ]
+    else if sseSupport
+    then [ "-DSIMD_WIDTH=128" ]
+    else [ "-DSIMD_WIDTH=64" ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/{bin,lib}
+    install -m 755 out/stim $out/bin/
+    install -m 755 out/stim_benchmark $out/bin
+    install -m 644 out/libstim.a $out/lib
+    runHook postInstall
+  '';
+}

--- a/stim.nix
+++ b/stim.nix
@@ -23,7 +23,6 @@ stdenv.mkDerivation {
     runHook preInstall
     mkdir -p $out/{bin,lib}
     install -m 755 out/stim $out/bin/
-    install -m 755 out/stim_benchmark $out/bin
     install -m 644 out/libstim.a $out/lib
     runHook postInstall
   '';

--- a/stim.nix
+++ b/stim.nix
@@ -1,6 +1,7 @@
 { stdenv
 , cmake
 , gitignoreSource
+, gtest
 , avx2Support ? stdenv.targetPlatform.avx2Support
 , sseSupport ? stdenv.targetPlatform.isx86_64
 }:
@@ -18,6 +19,16 @@ stdenv.mkDerivation {
     else if sseSupport
     then [ "-DSIMD_WIDTH=128" ]
     else [ "-DSIMD_WIDTH=64" ];
+
+  doCheck = true;
+
+  checkInputs = [ gtest ];
+
+  checkPhase = ''
+    runHook preCheck
+    out/stim_test
+    runHook postCheck
+  '';
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
Alright @Strilanc, a promise is a debt and here's the payment :)

This packages libstim and pystim with Nix, and makes it available for a range of
Python interpreters.

It would be nicer to do this if Stim used Poetry, but I think things are working
alright as-is.

You can build libstim and all the python packages with `nix build`, and you can
use the `overlay` attribute to easily import Stim into another flake:

```Nix
{
  inputs.stim = "github:lovesegfault/Stim/nix-init";
  outputs = { self, nixpkgs, stim }:
  let
    system = "x86_64-linux";
    pkgs = import nixpkgs { inherit system; overlays = [ stim.overlay ]; };
  in
  {
    defaultPackage = pkgs.writeShellScript "stimDemo" ''
      ${pkgs.stim}/bin/stim "${@}"
    '';
  };
}
```

I'd be happy to try my hand at moving Stim to Poetry in the future, if there's
interest.
