### PR TITLE
Fix package installation issues

### DIFF
--- a/glue/python/src/stim/__init__.py
+++ b/glue/python/src/stim/__init__.py
@@ -5,7 +5,7 @@ It does runtime detection of CPU features, and based on that imports the fastest
 compatible instructions. Importing a different one can result in runtime segfaults that crash the python interpreter.
 """
 
-import stim._stim_march_avx2 as _tmp
+import stim._stim_march_polyfill as _tmp
 
 _tmp = _tmp._UNSTABLE_detect_march()
 if _tmp == 'avx2':

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ common_compile_args = [
 stim_polyfill = Extension(
     'stim._stim_march_polyfill',
     sources=RELEVANT_SOURCE_FILES,
+    headers=HEADER_FILES,
     include_dirs=[pybind11.get_include(), "src"],
     language='c++',
     extra_compile_args=[
@@ -47,6 +48,7 @@ stim_polyfill = Extension(
 stim_sse2 = Extension(
     'stim._stim_march_sse2',
     sources=RELEVANT_SOURCE_FILES,
+    headers=HEADER_FILES,
     include_dirs=[pybind11.get_include(), "src"],
     language='c++',
     extra_compile_args=[
@@ -59,6 +61,7 @@ stim_sse2 = Extension(
 stim_avx2 = Extension(
     'stim._stim_march_avx2',
     sources=RELEVANT_SOURCE_FILES,
+    headers=HEADER_FILES,
     include_dirs=[pybind11.get_include(), "src"],
     language='c++',
     extra_compile_args=[
@@ -84,7 +87,6 @@ setup(
     long_description_content_type='text/markdown',
     ext_modules=[stim_polyfill, stim_sse2, stim_avx2],
     python_requires='>=3.6.0',
-    headers=HEADER_FILES,
     data_files=[('', ['glue/python/README.md', 'pyproject.toml'])],
     packages=['stim'],
     package_dir={'stim': 'glue/python/src/stim'},

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ stim_polyfill = Extension(
     sources=RELEVANT_SOURCE_FILES,
     include_dirs=[pybind11.get_include(), "src"],
     language='c++',
-    data_files=['pyproject.toml'] + HEADER_FILES,
     extra_compile_args=[
         *common_compile_args,
         # I would specify -mno-sse2 but that causes build failures in non-stim code...?
@@ -50,7 +49,6 @@ stim_sse2 = Extension(
     sources=RELEVANT_SOURCE_FILES,
     include_dirs=[pybind11.get_include(), "src"],
     language='c++',
-    data_files=['pyproject.toml'] + HEADER_FILES,
     extra_compile_args=[
         *common_compile_args,
         '-msse2',
@@ -63,7 +61,6 @@ stim_avx2 = Extension(
     sources=RELEVANT_SOURCE_FILES,
     include_dirs=[pybind11.get_include(), "src"],
     language='c++',
-    data_files=['pyproject.toml'] + HEADER_FILES,
     extra_compile_args=[
         *common_compile_args,
         '-msse2',
@@ -87,7 +84,8 @@ setup(
     long_description_content_type='text/markdown',
     ext_modules=[stim_polyfill, stim_sse2, stim_avx2],
     python_requires='>=3.6.0',
-    data_files=[('', ['glue/python/README.md'])],
+    headers=HEADER_FILES,
+    data_files=[('', ['glue/python/README.md', 'pyproject.toml'])],
     packages=['stim'],
     package_dir={'stim': 'glue/python/src/stim'},
     install_requires=['numpy'],


### PR DESCRIPTION
- For sdist, fix specifying `data_files=` on each Extension instead of on the package itself
- For sdist, fix headers being given as `data_files=` instead of `headers=`
- For wheels, fix using the avx2 instead of the vanilla package to determine CPU capabilities
    - It was touching avx instructions along the way, causing crashes on M1 macs

First part of fixing https://github.com/quantumlib/Stim/issues/179