### PR TITLE
Improve error messages for anticommuting obs/dets *even more*

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
+load("@rules_python//python:packaging.bzl", "py_wheel")
+
 SOURCE_FILES_NO_MAIN = glob(
     [
         "src/**/*.cc",
@@ -47,22 +49,22 @@ cc_library(
 cc_binary(
     name = "stim",
     srcs = SOURCE_FILES_NO_MAIN + glob(["src/**/main.cc"]),
-    includes = ["src/"],
     copts = [
         "-march=native",
         "-O3",
     ],
+    includes = ["src/"],
     linkopts = ["-lpthread"],
 )
 
 cc_binary(
     name = "stim_benchmark",
     srcs = SOURCE_FILES_NO_MAIN + PERF_FILES,
-    includes = ["src/"],
     copts = [
         "-march=native",
         "-O3",
     ],
+    includes = ["src/"],
     linkopts = ["-lpthread"],
 )
 
@@ -81,7 +83,7 @@ cc_test(
 )
 
 cc_binary(
-    name = "stim_pybind.so",
+    name = "stim.so",
     srcs = SOURCE_FILES_NO_MAIN + PYBIND_FILES,
     copts = [
         "-O3",
@@ -92,7 +94,13 @@ cc_binary(
     includes = ["src/"],
     linkopts = ["-lpthread"],
     linkshared = 1,
-    deps = [
-        "@pybind11",
-    ],
+    deps = ["@pybind11"],
+)
+
+py_wheel(
+    name = "stim_dev_wheel",
+    distribution = "stim",
+    requires = ["numpy"],
+    version = "dev",
+    deps = [":stim.so"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,11 +16,10 @@ http_archive(
     urls = ["https://github.com/pybind/pybind11/archive/v2.6.0.tar.gz"],
 )
 
-git_repository(
+http_archive(
     name = "rules_python",
-    commit = "38f86fb55b698c51e8510c807489c9f4e047480e",
-    remote = "https://github.com/bazelbuild/rules_python.git",
-    shallow_since = "1575517988 -0500",
+    sha256 = "954aa89b491be4a083304a2cb838019c8b8c3720a7abb9c4cb81ac7a24230cea",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.4.0/rules_python-0.4.0.tar.gz",
 )
 
 http_archive(

--- a/doc/regen_docs_not_portable.sh
+++ b/doc/regen_docs_not_portable.sh
@@ -8,9 +8,9 @@ cd "$( dirname "${BASH_SOURCE[0]}" )"
 cd "$(git rev-parse --show-toplevel)"
 
 # Put latest stim python wheel into python environment.
-bazel build :stim_pybind.so
+bazel build :stim.so
 rm -f stim.so
-cp bazel-bin/stim_pybind.so stim.so
+cp bazel-bin/stim.so stim.so
 
 # Build latest stim command line tool.
 cmake .

--- a/glue/cirq/stimcirq/_cirq_to_stim.py
+++ b/glue/cirq/stimcirq/_cirq_to_stim.py
@@ -355,6 +355,10 @@ def _c2s_helper(
         try:
             _c2s_helper(cirq.decompose_once(op), q2i, out, key_out)
         except TypeError as ex:
-            raise TypeError(f"Don't know how to translate {op!r} into stim gates.") from ex
+            raise TypeError(
+                f"Don't know how to translate {op!r} into stim gates.\n"
+                f"- It doesn't have a _decompose_ method that returns stim-compatible operations.\n"
+                f"- It doesn't have a _stim_conversion_ method.\n"
+            ) from ex
 
     return out

--- a/src/stim/circuit/circuit.h
+++ b/src/stim/circuit/circuit.h
@@ -21,6 +21,7 @@
 #include <cstring>
 #include <functional>
 #include <iostream>
+#include <map>
 #include <memory>
 #include <unordered_map>
 #include <vector>
@@ -101,6 +102,8 @@ struct Circuit {
     uint64_t count_detectors() const;
     // Returns one more than the largest `k` from any `OBSERVABLE_INCLUDE(k)` instruction.
     uint64_t count_observables() const;
+    // Returns the number of ticks performed when running the circuit.
+    uint64_t count_ticks() const;
     // Returns the largest `k` from any `rec[-k]` target.
     size_t max_lookback() const;
     // Returns one more than the largest `k` from any `sweep[k]` target.
@@ -253,6 +256,16 @@ struct Circuit {
         }
         return n;
     }
+
+    /// Looks for QUBIT_COORDS instructions in the circuit, and returns a map from qubit index to qubit coordinate.
+    ///
+    /// This method efficiently handles REPEAT blocks. It finishes in time proportional to the size of the circuit
+    /// file, not time proportional to the amount of data produced by the circuit.
+    std::map<uint64_t, std::vector<double>> get_final_qubit_coords() const;
+
+    std::vector<double> coords_of_detector(uint64_t detector_index) const;
+    std::vector<double> final_coord_shift() const;
+    std::string describe_instruction_location(size_t instruction_offset) const;
 };
 
 /// Lists sets of measurements that have deterministic parity under noiseless execution from a circuit.

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -1098,6 +1098,5 @@ void pybind_circuit(pybind11::module &m) {
         },
         [](const pybind11::str &text) {
             return Circuit(pybind11::cast<std::string>(text).data());
-        }
-    ));
+        }));
 }

--- a/src/stim/circuit/gate_data_annotations.cc
+++ b/src/stim/circuit/gate_data_annotations.cc
@@ -195,7 +195,7 @@ circuit-to-detector-error-model conversion will refuse to operate on circuits co
             0,
             &TableauSimulator::I,
             &FrameSimulator::I,
-            &ErrorAnalyzer::I,
+            &ErrorAnalyzer::TICK,
             (GateFlags)(GATE_IS_NOT_FUSABLE | GATE_TAKES_NO_TARGETS),
             []() -> ExtraGateData {
                 return {

--- a/src/stim/dem/detector_error_model.pybind.cc
+++ b/src/stim/dem/detector_error_model.pybind.cc
@@ -14,11 +14,11 @@
 
 #include "stim/dem/detector_error_model.pybind.h"
 
-#include "stim/simulators/min_distance.h"
 #include "stim/dem/detector_error_model_instruction.pybind.h"
 #include "stim/dem/detector_error_model_repeat_block.pybind.h"
 #include "stim/dem/detector_error_model_target.pybind.h"
 #include "stim/py/base.pybind.h"
+#include "stim/simulators/min_distance.h"
 
 using namespace stim;
 
@@ -420,7 +420,6 @@ void pybind_detector_error_model(pybind11::module &m) {
            const pybind11::object &instruction,
            const pybind11::object &parens_arguments,
            const std::vector<pybind11::object> &targets) {
-
             bool is_name = pybind11::isinstance<pybind11::str>(instruction);
             if (!is_name && (!targets.empty() || !parens_arguments.is_none())) {
                 throw std::invalid_argument(
@@ -670,8 +669,7 @@ void pybind_detector_error_model(pybind11::module &m) {
         },
         [](const pybind11::str &text) -> DetectorErrorModel {
             return DetectorErrorModel(pybind11::cast<std::string>(text).data());
-        }
-    ));
+        }));
 
     c.def(
         "shortest_graphlike_error",

--- a/src/stim/dem/detector_error_model.test.cc
+++ b/src/stim/dem/detector_error_model.test.cc
@@ -604,7 +604,7 @@ TEST(detector_error_model, iadd) {
     // Aliased.
     a = original;
     a += a;
-    a = DetectorErrorModel(a.str().data()); // Remove memory deduplication, because it affects equality.
+    a = DetectorErrorModel(a.str().data());  // Remove memory deduplication, because it affects equality.
     ASSERT_EQ(a, original + original);
 }
 

--- a/src/stim/dem/detector_error_model_target.pybind.cc
+++ b/src/stim/dem/detector_error_model_target.pybind.cc
@@ -21,10 +21,7 @@ using namespace stim;
 
 void pybind_detector_error_model_target(pybind11::module &m) {
     auto c = pybind11::class_<ExposedDemTarget>(
-        m,
-        "DemTarget",
-        pybind11::module_local(),
-        "An instruction target from a detector error model (.dem) file.");
+        m, "DemTarget", pybind11::module_local(), "An instruction target from a detector error model (.dem) file.");
 
     m.def(
         "target_relative_detector_id",

--- a/src/stim/main_namespaced.test.cc
+++ b/src/stim/main_namespaced.test.cc
@@ -711,10 +711,32 @@ M 0 1
 DETECTOR rec[-1]
 DETECTOR rec[-2]
             )input")),
-        trim("[stderr=\x1B[31mThe detectors D0, D1 anti-commuted with a Z-basis reset, and allow_gauge_detectors isn't "
-             "set.\n"
-             "Context: analyzing the circuit operation at offset 0 which is 'R 0'.\n"
-             "\x1B[0m]"));
+        trim(R"OUTPUT(
+[stderr=)OUTPUT"
+             "\x1B"
+             R"OUTPUT([31mThe circuit contains non-deterministic detectors.
+(To allow non-deterministic detectors, use the `allow_gauge_detectors` option.)
+
+This was discovered while analyzing a Z-basis reset (R) on:
+    qubit 0
+
+The collapse anti-commuted with these detectors/observables:
+    D0
+    D1
+
+The backward-propagating error sensitivity for D0 was:
+    X0
+    Z1
+
+The backward-propagating error sensitivity for D1 was:
+    X0
+
+Circuit stack trace:
+    at instruction #1 [which is R 0]
+)OUTPUT"
+             "\x1B"
+             R"OUTPUT([0m]
+)OUTPUT"));
 }
 
 TEST(main, analyze_errors_all_approximate_disjoint_errors) {
@@ -736,10 +758,17 @@ PAULI_CHANNEL_1(0.125, 0.25, 0.375) 0
 M 0
 DETECTOR rec[-1]
             )input")),
-        trim("[stderr=\x1B[31mHandling PAULI_CHANNEL_1 requires `approximate_disjoint_errors` argument to be "
-             "specified.\n"
-             "Context: analyzing the circuit operation at offset 1 which is 'PAULI_CHANNEL_1(0.125, 0.25, 0.375) 0'.\n"
-             "\x1B[0m]"));
+        trim(R"OUTPUT(
+[stderr=)OUTPUT"
+             "\x1B"
+             R"OUTPUT([31mHandling PAULI_CHANNEL_1 requires `approximate_disjoint_errors` argument to be specified.
+
+Circuit stack trace:
+    at instruction #2 [which is PAULI_CHANNEL_1(0.125, 0.25, 0.375) 0]
+)OUTPUT"
+             "\x1B"
+             R"OUTPUT([0m]
+)OUTPUT"));
 
     ASSERT_EQ(
         trim(execute({"--analyze_errors", "--approximate_disjoint_errors", "0.3"}, R"input(
@@ -748,10 +777,18 @@ PAULI_CHANNEL_1(0.125, 0.25, 0.375) 0
 M 0
 DETECTOR rec[-1]
             )input")),
-        trim("[stderr=\x1B[31mPAULI_CHANNEL_1 has a component probability '0.375000' larger than the "
-             "`approximate_disjoint_errors` threshold of '0.300000'.\n"
-             "Context: analyzing the circuit operation at offset 1 which is 'PAULI_CHANNEL_1(0.125, 0.25, 0.375) 0'.\n"
-             "\x1B[0m]"));
+        trim(
+            R"OUTPUT(
+[stderr=)OUTPUT"
+            "\x1B"
+            R"OUTPUT([31mPAULI_CHANNEL_1 has a component probability '0.375000' larger than the `approximate_disjoint_errors` threshold of '0.300000'.
+
+Circuit stack trace:
+    at instruction #2 [which is PAULI_CHANNEL_1(0.125, 0.25, 0.375) 0]
+)OUTPUT"
+            "\x1B"
+            R"OUTPUT([0m]
+)OUTPUT"));
 }
 
 TEST(main, generate_circuits) {

--- a/src/stim/py/compiled_measurement_sampler.pybind.cc
+++ b/src/stim/py/compiled_measurement_sampler.pybind.cc
@@ -43,7 +43,8 @@ pybind11::array_t<uint8_t> CompiledMeasurementSampler::sample(size_t num_samples
 
     void *ptr = bytes.data();
     pybind11::ssize_t itemsize = sizeof(uint8_t);
-    std::vector<pybind11::ssize_t> shape{(pybind11::ssize_t)num_samples, (pybind11::ssize_t)circuit.count_measurements()};
+    std::vector<pybind11::ssize_t> shape{
+        (pybind11::ssize_t)num_samples, (pybind11::ssize_t)circuit.count_measurements()};
     std::vector<pybind11::ssize_t> stride{(pybind11::ssize_t)sample.num_minor_bits_padded(), 1};
     const std::string &format = pybind11::format_descriptor<uint8_t>::value;
     bool readonly = true;
@@ -55,7 +56,8 @@ pybind11::array_t<uint8_t> CompiledMeasurementSampler::sample_bit_packed(size_t 
 
     void *ptr = sample.data.u8;
     pybind11::ssize_t itemsize = sizeof(uint8_t);
-    std::vector<pybind11::ssize_t> shape{(pybind11::ssize_t)num_samples, (pybind11::ssize_t)(circuit.count_measurements() + 7) / 8};
+    std::vector<pybind11::ssize_t> shape{
+        (pybind11::ssize_t)num_samples, (pybind11::ssize_t)(circuit.count_measurements() + 7) / 8};
     std::vector<pybind11::ssize_t> stride{(pybind11::ssize_t)sample.num_minor_u8_padded(), 1};
     const std::string &format = pybind11::format_descriptor<uint8_t>::value;
     bool readonly = true;

--- a/src/stim/py/march.pybind.cc
+++ b/src/stim/py/march.pybind.cc
@@ -7,39 +7,39 @@
 #else
 //  GCC Intrinsics
 #include <cpuid.h>
-void cpuid(int info[4], int infoType){
+void cpuid(int info[4], int infoType) {
     __cpuid_count(infoType, 0, info[0], info[1], info[2], info[3]);
 }
 #endif
 
 std::string detect_march() {
-  // From: https://en.wikipedia.org/wiki/CPUID
-  constexpr int EAX = 0;
-  constexpr int EBX = 1;
-  constexpr int EDX = 3;
-  constexpr int INFO_HIGHEST_FUNCTION_PARAMETER = 0;
-  constexpr int INFO_PROCESSOR_FEATURE_BITS = 1;
-  constexpr int INFO_EXTENDED_FEATURES = 7;
-  constexpr int avx2_bit_in_ebx = 1 << 5;
-  constexpr int sse2_bit_in_edx = 1 << 26;
+    // From: https://en.wikipedia.org/wiki/CPUID
+    constexpr int EAX = 0;
+    constexpr int EBX = 1;
+    constexpr int EDX = 3;
+    constexpr int INFO_HIGHEST_FUNCTION_PARAMETER = 0;
+    constexpr int INFO_PROCESSOR_FEATURE_BITS = 1;
+    constexpr int INFO_EXTENDED_FEATURES = 7;
+    constexpr int avx2_bit_in_ebx = 1 << 5;
+    constexpr int sse2_bit_in_edx = 1 << 26;
 
-  int regs[4];
-  cpuid(regs, INFO_HIGHEST_FUNCTION_PARAMETER);
-  auto max_info_param = regs[EAX];
+    int regs[4];
+    cpuid(regs, INFO_HIGHEST_FUNCTION_PARAMETER);
+    auto max_info_param = regs[EAX];
 
-  if (max_info_param >= INFO_EXTENDED_FEATURES) {
-    cpuid(regs, INFO_EXTENDED_FEATURES);
-    if (regs[EBX] & avx2_bit_in_ebx) {
-      return "avx2";
+    if (max_info_param >= INFO_EXTENDED_FEATURES) {
+        cpuid(regs, INFO_EXTENDED_FEATURES);
+        if (regs[EBX] & avx2_bit_in_ebx) {
+            return "avx2";
+        }
     }
-  }
 
-  if (max_info_param >= INFO_PROCESSOR_FEATURE_BITS) {
-    cpuid(regs, INFO_PROCESSOR_FEATURE_BITS);
-    if (regs[EDX] & sse2_bit_in_edx) {
-      return "sse2";
+    if (max_info_param >= INFO_PROCESSOR_FEATURE_BITS) {
+        cpuid(regs, INFO_PROCESSOR_FEATURE_BITS);
+        if (regs[EDX] & sse2_bit_in_edx) {
+            return "sse2";
+        }
     }
-  }
 
-  return "polyfill";
+    return "polyfill";
 }

--- a/src/stim/simulators/error_analyzer.cc
+++ b/src/stim/simulators/error_analyzer.cc
@@ -624,7 +624,7 @@ void ErrorAnalyzer::run_circuit(const Circuit &circuit) {
                 auto total_ticks = circuit.count_ticks();
                 if (total_ticks) {
                     uint64_t current_tick = total_ticks - ticks_seen;
-                    error_msg << "\n    during TICK layer #" << (current_tick + 1) << " of " << total_ticks;
+                    error_msg << "\n    during TICK layer #" << (current_tick + 1) << " of " << (total_ticks + 1);
                 }
             }
             error_msg << '\n' << circuit.describe_instruction_location(k);

--- a/src/stim/simulators/error_analyzer.cc
+++ b/src/stim/simulators/error_analyzer.cc
@@ -42,41 +42,90 @@ void ErrorAnalyzer::remove_gauge(ConstPointerRange<DemTarget> sorted) {
 }
 
 void ErrorAnalyzer::RX(const OperationData &dat) {
-    for (size_t k = dat.targets.size(); k-- > 0;) {
-        auto q = dat.targets[k].qubit_value();
-        check_for_gauge(zs[q], "an X-basis reset");
-        xs[q].clear();
-        zs[q].clear();
-    }
+    RX_with_context(dat, "an X-basis reset (RX)");
 }
-
 void ErrorAnalyzer::RY(const OperationData &dat) {
+    RY_with_context(dat, "an X-basis reset (RY)");
+}
+void ErrorAnalyzer::RZ(const OperationData &dat) {
+    RZ_with_context(dat, "a Z-basis reset (R)");
+}
+
+void ErrorAnalyzer::RX_with_context(const OperationData &dat, const char *context_op) {
     for (size_t k = dat.targets.size(); k-- > 0;) {
         auto q = dat.targets[k].qubit_value();
-        check_for_gauge(xs[q], zs[q], "a Y-basis reset");
+        check_for_gauge(zs[q], context_op, q);
         xs[q].clear();
         zs[q].clear();
     }
 }
 
-void ErrorAnalyzer::RZ(const OperationData &dat) {
+void ErrorAnalyzer::RY_with_context(const OperationData &dat, const char *context_op) {
     for (size_t k = dat.targets.size(); k-- > 0;) {
         auto q = dat.targets[k].qubit_value();
-        check_for_gauge(xs[q], "a Z-basis reset");
+        check_for_gauge(xs[q], zs[q], context_op, q);
         xs[q].clear();
         zs[q].clear();
+    }
+}
+
+void ErrorAnalyzer::RZ_with_context(const OperationData &dat, const char *context_op) {
+    for (size_t k = dat.targets.size(); k-- > 0;) {
+        auto q = dat.targets[k].qubit_value();
+        check_for_gauge(xs[q], context_op, q);
+        xs[q].clear();
+        zs[q].clear();
+    }
+}
+
+void ErrorAnalyzer::MX_with_context(const OperationData &dat, const char *op) {
+    for (size_t k = dat.targets.size(); k-- > 0;) {
+        auto q = dat.targets[k].qubit_value();
+        scheduled_measurement_time++;
+
+        std::vector<DemTarget> &d = measurement_to_detectors[scheduled_measurement_time];
+        xor_sort_measurement_error(d, dat);
+        xs[q].xor_sorted_items(d);
+        check_for_gauge(zs[q], op, q);
+    }
+}
+
+void ErrorAnalyzer::MY_with_context(const OperationData &dat, const char *op) {
+    for (size_t k = dat.targets.size(); k-- > 0;) {
+        auto q = dat.targets[k].qubit_value();
+        scheduled_measurement_time++;
+
+        std::vector<DemTarget> &d = measurement_to_detectors[scheduled_measurement_time];
+        xor_sort_measurement_error(d, dat);
+        xs[q].xor_sorted_items(d);
+        zs[q].xor_sorted_items(d);
+        check_for_gauge(xs[q], zs[q], op, q);
+    }
+}
+
+void ErrorAnalyzer::MZ_with_context(const OperationData &dat, const char *context_op) {
+    for (size_t k = dat.targets.size(); k-- > 0;) {
+        auto q = dat.targets[k].qubit_value();
+        scheduled_measurement_time++;
+
+        std::vector<DemTarget> &d = measurement_to_detectors[scheduled_measurement_time];
+        xor_sort_measurement_error(d, dat);
+
+        zs[q].xor_sorted_items(d);
+        check_for_gauge(xs[q], context_op, q);
     }
 }
 
 void ErrorAnalyzer::check_for_gauge(
     SparseXorVec<DemTarget> &potential_gauge_summand_1,
     SparseXorVec<DemTarget> &potential_gauge_summand_2,
-    const char *context) {
+    const char *context_op,
+    uint64_t context_qubit) {
     if (potential_gauge_summand_1 == potential_gauge_summand_2) {
         return;
     }
     potential_gauge_summand_1 ^= potential_gauge_summand_2;
-    check_for_gauge(potential_gauge_summand_1, context);
+    check_for_gauge(potential_gauge_summand_1, context_op, context_qubit);
     potential_gauge_summand_1 ^= potential_gauge_summand_2;
 }
 
@@ -98,23 +147,101 @@ std::string comma_sep_workaround(const TIter &iterable) {
     return out.str();
 }
 
-void ErrorAnalyzer::check_for_gauge(const SparseXorVec<DemTarget> &potential_gauge, const char *context) {
+void ErrorAnalyzer::check_for_gauge(
+    const SparseXorVec<DemTarget> &potential_gauge, const char *context_op, uint64_t context_qubit) {
     if (potential_gauge.empty()) {
         return;
     }
+
+    bool has_observables = false;
+    bool has_detectors = false;
     for (const auto &t : potential_gauge) {
-        if (t.is_observable_id()) {
-            throw std::invalid_argument(
-                "The observable " + t.str() + " anti-commuted with " + std::string(context) +
-                ".\nAll objects anti-commuting with that operation: " + comma_sep_workaround(potential_gauge));
+        has_observables |= t.is_observable_id();
+        has_detectors |= t.is_relative_detector_id();
+    }
+    if (allow_gauge_detectors && !has_observables) {
+        remove_gauge(add_error(0.5, potential_gauge.range()));
+        return;
+    }
+
+    // We are now in an error condition, and it's a bit hard to debug for the user.
+    // The goal is to collect a *lot* of information that might be useful to them.
+
+    std::stringstream error_msg;
+    has_detectors &= !allow_gauge_detectors;
+    if (has_observables) {
+        error_msg << "The circuit contains non-deterministic observables.\n";
+        error_msg << "(Error analysis requires deterministic observables.)\n";
+    }
+    if (has_detectors) {
+        error_msg << "The circuit contains non-deterministic detectors.\n";
+        error_msg << "(To allow non-deterministic detectors, use the `allow_gauge_detectors` option.)\n";
+    }
+
+    std::map<uint64_t, std::vector<double>> qubit_coords_map;
+    if (current_circuit_being_analyzed != nullptr) {
+        qubit_coords_map = current_circuit_being_analyzed->get_final_qubit_coords();
+    }
+    auto error_msg_qubit_with_coords = [&](uint64_t q, uint8_t p) {
+        error_msg << "\n";
+        auto qubit_coords = qubit_coords_map[q];
+        if (p == 0) {
+            error_msg << "    qubit " << q;
+        } else if (p == 1) {
+            error_msg << "    X" << q;
+        } else if (p == 2) {
+            error_msg << "    Z" << q;
+        } else if (p == 3) {
+            error_msg << "    Y" << q;
+        }
+        if (!qubit_coords.empty()) {
+            error_msg << " [coords (" << comma_sep_workaround(qubit_coords) << ")]";
+        }
+    };
+
+    error_msg << "\n";
+    error_msg << "This was discovered while analyzing " << context_op << " on:";
+    error_msg_qubit_with_coords(context_qubit, 0);
+
+    error_msg << "\n\n";
+    error_msg << "The collapse anti-commuted with these detectors/observables:";
+    for (const auto &t : potential_gauge) {
+        error_msg << "\n    " << t;
+
+        // Try to find recorded coordinate information for the detector.
+        if (t.is_relative_detector_id() && current_circuit_being_analyzed != nullptr) {
+            auto coords = current_circuit_being_analyzed->coords_of_detector(t.raw_id());
+            if (!coords.empty()) {
+                error_msg << " [coords (" << comma_sep_workaround(coords) << ")]";
+            }
         }
     }
-    if (!allow_gauge_detectors) {
-        throw std::invalid_argument(
-            "The detectors " + comma_sep_workaround(potential_gauge) + " anti-commuted with " + std::string(context) +
-            ", and allow_gauge_detectors isn't set.");
+
+    for (const auto &t : potential_gauge) {
+        if (t.is_relative_detector_id() && allow_gauge_detectors) {
+            continue;
+        }
+        error_msg << "\n\n";
+        error_msg << "The backward-propagating error sensitivity for " << t << " was:";
+        auto sensitivity = current_error_sensitivity_for(t);
+        for (size_t q = 0; q < sensitivity.num_qubits; q++) {
+            uint8_t p = sensitivity.xs[q] + sensitivity.zs[q] * 2;
+            if (p) {
+                error_msg_qubit_with_coords(q, p);
+            }
+        }
     }
-    remove_gauge(add_error(0.5, potential_gauge.range()));
+
+    throw std::invalid_argument(error_msg.str());
+}
+
+PauliString ErrorAnalyzer::current_error_sensitivity_for(DemTarget t) const {
+    PauliString result(xs.size());
+    for (size_t q = 0; q < xs.size(); q++) {
+        result.xs[q] = std::find(xs[q].begin(), xs[q].end(), t) != xs[q].end();
+        result.zs[q] = std::find(zs[q].begin(), zs[q].end(), t) != zs[q].end();
+    }
+    return result;
 }
 
 void ErrorAnalyzer::xor_sort_measurement_error(std::vector<DemTarget> &d, const OperationData &dat) {
@@ -139,49 +266,21 @@ void ErrorAnalyzer::xor_sort_measurement_error(std::vector<DemTarget> &d, const 
 }
 
 void ErrorAnalyzer::MX(const OperationData &dat) {
-    for (size_t k = dat.targets.size(); k-- > 0;) {
-        auto q = dat.targets[k].qubit_value();
-        scheduled_measurement_time++;
-
-        std::vector<DemTarget> &d = measurement_to_detectors[scheduled_measurement_time];
-        xor_sort_measurement_error(d, dat);
-        xs[q].xor_sorted_items(d);
-        check_for_gauge(zs[q], "an X-basis measurement");
-    }
+    MX_with_context(dat, "an X-basis measurement (MX)");
 }
-
 void ErrorAnalyzer::MY(const OperationData &dat) {
-    for (size_t k = dat.targets.size(); k-- > 0;) {
-        auto q = dat.targets[k].qubit_value();
-        scheduled_measurement_time++;
-
-        std::vector<DemTarget> &d = measurement_to_detectors[scheduled_measurement_time];
-        xor_sort_measurement_error(d, dat);
-        xs[q].xor_sorted_items(d);
-        zs[q].xor_sorted_items(d);
-        check_for_gauge(xs[q], zs[q], "a Y-basis measurement");
-    }
+    MY_with_context(dat, "a Y-basis measurement (MY)");
 }
-
 void ErrorAnalyzer::MZ(const OperationData &dat) {
-    for (size_t k = dat.targets.size(); k-- > 0;) {
-        auto q = dat.targets[k].qubit_value();
-        scheduled_measurement_time++;
-
-        std::vector<DemTarget> &d = measurement_to_detectors[scheduled_measurement_time];
-        xor_sort_measurement_error(d, dat);
-
-        zs[q].xor_sorted_items(d);
-        check_for_gauge(xs[q], "a Z-basis measurement");
-    }
+    MZ_with_context(dat, "a Z-basis measurement (M)");
 }
 
 void ErrorAnalyzer::MRX(const OperationData &dat) {
     for (size_t k = dat.targets.size(); k-- > 0;) {
         auto q = dat.targets[k];
         OperationData d{dat.args, {&q}};
-        RX(d);
-        MX(d);
+        RX_with_context(d, "an X-basis demolition measurement (MRX)");
+        MX_with_context(d, "an X-basis demolition measurement (MRX)");
     }
 }
 
@@ -189,8 +288,8 @@ void ErrorAnalyzer::MRY(const OperationData &dat) {
     for (size_t k = dat.targets.size(); k-- > 0;) {
         auto q = dat.targets[k];
         OperationData d{dat.args, {&q}};
-        RY(d);
-        MY(d);
+        RY_with_context(d, "a Y-basis demolition measurement (MRY)");
+        MY_with_context(d, "a Y-basis demolition measurement (MRY)");
     }
 }
 
@@ -198,8 +297,8 @@ void ErrorAnalyzer::MRZ(const OperationData &dat) {
     for (size_t k = dat.targets.size(); k-- > 0;) {
         auto q = dat.targets[k];
         OperationData d{dat.args, {&q}};
-        RZ(d);
-        MZ(d);
+        RZ_with_context(d, "a Z-basis demolition measurement (MR)");
+        MZ_with_context(d, "a Z-basis demolition measurement (MR)");
     }
 }
 
@@ -269,6 +368,10 @@ void ErrorAnalyzer::YCX(const OperationData &dat) {
         xs[ty] ^= zs[tx];
         zs[ty] ^= zs[tx];
     }
+}
+
+void ErrorAnalyzer::TICK(const OperationData &dat) {
+    ticks_seen += 1;
 }
 
 void ErrorAnalyzer::ZCY(const OperationData &dat) {
@@ -495,34 +598,47 @@ void ErrorAnalyzer::run_circuit(const Circuit &circuit) {
     for (size_t k = circuit.operations.size(); k--;) {
         const auto &op = circuit.operations[k];
         assert(op.gate != nullptr);
-        if (op.gate->id == gate_name_to_id("REPEAT")) {
-            assert(op.target_data.targets.size() == 3);
-            auto b = op.target_data.targets[0].data;
-            assert(op.target_data.targets[0].data < circuit.blocks.size());
-            uint64_t repeats = op_data_rep_count(op.target_data);
-            const auto &block = circuit.blocks[b];
-            try {
+        try {
+            if (op.gate->id == gate_name_to_id("REPEAT")) {
+                assert(op.target_data.targets.size() == 3);
+                auto b = op.target_data.targets[0].data;
+                assert(op.target_data.targets[0].data < circuit.blocks.size());
+                uint64_t repeats = op_data_rep_count(op.target_data);
+                const auto &block = circuit.blocks[b];
                 run_loop(block, repeats);
-            } catch (std::invalid_argument &ex) {
-                throw std::invalid_argument(
-                    std::string(ex.what()) + "\nContext: inside of the REPEAT block at offset " + std::to_string(k) +
-                    ".");
-            }
-        } else {
-            try {
+            } else {
                 (this->*op.gate->reverse_error_analyzer_function)(op.target_data);
-            } catch (std::invalid_argument &ex) {
-                throw std::invalid_argument(
-                    std::string(ex.what()) + "\nContext: analyzing the circuit operation at offset " +
-                    std::to_string(k) + " which is '" + op.str() + "'.");
             }
+        } catch (std::invalid_argument &ex) {
+            std::stringstream error_msg;
+            std::string body = ex.what();
+            const char *marker = "\n\nCircuit stack trace:\n    at instruction";
+            size_t p = body.find(marker);
+            if (p == std::string::npos) {
+                error_msg << body;
+            } else {
+                error_msg << body.substr(0, p);
+            }
+            error_msg << "\n\nCircuit stack trace:";
+            if (&circuit == current_circuit_being_analyzed) {
+                auto total_ticks = circuit.count_ticks();
+                if (total_ticks) {
+                    uint64_t current_tick = total_ticks - ticks_seen;
+                    error_msg << "\n    during TICK layer #" << (current_tick + 1) << " of " << total_ticks;
+                }
+            }
+            error_msg << '\n' << circuit.describe_instruction_location(k);
+            if (p != std::string::npos) {
+                error_msg << "\n    at block's instruction" << body.substr(p + strlen(marker));
+            }
+            throw std::invalid_argument(error_msg.str());
         }
     }
 }
 
 void ErrorAnalyzer::post_check_initialization() {
-    for (const auto &x : xs) {
-        check_for_gauge(x, "qubit initialization into |0> at the start of the circuit");
+    for (uint32_t q = 0; q < xs.size(); q++) {
+        check_for_gauge(xs[q], "qubit initialization into |0> at the start of the circuit", q);
     }
 }
 
@@ -752,6 +868,7 @@ DetectorErrorModel ErrorAnalyzer::circuit_to_detector_error_model(
         fold_loops,
         allow_gauge_detectors,
         approximate_disjoint_errors_threshold);
+    analyzer.current_circuit_being_analyzed = &circuit;
     analyzer.run_circuit(circuit);
     analyzer.post_check_initialization();
     analyzer.flush();
@@ -850,6 +967,7 @@ void ErrorAnalyzer::run_loop(const Circuit &loop, uint64_t iterations) {
         approximate_disjoint_errors_threshold);
     hare.xs = xs;
     hare.zs = zs;
+    hare.ticks_seen = ticks_seen;
     hare.measurement_to_detectors = measurement_to_detectors;
     hare.scheduled_measurement_time = scheduled_measurement_time;
     hare.accumulate_errors = false;
@@ -871,7 +989,13 @@ void ErrorAnalyzer::run_loop(const Circuit &loop, uint64_t iterations) {
 
     // Perform tortoise-and-hare cycle finding.
     while (hare_iter < iterations) {
-        hare.run_circuit(loop);
+        try {
+            hare.run_circuit(loop);
+        } catch (const std::invalid_argument &ex) {
+            // Encountered an error. Abort loop folding so it can be re-triggered in a normal way.
+            hare_iter = iterations;
+            break;
+        }
         hare_iter++;
         if (hare_is_colliding_with_tortoise()) {
             break;
@@ -890,6 +1014,7 @@ void ErrorAnalyzer::run_loop(const Circuit &loop, uint64_t iterations) {
         // Don't bother folding a single iteration into a repeated block.
         uint64_t period = hare_iter - tortoise_iter;
         uint64_t period_iterations = (iterations - tortoise_iter) / period;
+        uint64_t ticks_per_circuit_loop_iteration = (hare.ticks_seen - ticks_seen) / period;
         if (period_iterations > 1) {
             // Stash error model build up so far.
             flush();
@@ -900,11 +1025,13 @@ void ErrorAnalyzer::run_loop(const Circuit &loop, uint64_t iterations) {
             int64_t detector_shift = (int64_t)((period_iterations - 1) * shift_per_iteration);
             shift_active_detector_ids(-detector_shift);
             used_detectors += detector_shift;
-            tortoise_iter += period_iterations * period;
+            ticks_seen += (period_iterations - 1) * period * ticks_per_circuit_loop_iteration;
+            tortoise_iter += (period_iterations - 1) * period;
 
             // Compute the loop's error model.
             for (size_t k = 0; k < period; k++) {
                 run_circuit(loop);
+                tortoise_iter++;
             }
             flush();
             DetectorErrorModel body = std::move(flushed_reversed_model);
@@ -1270,7 +1397,7 @@ void ErrorAnalyzer::MPP(const OperationData &target_data) {
     std::vector<GateTarget> reversed_targets(n);
     std::vector<GateTarget> reversed_measure_targets;
     for (size_t k = 0; k < n; k++) {
-        reversed_targets[k] = target_data.targets[n-k-1];
+        reversed_targets[k] = target_data.targets[n - k - 1];
     }
     decompose_mpp_operation(
         OperationData{target_data.args, reversed_targets},

--- a/src/stim/simulators/error_analyzer.h
+++ b/src/stim/simulators/error_analyzer.h
@@ -33,27 +33,75 @@
 
 namespace stim {
 
+/// This class is responsible for iterating backwards over a circuit, tracking which detectors are currently
+/// sensitive to an X or Z error on each qubit. This is done by having a SparseXorVec for the X and Z
+/// sensitivities of each qubit, and transforming these collections in response to operations.
+///
+/// Y error sensitivity is always implicit in the xor of the X and Z components.
+///
+/// For example, applying a CNOT gate from qubit A to qubit B will xor the X sensitivity of A into B and the
+/// Z sensitivity of B into A.
+///
+/// Note that the class iterates over the circuit *backward*, so that DETECTOR instructions are seen before
+/// the measurement operations that the detector depends on. When a DETECTOR is seen, it is noted which
+/// measurements it depends on and then when those measurements are seen the detector is added as one of the
+/// things sensitive to errors that anticommute with the measurement.
+///
+/// Be wary that this class is definitely one of the more complex things in Stim. For example:
+/// - There is a monobuf that is often used as a temporary buffer to avoid allocations, meaning
+///     the state and meaning of the monobuf's tail is highly coupled to what method is currently
+///     executing.
+/// - The class recursively uses itself when  recursion
 struct ErrorAnalyzer {
+    /// Queued detectors to add into the xs/zs frame lists once the relevant measurement
+    /// is iterated over. When a detector is iterated over, it adds itself to the vector
+    /// of each of the measurements that define it.
     std::map<uint64_t, std::vector<DemTarget>> measurement_to_detectors;
+    /// Cached value for the number of detectors in the circuit being analyzed.
     uint64_t total_detectors;
+    /// The number of detectors that have been seen so far.
     uint64_t used_detectors;
     /// For each qubit, at the current time, the set of detectors with X dependence on that qubit.
     std::vector<SparseXorVec<DemTarget>> xs;
     /// For each qubit, at the current time, the set of detectors with Z dependence on that qubit.
     std::vector<SparseXorVec<DemTarget>> zs;
+    /// Tracks the number of measurements seen, so that when the next one is encountered the correct
+    /// detectors can be pulled from the measurement_to_detectors collection.
     size_t scheduled_measurement_time;
+
+    /// When false, no error decomposition is performed.
+    /// When true, must decompose any non-graphlike error into graphlike components or fail.
     bool decompose_errors;
+
+    /// When false, errors are skipped over instead of recorded.
+    /// When true, errors are recorded into the error_class_probabilities dictionary.
     bool accumulate_errors;
+
+    /// When false, loops are flattened and directly iterated over.
+    /// When true, a tortoise-and-hare algorithm is used to notice periodicity in the errors.
+    /// If periodicity is found, the rest of the loop becomes a loop in the output error model.
     bool fold_loops;
+
+    /// When false, detectors with non-deterministic parities under noiseless execution cause failure.
+    /// When true, the non-determinism is translated into a 50/50 random error mechanisms.
     bool allow_gauge_detectors;
+
+    /// Determines how small the probabilities in disjoint error mechanisms like PAULI_CHANNEL_2 must be
+    /// before they can be approximated as being independent. Any larger probabilities cause failure.
     double approximate_disjoint_errors_threshold;
+
+    /// A buffer containing the growing output error model as the circuit is traversed.
+    /// The buffer is in reverse order because the circuit is traversed back to front.
+    /// Certain events during period solving of loops can cause the error probabilities
+    /// to flush into this buffer.
     DetectorErrorModel flushed_reversed_model;
 
-    /// The final result. Independent probabilities of flipping various sets of detectors.
+    /// Recorded errors. Independent probabilities of flipping various sets of detectors.
     std::map<ConstPointerRange<DemTarget>, double> error_class_probabilities;
     /// Backing datastore for values in error_class_probabilities.
     MonotonicBuffer<DemTarget> mono_buf;
 
+    /// Creates an instance ready to start processing instructions from a circuit of known size.
     ErrorAnalyzer(
         uint64_t num_detectors,
         size_t num_qubits,
@@ -62,6 +110,19 @@ struct ErrorAnalyzer {
         bool allow_gauge_detectors,
         double approximate_disjoint_errors_threshold);
 
+    /// Returns the detector error model of the given circuit.
+    ///
+    /// Args:
+    ///     circuit: The circuit to analyze.
+    ///     decompose_errors: When true, complex errors must be split into graphlike components.
+    ///     fold_loops: When true, use a tortoise-and-hare algorithm to solve loops instead of flattening them.
+    ///     allow_gauge_detectors: When true, replace non-deterministic detectors with 50/50 error mechanisms instead
+    ///         of failing.
+    ///     approximate_disjoint_errors_threshold: When larger than 0, allows disjoint errors like PAULI_CHANNEL_2 to
+    ///         be present in the circuit, as long as their probabilities are not larger than this.
+    ///
+    /// Returns:
+    ///     The detector error model.
     static DetectorErrorModel circuit_to_detector_error_model(
         const Circuit &circuit,
         bool decompose_errors,
@@ -69,12 +130,20 @@ struct ErrorAnalyzer {
         bool allow_gauge_detectors,
         double approximate_disjoint_errors_threshold);
 
-    /// Moving is deadly due to the map containing pointers to the jagged data.
+    /// Copying is unsafe because `error_class_probabilities` has overlapping pointers to `monobuf`'s internals.
     ErrorAnalyzer(const ErrorAnalyzer &analyzer) = delete;
     ErrorAnalyzer(ErrorAnalyzer &&analyzer) noexcept = delete;
     ErrorAnalyzer &operator=(ErrorAnalyzer &&analyzer) noexcept = delete;
     ErrorAnalyzer &operator=(const ErrorAnalyzer &analyzer) = delete;
 
+    /// ======================================================================================
+    /// === Individual methods for processing each operation that can appear in a circuit. ===
+    /// ======================================================================================
+    /// Note that the circuit is iterated over backwards, so it may appear that these methods
+    /// do the opposite of what is expected (eg. C_XYZ turning X into Z instead of into Y).
+    /// ======================================================================================
+    /// These are pointed to by the `reverse_error_analyzer_function` field in gate data.
+    /// ======================================================================================
     void SHIFT_COORDS(const OperationData &dat);
     void RX(const OperationData &dat);
     void RY(const OperationData &dat);
@@ -101,11 +170,9 @@ struct ErrorAnalyzer {
     void ZCY(const OperationData &dat);
     void ZCZ(const OperationData &dat);
     void I(const OperationData &dat);
-
     void SQRT_XX(const OperationData &dat);
     void SQRT_YY(const OperationData &dat);
     void SQRT_ZZ(const OperationData &dat);
-
     void SWAP(const OperationData &dat);
     void DETECTOR(const OperationData &dat);
     void OBSERVABLE_INCLUDE(const OperationData &dat);
@@ -120,7 +187,10 @@ struct ErrorAnalyzer {
     void PAULI_CHANNEL_2(const OperationData &dat);
     void ISWAP(const OperationData &dat);
 
+    /// Processes each of the instructions in the circuit, in reverse order.
     void run_circuit(const Circuit &circuit);
+    /// This is used at the end of the analysis to check that any remaining sensitivities commute
+    /// with the implicit Z basis initialization at the start of a circuit.
     void post_check_initialization();
 
    private:
@@ -129,22 +199,43 @@ struct ErrorAnalyzer {
     void remove_gauge(ConstPointerRange<DemTarget> sorted);
     /// Sorts the targets coming out of the measurement queue, then optionally inserts a measurement error.
     void xor_sort_measurement_error(std::vector<DemTarget> &queued, const OperationData &dat);
+    /// Checks if the given sparse vector is empty. If it isn't, something that was supposed to be
+    /// deterministic is actually random. Produces an error message with debug information that can be
+    /// used to understand what went wrong.
     void check_for_gauge(const SparseXorVec<DemTarget> &potential_gauge, const char *context);
+    /// Checks if the given sparse vectors are equal. If they aren't, something that was supposed to be
+    /// deterministic is actually random. Produces an error message with debug information that can be
+    /// used to understand what went wrong.
     void check_for_gauge(
         SparseXorVec<DemTarget> &potential_gauge_summand_1,
         SparseXorVec<DemTarget> &potential_gauge_summand_2,
         const char *context);
 
+    /// Rewrites all stored detectors id. Used when jumping across the rest of a loop when period analysis
+    /// succeeds at folding the loop.
     void shift_active_detector_ids(int64_t shift);
+    /// Empties error_class_probabilities into flushed_reversed_model.
     void flush();
+    /// Processes the instructions in a circuit multiple times.
+    /// If loop folding is enabled, also uses a tortoise-and-hare algorithm to attempt to solve the loop's period.
     void run_loop(const Circuit &loop, uint64_t iterations);
+    /// Adds (or folds) an error mechanism into error_class_probabilities.
     ConstPointerRange<DemTarget> add_error(double probability, ConstPointerRange<DemTarget> flipped_sorted);
+    /// Adds (or folds) an error mechanism equal into error_class_probabilities.
+    /// The error is defined as the xor of two sparse vectors, because this is a common situation.
+    /// Deals with the details of efficiently computing the xor of the vectors with minimal allocations.
     ConstPointerRange<DemTarget> add_xored_error(
         double probability, ConstPointerRange<DemTarget> flipped1, ConstPointerRange<DemTarget> flipped2);
+    /// Adds an error mechanism into error_class_probabilities.
+    /// The error mechanism is not passed as an argument but is instead the current tail of `this->mono_buf`.
     ConstPointerRange<DemTarget> add_error_in_sorted_jagged_tail(double probability);
+    /// Processes a single CX operation.
     void single_cx(uint32_t c, uint32_t t);
+    /// Processes a single CY operation.
     void single_cy(uint32_t c, uint32_t t);
+    /// Processes a single CZ operation.
     void single_cz(uint32_t c, uint32_t t);
+    /// Processes a single classically controlled Pauli operation.
     void feedback(uint32_t record_control, size_t target, bool x, bool z);
     /// Saves the current tail of the monotonic buffer, deduping it to equal already stored data if possible.
     ///
@@ -172,11 +263,18 @@ struct ErrorAnalyzer {
     void add_error_combinations(
         std::array<double, 1 << s> independent_probabilities, std::array<ConstPointerRange<DemTarget>, s> basis_errors);
 
+    /// Handles local decomposition of errors.
+    /// When an error has multiple channels, eg. a DEPOLARIZE2 error, this method attempts to express the more complex
+    /// channels (the ones with more symptoms) in terms of the simpler ones that have just 1 or 2 symptoms.
+    /// Works by rewriting the `stored_ids` argument.
     template <size_t s>
     void decompose_helper_add_error_combinations(
         const std::array<uint64_t, 1 << s> &detector_masks,
         std::array<ConstPointerRange<DemTarget>, 1 << s> &stored_ids);
 
+    /// Handles global decomposition of errors.
+    /// When an error has more than two symptoms, this method attempts to find other known errors that can be used as
+    /// components of this error, so that it is decomposed into graphlike components.
     void decompose_and_append_component_to_tail(
         ConstPointerRange<DemTarget> component,
         const std::map<FixedCapVector<DemTarget, 2>, ConstPointerRange<DemTarget>> &known_symptoms);
@@ -189,6 +287,10 @@ struct ErrorAnalyzer {
     bool has_unflushed_ungraphlike_errors() const;
 };
 
+/// Determines if an error's targets are graphlike.
+///
+/// An error is graphlike if it has at most two symptoms (two detectors) per component.
+/// For example, error(0.1) D0 D1 ^ D2 D3 L55 is graphlike but error(0.1) D0 D1 ^ D2 D3 D55 is not.
 bool is_graphlike(const ConstPointerRange<DemTarget> &components);
 
 }  // namespace stim

--- a/src/stim/simulators/error_analyzer.h
+++ b/src/stim/simulators/error_analyzer.h
@@ -34,20 +34,6 @@
 
 namespace stim {
 
-enum ErrorAnalyzerMode : uint8_t {
-    /// Normal operating mode.
-    NormalWork_RecordDetectorErrors,
-
-    /// Reduce execution cost by skipping recording of errors, and instead just tracking sensitivities.
-    /// Used by the hare in the tortoise-and-hare algorithm looking for periodicity in the error sensitivity state
-    /// of REPEAT blocks, in order to make the hare cheaper to run.
-    MinimumWork_OnlyTrackErrorSensitivity,
-
-    /// Collect information useful when debugging why a circuit isn't working as expected (eg. why a logical observable
-    /// is anti-commuting with a reset operation).
-    ExtraWork_RecordDebugInformation,
-};
-
 /// This class is responsible for iterating backwards over a circuit, tracking which detectors are currently
 /// sensitive to an X or Z error on each qubit. This is done by having a SparseXorVec for the X and Z
 /// sensitivities of each qubit, and transforming these collections in response to operations.

--- a/src/stim/simulators/error_analyzer.test.cc
+++ b/src/stim/simulators/error_analyzer.test.cc
@@ -2613,7 +2613,7 @@ The backward-propagating error sensitivity for L0 was:
     Z2
 
 Circuit stack trace:
-    during TICK layer #1 of 200
+    during TICK layer #1 of 201
     at instruction #2 [which is RX 2])ERROR",
                 [&] {
                     ErrorAnalyzer::circuit_to_detector_error_model(
@@ -2661,7 +2661,7 @@ The backward-propagating error sensitivity for L0 was:
     Z1
 
 Circuit stack trace:
-    during TICK layer #101 of 1401
+    during TICK layer #101 of 1402
     at instruction #4 [which is a REPEAT 100 block]
     at block's instruction #1 [which is RX 0])ERROR",
                 [&] {

--- a/src/stim/simulators/measurements_to_detection_events.h
+++ b/src/stim/simulators/measurements_to_detection_events.h
@@ -105,7 +105,7 @@ simd_bit_table measurements_to_detection_events(
     bool append_observables,
     bool skip_reference_sample);
 /// A variant of `stim::measurements_to_detection_events` with derived values passed in, not recomputed.
-    void measurements_to_detection_events_helper(
+void measurements_to_detection_events_helper(
     const simd_bit_table &measurements__minor_shot_index,
     const simd_bit_table &sweep_bits__minor_shot_index,
     simd_bit_table &out_detection_results__minor_shot_index,

--- a/src/stim/simulators/min_distance.h
+++ b/src/stim/simulators/min_distance.h
@@ -1,18 +1,18 @@
 /*
-* Copyright 2021 Google LLC
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*      http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #ifndef _STIM_SIMULATORS_MIN_DISTANCE_H
 #define _STIM_SIMULATORS_MIN_DISTANCE_H
@@ -37,8 +37,8 @@ namespace stim {
 /// Returns:
 ///     A detector error model containing only the error mechanisms that cause the undetectable logical error.
 ///     Note that the error mechanisms will have their probabilities set to 1 (indicating they are necessary).
-DetectorErrorModel shortest_graphlike_undetectable_logical_error(const DetectorErrorModel &model,
-                                                                 bool ignore_ungraphlike_errors);
+DetectorErrorModel shortest_graphlike_undetectable_logical_error(
+    const DetectorErrorModel &model, bool ignore_ungraphlike_errors);
 
 namespace impl_min_distance {
 
@@ -67,7 +67,8 @@ struct DemAdjGraph {
     DemAdjGraph(std::vector<DemAdjNode> nodes, uint64_t distance_1_error_mask);
 
     void add_outward_edge(size_t src, uint64_t dst, uint64_t obs_mask);
-    void add_edges_from_targets_with_no_separators(ConstPointerRange<DemTarget> targets, bool ignore_ungraphlike_errors);
+    void add_edges_from_targets_with_no_separators(
+        ConstPointerRange<DemTarget> targets, bool ignore_ungraphlike_errors);
     void add_edges_from_separable_targets(ConstPointerRange<DemTarget> targets, bool ignore_ungraphlike_errors);
     static DemAdjGraph from_dem(const DetectorErrorModel &model, bool ignore_ungraphlike_errors);
     bool operator==(const DemAdjGraph &other) const;
@@ -78,8 +79,8 @@ std::ostream &operator<<(std::ostream &out, const DemAdjGraph &v);
 
 struct DemAdjGraphSearchState {
     uint64_t det_active;  // The detection event being moved around in an attempt to remove it (or NO_NODE_INDEX).
-    uint64_t det_held;  // The detection event being left in the same place (or NO_NODE_INDEX).
-    uint64_t obs_mask;  // The accumulated frame changes from moving the detection events around.
+    uint64_t det_held;    // The detection event being left in the same place (or NO_NODE_INDEX).
+    uint64_t obs_mask;    // The accumulated frame changes from moving the detection events around.
 
     DemAdjGraphSearchState();
     DemAdjGraphSearchState(uint64_t det_active, uint64_t det_held, uint64_t obs_mask);

--- a/src/stim/simulators/min_distance.perf.cc
+++ b/src/stim/simulators/min_distance.perf.cc
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include "stim/simulators/min_distance.h"
-#include "stim/gen/gen_surface_code.h"
-#include "stim/simulators/error_analyzer.h"
 
 #include "stim/benchmark_util.perf.h"
+#include "stim/gen/gen_surface_code.h"
+#include "stim/simulators/error_analyzer.h"
 
 using namespace stim;
 
@@ -27,14 +27,12 @@ BENCHMARK(find_graphlike_logical_error_surface_code_d25) {
     params.after_reset_flip_probability = 0.001;
     params.before_round_data_depolarization = 0.001;
     auto circuit = generate_surface_code_circuit(params).circuit;
-    auto model = ErrorAnalyzer::circuit_to_detector_error_model(
-        circuit, true, true, false, false);
+    auto model = ErrorAnalyzer::circuit_to_detector_error_model(circuit, true, true, false, false);
 
     size_t total = 0;
     benchmark_go([&]() {
         total += stim::shortest_graphlike_undetectable_logical_error(model, false).instructions.size();
-    })
-        .goal_millis(35);
+    }).goal_millis(35);
     if (total % 25 != 0 || total == 0) {
         std::cout << "bad";
     }

--- a/src/stim/simulators/min_distance.test.cc
+++ b/src/stim/simulators/min_distance.test.cc
@@ -27,24 +27,32 @@ using namespace stim::impl_min_distance;
 
 TEST(shortest_graphlike_undetectable_logical_error, no_error) {
     // No error.
-    ASSERT_THROW({ stim::shortest_graphlike_undetectable_logical_error(DetectorErrorModel(), false);
-    }, std::invalid_argument);
+    ASSERT_THROW(
+        { stim::shortest_graphlike_undetectable_logical_error(DetectorErrorModel(), false); }, std::invalid_argument);
 
     // No undetectable error.
-    ASSERT_THROW({
-        stim::shortest_graphlike_undetectable_logical_error(DetectorErrorModel(R"MODEL(
+    ASSERT_THROW(
+        {
+            stim::shortest_graphlike_undetectable_logical_error(
+                DetectorErrorModel(R"MODEL(
             error(0.1) D0 L0
-        )MODEL"), false);
-    }, std::invalid_argument);
+        )MODEL"),
+                false);
+        },
+        std::invalid_argument);
 
     // No logical flips.
-    ASSERT_THROW({
-        stim::shortest_graphlike_undetectable_logical_error(DetectorErrorModel(R"MODEL(
+    ASSERT_THROW(
+        {
+            stim::shortest_graphlike_undetectable_logical_error(
+                DetectorErrorModel(R"MODEL(
             error(0.1) D0
             error(0.1) D0 D1
             error(0.1) D1
-        )MODEL"), false);
-    }, std::invalid_argument);
+        )MODEL"),
+                false);
+        },
+        std::invalid_argument);
 }
 
 TEST(shortest_graphlike_undetectable_logical_error, distance_1) {
@@ -146,38 +154,27 @@ TEST(shortest_graphlike_undetectable_logical_error, surface_code) {
     params.after_reset_flip_probability = 0.001;
     params.before_round_data_depolarization = 0.001;
     auto circuit = generate_surface_code_circuit(params).circuit;
-    auto graphlike_model = ErrorAnalyzer::circuit_to_detector_error_model(
-        circuit, true, true, false, false);
-    auto ungraphlike_model = ErrorAnalyzer::circuit_to_detector_error_model(
-        circuit, false, true, false, false);
+    auto graphlike_model = ErrorAnalyzer::circuit_to_detector_error_model(circuit, true, true, false, false);
+    auto ungraphlike_model = ErrorAnalyzer::circuit_to_detector_error_model(circuit, false, true, false, false);
 
-    ASSERT_EQ(
-        stim::shortest_graphlike_undetectable_logical_error(graphlike_model, false).instructions.size(),
-        5);
+    ASSERT_EQ(stim::shortest_graphlike_undetectable_logical_error(graphlike_model, false).instructions.size(), 5);
 
-    ASSERT_EQ(
-        stim::shortest_graphlike_undetectable_logical_error(graphlike_model, true).instructions.size(),
-        5);
+    ASSERT_EQ(stim::shortest_graphlike_undetectable_logical_error(graphlike_model, true).instructions.size(), 5);
 
-    ASSERT_EQ(
-        stim::shortest_graphlike_undetectable_logical_error(ungraphlike_model, true).instructions.size(),
-        5);
+    ASSERT_EQ(stim::shortest_graphlike_undetectable_logical_error(ungraphlike_model, true).instructions.size(), 5);
 
     // Throw due to ungraphlike errors.
-    ASSERT_THROW({ stim::shortest_graphlike_undetectable_logical_error(ungraphlike_model, false);
-    }, std::invalid_argument);
+    ASSERT_THROW(
+        { stim::shortest_graphlike_undetectable_logical_error(ungraphlike_model, false); }, std::invalid_argument);
 }
 
 TEST(shortest_graphlike_undetectable_logical_error, repetition_code) {
     CircuitGenParameters params(10, 7, "memory");
     params.before_round_data_depolarization = 0.01;
     auto circuit = generate_rep_code_circuit(params).circuit;
-    auto graphlike_model = ErrorAnalyzer::circuit_to_detector_error_model(
-        circuit, true, true, false, false);
+    auto graphlike_model = ErrorAnalyzer::circuit_to_detector_error_model(circuit, true, true, false, false);
 
-    ASSERT_EQ(
-        stim::shortest_graphlike_undetectable_logical_error(graphlike_model, false).instructions.size(),
-        7);
+    ASSERT_EQ(stim::shortest_graphlike_undetectable_logical_error(graphlike_model, false).instructions.size(), 7);
 }
 
 TEST(impl_min_distance, DemAdjEdge) {
@@ -271,14 +268,12 @@ TEST(impl_min_distance, DemAdjGraphSearchState_canonical) {
 TEST(impl_min_distance, DemAdjGraphSearchState_append_transition_as_error_instruction_to) {
     DetectorErrorModel out;
 
-    DemAdjGraphSearchState(1, 2, 9).append_transition_as_error_instruction_to(
-        DemAdjGraphSearchState(1, 2, 16), out);
+    DemAdjGraphSearchState(1, 2, 9).append_transition_as_error_instruction_to(DemAdjGraphSearchState(1, 2, 16), out);
     ASSERT_EQ(out, DetectorErrorModel(R"MODEL(
         error(1) L0 L3 L4
     )MODEL"));
 
-    DemAdjGraphSearchState(1, 2, 9).append_transition_as_error_instruction_to(
-        DemAdjGraphSearchState(3, 2, 9), out);
+    DemAdjGraphSearchState(1, 2, 9).append_transition_as_error_instruction_to(DemAdjGraphSearchState(3, 2, 9), out);
     ASSERT_EQ(out, DetectorErrorModel(R"MODEL(
         error(1) L0 L3 L4
         error(1) D1 D3
@@ -292,8 +287,8 @@ TEST(impl_min_distance, DemAdjGraphSearchState_append_transition_as_error_instru
         error(1) D2
     )MODEL"));
 
-    DemAdjGraphSearchState(NO_NODE_INDEX, NO_NODE_INDEX, 0).append_transition_as_error_instruction_to(
-        DemAdjGraphSearchState(1, NO_NODE_INDEX, 9), out);
+    DemAdjGraphSearchState(NO_NODE_INDEX, NO_NODE_INDEX, 0)
+        .append_transition_as_error_instruction_to(DemAdjGraphSearchState(1, NO_NODE_INDEX, 9), out);
     ASSERT_EQ(out, DetectorErrorModel(R"MODEL(
         error(1) L0 L3 L4
         error(1) D1 D3
@@ -301,8 +296,7 @@ TEST(impl_min_distance, DemAdjGraphSearchState_append_transition_as_error_instru
         error(1) D1 L0 L3
     )MODEL"));
 
-    DemAdjGraphSearchState(1, 1, 0).append_transition_as_error_instruction_to(
-        DemAdjGraphSearchState(2, 2, 4), out);
+    DemAdjGraphSearchState(1, 1, 0).append_transition_as_error_instruction_to(DemAdjGraphSearchState(2, 2, 4), out);
     ASSERT_EQ(out, DetectorErrorModel(R"MODEL(
         error(1) L0 L3 L4
         error(1) D1 D3
@@ -362,81 +356,113 @@ TEST(impl_min_distance, DemAdjGraph_add_outward_edge) {
     DemAdjGraph g(3);
 
     g.add_outward_edge(1, 2, 3);
-    ASSERT_EQ(g, (DemAdjGraph{std::vector<DemAdjNode>{
-        DemAdjNode{},
-        DemAdjNode{{DemAdjEdge{2, 3}}},
-        DemAdjNode{},
-    }, 0}));
+    ASSERT_EQ(
+        g,
+        (DemAdjGraph{
+            std::vector<DemAdjNode>{
+                DemAdjNode{},
+                DemAdjNode{{DemAdjEdge{2, 3}}},
+                DemAdjNode{},
+            },
+            0}));
 
     g.add_outward_edge(1, 2, 3);
-    ASSERT_EQ(g, (DemAdjGraph{std::vector<DemAdjNode>{
-                                  DemAdjNode{},
-                                  DemAdjNode{{DemAdjEdge{2, 3}}},
-                                  DemAdjNode{},
-                              }, 0}));
+    ASSERT_EQ(
+        g,
+        (DemAdjGraph{
+            std::vector<DemAdjNode>{
+                DemAdjNode{},
+                DemAdjNode{{DemAdjEdge{2, 3}}},
+                DemAdjNode{},
+            },
+            0}));
 
     g.add_outward_edge(1, 2, 4);
-    ASSERT_EQ(g, (DemAdjGraph{std::vector<DemAdjNode>{
-                                  DemAdjNode{},
-                                  DemAdjNode{{DemAdjEdge{2, 3}, DemAdjEdge{2, 4}}},
-                                  DemAdjNode{},
-                              }, 0}));
+    ASSERT_EQ(
+        g,
+        (DemAdjGraph{
+            std::vector<DemAdjNode>{
+                DemAdjNode{},
+                DemAdjNode{{DemAdjEdge{2, 3}, DemAdjEdge{2, 4}}},
+                DemAdjNode{},
+            },
+            0}));
 
     g.add_outward_edge(2, 1, 3);
-    ASSERT_EQ(g, (DemAdjGraph{std::vector<DemAdjNode>{
-                                  DemAdjNode{},
-                                  DemAdjNode{{DemAdjEdge{2, 3}, DemAdjEdge{2, 4}}},
-                                  DemAdjNode{{DemAdjEdge{1, 3}}},
-                              }, 0}));
+    ASSERT_EQ(
+        g,
+        (DemAdjGraph{
+            std::vector<DemAdjNode>{
+                DemAdjNode{},
+                DemAdjNode{{DemAdjEdge{2, 3}, DemAdjEdge{2, 4}}},
+                DemAdjNode{{DemAdjEdge{1, 3}}},
+            },
+            0}));
 
     g.add_outward_edge(2, NO_NODE_INDEX, 3);
-    ASSERT_EQ(g, (DemAdjGraph{std::vector<DemAdjNode>{
-                                  DemAdjNode{},
-                                  DemAdjNode{{DemAdjEdge{2, 3}, DemAdjEdge{2, 4}}},
-                                  DemAdjNode{{DemAdjEdge{1, 3}, DemAdjEdge{NO_NODE_INDEX, 3}}},
-                              }, 0}));
+    ASSERT_EQ(
+        g,
+        (DemAdjGraph{
+            std::vector<DemAdjNode>{
+                DemAdjNode{},
+                DemAdjNode{{DemAdjEdge{2, 3}, DemAdjEdge{2, 4}}},
+                DemAdjNode{{DemAdjEdge{1, 3}, DemAdjEdge{NO_NODE_INDEX, 3}}},
+            },
+            0}));
 }
 
 TEST(impl_min_distance, DemAdjGraph_add_edges_from_targets_with_no_separators) {
     DemAdjGraph g(4);
 
+    g.add_edges_from_targets_with_no_separators(std::vector<DemTarget>{DemTarget::relative_detector_id(1)}, false);
+
+    ASSERT_EQ(
+        g,
+        (DemAdjGraph{
+            {
+                DemAdjNode{},
+                DemAdjNode{{DemAdjEdge{NO_NODE_INDEX, 0}}},
+                DemAdjNode{},
+                DemAdjNode{},
+            },
+            0}));
+
     g.add_edges_from_targets_with_no_separators(
-        std::vector<DemTarget>{DemTarget::relative_detector_id(1)},
+        std::vector<DemTarget>{
+            DemTarget::relative_detector_id(1),
+            DemTarget::relative_detector_id(3),
+            DemTarget::observable_id(5),
+        },
         false);
 
-    ASSERT_EQ(g, (DemAdjGraph{{
-                     DemAdjNode{},
-                     DemAdjNode{{DemAdjEdge{NO_NODE_INDEX, 0}}},
-                     DemAdjNode{},
-                     DemAdjNode{},
-                 }, 0}));
+    ASSERT_EQ(
+        g,
+        (DemAdjGraph{
+            {
+                DemAdjNode{},
+                DemAdjNode{{DemAdjEdge{NO_NODE_INDEX, 0}, DemAdjEdge{3, 32}}},
+                DemAdjNode{},
+                DemAdjNode{{DemAdjEdge{1, 32}}},
+            },
+            0}));
 
-    g.add_edges_from_targets_with_no_separators(std::vector<DemTarget>{
-                                                    DemTarget::relative_detector_id(1),
-                                                    DemTarget::relative_detector_id(3),
-                                                    DemTarget::observable_id(5),
-                                                },
+    g.add_edges_from_targets_with_no_separators(
+        std::vector<DemTarget>{
+            DemTarget::observable_id(3),
+            DemTarget::observable_id(7),
+        },
         false);
 
-    ASSERT_EQ(g, (DemAdjGraph{{
-                                  DemAdjNode{},
-                                  DemAdjNode{{DemAdjEdge{NO_NODE_INDEX, 0}, DemAdjEdge{3, 32}}},
-                                  DemAdjNode{},
-                                  DemAdjNode{{DemAdjEdge{1, 32}}},
-                              }, 0}));
-
-    g.add_edges_from_targets_with_no_separators(std::vector<DemTarget>{
-                                                    DemTarget::observable_id(3),
-                                                    DemTarget::observable_id(7),
-                                                },
-                                                false);
-
-    ASSERT_EQ(g, (DemAdjGraph{{
-                                  DemAdjNode{},
-                                  DemAdjNode{{DemAdjEdge{NO_NODE_INDEX, 0}, DemAdjEdge{3, 32}}},
-                                  DemAdjNode{},
-                                  DemAdjNode{{DemAdjEdge{1, 32}}},
-                              }, (1 << 3) + (1 << 7)}));
+    ASSERT_EQ(
+        g,
+        (DemAdjGraph{
+            {
+                DemAdjNode{},
+                DemAdjNode{{DemAdjEdge{NO_NODE_INDEX, 0}, DemAdjEdge{3, 32}}},
+                DemAdjNode{},
+                DemAdjNode{{DemAdjEdge{1, 32}}},
+            },
+            (1 << 3) + (1 << 7)}));
 
     DemAdjGraph same_g = g;
     std::vector<DemTarget> too_big{
@@ -444,29 +470,30 @@ TEST(impl_min_distance, DemAdjGraph_add_edges_from_targets_with_no_separators) {
         DemTarget::relative_detector_id(2),
         DemTarget::relative_detector_id(3),
     };
-    ASSERT_THROW({
-        same_g.add_edges_from_targets_with_no_separators(too_big, false);
-    }, std::invalid_argument);
+    ASSERT_THROW({ same_g.add_edges_from_targets_with_no_separators(too_big, false); }, std::invalid_argument);
     ASSERT_EQ(g, same_g);
     same_g.add_edges_from_targets_with_no_separators(too_big, true);
     ASSERT_EQ(g, same_g);
 }
 
 TEST(impl_min_distance, DemAdjGraph_str) {
-    DemAdjGraph g{{
-        DemAdjNode{},
-        DemAdjNode{{DemAdjEdge{NO_NODE_INDEX, 0}, DemAdjEdge{3, 32}}},
-        DemAdjNode{},
-        DemAdjNode{{DemAdjEdge{1, 32}}},
-    }, 0};
-    ASSERT_EQ(g.str(),
-              "0:\n"
-              "1:\n"
-              "    [boundary]\n"
-              "    D3 L5\n"
-              "2:\n"
-              "3:\n"
-              "    D1 L5\n");
+    DemAdjGraph g{
+        {
+            DemAdjNode{},
+            DemAdjNode{{DemAdjEdge{NO_NODE_INDEX, 0}, DemAdjEdge{3, 32}}},
+            DemAdjNode{},
+            DemAdjNode{{DemAdjEdge{1, 32}}},
+        },
+        0};
+    ASSERT_EQ(
+        g.str(),
+        "0:\n"
+        "1:\n"
+        "    [boundary]\n"
+        "    D3 L5\n"
+        "2:\n"
+        "3:\n"
+        "    D1 L5\n");
 }
 
 TEST(impl_min_distance, DemAdjGraph_add_edges_from_separable_targets) {
@@ -482,16 +509,22 @@ TEST(impl_min_distance, DemAdjGraph_add_edges_from_separable_targets) {
         },
         false);
 
-    ASSERT_EQ(g, (DemAdjGraph{{
-                                  DemAdjNode{},
-                                  DemAdjNode{{DemAdjEdge{NO_NODE_INDEX, 0}, DemAdjEdge{2, 16}}},
-                                  DemAdjNode{{DemAdjEdge{1, 16}}},
-                                  DemAdjNode{},
-                              }, 0}));
+    ASSERT_EQ(
+        g,
+        (DemAdjGraph{
+            {
+                DemAdjNode{},
+                DemAdjNode{{DemAdjEdge{NO_NODE_INDEX, 0}, DemAdjEdge{2, 16}}},
+                DemAdjNode{{DemAdjEdge{1, 16}}},
+                DemAdjNode{},
+            },
+            0}));
 }
 
 TEST(impl_min_distance, DemAdjGraph_from_dem) {
-    ASSERT_EQ(DemAdjGraph::from_dem(DetectorErrorModel(R"MODEL(
+    ASSERT_EQ(
+        DemAdjGraph::from_dem(
+            DetectorErrorModel(R"MODEL(
         error(0.1) D0
         repeat 3 {
             error(0.1) D0 D1
@@ -500,15 +533,19 @@ TEST(impl_min_distance, DemAdjGraph_from_dem) {
         error(0.1) D0 L7
         error(0.1) D2 ^ D3 D4 L2
         detector D5
-    )MODEL"), false), DemAdjGraph({
-                  DemAdjNode{{DemAdjEdge{NO_NODE_INDEX, 0}, DemAdjEdge{1, 0}}},
-                  DemAdjNode{{DemAdjEdge{0, 0}, DemAdjEdge{2, 0}}},
-                  DemAdjNode{{DemAdjEdge{1, 0}, DemAdjEdge{3, 0}}},
-                  DemAdjNode{{DemAdjEdge{2, 0}, DemAdjEdge{NO_NODE_INDEX, 128}}},
-                  DemAdjNode{},
-                  DemAdjNode{{DemAdjEdge{NO_NODE_INDEX, 0}}},
-                  DemAdjNode{{DemAdjEdge{7, 4}}},
-                  DemAdjNode{{DemAdjEdge{6, 4}}},
-                  DemAdjNode{},
-              }, 0));
+    )MODEL"),
+            false),
+        DemAdjGraph(
+            {
+                DemAdjNode{{DemAdjEdge{NO_NODE_INDEX, 0}, DemAdjEdge{1, 0}}},
+                DemAdjNode{{DemAdjEdge{0, 0}, DemAdjEdge{2, 0}}},
+                DemAdjNode{{DemAdjEdge{1, 0}, DemAdjEdge{3, 0}}},
+                DemAdjNode{{DemAdjEdge{2, 0}, DemAdjEdge{NO_NODE_INDEX, 128}}},
+                DemAdjNode{},
+                DemAdjNode{{DemAdjEdge{NO_NODE_INDEX, 0}}},
+                DemAdjNode{{DemAdjEdge{7, 4}}},
+                DemAdjNode{{DemAdjEdge{6, 4}}},
+                DemAdjNode{},
+            },
+            0));
 }

--- a/src/stim/stabilizers/pauli_string.pybind.cc
+++ b/src/stim/stabilizers/pauli_string.pybind.cc
@@ -909,6 +909,5 @@ void pybind_pauli_string(pybind11::module &m) {
         },
         [](const pybind11::str &d) {
             return PyPauliString::from_text(pybind11::cast<std::string>(d).data());
-        }
-    ));
+        }));
 }

--- a/src/stim/stabilizers/tableau.pybind.cc
+++ b/src/stim/stabilizers/tableau.pybind.cc
@@ -1077,10 +1077,8 @@ void pybind_tableau(pybind11::module &m) {
                 result.zs[q] = zs[q].value;
             }
             if (!result.satisfies_invariants()) {
-                throw std::invalid_argument(
-                    "Pickled tableau was invalid. It doesn't preserve commutativity.");
+                throw std::invalid_argument("Pickled tableau was invalid. It doesn't preserve commutativity.");
             }
             return result;
-        }
-    ));
+        }));
 }


### PR DESCRIPTION
- Give a proper circuit stack trace of the instruction location when error analysis fails:
    - tick layer
    - most-general-to-most-specific ordering
    - error sensitivities of involved detectors/observables
    - the specific qubit that was collapsing
    - coordinate metadata of involved detectors and qubits
- Add `Circuit::count_ticks`
- Add `Circuit::get_final_qubit_coords`
- Add `Circuit::describe_instruction_location`
- Add `ErrorAnalyzer::TICK`
- Add `Circuit::final_coord_shift`
- Add `Circuit::coords_of_detector`
- Run autoformat
- Add `:stim_dev_wheel` bazel target for easier python testing during development