### PR TITLE
Fix error analyzer iterating fused MPP operations in wrong order

### DIFF
--- a/src/stim/simulators/error_analyzer.cc
+++ b/src/stim/simulators/error_analyzer.cc
@@ -1266,8 +1266,13 @@ void ErrorAnalyzer::add_error_combinations(
 }
 
 void ErrorAnalyzer::MPP(const OperationData &target_data) {
+    size_t n = target_data.targets.size();
+    std::vector<GateTarget> reversed_targets(n);
+    for (size_t k = 0; k < n; k++) {
+        reversed_targets[k] = target_data.targets[n-k-1];
+    }
     decompose_mpp_operation(
-        target_data,
+        OperationData{target_data.args, reversed_targets},
         xs.size(),
         [&](const OperationData &h_xz,
             const OperationData &h_yz,

--- a/src/stim/simulators/error_analyzer.test.cc
+++ b/src/stim/simulators/error_analyzer.test.cc
@@ -2498,3 +2498,35 @@ TEST(ErrorAnalyzer, ignores_sweep_controls) {
             error(0.25) D0
         )MODEL"));
 }
+
+TEST(ErrorAnalyzer, mpp_ordering) {
+    ASSERT_EQ(
+        ErrorAnalyzer::circuit_to_detector_error_model(
+            Circuit(R"CIRCUIT(
+                MPP X0*X1 X0
+                TICK
+                MPP X0
+                DETECTOR rec[-1] rec[-2]
+            )CIRCUIT"),
+            false,
+            false,
+            false,
+            false),
+        DetectorErrorModel(R"MODEL(
+            detector D0
+        )MODEL"));
+
+    ASSERT_THROW({
+        ErrorAnalyzer::circuit_to_detector_error_model(
+            Circuit(R"CIRCUIT(
+                MPP X0 X0*X1
+                TICK
+                MPP X0
+                DETECTOR rec[-1] rec[-2]
+            )CIRCUIT"),
+            false,
+            false,
+            false,
+            false);
+    }, std::invalid_argument);
+}


### PR DESCRIPTION
- Error analyzer goes back to front, not front to back