### PR TITLE
Compute graphlike distance given an error model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==1.8.0
+        run: python -m pip install cibuildwheel==2.3.0
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_SKIP: "cp27-* cp35-* pp* cp310-win32 cp310-manylinux_i686"
+          CIBW_SKIP: "cp27-* cp35-* pp* cp310-win32 cp310-manylinux_i686 cp36-musllinux_x86_64"
           CIBW_TEST_REQUIRES: cirq-core pytest
           CIBW_TEST_COMMAND: pytest {project}/src {project}/glue/cirq
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_SKIP: "cp27-* cp35-* pp* cp310-win32 cp310-manylinux_i686 cp36-musllinux_x86_64"
+          CIBW_SKIP: "cp27-* cp35-* pp* cp310-win32 cp310-manylinux_i686 *-musllinux_*"
           CIBW_TEST_REQUIRES: cirq-core pytest
           CIBW_TEST_COMMAND: pytest {project}/src {project}/glue/cirq
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_SKIP: "cp27-* cp35-* pp*"
+          CIBW_SKIP: "cp27-* cp35-* pp* cp310-win32"
           CIBW_TEST_REQUIRES: cirq-core pytest
           CIBW_TEST_COMMAND: pytest {project}/src {project}/glue/cirq
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           CIBW_SKIP: "cp27-* cp35-* pp*"
           CIBW_TEST_REQUIRES: cirq-core pytest
-          CIBW_TEST_COMMAND: pytest -s -v {project}/src {project}/glue/cirq
+          CIBW_TEST_COMMAND: pytest {project}/src {project}/glue/cirq
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
@@ -134,7 +134,7 @@ jobs:
       - run: pip install -e .
       - run: pip install pybind11 && python setup.py install  # Workaround for https://github.com/pypa/setuptools/issues/230
       - run: pip install pytest
-      - run: pytest -s -v src
+      - run: pytest src
       - run: python -c "import stim; import doctest; assert doctest.testmod(stim).failed == 0"
   test_stimcirq:
     runs-on: ubuntu-latest
@@ -148,7 +148,7 @@ jobs:
       - run: pip install pybind11 && python setup.py install  # Workaround for https://github.com/pypa/setuptools/issues/230
       - run: pip install -e glue/cirq
       - run: pip install pytest
-      - run: pytest -s -v glue/cirq
+      - run: pytest glue/cirq
       - run: python -c "import stimcirq; import doctest; assert doctest.testmod(stimcirq).failed == 0"
   test_stimzx:
     runs-on: ubuntu-latest
@@ -162,7 +162,7 @@ jobs:
       - run: pip install pybind11 && python setup.py install  # Workaround for https://github.com/pypa/setuptools/issues/230
       - run: pip install -e glue/zx
       - run: pip install pytest
-      - run: pytest -s -v glue/zx
+      - run: pytest glue/zx
       - run: python -c "import stimzx; import doctest; assert doctest.testmod(stimzx).failed == 0"
   test_stimjs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
       - run: pip install -e .
       - run: pip install pybind11 && python setup.py install  # Workaround for https://github.com/pypa/setuptools/issues/230
       - run: pip install pytest
-      - run: pytest src
+      - run: pytest -s src
       - run: python -c "import stim; import doctest; assert doctest.testmod(stim).failed == 0"
   test_stimcirq:
     runs-on: ubuntu-latest
@@ -148,7 +148,7 @@ jobs:
       - run: pip install pybind11 && python setup.py install  # Workaround for https://github.com/pypa/setuptools/issues/230
       - run: pip install -e glue/cirq
       - run: pip install pytest
-      - run: pytest glue/cirq
+      - run: pytest -s glue/cirq
       - run: python -c "import stimcirq; import doctest; assert doctest.testmod(stimcirq).failed == 0"
   test_stimzx:
     runs-on: ubuntu-latest
@@ -162,7 +162,7 @@ jobs:
       - run: pip install pybind11 && python setup.py install  # Workaround for https://github.com/pypa/setuptools/issues/230
       - run: pip install -e glue/zx
       - run: pip install pytest
-      - run: pytest glue/zx
+      - run: pytest -s glue/zx
       - run: python -c "import stimzx; import doctest; assert doctest.testmod(stimzx).failed == 0"
   test_stimjs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_SKIP: "cp27-* cp35-* pp* cp310-win32"
+          CIBW_SKIP: "cp27-* cp35-* pp* cp310-win32 cp310-manylinux_i686"
           CIBW_TEST_REQUIRES: cirq-core pytest
           CIBW_TEST_COMMAND: pytest {project}/src {project}/glue/cirq
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           CIBW_SKIP: "cp27-* cp35-* pp*"
           CIBW_TEST_REQUIRES: cirq-core pytest
-          CIBW_TEST_COMMAND: pytest {project}/src {project}/glue/cirq
+          CIBW_TEST_COMMAND: pytest -s -v {project}/src {project}/glue/cirq
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
@@ -134,7 +134,7 @@ jobs:
       - run: pip install -e .
       - run: pip install pybind11 && python setup.py install  # Workaround for https://github.com/pypa/setuptools/issues/230
       - run: pip install pytest
-      - run: pytest -s src
+      - run: pytest -s -v src
       - run: python -c "import stim; import doctest; assert doctest.testmod(stim).failed == 0"
   test_stimcirq:
     runs-on: ubuntu-latest
@@ -148,7 +148,7 @@ jobs:
       - run: pip install pybind11 && python setup.py install  # Workaround for https://github.com/pypa/setuptools/issues/230
       - run: pip install -e glue/cirq
       - run: pip install pytest
-      - run: pytest -s glue/cirq
+      - run: pytest -s -v glue/cirq
       - run: python -c "import stimcirq; import doctest; assert doctest.testmod(stimcirq).failed == 0"
   test_stimzx:
     runs-on: ubuntu-latest
@@ -162,7 +162,7 @@ jobs:
       - run: pip install pybind11 && python setup.py install  # Workaround for https://github.com/pypa/setuptools/issues/230
       - run: pip install -e glue/zx
       - run: pip install pytest
-      - run: pytest -s glue/zx
+      - run: pytest -s -v glue/zx
       - run: python -c "import stimzx; import doctest; assert doctest.testmod(stimzx).failed == 0"
   test_stimjs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_SKIP: "cp27-* cp35-* pp*"
-          CIBW_TEST_REQUIRES: cirq-core pytest Pillow==8.3.1  # workaround for build breakage in pillow 8.4
+          CIBW_TEST_REQUIRES: cirq-core pytest
           CIBW_TEST_COMMAND: pytest {project}/src {project}/glue/cirq
       - uses: actions/upload-artifact@v2
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ set(SOURCE_FILES_NO_MAIN
         src/stim/simulators/error_analyzer.cc
         src/stim/simulators/frame_simulator.cc
         src/stim/simulators/measurements_to_detection_events.cc
+        src/stim/simulators/min_distance.cc
         src/stim/simulators/tableau_simulator.cc
         src/stim/simulators/vector_simulator.cc
         src/stim/stabilizers/pauli_string.cc
@@ -115,6 +116,7 @@ set(TEST_FILES
         src/stim/simulators/error_analyzer.test.cc
         src/stim/simulators/frame_simulator.test.cc
         src/stim/simulators/measurements_to_detection_events.test.cc
+        src/stim/simulators/min_distance.test.cc
         src/stim/simulators/tableau_simulator.test.cc
         src/stim/simulators/vector_simulator.test.cc
         src/stim/stabilizers/pauli_string.test.cc
@@ -138,6 +140,7 @@ set(BENCHMARK_FILES
         src/stim/probability_util.perf.cc
         src/stim/simulators/error_analyzer.perf.cc
         src/stim/simulators/frame_simulator.perf.cc
+        src/stim/simulators/min_distance.perf.cc
         src/stim/simulators/tableau_simulator.perf.cc
         src/stim/stabilizers/pauli_string.perf.cc
         src/stim/stabilizers/tableau.perf.cc

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ ALL_SOURCE_FILES = glob.glob("src/**/*.cc", recursive=True)
 TEST_FILES = glob.glob("src/**/*.test.cc", recursive=True)
 PERF_FILES = glob.glob("src/**/*.perf.cc", recursive=True)
 MAIN_FILES = glob.glob("src/**/main.cc", recursive=True)
+HEADER_FILES = glob.glob("src/**/*.h", recursive=True)
 RELEVANT_SOURCE_FILES = sorted(set(ALL_SOURCE_FILES) - set(TEST_FILES + PERF_FILES + MAIN_FILES))
 
 version = '1.7.dev1'
@@ -36,8 +37,10 @@ stim_polyfill = Extension(
     sources=RELEVANT_SOURCE_FILES,
     include_dirs=[pybind11.get_include(), "src"],
     language='c++',
+    data_files=['pyproject.toml'] + HEADER_FILES,
     extra_compile_args=[
         *common_compile_args,
+        # I would specify -mno-sse2 but that causes build failures in non-stim code...?
         '-mno-avx2',
         '-DSTIM_PYBIND11_MODULE_NAME=_stim_march_polyfill',
     ],
@@ -47,6 +50,7 @@ stim_sse2 = Extension(
     sources=RELEVANT_SOURCE_FILES,
     include_dirs=[pybind11.get_include(), "src"],
     language='c++',
+    data_files=['pyproject.toml'] + HEADER_FILES,
     extra_compile_args=[
         *common_compile_args,
         '-msse2',
@@ -59,6 +63,7 @@ stim_avx2 = Extension(
     sources=RELEVANT_SOURCE_FILES,
     include_dirs=[pybind11.get_include(), "src"],
     language='c++',
+    data_files=['pyproject.toml'] + HEADER_FILES,
     extra_compile_args=[
         *common_compile_args,
         '-msse2',

--- a/src/stim.h
+++ b/src/stim.h
@@ -49,6 +49,8 @@
 #include "stim/simulators/detection_simulator.h"
 #include "stim/simulators/error_analyzer.h"
 #include "stim/simulators/frame_simulator.h"
+#include "stim/simulators/measurements_to_detection_events.h"
+#include "stim/simulators/min_distance.h"
 #include "stim/simulators/tableau_simulator.h"
 #include "stim/simulators/vector_simulator.h"
 #include "stim/stabilizers/pauli_string.h"

--- a/src/stim/dem/detector_error_model.cc
+++ b/src/stim/dem/detector_error_model.cc
@@ -92,6 +92,16 @@ void DemTarget::shift_if_detector_id(int64_t offset) {
     }
 }
 
+bool DemInstruction::operator<(const DemInstruction &other) const {
+    if (type != other.type) {
+        return type < other.type;
+    }
+    if (target_data != other.target_data) {
+        return target_data < other.target_data;
+    }
+    return arg_data < other.arg_data;
+}
+
 bool DemInstruction::operator==(const DemInstruction &other) const {
     return approx_equals(other, 0);
 }

--- a/src/stim/dem/detector_error_model.pybind.cc
+++ b/src/stim/dem/detector_error_model.pybind.cc
@@ -14,6 +14,7 @@
 
 #include "stim/dem/detector_error_model.pybind.h"
 
+#include "stim/simulators/min_distance.h"
 #include "stim/dem/detector_error_model_instruction.pybind.h"
 #include "stim/dem/detector_error_model_repeat_block.pybind.h"
 #include "stim/dem/detector_error_model_target.pybind.h"
@@ -671,4 +672,85 @@ void pybind_detector_error_model(pybind11::module &m) {
             return DetectorErrorModel(pybind11::cast<std::string>(text).data());
         }
     ));
+
+    c.def(
+        "shortest_graphlike_error",
+        &shortest_graphlike_undetectable_logical_error,
+        pybind11::arg("ignore_ungraphlike_errors") = false,
+        clean_doc_string(u8R"DOC(
+            Finds a minimum sized set of graphlike errors that produce an undetected logical error.
+
+            Note that this method does not pay attention to error probabilities (other than ignoring errors with
+            probability 0). It searches for a logical error with the minimum *number* of physical errors, not the
+            maximum probability of those physical errors all occurring.
+
+            This method works by looking for errors that have frame changes (eg. "error(0.1) D0 D1 L5" flips the frame
+            of observable 5). These errors are converted into one or two symptoms and a net frame change. The symptoms
+            can then be moved around by following errors touching that symptom. Each symptom is moved until it
+            disappears into a boundary or cancels against another remaining symptom, while leaving the other symptoms
+            alone (ensuring only one symptom is allowed to move significantly reduces waste in the search space).
+            Eventually a path or cycle of errors is found that cancels out the symptoms, and if there is still a frame
+            change at that point then that path or cycle is a logical error (otherwise all that was found was a
+            stabilizer of the system; a dead end). The search process advances like a breadth first search, seeded from
+            all the frame-change errors and branching them outward in tandem, until one of them wins the race to find a
+            solution.
+
+            Args:
+                ignore_ungraphlike_errors: Defaults to False. When False, an exception is raised if there are any
+                    errors in the model that are not graphlike. When True, those errors are skipped as if they weren't
+                    present.
+
+                    A graphlike error is an error with at most two symptoms per decomposed component.
+                        graphlike:
+                            error(0.1) D0
+                            error(0.1) D0 D1
+                            error(0.1) D0 D1 L0
+                            error(0.1) D0 D1 ^ D2
+                        not graphlike:
+                            error(0.1) D0 D1 D2
+                            error(0.1) D0 D1 D2 ^ D3
+
+            Returns:
+                A detector error model containing just the error instructions corresponding to an undetectable logical
+                error. There will be no other kinds of instructions (no `repeat`s, no `shift_detectors`, etc).
+                The error probabilities will all be set to 1.
+
+                The `len` of the returned model is the graphlike code distance of the circuit. But beware that in
+                general the true code distance may be smaller. For example, in the XZ surface code with twists, the true
+                minimum sized logical error is likely to use Y errors. But each Y error decomposes into two graphlike
+                components (the X part and the Z part). As a result, the graphlike code distance in that context is
+                likely to be nearly twice as large as the true code distance.
+
+            Examples:
+                >>> import stim
+
+                >>> stim.DetectorErrorModel("""
+                ...     error(0.125) D0
+                ...     error(0.125) D0 D1
+                ...     error(0.125) D1 L55
+                ...     error(0.125) D1
+                ... """).shortest_graphlike_error()
+                stim.DetectorErrorModel('''
+                    error(1) D1
+                    error(1) D1 L55
+                ''')
+
+                >>> stim.DetectorErrorModel("""
+                ...     error(0.125) D0 D1 D2
+                ...     error(0.125) L0
+                ... """).shortest_graphlike_error(ignore_ungraphlike_errors=True)
+                stim.DetectorErrorModel('''
+                    error(1) L0
+                ''')
+
+                >>> circuit = stim.Circuit.generated(
+                ...     "repetition_code:memory",
+                ...     rounds=10,
+                ...     distance=7,
+                ...     before_round_data_depolarization=0.01)
+                >>> model = circuit.detector_error_model(decompose_errors=True)
+                >>> len(model.shortest_graphlike_error())
+                7
+        )DOC")
+            .data());
 }

--- a/src/stim/dem/detector_error_model_pybind_test.py
+++ b/src/stim/dem/detector_error_model_pybind_test.py
@@ -204,3 +204,29 @@ def test_count_errors():
             }
         }
     """).num_errors == 501
+
+
+def test_shortest_graphlike_error():
+    assert stim.DetectorErrorModel("""
+        error(0.125) D0
+        error(0.125) D0 D1
+        error(0.125) D1 L55
+        error(0.125) D1
+    """).shortest_graphlike_error() == stim.DetectorErrorModel("""
+        error(1) D1
+        error(1) D1 L55
+    """)
+
+    assert stim.DetectorErrorModel("""
+        error(0.125) D0 D1 D2
+        error(0.125) L0
+    """).shortest_graphlike_error(ignore_ungraphlike_errors=True) == stim.DetectorErrorModel("""
+        error(1) L0
+    """)
+
+    circuit = stim.Circuit.generated("repetition_code:memory",
+                                     rounds=10,
+                                     distance=7,
+                                     before_round_data_depolarization=0.01)
+    model = circuit.detector_error_model(decompose_errors=True)
+    assert len(model.shortest_graphlike_error()) == 7

--- a/src/stim/dem/detector_error_model_pybind_test.py
+++ b/src/stim/dem/detector_error_model_pybind_test.py
@@ -206,8 +206,32 @@ def test_count_errors():
     """).num_errors == 501
 
 
+def test_shortest_graphlike_error_trivial():
+    with pytest.raises(ValueError, match="any graphlike logical errors"):
+        _ = stim.DetectorErrorModel().shortest_graphlike_error()
+    with pytest.raises(ValueError, match="any graphlike logical errors"):
+        _ = stim.DetectorErrorModel("""
+            error(0.1) D0
+        """).shortest_graphlike_error()
+    with pytest.raises(ValueError, match="any graphlike logical errors"):
+        _ = stim.DetectorErrorModel("""
+            error(0.1) D0 L0
+        """).shortest_graphlike_error()
+    assert stim.DetectorErrorModel("""
+        error(0.1) L0
+    """).shortest_graphlike_error() == stim.DetectorErrorModel("""
+        error(1) L0
+    """)
+    assert stim.DetectorErrorModel("""
+        error(0.1) D0 D1 L0
+        error(0.1) D0 D1
+    """).shortest_graphlike_error() == stim.DetectorErrorModel("""
+        error(1) D0 D1
+        error(1) D0 D1 L0
+    """)
+
+
 def test_shortest_graphlike_error_line():
-    print("LINE START")
     assert stim.DetectorErrorModel("""
         error(0.125) D0
         error(0.125) D0 D1
@@ -217,7 +241,17 @@ def test_shortest_graphlike_error_line():
         error(1) D1
         error(1) D1 L55
     """)
-    print("LINE END")
+
+    assert len(stim.DetectorErrorModel("""
+        error(0.1) D0 D1 L5
+        REPEAT 1000 {
+            error(0.1) D0 D2
+            error(0.1) D1 D3
+            shift_detectors 2
+        }
+        error(0.1) D0
+        error(0.1) D1
+    """).shortest_graphlike_error()) == 2003
 
 
 def test_shortest_graphlike_error_ignore():

--- a/src/stim/dem/detector_error_model_pybind_test.py
+++ b/src/stim/dem/detector_error_model_pybind_test.py
@@ -206,7 +206,8 @@ def test_count_errors():
     """).num_errors == 501
 
 
-def test_shortest_graphlike_error():
+def test_shortest_graphlike_error_line():
+    print("LINE START")
     assert stim.DetectorErrorModel("""
         error(0.125) D0
         error(0.125) D0 D1
@@ -216,17 +217,26 @@ def test_shortest_graphlike_error():
         error(1) D1
         error(1) D1 L55
     """)
+    print("LINE END")
 
+
+def test_shortest_graphlike_error_ignore():
+    print("IGNORE START")
     assert stim.DetectorErrorModel("""
         error(0.125) D0 D1 D2
         error(0.125) L0
     """).shortest_graphlike_error(ignore_ungraphlike_errors=True) == stim.DetectorErrorModel("""
         error(1) L0
     """)
+    print("IGNORE END")
 
+
+def test_shortest_graphlike_error_rep_code():
+    print("REP CODE START")
     circuit = stim.Circuit.generated("repetition_code:memory",
                                      rounds=10,
                                      distance=7,
                                      before_round_data_depolarization=0.01)
     model = circuit.detector_error_model(decompose_errors=True)
     assert len(model.shortest_graphlike_error()) == 7
+    print("REP CODE FINISH")

--- a/src/stim/dem/detector_error_model_pybind_test.py
+++ b/src/stim/dem/detector_error_model_pybind_test.py
@@ -255,22 +255,18 @@ def test_shortest_graphlike_error_line():
 
 
 def test_shortest_graphlike_error_ignore():
-    print("IGNORE START")
     assert stim.DetectorErrorModel("""
         error(0.125) D0 D1 D2
         error(0.125) L0
     """).shortest_graphlike_error(ignore_ungraphlike_errors=True) == stim.DetectorErrorModel("""
         error(1) L0
     """)
-    print("IGNORE END")
 
 
 def test_shortest_graphlike_error_rep_code():
-    print("REP CODE START")
     circuit = stim.Circuit.generated("repetition_code:memory",
                                      rounds=10,
                                      distance=7,
                                      before_round_data_depolarization=0.01)
     model = circuit.detector_error_model(decompose_errors=True)
     assert len(model.shortest_graphlike_error()) == 7
-    print("REP CODE FINISH")

--- a/src/stim/io/measure_record_reader.cc
+++ b/src/stim/io/measure_record_reader.cc
@@ -399,7 +399,7 @@ bool MeasureRecordReaderFormatHits::start_record() {
                 "Bits per record is " + std::to_string(bits_per_record()) + " but got a hit value " +
                 std::to_string(value) + ".");
         }
-        buffer[value] ^= true;
+        buffer[(size_t)value] ^= true;
         is_first = false;
     }
     return true;
@@ -613,7 +613,7 @@ bool MeasureRecordReaderFormatDets::start_record() {
                 "Got '" + std::to_string(c) + std::to_string(number) + "' but expected num values of that type is " +
                 std::to_string(size) + ".");
         }
-        buffer[offset + number] ^= true;
+        buffer[(size_t)(offset + number)] ^= true;
     }
     return true;
 }

--- a/src/stim/io/measure_record_reader.h
+++ b/src/stim/io/measure_record_reader.h
@@ -260,7 +260,7 @@ struct MeasureRecordReaderFormatHits : MeasureRecordReader {
                 }
                 throw std::invalid_argument("HITS data wasn't comma-separated integers terminated by a newline.");
             }
-            handle_hit(value);
+            handle_hit((size_t)value);
             first = false;
             if (next_char == '\n') {
                 return true;
@@ -396,7 +396,7 @@ struct MeasureRecordReaderFormatDets : MeasureRecordReader {
                     << ".";
                 throw std::invalid_argument(msg.str());
             }
-            handle_hit(offset + value);
+            handle_hit((size_t)(offset + value));
         }
     }
 };

--- a/src/stim/py/compiled_detector_sampler.pybind.cc
+++ b/src/stim/py/compiled_detector_sampler.pybind.cc
@@ -45,9 +45,9 @@ pybind11::array_t<uint8_t> CompiledDetectorSampler::sample(
     size_t n = dets_obs.detectors.size() + dets_obs.observables.size() * (prepend_observables + append_observables);
 
     void *ptr = bytes.data();
-    ssize_t itemsize = sizeof(uint8_t);
-    std::vector<ssize_t> shape{(ssize_t)num_shots, (ssize_t)n};
-    std::vector<ssize_t> stride{(ssize_t)sample.num_minor_bits_padded(), 1};
+    pybind11::ssize_t itemsize = sizeof(uint8_t);
+    std::vector<pybind11::ssize_t> shape{(pybind11::ssize_t)num_shots, (pybind11::ssize_t)n};
+    std::vector<pybind11::ssize_t> stride{(pybind11::ssize_t)sample.num_minor_bits_padded(), 1};
     const std::string &format = pybind11::format_descriptor<uint8_t>::value;
     bool readonly = true;
     return pybind11::array_t<uint8_t>(pybind11::buffer_info(ptr, itemsize, format, 2, shape, stride, readonly));
@@ -60,9 +60,9 @@ pybind11::array_t<uint8_t> CompiledDetectorSampler::sample_bit_packed(
     size_t n = dets_obs.detectors.size() + dets_obs.observables.size() * (prepend_observables + append_observables);
 
     void *ptr = sample.data.u8;
-    ssize_t itemsize = sizeof(uint8_t);
-    std::vector<ssize_t> shape{(ssize_t)num_shots, (ssize_t)(n + 7) / 8};
-    std::vector<ssize_t> stride{(ssize_t)sample.num_minor_u8_padded(), 1};
+    pybind11::ssize_t itemsize = sizeof(uint8_t);
+    std::vector<pybind11::ssize_t> shape{(pybind11::ssize_t)num_shots, (pybind11::ssize_t)(n + 7) / 8};
+    std::vector<pybind11::ssize_t> stride{(pybind11::ssize_t)sample.num_minor_u8_padded(), 1};
     const std::string &format = pybind11::format_descriptor<uint8_t>::value;
     bool readonly = true;
     return pybind11::array_t<uint8_t>(pybind11::buffer_info(ptr, itemsize, format, 2, shape, stride, readonly));

--- a/src/stim/py/compiled_measurement_sampler.pybind.cc
+++ b/src/stim/py/compiled_measurement_sampler.pybind.cc
@@ -42,9 +42,9 @@ pybind11::array_t<uint8_t> CompiledMeasurementSampler::sample(size_t num_samples
     }
 
     void *ptr = bytes.data();
-    ssize_t itemsize = sizeof(uint8_t);
-    std::vector<ssize_t> shape{(ssize_t)num_samples, (ssize_t)circuit.count_measurements()};
-    std::vector<ssize_t> stride{(ssize_t)sample.num_minor_bits_padded(), 1};
+    pybind11::ssize_t itemsize = sizeof(uint8_t);
+    std::vector<pybind11::ssize_t> shape{(pybind11::ssize_t)num_samples, (pybind11::ssize_t)circuit.count_measurements()};
+    std::vector<pybind11::ssize_t> stride{(pybind11::ssize_t)sample.num_minor_bits_padded(), 1};
     const std::string &format = pybind11::format_descriptor<uint8_t>::value;
     bool readonly = true;
     return pybind11::array_t<uint8_t>(pybind11::buffer_info(ptr, itemsize, format, 2, shape, stride, readonly));
@@ -54,9 +54,9 @@ pybind11::array_t<uint8_t> CompiledMeasurementSampler::sample_bit_packed(size_t 
     auto sample = FrameSimulator::sample(circuit, ref_sample, num_samples, *prng);
 
     void *ptr = sample.data.u8;
-    ssize_t itemsize = sizeof(uint8_t);
-    std::vector<ssize_t> shape{(ssize_t)num_samples, (ssize_t)(circuit.count_measurements() + 7) / 8};
-    std::vector<ssize_t> stride{(ssize_t)sample.num_minor_u8_padded(), 1};
+    pybind11::ssize_t itemsize = sizeof(uint8_t);
+    std::vector<pybind11::ssize_t> shape{(pybind11::ssize_t)num_samples, (pybind11::ssize_t)(circuit.count_measurements() + 7) / 8};
+    std::vector<pybind11::ssize_t> stride{(pybind11::ssize_t)sample.num_minor_u8_padded(), 1};
     const std::string &format = pybind11::format_descriptor<uint8_t>::value;
     bool readonly = true;
     return pybind11::array_t<uint8_t>(pybind11::buffer_info(ptr, itemsize, format, 2, shape, stride, readonly));

--- a/src/stim/simulators/measurements_to_detection_events.pybind.cc
+++ b/src/stim/simulators/measurements_to_detection_events.pybind.cc
@@ -172,9 +172,9 @@ pybind11::array_t<bool> CompiledMeasurementsToDetectionEventsConverter::convert(
     }
 
     void *ptr = bytes.data();
-    ssize_t itemsize = sizeof(uint8_t);
-    std::vector<ssize_t> shape{(ssize_t)num_shots, (ssize_t)num_output_bits};
-    std::vector<ssize_t> stride{(ssize_t)num_output_bits, 1};
+    pybind11::ssize_t itemsize = sizeof(uint8_t);
+    std::vector<pybind11::ssize_t> shape{(pybind11::ssize_t)num_shots, (pybind11::ssize_t)num_output_bits};
+    std::vector<pybind11::ssize_t> stride{(pybind11::ssize_t)num_output_bits, 1};
     const std::string &format = pybind11::format_descriptor<bool>::value;
     bool readonly = true;
     return pybind11::array_t<bool>(pybind11::buffer_info(ptr, itemsize, format, 2, shape, stride, readonly));

--- a/src/stim/simulators/min_distance.cc
+++ b/src/stim/simulators/min_distance.cc
@@ -1,0 +1,296 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "stim/simulators/min_distance.h"
+
+#include <algorithm>
+#include <map>
+#include <queue>
+
+using namespace stim;
+
+constexpr uint64_t NO_NODE_INDEX = UINT64_MAX;
+
+struct DemAdjEdge {
+    uint64_t opposite_node_index;
+    uint64_t crossing_observable_mask;
+
+    std::string str() const {
+        std::stringstream result;
+        if (opposite_node_index == NO_NODE_INDEX) {
+            result << "[boundary]";
+        } else {
+            result << opposite_node_index;
+        }
+        size_t obs_id = 0;
+        uint64_t m = crossing_observable_mask;
+        while (m) {
+            if (m & 1) {
+                result << " L" << m;
+            }
+            m >>= 1;
+            obs_id++;
+        }
+        return result.str();
+    }
+};
+
+struct DemAdjNode {
+    std::vector<DemAdjEdge> edges;
+};
+
+struct DemAdjGraph {
+    std::vector<DemAdjNode> nodes;
+    uint64_t distance_1_error_mask = 0;
+
+    void add_outward_edge(size_t src, uint64_t dst, uint64_t obs_mask) {
+        assert(src < nodes.size());
+        auto &node = nodes[src];
+
+        // Don't add duplicate edges.
+        // Note: the neighbor list is expected to be short, so we do a linear scan instead of e.g. a binary search.
+        for (const auto &e : node.edges) {
+            if (e.opposite_node_index == dst && e.crossing_observable_mask == obs_mask) {
+                return;
+            }
+        }
+
+        node.edges.push_back({dst, obs_mask});
+    }
+
+    void add_edges_from_targets_with_no_separators(ConstPointerRange<DemTarget> targets, bool ignore_ungraphlike_errors) {
+        FixedCapVector<uint64_t, 2> detectors;
+        uint64_t obs_mask = 0;
+
+        // Collect detectors and observables.
+        for (const auto &t : targets) {
+            if (t.is_relative_detector_id()) {
+                if (detectors.size() == 2) {
+                    if (ignore_ungraphlike_errors) {
+                        return;
+                    }
+                    throw std::invalid_argument(
+                        "The detector error model contained a non-graphlike error mechanism.\n"
+                        "You can ignore such errors using `ignore_ungraphlike_errors`.\n"
+                        "You can use `decompose_errors` when converting a circuit into a model "
+                        "to ensure no such errors are present.\n");
+                }
+                detectors.push_back(t.raw_id());
+            } else if (t.is_observable_id()) {
+                obs_mask ^= 1ULL << t.raw_id();
+            }
+        }
+
+        // Add edges between detector nodes.
+        if (detectors.size() == 1) {
+            add_outward_edge(detectors[0], NO_NODE_INDEX, obs_mask);
+        } else if (detectors.size() == 2) {
+            add_outward_edge(detectors[0], detectors[1], obs_mask);
+            add_outward_edge(detectors[1], detectors[0], obs_mask);
+        } else if (detectors.size() == 0 && obs_mask && distance_1_error_mask == 0) {
+            distance_1_error_mask = obs_mask;
+        }
+    }
+
+    void add_edges_from_separable_targets(ConstPointerRange<DemTarget> targets, bool ignore_ungraphlike_errors) {
+        const DemTarget *prev = targets.begin();
+        const DemTarget *cur = targets.begin();
+        while (true) {
+            if (cur == targets.end() || cur->is_separator()) {
+                add_edges_from_targets_with_no_separators({prev, cur}, ignore_ungraphlike_errors);
+                prev = cur + 1;
+            }
+            if (cur == targets.end()) {
+                break;
+            }
+            cur++;
+        }
+    }
+
+    static DemAdjGraph from_dem(const DetectorErrorModel &model, bool ignore_ungraphlike_errors) {
+        DemAdjGraph result;
+        if (model.count_observables() > 64) {
+            throw std::invalid_argument("NotImplemented: shortest_graphlike_undetectable_logical_error with more than 64 observables.");
+        }
+        result.nodes.resize(model.count_detectors());
+        model.iter_flatten_error_instructions([&](const DemInstruction &e){
+            if (e.arg_data[0] != 0) {
+                result.add_edges_from_separable_targets(e.target_data, ignore_ungraphlike_errors);
+            }
+        });
+        return result;
+    }
+
+    std::string str() const {
+        std::stringstream result;
+        for (size_t k = 0; k < nodes.size(); k++) {
+            result << k << ":\n";
+            for (const auto &e : nodes[k].edges) {
+                result << "    " << e.str() << "\n";
+            }
+        }
+        return result.str();
+    }
+};
+
+struct DemAdjGraphSearchState {
+    uint64_t node1;
+    uint64_t node2;
+    uint64_t obs_mask;
+
+    DemAdjGraphSearchState() : node1(NO_NODE_INDEX), node2(NO_NODE_INDEX), obs_mask(0) {
+    }
+    DemAdjGraphSearchState(uint64_t init_node1, uint64_t init_node2, uint64_t obs_mask) : obs_mask(obs_mask) {
+        if (init_node1 < init_node2) {
+            node1 = init_node1;
+            node2 = init_node2;
+        } else if (init_node1 > init_node2) {
+            node1 = init_node2;
+            node2 = init_node1;
+        } else {
+            node1 = NO_NODE_INDEX;
+            node2 = NO_NODE_INDEX;
+        }
+    }
+
+    void append_transition_as_error_instruction_to(const DemAdjGraphSearchState &other, DetectorErrorModel &out) {
+        // Extract detector indices while cancelling duplicates.
+        std::array<uint64_t, 5> nodes{node1, node2, other.node1, other.node2, NO_NODE_INDEX};
+        std::sort(nodes.begin(), nodes.end());
+        for (size_t k = 0; k < 4; k++) {
+            if (nodes[k] == nodes[k + 1]) {
+                k++;
+            } else {
+                out.target_buf.append_tail(DemTarget::relative_detector_id(nodes[k]));
+            }
+        }
+
+        // Extract logical observable indices.
+        uint64_t dif_mask = obs_mask ^ other.obs_mask;
+        size_t obs_id = 0;
+        while (dif_mask) {
+            if (dif_mask & 1) {
+                out.target_buf.append_tail(DemTarget::observable_id(obs_id));
+            }
+            dif_mask >>= 1;
+            obs_id++;
+        }
+
+        out.arg_buf.append_tail(1);
+
+        out.instructions.push_back(DemInstruction{out.arg_buf.commit_tail(), out.target_buf.commit_tail(), DEM_ERROR});
+    }
+
+    bool operator==(const DemAdjGraphSearchState &other) const {
+        return node1 == other.node1 && node2 == other.node2 && obs_mask == other.obs_mask;
+    }
+
+    bool operator<(const DemAdjGraphSearchState &other) const {
+        if (node1 != other.node1) {
+            return node1 < other.node1;
+        }
+        if (node2 != other.node2) {
+            return node2 < other.node2;
+        }
+        return obs_mask < other.obs_mask;
+    }
+
+    std::string str() const {
+        std::stringstream result;
+        if (node1 != NO_NODE_INDEX) {
+            result << "D" << node1;
+            if (node2 != NO_NODE_INDEX) {
+                result << " D" << node2;
+            }
+        } else {
+            result << "[no symptoms]";
+        }
+
+        uint64_t dif_mask = obs_mask;
+        size_t obs_id = 0;
+        while (dif_mask) {
+            if (dif_mask & 1) {
+                result << " L" << obs_id;
+            }
+            dif_mask >>= 1;
+            obs_id++;
+        }
+
+        return result.str();
+    }
+};
+
+DetectorErrorModel backtrack_path(
+        const std::map<DemAdjGraphSearchState, DemAdjGraphSearchState> &back_map,
+        DemAdjGraphSearchState final_state) {
+
+    DetectorErrorModel out;
+    auto cur_state = final_state;
+    while (true) {
+        auto prev_state = back_map.at(cur_state);
+        cur_state.append_transition_as_error_instruction_to(prev_state, out);
+        if (prev_state.node1 == NO_NODE_INDEX) {
+            break;
+        }
+        cur_state = prev_state;
+    }
+    std::sort(out.instructions.begin(), out.instructions.end());
+    return out;
+}
+
+DetectorErrorModel stim::shortest_graphlike_undetectable_logical_error(const DetectorErrorModel &model,
+                                                                       bool ignore_ungraphlike_errors) {
+    DemAdjGraph graph = DemAdjGraph::from_dem(model, ignore_ungraphlike_errors);
+
+    if (graph.distance_1_error_mask) {
+        DetectorErrorModel out;
+        DemAdjGraphSearchState s1(NO_NODE_INDEX, NO_NODE_INDEX, graph.distance_1_error_mask);
+        s1.append_transition_as_error_instruction_to({}, out);
+        return out;
+    }
+
+    std::queue<DemAdjGraphSearchState> queue;
+    std::map<DemAdjGraphSearchState, DemAdjGraphSearchState> back_map;
+
+    // Search starts from any and all edges crossing an observable.
+    for (size_t node1 = 0; node1 < graph.nodes.size(); node1++) {
+        for (const auto &e : graph.nodes[node1].edges) {
+            size_t node2 = e.opposite_node_index;
+            if (node1 < node2 && e.crossing_observable_mask) {
+                DemAdjGraphSearchState start{node1, node2, e.crossing_observable_mask};
+                queue.push(start);
+                back_map.emplace(start, DemAdjGraphSearchState());
+            }
+        }
+    }
+
+    for (; !queue.empty(); queue.pop()) {
+        DemAdjGraphSearchState cur = queue.front();
+        for (const auto &e : graph.nodes[cur.node1].edges) {
+            DemAdjGraphSearchState next(e.opposite_node_index, cur.node2, e.crossing_observable_mask ^ cur.obs_mask);
+            if (!back_map.emplace(next, cur).second) {
+                continue;
+            }
+            if (next.node1 == NO_NODE_INDEX) {
+                if (next.obs_mask) {
+                    return backtrack_path(back_map, next);
+                }
+            } else {
+                queue.push(next);
+            }
+        }
+    }
+
+    throw std::invalid_argument("Failed to find any graphlike logical errors.");
+}

--- a/src/stim/simulators/min_distance.cc
+++ b/src/stim/simulators/min_distance.cc
@@ -309,7 +309,7 @@ DetectorErrorModel stim::shortest_graphlike_undetectable_logical_error(const Det
     // Search starts from any and all edges crossing an observable.
     for (size_t node1 = 0; node1 < graph.nodes.size(); node1++) {
         for (const auto &e : graph.nodes[node1].edges) {
-            size_t node2 = e.opposite_node_index;
+            uint64_t node2 = e.opposite_node_index;
             if (node1 < node2 && e.crossing_observable_mask) {
                 DemAdjGraphSearchState start{node1, node2, e.crossing_observable_mask};
                 queue.push(start);

--- a/src/stim/simulators/min_distance.cc
+++ b/src/stim/simulators/min_distance.cc
@@ -319,10 +319,8 @@ DetectorErrorModel stim::shortest_graphlike_undetectable_logical_error(const Det
     }
 
     // Breadth first search for a symptomless state that has a frame change.
-    std::cerr << "starting breadth first search\n";
     for (; !queue.empty(); queue.pop()) {
         DemAdjGraphSearchState cur = queue.front();
-        std::cerr << "    popped " << cur.str() << "\n";
         assert(cur.det_active != NO_NODE_INDEX);
         for (const auto &e : graph.nodes[cur.det_active].edges) {
             DemAdjGraphSearchState next(e.opposite_node_index, cur.det_held, e.crossing_observable_mask ^ cur.obs_mask);

--- a/src/stim/simulators/min_distance.h
+++ b/src/stim/simulators/min_distance.h
@@ -1,0 +1,45 @@
+/*
+* Copyright 2021 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef _STIM_SIMULATORS_MIN_DISTANCE_H
+#define _STIM_SIMULATORS_MIN_DISTANCE_H
+
+#include "stim/dem/detector_error_model.h"
+
+namespace stim {
+
+/// Finds a list of graphlike errors from the model that form an undetectable logical error.
+///
+/// An error is graphlike if it has at most 2 symptoms (detector indices).
+///
+/// The components of composite errors like D0 ^ D1 D2 are included in the set of graphlike errors being considered when
+/// trying to find an undetectable error (even if that specific graphlike error component doesn't occur on its own
+/// outside a composite error anywhere in the model).
+///
+/// Args:
+///     model: The detector error model to search for undetectable errors.
+///     ignore_ungraphlike_errors: Determines whether or not error components with more than 2 symptoms should raise an
+///         exception, or just be ignored as if they weren't there.
+///
+/// Returns:
+///     A detector error model containing only the error mechanisms that cause the undetectable logical error.
+///     Note that the error mechanisms will have their probabilities set to 1 (indicating they are necessary).
+DetectorErrorModel shortest_graphlike_undetectable_logical_error(const DetectorErrorModel &model,
+                                                                 bool ignore_ungraphlike_errors);
+
+}  // namespace stim
+
+#endif

--- a/src/stim/simulators/min_distance.h
+++ b/src/stim/simulators/min_distance.h
@@ -40,6 +40,60 @@ namespace stim {
 DetectorErrorModel shortest_graphlike_undetectable_logical_error(const DetectorErrorModel &model,
                                                                  bool ignore_ungraphlike_errors);
 
+namespace impl_min_distance {
+
+struct DemAdjEdge {
+    uint64_t opposite_node_index;
+    uint64_t crossing_observable_mask;
+    std::string str() const;
+    bool operator==(const DemAdjEdge &other) const;
+    bool operator!=(const DemAdjEdge &other) const;
+};
+std::ostream &operator<<(std::ostream &out, const DemAdjEdge &v);
+
+struct DemAdjNode {
+    std::vector<DemAdjEdge> edges;
+    std::string str() const;
+    bool operator==(const DemAdjNode &other) const;
+    bool operator!=(const DemAdjNode &other) const;
+};
+std::ostream &operator<<(std::ostream &out, const DemAdjNode &v);
+
+struct DemAdjGraph {
+    std::vector<DemAdjNode> nodes;
+    uint64_t distance_1_error_mask;
+
+    explicit DemAdjGraph(size_t node_count);
+    DemAdjGraph(std::vector<DemAdjNode> nodes, uint64_t distance_1_error_mask);
+
+    void add_outward_edge(size_t src, uint64_t dst, uint64_t obs_mask);
+    void add_edges_from_targets_with_no_separators(ConstPointerRange<DemTarget> targets, bool ignore_ungraphlike_errors);
+    void add_edges_from_separable_targets(ConstPointerRange<DemTarget> targets, bool ignore_ungraphlike_errors);
+    static DemAdjGraph from_dem(const DetectorErrorModel &model, bool ignore_ungraphlike_errors);
+    bool operator==(const DemAdjGraph &other) const;
+    bool operator!=(const DemAdjGraph &other) const;
+    std::string str() const;
+};
+std::ostream &operator<<(std::ostream &out, const DemAdjGraph &v);
+
+struct DemAdjGraphSearchState {
+    uint64_t det_active;  // The detection event being moved around in an attempt to remove it (or NO_NODE_INDEX).
+    uint64_t det_held;  // The detection event being left in the same place (or NO_NODE_INDEX).
+    uint64_t obs_mask;  // The accumulated frame changes from moving the detection events around.
+
+    DemAdjGraphSearchState();
+    DemAdjGraphSearchState(uint64_t det_active, uint64_t det_held, uint64_t obs_mask);
+    bool is_undetected() const;
+    DemAdjGraphSearchState canonical() const;
+    void append_transition_as_error_instruction_to(const DemAdjGraphSearchState &other, DetectorErrorModel &out);
+    bool operator==(const DemAdjGraphSearchState &other) const;
+    bool operator!=(const DemAdjGraphSearchState &other) const;
+    bool operator<(const DemAdjGraphSearchState &other) const;
+    std::string str() const;
+};
+std::ostream &operator<<(std::ostream &out, const DemAdjGraphSearchState &v);
+
+}  // namespace impl_min_distance
 }  // namespace stim
 
 #endif

--- a/src/stim/simulators/min_distance.perf.cc
+++ b/src/stim/simulators/min_distance.perf.cc
@@ -1,0 +1,41 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "stim/simulators/min_distance.h"
+#include "stim/gen/gen_surface_code.h"
+#include "stim/simulators/error_analyzer.h"
+
+#include "stim/benchmark_util.perf.h"
+
+using namespace stim;
+
+BENCHMARK(find_graphlike_logical_error_surface_code_d25) {
+    CircuitGenParameters params(25, 25, "rotated_memory_x");
+    params.after_clifford_depolarization = 0.001;
+    params.before_measure_flip_probability = 0.001;
+    params.after_reset_flip_probability = 0.001;
+    params.before_round_data_depolarization = 0.001;
+    auto circuit = generate_surface_code_circuit(params).circuit;
+    auto model = ErrorAnalyzer::circuit_to_detector_error_model(
+        circuit, true, true, false, false);
+
+    size_t total = 0;
+    benchmark_go([&]() {
+        total += stim::shortest_graphlike_undetectable_logical_error(model, false).instructions.size();
+    })
+        .goal_millis(35);
+    if (total % 25 != 0 || total == 0) {
+        std::cout << "bad";
+    }
+}

--- a/src/stim/simulators/min_distance.test.cc
+++ b/src/stim/simulators/min_distance.test.cc
@@ -20,7 +20,10 @@
 #include "stim/gen/gen_surface_code.h"
 #include "stim/simulators/error_analyzer.h"
 
+constexpr uint64_t NO_NODE_INDEX = UINT64_MAX;
+
 using namespace stim;
+using namespace stim::impl_min_distance;
 
 TEST(shortest_graphlike_undetectable_logical_error, no_error) {
     // No error.
@@ -175,4 +178,337 @@ TEST(shortest_graphlike_undetectable_logical_error, repetition_code) {
     ASSERT_EQ(
         stim::shortest_graphlike_undetectable_logical_error(graphlike_model, false).instructions.size(),
         7);
+}
+
+TEST(impl_min_distance, DemAdjEdge) {
+    DemAdjEdge e1{NO_NODE_INDEX, 0};
+    DemAdjEdge e2{1, 0};
+    DemAdjEdge e3{NO_NODE_INDEX, 1};
+    DemAdjEdge e4{NO_NODE_INDEX, 5};
+    ASSERT_EQ(e1.str(), "[boundary]");
+    ASSERT_EQ(e2.str(), "D1");
+    ASSERT_EQ(e3.str(), "[boundary] L0");
+    ASSERT_EQ(e4.str(), "[boundary] L0 L2");
+
+    ASSERT_TRUE(e1 == e1);
+    ASSERT_TRUE(!(e1 == e2));
+    ASSERT_FALSE(e1 == e2);
+    ASSERT_FALSE(!(e1 == e1));
+
+    ASSERT_EQ(e1, (DemAdjEdge{NO_NODE_INDEX, 0}));
+    ASSERT_EQ(e2, e2);
+    ASSERT_EQ(e3, e3);
+    ASSERT_NE(e1, e3);
+}
+
+TEST(impl_min_distance, DemAdjNode) {
+    DemAdjNode n1{};
+    DemAdjNode n2{{DemAdjEdge{NO_NODE_INDEX, 0}}};
+    DemAdjNode n3{{DemAdjEdge{1, 5}, DemAdjEdge{NO_NODE_INDEX, 8}}};
+    ASSERT_EQ(n1.str(), "");
+    ASSERT_EQ(n2.str(), "    [boundary]\n");
+    ASSERT_EQ(n3.str(), "    D1 L0 L2\n    [boundary] L3\n");
+
+    ASSERT_TRUE(n1 == n1);
+    ASSERT_TRUE(!(n1 == n2));
+    ASSERT_FALSE(n1 == n2);
+    ASSERT_FALSE(!(n1 == n1));
+
+    ASSERT_EQ(n1, (DemAdjNode{}));
+    ASSERT_EQ(n2, n2);
+    ASSERT_EQ(n3, n3);
+    ASSERT_NE(n1, n3);
+}
+
+TEST(impl_min_distance, DemAdjGraphSearchState_construct) {
+    DemAdjGraphSearchState r;
+    ASSERT_EQ(r.det_active, NO_NODE_INDEX);
+    ASSERT_EQ(r.det_held, NO_NODE_INDEX);
+    ASSERT_EQ(r.obs_mask, 0);
+
+    DemAdjGraphSearchState r2(2, 1, 3);
+    ASSERT_EQ(r2.det_active, 2);
+    ASSERT_EQ(r2.det_held, 1);
+    ASSERT_EQ(r2.obs_mask, 3);
+}
+
+TEST(impl_min_distance, DemAdjGraphSearchState_is_undetected) {
+    ASSERT_FALSE(DemAdjGraphSearchState(1, 2, 3).is_undetected());
+    ASSERT_FALSE(DemAdjGraphSearchState(1, 2, 2).is_undetected());
+    ASSERT_FALSE(DemAdjGraphSearchState(1, 2, 0).is_undetected());
+    ASSERT_TRUE(DemAdjGraphSearchState(1, 1, 3).is_undetected());
+    ASSERT_TRUE(DemAdjGraphSearchState(NO_NODE_INDEX, NO_NODE_INDEX, 32).is_undetected());
+    ASSERT_TRUE(DemAdjGraphSearchState(NO_NODE_INDEX, NO_NODE_INDEX, 0).is_undetected());
+}
+
+TEST(impl_min_distance, DemAdjGraphSearchState_canonical) {
+    DemAdjGraphSearchState a = DemAdjGraphSearchState(1, 2, 3).canonical();
+    ASSERT_EQ(a.det_active, 1);
+    ASSERT_EQ(a.det_held, 2);
+    ASSERT_EQ(a.obs_mask, 3);
+
+    a = DemAdjGraphSearchState(2, 1, 3).canonical();
+    ASSERT_EQ(a.det_active, 1);
+    ASSERT_EQ(a.det_held, 2);
+    ASSERT_EQ(a.obs_mask, 3);
+
+    a = DemAdjGraphSearchState(1, 1, 3).canonical();
+    ASSERT_EQ(a.det_active, NO_NODE_INDEX);
+    ASSERT_EQ(a.det_held, NO_NODE_INDEX);
+    ASSERT_EQ(a.obs_mask, 3);
+
+    a = DemAdjGraphSearchState(1, 1, 1).canonical();
+    ASSERT_EQ(a.det_active, NO_NODE_INDEX);
+    ASSERT_EQ(a.det_held, NO_NODE_INDEX);
+    ASSERT_EQ(a.obs_mask, 1);
+
+    a = DemAdjGraphSearchState(1, NO_NODE_INDEX, 1).canonical();
+    ASSERT_EQ(a.det_active, 1);
+    ASSERT_EQ(a.det_held, NO_NODE_INDEX);
+    ASSERT_EQ(a.obs_mask, 1);
+}
+
+TEST(impl_min_distance, DemAdjGraphSearchState_append_transition_as_error_instruction_to) {
+    DetectorErrorModel out;
+
+    DemAdjGraphSearchState(1, 2, 9).append_transition_as_error_instruction_to(
+        DemAdjGraphSearchState(1, 2, 16), out);
+    ASSERT_EQ(out, DetectorErrorModel(R"MODEL(
+        error(1) L0 L3 L4
+    )MODEL"));
+
+    DemAdjGraphSearchState(1, 2, 9).append_transition_as_error_instruction_to(
+        DemAdjGraphSearchState(3, 2, 9), out);
+    ASSERT_EQ(out, DetectorErrorModel(R"MODEL(
+        error(1) L0 L3 L4
+        error(1) D1 D3
+    )MODEL"));
+
+    DemAdjGraphSearchState(1, 2, 9).append_transition_as_error_instruction_to(
+        DemAdjGraphSearchState(1, NO_NODE_INDEX, 9), out);
+    ASSERT_EQ(out, DetectorErrorModel(R"MODEL(
+        error(1) L0 L3 L4
+        error(1) D1 D3
+        error(1) D2
+    )MODEL"));
+
+    DemAdjGraphSearchState(NO_NODE_INDEX, NO_NODE_INDEX, 0).append_transition_as_error_instruction_to(
+        DemAdjGraphSearchState(1, NO_NODE_INDEX, 9), out);
+    ASSERT_EQ(out, DetectorErrorModel(R"MODEL(
+        error(1) L0 L3 L4
+        error(1) D1 D3
+        error(1) D2
+        error(1) D1 L0 L3
+    )MODEL"));
+
+    DemAdjGraphSearchState(1, 1, 0).append_transition_as_error_instruction_to(
+        DemAdjGraphSearchState(2, 2, 4), out);
+    ASSERT_EQ(out, DetectorErrorModel(R"MODEL(
+        error(1) L0 L3 L4
+        error(1) D1 D3
+        error(1) D2
+        error(1) D1 L0 L3
+        error(1) L2
+    )MODEL"));
+}
+
+TEST(impl_min_distance, DemAdjGraphSearchState_canonical_equality) {
+    DemAdjGraphSearchState v1{1, 2, 3};
+    DemAdjGraphSearchState v2{1, 4, 3};
+    ASSERT_TRUE(v1 == v1);
+    ASSERT_FALSE(v1 == v2);
+    ASSERT_FALSE(v1 != v1);
+    ASSERT_TRUE(v1 != v2);
+
+    ASSERT_EQ(v1, DemAdjGraphSearchState(2, 1, 3));
+    ASSERT_NE(v1, DemAdjGraphSearchState(1, NO_NODE_INDEX, 3));
+    ASSERT_EQ(DemAdjGraphSearchState(NO_NODE_INDEX, NO_NODE_INDEX, 0), DemAdjGraphSearchState(1, 1, 0));
+    ASSERT_EQ(DemAdjGraphSearchState(3, 3, 0), DemAdjGraphSearchState(1, 1, 0));
+    ASSERT_NE(DemAdjGraphSearchState(3, 3, 1), DemAdjGraphSearchState(1, 1, 0));
+    ASSERT_EQ(DemAdjGraphSearchState(3, 3, 1), DemAdjGraphSearchState(1, 1, 1));
+    ASSERT_EQ(DemAdjGraphSearchState(2, NO_NODE_INDEX, 3), DemAdjGraphSearchState(NO_NODE_INDEX, 2, 3));
+}
+
+TEST(impl_min_distance, DemAdjGraphSearchState_canonical_ordering) {
+    ASSERT_TRUE(DemAdjGraphSearchState(1, 999, 999) < DemAdjGraphSearchState(101, 102, 103));
+    ASSERT_TRUE(DemAdjGraphSearchState(999, 1, 999) < DemAdjGraphSearchState(101, 102, 103));
+    ASSERT_TRUE(DemAdjGraphSearchState(101, 1, 999) < DemAdjGraphSearchState(101, 102, 103));
+    ASSERT_TRUE(DemAdjGraphSearchState(102, 1, 999) < DemAdjGraphSearchState(101, 102, 103));
+    ASSERT_TRUE(DemAdjGraphSearchState(101, 102, 3) < DemAdjGraphSearchState(101, 102, 103));
+
+    ASSERT_FALSE(DemAdjGraphSearchState(101, 102, 103) < DemAdjGraphSearchState(101, 102, 103));
+    ASSERT_FALSE(DemAdjGraphSearchState(101, 104, 103) < DemAdjGraphSearchState(101, 102, 103));
+    ASSERT_FALSE(DemAdjGraphSearchState(101, 102, 104) < DemAdjGraphSearchState(101, 102, 103));
+}
+
+TEST(impl_min_distance, DemAdjGraphSearchState_str) {
+    ASSERT_EQ(DemAdjGraphSearchState(1, 2, 3).str(), "D1 D2 L0 L1 ");
+}
+
+TEST(impl_min_distance, DemAdjGraph_equality) {
+    ASSERT_TRUE(DemAdjGraph(1) == DemAdjGraph(1));
+    ASSERT_TRUE(DemAdjGraph(1) != DemAdjGraph(2));
+    ASSERT_FALSE(DemAdjGraph(1) == DemAdjGraph(2));
+    ASSERT_FALSE(DemAdjGraph(1) != DemAdjGraph(1));
+
+    DemAdjGraph a(1);
+    DemAdjGraph b(1);
+    ASSERT_EQ(a, b);
+    b.distance_1_error_mask = 1;
+    ASSERT_NE(a, b);
+}
+
+TEST(impl_min_distance, DemAdjGraph_add_outward_edge) {
+    DemAdjGraph g(3);
+
+    g.add_outward_edge(1, 2, 3);
+    ASSERT_EQ(g, (DemAdjGraph{std::vector<DemAdjNode>{
+        DemAdjNode{},
+        DemAdjNode{{DemAdjEdge{2, 3}}},
+        DemAdjNode{},
+    }, 0}));
+
+    g.add_outward_edge(1, 2, 3);
+    ASSERT_EQ(g, (DemAdjGraph{std::vector<DemAdjNode>{
+                                  DemAdjNode{},
+                                  DemAdjNode{{DemAdjEdge{2, 3}}},
+                                  DemAdjNode{},
+                              }, 0}));
+
+    g.add_outward_edge(1, 2, 4);
+    ASSERT_EQ(g, (DemAdjGraph{std::vector<DemAdjNode>{
+                                  DemAdjNode{},
+                                  DemAdjNode{{DemAdjEdge{2, 3}, DemAdjEdge{2, 4}}},
+                                  DemAdjNode{},
+                              }, 0}));
+
+    g.add_outward_edge(2, 1, 3);
+    ASSERT_EQ(g, (DemAdjGraph{std::vector<DemAdjNode>{
+                                  DemAdjNode{},
+                                  DemAdjNode{{DemAdjEdge{2, 3}, DemAdjEdge{2, 4}}},
+                                  DemAdjNode{{DemAdjEdge{1, 3}}},
+                              }, 0}));
+
+    g.add_outward_edge(2, NO_NODE_INDEX, 3);
+    ASSERT_EQ(g, (DemAdjGraph{std::vector<DemAdjNode>{
+                                  DemAdjNode{},
+                                  DemAdjNode{{DemAdjEdge{2, 3}, DemAdjEdge{2, 4}}},
+                                  DemAdjNode{{DemAdjEdge{1, 3}, DemAdjEdge{NO_NODE_INDEX, 3}}},
+                              }, 0}));
+}
+
+TEST(impl_min_distance, DemAdjGraph_add_edges_from_targets_with_no_separators) {
+    DemAdjGraph g(4);
+
+    g.add_edges_from_targets_with_no_separators(
+        std::vector<DemTarget>{DemTarget::relative_detector_id(1)},
+        false);
+
+    ASSERT_EQ(g, (DemAdjGraph{{
+                     DemAdjNode{},
+                     DemAdjNode{{DemAdjEdge{NO_NODE_INDEX, 0}}},
+                     DemAdjNode{},
+                     DemAdjNode{},
+                 }, 0}));
+
+    g.add_edges_from_targets_with_no_separators(std::vector<DemTarget>{
+                                                    DemTarget::relative_detector_id(1),
+                                                    DemTarget::relative_detector_id(3),
+                                                    DemTarget::observable_id(5),
+                                                },
+        false);
+
+    ASSERT_EQ(g, (DemAdjGraph{{
+                                  DemAdjNode{},
+                                  DemAdjNode{{DemAdjEdge{NO_NODE_INDEX, 0}, DemAdjEdge{3, 32}}},
+                                  DemAdjNode{},
+                                  DemAdjNode{{DemAdjEdge{1, 32}}},
+                              }, 0}));
+
+    g.add_edges_from_targets_with_no_separators(std::vector<DemTarget>{
+                                                    DemTarget::observable_id(3),
+                                                    DemTarget::observable_id(7),
+                                                },
+                                                false);
+
+    ASSERT_EQ(g, (DemAdjGraph{{
+                                  DemAdjNode{},
+                                  DemAdjNode{{DemAdjEdge{NO_NODE_INDEX, 0}, DemAdjEdge{3, 32}}},
+                                  DemAdjNode{},
+                                  DemAdjNode{{DemAdjEdge{1, 32}}},
+                              }, (1 << 3) + (1 << 7)}));
+
+    DemAdjGraph same_g = g;
+    std::vector<DemTarget> too_big{
+        DemTarget::relative_detector_id(1),
+        DemTarget::relative_detector_id(2),
+        DemTarget::relative_detector_id(3),
+    };
+    ASSERT_THROW({
+        same_g.add_edges_from_targets_with_no_separators(too_big, false);
+    }, std::invalid_argument);
+    ASSERT_EQ(g, same_g);
+    same_g.add_edges_from_targets_with_no_separators(too_big, true);
+    ASSERT_EQ(g, same_g);
+}
+
+TEST(impl_min_distance, DemAdjGraph_str) {
+    DemAdjGraph g{{
+        DemAdjNode{},
+        DemAdjNode{{DemAdjEdge{NO_NODE_INDEX, 0}, DemAdjEdge{3, 32}}},
+        DemAdjNode{},
+        DemAdjNode{{DemAdjEdge{1, 32}}},
+    }, 0};
+    ASSERT_EQ(g.str(),
+              "0:\n"
+              "1:\n"
+              "    [boundary]\n"
+              "    D3 L5\n"
+              "2:\n"
+              "3:\n"
+              "    D1 L5\n");
+}
+
+TEST(impl_min_distance, DemAdjGraph_add_edges_from_separable_targets) {
+    DemAdjGraph g(4);
+
+    g.add_edges_from_separable_targets(
+        std::vector<DemTarget>{
+            DemTarget::relative_detector_id(1),
+            DemTarget::separator(),
+            DemTarget::relative_detector_id(1),
+            DemTarget::relative_detector_id(2),
+            DemTarget::observable_id(4),
+        },
+        false);
+
+    ASSERT_EQ(g, (DemAdjGraph{{
+                                  DemAdjNode{},
+                                  DemAdjNode{{DemAdjEdge{NO_NODE_INDEX, 0}, DemAdjEdge{2, 16}}},
+                                  DemAdjNode{{DemAdjEdge{1, 16}}},
+                                  DemAdjNode{},
+                              }, 0}));
+}
+
+TEST(impl_min_distance, DemAdjGraph_from_dem) {
+    ASSERT_EQ(DemAdjGraph::from_dem(DetectorErrorModel(R"MODEL(
+        error(0.1) D0
+        repeat 3 {
+            error(0.1) D0 D1
+            shift_detectors 1
+        }
+        error(0.1) D0 L7
+        error(0.1) D2 ^ D3 D4 L2
+        detector D5
+    )MODEL"), false), DemAdjGraph({
+                  DemAdjNode{{DemAdjEdge{NO_NODE_INDEX, 0}, DemAdjEdge{1, 0}}},
+                  DemAdjNode{{DemAdjEdge{0, 0}, DemAdjEdge{2, 0}}},
+                  DemAdjNode{{DemAdjEdge{1, 0}, DemAdjEdge{3, 0}}},
+                  DemAdjNode{{DemAdjEdge{2, 0}, DemAdjEdge{NO_NODE_INDEX, 128}}},
+                  DemAdjNode{},
+                  DemAdjNode{{DemAdjEdge{NO_NODE_INDEX, 0}}},
+                  DemAdjNode{{DemAdjEdge{7, 4}}},
+                  DemAdjNode{{DemAdjEdge{6, 4}}},
+                  DemAdjNode{},
+              }, 0));
 }

--- a/src/stim/simulators/min_distance.test.cc
+++ b/src/stim/simulators/min_distance.test.cc
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include "stim/gen/gen_rep_code.h"
 #include "stim/gen/gen_surface_code.h"
 #include "stim/simulators/error_analyzer.h"
 
@@ -162,4 +163,16 @@ TEST(shortest_graphlike_undetectable_logical_error, surface_code) {
     // Throw due to ungraphlike errors.
     ASSERT_THROW({ stim::shortest_graphlike_undetectable_logical_error(ungraphlike_model, false);
     }, std::invalid_argument);
+}
+
+TEST(shortest_graphlike_undetectable_logical_error, repetition_code) {
+    CircuitGenParameters params(10, 7, "memory");
+    params.before_round_data_depolarization = 0.01;
+    auto circuit = generate_rep_code_circuit(params).circuit;
+    auto graphlike_model = ErrorAnalyzer::circuit_to_detector_error_model(
+        circuit, true, true, false, false);
+
+    ASSERT_EQ(
+        stim::shortest_graphlike_undetectable_logical_error(graphlike_model, false).instructions.size(),
+        7);
 }

--- a/src/stim/simulators/min_distance.test.cc
+++ b/src/stim/simulators/min_distance.test.cc
@@ -1,0 +1,165 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "stim/simulators/min_distance.h"
+
+#include <gtest/gtest.h>
+
+#include "stim/gen/gen_surface_code.h"
+#include "stim/simulators/error_analyzer.h"
+
+using namespace stim;
+
+TEST(shortest_graphlike_undetectable_logical_error, no_error) {
+    // No error.
+    ASSERT_THROW({ stim::shortest_graphlike_undetectable_logical_error(DetectorErrorModel(), false);
+    }, std::invalid_argument);
+
+    // No undetectable error.
+    ASSERT_THROW({
+        stim::shortest_graphlike_undetectable_logical_error(DetectorErrorModel(R"MODEL(
+            error(0.1) D0 L0
+        )MODEL"), false);
+    }, std::invalid_argument);
+
+    // No logical flips.
+    ASSERT_THROW({
+        stim::shortest_graphlike_undetectable_logical_error(DetectorErrorModel(R"MODEL(
+            error(0.1) D0
+            error(0.1) D0 D1
+            error(0.1) D1
+        )MODEL"), false);
+    }, std::invalid_argument);
+}
+
+TEST(shortest_graphlike_undetectable_logical_error, distance_1) {
+    ASSERT_EQ(
+        stim::shortest_graphlike_undetectable_logical_error(
+            DetectorErrorModel(R"MODEL(
+                error(0.1) L0
+            )MODEL"),
+            false),
+        DetectorErrorModel(R"MODEL(
+            error(1) L0
+        )MODEL"));
+}
+
+TEST(shortest_graphlike_undetectable_logical_error, distance_2) {
+    ASSERT_EQ(
+        stim::shortest_graphlike_undetectable_logical_error(
+            DetectorErrorModel(R"MODEL(
+                error(0.1) D0
+                error(0.1) D0 L0
+            )MODEL"),
+            false),
+        DetectorErrorModel(R"MODEL(
+            error(1) D0
+            error(1) D0 L0
+        )MODEL"));
+
+    ASSERT_EQ(
+        stim::shortest_graphlike_undetectable_logical_error(
+            DetectorErrorModel(R"MODEL(
+                error(0.1) D0 L0
+                error(0.1) D0 L1
+            )MODEL"),
+            false),
+        DetectorErrorModel(R"MODEL(
+            error(1) D0 L0
+            error(1) D0 L1
+        )MODEL"));
+
+    ASSERT_EQ(
+        stim::shortest_graphlike_undetectable_logical_error(
+            DetectorErrorModel(R"MODEL(
+                error(0.1) D0 D1 L0
+                error(0.1) D0 D1 L1
+            )MODEL"),
+            false),
+        DetectorErrorModel(R"MODEL(
+            error(1) D0 D1 L0
+            error(1) D0 D1 L1
+        )MODEL"));
+
+    ASSERT_EQ(
+        stim::shortest_graphlike_undetectable_logical_error(
+            DetectorErrorModel(R"MODEL(
+                error(0.1) D0 D1 L1
+                error(0.1) D0 D1 L0
+            )MODEL"),
+            false),
+        DetectorErrorModel(R"MODEL(
+            error(1) D0 D1 L0
+            error(1) D0 D1 L1
+        )MODEL"));
+}
+
+TEST(shortest_graphlike_undetectable_logical_error, distance_3) {
+    ASSERT_EQ(
+        stim::shortest_graphlike_undetectable_logical_error(
+            DetectorErrorModel(R"MODEL(
+                error(0.1) D0
+                error(0.1) D0 D1 L0
+                error(0.1) D1
+            )MODEL"),
+            false),
+        DetectorErrorModel(R"MODEL(
+            error(1) D0
+            error(1) D0 D1 L0
+            error(1) D1
+        )MODEL"));
+
+    ASSERT_EQ(
+        stim::shortest_graphlike_undetectable_logical_error(
+            DetectorErrorModel(R"MODEL(
+                error(0.1) D1
+                error(0.1) D1 D0 L0
+                error(0.1) D0
+            )MODEL"),
+            false),
+        DetectorErrorModel(R"MODEL(
+            error(1) D0
+            error(1) D0 D1 L0
+            error(1) D1
+        )MODEL"));
+}
+
+TEST(shortest_graphlike_undetectable_logical_error, surface_code) {
+    CircuitGenParameters params(5, 5, "rotated_memory_x");
+    params.after_clifford_depolarization = 0.001;
+    params.before_measure_flip_probability = 0.001;
+    params.after_reset_flip_probability = 0.001;
+    params.before_round_data_depolarization = 0.001;
+    auto circuit = generate_surface_code_circuit(params).circuit;
+    auto graphlike_model = ErrorAnalyzer::circuit_to_detector_error_model(
+        circuit, true, true, false, false);
+    auto ungraphlike_model = ErrorAnalyzer::circuit_to_detector_error_model(
+        circuit, false, true, false, false);
+
+    ASSERT_EQ(
+        stim::shortest_graphlike_undetectable_logical_error(graphlike_model, false).instructions.size(),
+        5);
+
+    ASSERT_EQ(
+        stim::shortest_graphlike_undetectable_logical_error(graphlike_model, true).instructions.size(),
+        5);
+
+    ASSERT_EQ(
+        stim::shortest_graphlike_undetectable_logical_error(ungraphlike_model, true).instructions.size(),
+        5);
+
+    // Throw due to ungraphlike errors.
+    ASSERT_THROW({ stim::shortest_graphlike_undetectable_logical_error(ungraphlike_model, false);
+    }, std::invalid_argument);
+}

--- a/src/stim/simulators/tableau_simulator.pybind.cc
+++ b/src/stim/simulators/tableau_simulator.pybind.cc
@@ -157,9 +157,9 @@ void pybind_tableau_simulator(pybind11::module &m) {
                 float_vec.push_back(e.imag());
             }
             void *ptr = float_vec.data();
-            ssize_t itemsize = sizeof(float) * 2;
-            std::vector<ssize_t> shape{(ssize_t)complex_vec.size()};
-            std::vector<ssize_t> stride{itemsize};
+            pybind11::ssize_t itemsize = sizeof(float) * 2;
+            std::vector<pybind11::ssize_t> shape{(pybind11::ssize_t)complex_vec.size()};
+            std::vector<pybind11::ssize_t> stride{itemsize};
             const std::string &format = pybind11::format_descriptor<std::complex<float>>::value;
             bool readonly = true;
             return pybind11::array_t<float>(

--- a/src/stim/stabilizers/pauli_string.pybind.cc
+++ b/src/stim/stabilizers/pauli_string.pybind.cc
@@ -109,9 +109,9 @@ PyPauliString &PyPauliString::operator*=(pybind11::object rhs) {
     } else if (rhs.equal(pybind11::cast(std::complex<float>{0, -1}))) {
         return *this *= std::complex<float>{0, -1};
     } else if (pybind11::isinstance<pybind11::int_>(rhs)) {
-        ssize_t k = pybind11::int_(rhs);
+        pybind11::ssize_t k = pybind11::int_(rhs);
         if (k >= 0) {
-            return *this *= (size_t)k;
+            return *this *= (pybind11::size_t)k;
         }
     }
     throw std::out_of_range("need isinstance(rhs, (stim.PauliString, int)) or rhs in (1, -1, 1j, -1j)");
@@ -303,13 +303,13 @@ void pybind_pauli_string(pybind11::module &m) {
             .data());
 
     c.def(
-        pybind11::init([](const std::vector<ssize_t> &pauli_indices) {
+        pybind11::init([](const std::vector<pybind11::ssize_t> &pauli_indices) {
             return PyPauliString(
                 PauliString::from_func(
                     false,
                     pauli_indices.size(),
                     [&](size_t i) {
-                        ssize_t p = pauli_indices[i];
+                        pybind11::ssize_t p = pauli_indices[i];
                         if (p < 0 || p > 3) {
                             throw std::invalid_argument(
                                 "Expected a pauli index (0->I, 1->X, 2->Y, 3->Z) but got " + std::to_string(p));


### PR DESCRIPTION
Performs a breadth first search over the graph defined by a graphlike error model, searching for the smallest set of errors that has no symptoms but does cause a logical error.

The actual graph being searched over is implicit. The nodes of the implicit graph have one or two detection events and a set of logical observable frame changes. The neighbors of a node are defined to be the states that can be reached by applying any error that touches the **single marked symptom that is allowed move**, producing tweaked symptoms and frame changes. The initial nodes that the search branches out from come from edges that actually cross an observable: the symptoms and frame changes of that edge define a starting node.

The reason for the restriction of neighbors to involve only one symptom at a time, until that symptom is gone, is that this still guarantees the optimal solution is reachable in the same number of steps but it can massively reduce the number of reachable/searched nodes. For example, consider a square patch with an observable across the middle. The starting state is an edge crossing the observable, with a symptom on the left and right. By forcing the left symptom to disappear before the right symptom can move, the reachable states are "right side symptom stays where it started, left side symptom anywhere" and then "left side symptom absorbed into boundary, right side symptom anywhere". The number of reachable states is roughly the area times 2. If both indices were allowed to move, then both symptoms could diffuse at the same time so all pairs of locations would be reachable so the number of reachable states would be proportional to the area squared.

The reason for starting the search from observable-crossing edges is because the solution must have one of those edges in it. In special cases it would be more efficient to do a "boundary to boundary" search, but unfortunately identifying whether or not the error model has the property that the boundary-to-boundary search will give the correct answer is highly non-trivial. For example, in a toric code there are no boundaries. Another example is that in a braiding based surface code some errors are cycles, not paths between boundaries. And another example is that in a surface code using lattice surgery and twists, whether or not a path between two boundaries is a logical error can depend on which specific route it took.