### PR TITLE
Bump dev version to 1.8.dev0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - v*
   pull_request:
     branches:
       - main
@@ -123,7 +125,7 @@ jobs:
           architecture: 'x64'
       - run: pip install -e .
       - run: pip install pybind11 && python setup.py install  # Workaround for https://github.com/pypa/setuptools/issues/230
-      - run: diff doc/python_api_reference_vDev.md <(python glue/python/generate_api_reference.py)
+      - run: diff doc/python_api_reference_vDev.md <(python glue/python/generate_api_reference.py -dev)
       - run: cmake .
       - run: make stim
       - run: diff doc/gates.md <(out/stim help gates_markdown)

--- a/doc/file_format_stim_circuit.md
+++ b/doc/file_format_stim_circuit.md
@@ -126,7 +126,7 @@ which indicate that the block's instructions should be iterated over `K` times i
 
 ### Target Types
 
-There are three types of targets that can be given to instructions:
+There are four types of targets that can be given to instructions:
 qubit targets, measurement record targets, sweep bit targets, and Pauli targets.
 
 A qubit target refers to a qubit by index.

--- a/glue/cirq/setup.py
+++ b/glue/cirq/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 with open('README.md') as f:
     long_description = f.read()
 
-version = '1.7.dev0'
+version = '1.8.dev0'
 
 setup(
     name='stimcirq',

--- a/glue/python/create_sdists.sh
+++ b/glue/python/create_sdists.sh
@@ -9,7 +9,7 @@
 #########################################################
 
 if [ -z "$1" ]; then
-  echo "Provide a version argument like 'v1.2.0' or 'v1.2.dev0'."
+  echo "Provide a version argument like '1.2.0' or '1.2.dev0'."
   exit 1
 fi
 

--- a/glue/python/generate_api_reference.py
+++ b/glue/python/generate_api_reference.py
@@ -6,6 +6,7 @@ import stim
 
 import collections
 import inspect
+import sys
 from typing import DefaultDict, List, Union
 
 keep = {
@@ -139,7 +140,7 @@ def main():
     index = []
     generate_documentation(obj=stim, full_name="stim", outs=level_entries, level=2, out_index=index)
     version = stim.__version__
-    if "dev" in version or version == "VERSION_INFO":
+    if "dev" in version or version == "VERSION_INFO" or "-dev" in sys.argv:
         version = "(Development Version)"
     else:
         version = "v" + version

--- a/glue/zx/setup.py
+++ b/glue/zx/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 with open('README.md') as f:
     long_description = f.read()
 
-version = '1.7.dev0'
+version = '1.8.dev0'
 
 setup(
     name='stimzx',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ MAIN_FILES = glob.glob("src/**/main.cc", recursive=True)
 HEADER_FILES = glob.glob("src/**/*.h", recursive=True)
 RELEVANT_SOURCE_FILES = sorted(set(ALL_SOURCE_FILES) - set(TEST_FILES + PERF_FILES + MAIN_FILES))
 
-version = '1.7.dev1'
+version = '1.8.dev0'
 
 common_compile_args = [
     '-std=c++11',


### PR DESCRIPTION
- Fix help text in create_sdists.sh
- Add "-dev" option to generate_api_reference.py and force it in ci
- Run ci on tags
- Fixes a typo in the stim file format documentation