### PR TITLE
Update stimcirq to handle more gates

### DIFF
--- a/doc/result_formats.md
+++ b/doc/result_formats.md
@@ -1,456 +1,461 @@
-# Result formats supported by Stim
+# Introduction
 
-- [01](#01)
-- [b8](#b8)
-- [dets](#dets)
-- [hits](#hits)
-- [ptb64](#ptb64)
-- [r8](#r8)
+A *result format* is a way of representing bits from shots sampled from a circuit.
+It is some way of converting between a list-of-list-of-bits (a list-of-shots) and
+a flat string of bytes or characters.
 
-- <a name="01"></a>**`01`**
-    
-    A human readable format that stores shots as lines of '0' and '1' characters.
-    
-    The data from each shot is terminated by a newline character '\n'. Each character in the line is a '0' (indicating
-    False) or a '1' (indicating True) corresponding to a measurement result (or a detector result) from a circuit.
-    
-    This is the default format used when saving to files.
-    
-    Example:
-    
-        >>> import pathlib
-        >>> import stim
-        >>> import tempfile
-        >>> with tempfile.TemporaryDirectory() as d:
-        ...     path = str(pathlib.Path(d) / "tmp.dat")
-        ...     stim.Circuit("""
-        ...         X 1
-        ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
-        ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="01")
-        ...     with open(path) as f:
-        ...         print(f.read().strip())
-        00001111001101
-        00001111001101
-        00001111001101
-        00001111001101
-        00001111001101
-        00001111001101
-        00001111001101
-        00001111001101
-        00001111001101
-        00001111001101
-    
-    - Sample parsing code (python):
-    
-        ```python
-        from typing import List
-        
-        def parse_01(data: str) -> List[List[bool]]:
-            shots = []
-            for line in data.split('\n'):
-                if not line:
-                    continue
-                shot = []
-                for c in line:
-                    assert c in '01'
-                    shot.append(c == '1')
-                shots.append(shot)
-            return shots
-        ```
-        
-    - Sample saving code (python):
-    
-        ```python
-        from typing import List
-        
-        def save_01(shots: List[List[bool]]) -> str:
-            output = ""
-            for shot in shots:
-                for sample in shot:
-                    output += '1' if sample else '0'
-                output += "\n"
-            return output
-        ```
-        
-    
-- <a name="b8"></a>**`b8`**
-    
-    A binary format that stores shots as bit-packed bytes.
-    
-    Each shot is stored into ceil(n / 8) bytes, where n is the number of bits in the shot. Effectively, each shot is padded
-    up to a multiple of 8 by appending False bits, so that shots always start on a byte boundary. Bits are packed into bytes
-    in significance order (the 1s bit is the first bit, the 2s bit is the second, the 4s bit is the third, and so forth
-    until the 128s bit which is the eighth bit).
-    
-    This format requires the reader to know the number of bits in each shot.
-    
-    Example:
-    
-        >>> import pathlib
-        >>> import stim
-        >>> import tempfile
-        >>> with tempfile.TemporaryDirectory() as d:
-        ...     path = str(pathlib.Path(d) / "tmp.dat")
-        ...     stim.Circuit("""
-        ...         X 1
-        ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
-        ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="b8")
-        ...     with open(path, 'rb') as f:
-        ...         print(' '.join(hex(e)[2:] for e in f.read()))
-        f0 2c f0 2c f0 2c f0 2c f0 2c f0 2c f0 2c f0 2c f0 2c f0 2c
-    
-    - Sample parsing code (python):
-    
-        ```python
-        from typing import List
-        
-        def parse_b8(data: bytes, bits_per_shot: int) -> List[List[bool]]:
-            shots = []
-            bytes_per_shot = (bits_per_shot + 7) // 8
-            for offset in range(0, len(data), bytes_per_shot):
-                shot = []
-                for k in range(bits_per_shot):
-                    byte = data[offset + k // 8]
-                    bit = (byte >> (k % 8)) % 2 == 1
-                    shot.append(bit)
-                shots.append(shot)
-            return shots
-        ```
-        
-    - Sample saving code (python):
-    
-        ```python
-        from typing import List
-        
-        def save_b8(shots: List[List[bool]]) -> bytes:
-            output = b""
-            for shot in shots:
-                bytes_per_shot = (len(shot) + 7) // 8
-                v = 0
-                for b in reversed(shot):
-                    v <<= 1
-                    v += b
-                output += v.to_bytes(bytes_per_shot, 'little')
-            return output
-        ```
-        
-    
-- <a name="dets"></a>**`dets`**
-    
-    A human readable format that stores shots as lines starting with 'shot' and space-separated prefixed values like 'D5'.
-    
-    The data from each shot is started with the text 'shot' and terminated by a newline character '\n'. The rest of the
-    line is a series of integers, separated by spaces and prefixed by a single letter. The prefix letter indicates the type
-    of value ('M' for measurement, 'D' for detector, and 'L' for logical observable). The integer indicates the index of the
-    value. For example, "D1 D3 L0" indicates detectors 1 and 3 fired, and logical observable 0 was flipped.
-    
-    This format requires the reader to know the number of measurements/detectors/observables in each shot, if the reader
-    wants to produce vectors of bits instead of sets.
-    
-    Example:
-    
-        >>> import pathlib
-        >>> import stim
-        >>> import tempfile
-        >>> with tempfile.TemporaryDirectory() as d:
-        ...     path = str(pathlib.Path(d) / "tmp.dat")
-        ...     stim.Circuit("""
-        ...         X 1
-        ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1 0 1
-        ...     """).compile_sampler().sample_write(shots=3, filepath=path, format="dets")
-        ...     with open(path) as f:
-        ...         print(f.read().strip())
-        shot M4 M5 M6 M7 M10 M11 M13 M15
-        shot M4 M5 M6 M7 M10 M11 M13 M15
-        shot M4 M5 M6 M7 M10 M11 M13 M15
-    
-        >>> with tempfile.TemporaryDirectory() as d:
-        ...     path = str(pathlib.Path(d) / "tmp.dat")
-        ...     stim.Circuit("""
-        ...         X_ERROR(1) 1
-        ...         M 0 1 2
-        ...         DETECTOR rec[-1]
-        ...         DETECTOR rec[-2]
-        ...         DETECTOR rec[-3]
-        ...         OBSERVABLE_INCLUDE(5) rec[-2]
-        ...     """).compile_detector_sampler().sample_write(shots=2, filepath=path, format="dets", append_observables=True)
-        ...     with open(path) as f:
-        ...         print(f.read().strip())
-        shot D1 L5
-        shot D1 L5
-    
-    - Sample parsing code (python):
-    
-        ```python
-        from typing import List
-        
-        def parse_dets(data: str, num_detectors: int, num_observables: int) -> List[List[bool]]:
-            shots = []
-            for line in data.split('\n'):
-                if not line.strip():
-                    continue
-                assert line.startswith('shot')
-                line = line[4:].strip()
-        
-                shot = [False] * (num_detectors + num_observables)
-                if line:
-                    for term in line.split(' '):
-                        c = term[0]
-                        v = int(term[1:])
-                        if c == 'D':
-                            assert 0 <= v < num_detectors
-                            shot[v] = True
-                        elif c == 'L':
-                            assert 0 <= v < num_observables
-                            shot[num_detectors + v] = True
-                        else:
-                            raise NotImplementedError(c)
-                shots.append(shot)
-            return shots
-        ```
-        
-    - Sample saving code (python):
-    
-        ```python
-        from typing import List
-        
-        def save_dets(shots: List[List[bool]], num_detectors: int, num_observables: int):
-            output = ""
-            for shot in shots:
-                assert len(shot) == num_detectors + num_observables
-                detectors = shot[:num_detectors]
-                observables = shot[num_detectors:]
-                output += "shot"
-                for k in range(num_detectors):
-                    if shot[k]:
-                        output += " D" + str(k)
-                for k in range(num_observables):
-                    if shot[num_detectors + k]:
-                        output += " L" + str(k)
-                output += "\n"
-            return output
-        ```
-        
-    
-- <a name="hits"></a>**`hits`**
-    
-    A human readable format that stores shots as a comma-separated list of integers indicating which bits were true.
-    
-    The data from each shot is terminated by a newline character '\n'. The line is a series of non-negative integers
-    separated by commas, with each integer indicating a bit from the shot that was true.
-    
-    This format requires the reader to know the number of bits in each shot (if they want to get a list instead of a set).
-    This format requires the reader to know how many trailing newlines, that don't correspond to shots with no hit, are in
-    the text data.
-    
-    This format is useful in contexts where the number of set bits is expected to be low, e.g. when sampling detection
-    events.
-    
-    Example:
-    
-        >>> import pathlib
-        >>> import stim
-        >>> import tempfile
-        >>> with tempfile.TemporaryDirectory() as d:
-        ...     path = str(pathlib.Path(d) / "tmp.dat")
-        ...     stim.Circuit("""
-        ...         X 1
-        ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
-        ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="hits")
-        ...     with open(path) as f:
-        ...         print(f.read().strip())
-        4,5,6,7,10,11,13
-        4,5,6,7,10,11,13
-        4,5,6,7,10,11,13
-        4,5,6,7,10,11,13
-        4,5,6,7,10,11,13
-        4,5,6,7,10,11,13
-        4,5,6,7,10,11,13
-        4,5,6,7,10,11,13
-        4,5,6,7,10,11,13
-        4,5,6,7,10,11,13
-    
-    - Sample parsing code (python):
-    
-        ```python
-        from typing import List
-        
-        def parse_hits(data: str, bits_per_shot: int) -> List[List[bool]]:
-            shots = []
-            if data.endswith('\n'):
-                data = data[:-1]
-            for line in data.split('\n'):
-                shot = [False] * bits_per_shot
-                if line:
-                    for term in line.split(','):
-                        shot[int(term)] = True
-                shots.append(shot)
-            return shots
-        ```
-        
-    - Sample saving code (python):
-    
-        ```python
-        from typing import List
-        
-        def save_hits(shots: List[List[bool]]) -> str:
-            output = ""
-            for shot in shots:
-                output += ",".join(str(index) for index, bit in enumerate(shot) if bit) + "\n"
-            return output
-        ```
-        
-    
-- <a name="ptb64"></a>**`ptb64`**
-    
-    A binary format that stores shots as partially transposed bit-packed data.
-    
-    Each 64 bit word (8 bytes) of the data contains bits from the same measurement result across 64 separate shots. The next
-    8 bytes contain bits for the next measurement result from the 64 separate shots. This continues until the 8 bytes
-    containing the bits from the last measurement result, and then starts over again with data from the next 64 shots (if
-    there are more).
-    
-    The shots are stored by byte order then significant order. The first shot's data goes into the least significant bit of
-    the first byte of each 8 byte group. When the number of shots is not a multiple of 64, the bits corresponding to the
-    missing shots are always zero.
-    
-    This format requires the reader to know the number of bits in each shot.
-    This format requires the reader to know the number of shots that were taken.
-    
-    This format is generally more tedious to work with, but useful for achieving good performance on data processing tasks
-    where it is possible to parallelize across shots using SIMD instructions.
-    
-    Example:
-    
-        >>> import pathlib
-        >>> import stim
-        >>> import tempfile
-        >>> with tempfile.TemporaryDirectory() as d:
-        ...     path = str(pathlib.Path(d) / "tmp.dat")
-        ...     stim.Circuit("""
-        ...         X 1
-        ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
-        ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="ptb64")
-        ...     with open(path, 'rb') as f:
-        ...         print(' '.join(hex(e)[2:] for e in f.read()))
-        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ff 3 0 0 0 0 0 0
-    
-    - Sample parsing code (python):
-    
-        ```python
-        from typing import List
-        
-        def parse_ptb64(data: bytes, bits_per_shot: int, num_shots: int) -> List[List[bool]]:
-            result = [[False] * bits_per_shot for _ in range(num_shots)]
-            group_byte_stride = bits_per_shot * 8
-            for shot_offset in range(num_shots):
-                shot_group = shot_offset // 64
-                shot_stripe = shot_offset % 64
-                for measure_index in range(bits_per_shot):
-                    byte_offset = group_byte_stride*shot_group + measure_index * 8 + shot_stripe // 8
-                    bit = (data[byte_offset] >> (shot_stripe % 8)) % 2 == 1
-                    result[shot_offset][measure_index] = bit
-            return result
-        ```
-        
-    - Sample saving code (python):
-    
-        ```python
-        from typing import List
-        
-        def save_ptb64(shots: List[List[bool]]):
-            output = b""
-            for shot_offset in range(0, len(shots), 64):
-                bits_per_shot = len(shots[0])
-                for measure_index in range(bits_per_shot):
-                    v = 0
-                    for k in reversed(range(min(64, len(shots) - shot_offset))):
-                        v <<= 1
-                        v += shots[shot_offset + k][measure_index]
-                    output += v.to_bytes(8, 'little')
-            return output
-        ```
-        
-    
-- <a name="r8"></a>**`r8`**
-    
-    A binary format that stores shots as the length of runs between 1s.
-    
-    Each byte in the data indicates how many False bits there are before the next True bit. The maximum byte value (255) is
-    special; it indicates to include 255 False bits but not follow them by a True bit. A shot always has a terminating True
-    bit appended to it before encoding. Decoding of the shot ends (and the next shot begin) when this True bit just past the
-    end of the shot data is reached.
-    
-    This format requires the reader to know the number of bits in each shot.
-    
-    This format is useful in contexts where the number of set bits is expected to be low, e.g. when sampling detection
-    events.
-    
-    Example:
-    
-        >>> import pathlib
-        >>> import stim
-        >>> import tempfile
-        >>> with tempfile.TemporaryDirectory() as d:
-        ...     path = str(pathlib.Path(d) / "tmp.dat")
-        ...     stim.Circuit("""
-        ...         X 1
-        ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
-        ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="r8")
-        ...     with open(path, 'rb') as f:
-        ...         print(' '.join(hex(e)[2:] for e in f.read()))
-        4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0
-    
-        >>> with tempfile.TemporaryDirectory() as d:
-        ...     path = str(pathlib.Path(d) / "tmp.dat")
-        ...     stim.Circuit("""
-        ...         X 1
-        ...         M 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
-        ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="r8")
-        ...     with open(path, 'rb') as f:
-        ...         print(' '.join(hex(e)[2:] for e in f.read()))
-        9 1f 9 1f 9 1f 9 1f 9 1f 9 1f 9 1f 9 1f 9 1f 9 1f
-    
-    - Sample parsing code (python):
-    
-        ```python
-        from typing import List
-        
-        def parse_r8(data: bytes, bits_per_shot: int) -> List[List[bool]]:
-            shots = []
+Generally, the result data formats supported by Stim are extremely minimalist.
+They do not contain metadata about which circuit was run,
+how many shots were taken,
+how many bits are in each shot,
+or even self-identifying information like a header with magic bytes.
+They produce *raw* data.
+Even details about which bits are measurements, which are detection events,
+and which are observable frame changes must be determined from context.
+
+The major driver for having multiple formats is context-dependent preferences for
+binary-vs-human-readable and dense-vs-sparse.
+For example, '`01`' is a dense text format and '`r8`' is a sparse binary format.
+Sometimes you want to be able to eyeball your data, so you want a text format.
+Other times you want maximum efficiency, so you want a binary format.
+Sometimes your data is high entropy, with as many 1s as 0s, so you use a dense format.
+Other times the data is highly biased, with 1s being much rarer and more interesting
+than 0s, so you use a sparse format.
+
+# Index
+- [The **01** Format](#01)
+- [The **b8** Format](#b8)
+- [The **dets** Format](#dets)
+- [The **hits** Format](#hits)
+- [The **ptb64** Format](#ptb64)
+- [The **r8** Format](#r8)
+
+
+# <a name="01"></a>The `01` Format
+
+The 01 format is a dense human readable format that stores shots as lines of '0' and '1' characters.
+
+The data from each shot is terminated by a newline character '\n'. Each character in the line is a '0' (indicating
+False) or a '1' (indicating True) corresponding to a measurement result (or a detector result) from a circuit.
+
+This is the default format used by Stim, because it's the easiest to understand.
+
+*Example of producing 01 format data using stim's python API:*
+
+    >>> import pathlib
+    >>> import stim
+    >>> import tempfile
+    >>> with tempfile.TemporaryDirectory() as d:
+    ...     path = str(pathlib.Path(d) / "tmp.dat")
+    ...     stim.Circuit("""
+    ...         X 1
+    ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
+    ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="01")
+    ...     with open(path) as f:
+    ...         print(f.read().strip())
+    00001111001101
+    00001111001101
+    00001111001101
+    00001111001101
+    00001111001101
+    00001111001101
+    00001111001101
+    00001111001101
+    00001111001101
+    00001111001101
+
+*Example 01 parsing code (python)*:
+```python
+from typing import List
+
+def parse_01(data: str) -> List[List[bool]]:
+    shots = []
+    for line in data.split('\n'):
+        if not line:
+            continue
+        shot = []
+        for c in line:
+            assert c in '01'
+            shot.append(c == '1')
+        shots.append(shot)
+    return shots
+```
+*Example 01 saving code (python):*
+```python
+from typing import List
+
+def save_01(shots: List[List[bool]]) -> str:
+    output = ""
+    for shot in shots:
+        for sample in shot:
+            output += '1' if sample else '0'
+        output += "\n"
+    return output
+```
+
+# <a name="b8"></a>The `b8` Format
+
+The b8 format is a dense binary format that stores shots as bit-packed bytes.
+
+Each shot is stored into ceil(n / 8) bytes, where n is the number of bits in the shot. Effectively, each shot is padded
+up to a multiple of 8 by appending False bits, so that shots always start on a byte boundary. Bits are packed into bytes
+in significance order (the 1s bit is the first bit, the 2s bit is the second, the 4s bit is the third, and so forth
+until the 128s bit which is the eighth bit).
+
+This format requires the reader to know the number of bits in each shot.
+
+*Example of producing b8 format data using stim's python API:*
+
+    >>> import pathlib
+    >>> import stim
+    >>> import tempfile
+    >>> with tempfile.TemporaryDirectory() as d:
+    ...     path = str(pathlib.Path(d) / "tmp.dat")
+    ...     stim.Circuit("""
+    ...         X 1
+    ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
+    ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="b8")
+    ...     with open(path, 'rb') as f:
+    ...         print(' '.join(hex(e)[2:] for e in f.read()))
+    f0 2c f0 2c f0 2c f0 2c f0 2c f0 2c f0 2c f0 2c f0 2c f0 2c
+
+*Example b8 parsing code (python)*:
+```python
+from typing import List
+
+def parse_b8(data: bytes, bits_per_shot: int) -> List[List[bool]]:
+    shots = []
+    bytes_per_shot = (bits_per_shot + 7) // 8
+    for offset in range(0, len(data), bytes_per_shot):
+        shot = []
+        for k in range(bits_per_shot):
+            byte = data[offset + k // 8]
+            bit = (byte >> (k % 8)) % 2 == 1
+            shot.append(bit)
+        shots.append(shot)
+    return shots
+```
+*Example b8 saving code (python):*
+```python
+from typing import List
+
+def save_b8(shots: List[List[bool]]) -> bytes:
+    output = b""
+    for shot in shots:
+        bytes_per_shot = (len(shot) + 7) // 8
+        v = 0
+        for b in reversed(shot):
+            v <<= 1
+            v += b
+        output += v.to_bytes(bytes_per_shot, 'little')
+    return output
+```
+
+# <a name="dets"></a>The `dets` Format
+
+The dets format is a sparse human readable format that stores shots as lines starting with the word 'shot'
+and then containing space-separated prefixed values like 'D5' and 'L2'. Each value's prefix indicates whether
+it is a measurement (M), a detector (D), or observable frame change (L) and its integer indicates that
+the corresponding measurement/detection-event/frame-change was True instead of False.
+
+The data from each shot is started with the text 'shot' and terminated by a newline character '\n'. The rest of the
+line is a series of integers, separated by spaces and prefixed by a single letter. The prefix letter indicates the type
+of value ('M' for measurement, 'D' for detector, and 'L' for logical observable). The integer indicates the index of the
+value. For example, "D1 D3 L0" indicates detectors 1 and 3 fired, and logical observable 0 was flipped.
+
+This format requires the reader to know the number of measurements/detectors/observables in each shot, if the reader
+wants to produce vectors of bits instead of sets.
+
+*Example of producing dets format data using stim's python API:*
+
+    >>> import pathlib
+    >>> import stim
+    >>> import tempfile
+    >>> with tempfile.TemporaryDirectory() as d:
+    ...     path = str(pathlib.Path(d) / "tmp.dat")
+    ...     stim.Circuit("""
+    ...         X 1
+    ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1 0 1
+    ...     """).compile_sampler().sample_write(shots=3, filepath=path, format="dets")
+    ...     with open(path) as f:
+    ...         print(f.read().strip())
+    shot M4 M5 M6 M7 M10 M11 M13 M15
+    shot M4 M5 M6 M7 M10 M11 M13 M15
+    shot M4 M5 M6 M7 M10 M11 M13 M15
+
+    >>> with tempfile.TemporaryDirectory() as d:
+    ...     path = str(pathlib.Path(d) / "tmp.dat")
+    ...     stim.Circuit("""
+    ...         X_ERROR(1) 1
+    ...         M 0 1 2
+    ...         DETECTOR rec[-1]
+    ...         DETECTOR rec[-2]
+    ...         DETECTOR rec[-3]
+    ...         OBSERVABLE_INCLUDE(5) rec[-2]
+    ...     """).compile_detector_sampler().sample_write(shots=2, filepath=path, format="dets", append_observables=True)
+    ...     with open(path) as f:
+    ...         print(f.read().strip())
+    shot D1 L5
+    shot D1 L5
+
+*Example dets parsing code (python)*:
+```python
+from typing import List
+
+def parse_dets(data: str, num_detectors: int, num_observables: int) -> List[List[bool]]:
+    shots = []
+    for line in data.split('\n'):
+        if not line.strip():
+            continue
+        assert line.startswith('shot')
+        line = line[4:].strip()
+
+        shot = [False] * (num_detectors + num_observables)
+        if line:
+            for term in line.split(' '):
+                c = term[0]
+                v = int(term[1:])
+                if c == 'D':
+                    assert 0 <= v < num_detectors
+                    shot[v] = True
+                elif c == 'L':
+                    assert 0 <= v < num_observables
+                    shot[num_detectors + v] = True
+                else:
+                    raise NotImplementedError(c)
+        shots.append(shot)
+    return shots
+```
+*Example dets saving code (python):*
+```python
+from typing import List
+
+def save_dets(shots: List[List[bool]], num_detectors: int, num_observables: int):
+    output = ""
+    for shot in shots:
+        assert len(shot) == num_detectors + num_observables
+        detectors = shot[:num_detectors]
+        observables = shot[num_detectors:]
+        output += "shot"
+        for k in range(num_detectors):
+            if shot[k]:
+                output += " D" + str(k)
+        for k in range(num_observables):
+            if shot[num_detectors + k]:
+                output += " L" + str(k)
+        output += "\n"
+    return output
+```
+
+# <a name="hits"></a>The `hits` Format
+
+The hits format is a dense human readable format that stores shots as a comma-separated list of integers.
+Each integer indicates the position of a bit that was True.
+Positions that aren't mentioned had bits that were False.
+
+The data from each shot is terminated by a newline character '\n'. The line is a series of non-negative integers
+separated by commas, with each integer indicating a bit from the shot that was true.
+
+This format requires the reader to know the number of bits in each shot (if they want to get a list instead of a set).
+This format requires the reader to know how many trailing newlines, that don't correspond to shots with no hit, are in
+the text data.
+
+This format is useful in contexts where the number of set bits is expected to be low, e.g. when sampling detection
+events.
+
+*Example of producing hits format data using stim's python API:*
+
+    >>> import pathlib
+    >>> import stim
+    >>> import tempfile
+    >>> with tempfile.TemporaryDirectory() as d:
+    ...     path = str(pathlib.Path(d) / "tmp.dat")
+    ...     stim.Circuit("""
+    ...         X 1
+    ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
+    ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="hits")
+    ...     with open(path) as f:
+    ...         print(f.read().strip())
+    4,5,6,7,10,11,13
+    4,5,6,7,10,11,13
+    4,5,6,7,10,11,13
+    4,5,6,7,10,11,13
+    4,5,6,7,10,11,13
+    4,5,6,7,10,11,13
+    4,5,6,7,10,11,13
+    4,5,6,7,10,11,13
+    4,5,6,7,10,11,13
+    4,5,6,7,10,11,13
+
+*Example hits parsing code (python)*:
+```python
+from typing import List
+
+def parse_hits(data: str, bits_per_shot: int) -> List[List[bool]]:
+    shots = []
+    if data.endswith('\n'):
+        data = data[:-1]
+    for line in data.split('\n'):
+        shot = [False] * bits_per_shot
+        if line:
+            for term in line.split(','):
+                shot[int(term)] = True
+        shots.append(shot)
+    return shots
+```
+*Example hits saving code (python):*
+```python
+from typing import List
+
+def save_hits(shots: List[List[bool]]) -> str:
+    output = ""
+    for shot in shots:
+        output += ",".join(str(index) for index, bit in enumerate(shot) if bit) + "\n"
+    return output
+```
+
+# <a name="ptb64"></a>The `ptb64` Format
+
+The ptb64 format is a dense SIMD-focused binary format that stores shots as partially transposed bit-packed data.
+
+Each 64 bit word (8 bytes) of the data contains bits from the same measurement result across 64 separate shots. The next
+8 bytes contain bits for the next measurement result from the 64 separate shots. This continues until the 8 bytes
+containing the bits from the last measurement result, and then starts over again with data from the next 64 shots (if
+there are more).
+
+The shots are stored by byte order then significant order. The first shot's data goes into the least significant bit of
+the first byte of each 8 byte group. When the number of shots is not a multiple of 64, the bits corresponding to the
+missing shots are always zero.
+
+This format requires the reader to know the number of bits in each shot.
+This format requires the reader to know the number of shots that were taken.
+
+This format is generally more tedious to work with, but useful for achieving good performance on data processing tasks
+where it is possible to parallelize across shots using SIMD instructions.
+
+*Example of producing ptb64 format data using stim's python API:*
+
+    >>> import pathlib
+    >>> import stim
+    >>> import tempfile
+    >>> with tempfile.TemporaryDirectory() as d:
+    ...     path = str(pathlib.Path(d) / "tmp.dat")
+    ...     stim.Circuit("""
+    ...         X 1
+    ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
+    ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="ptb64")
+    ...     with open(path, 'rb') as f:
+    ...         print(' '.join(hex(e)[2:] for e in f.read()))
+    0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ff 3 0 0 0 0 0 0
+
+*Example ptb64 parsing code (python)*:
+```python
+from typing import List
+
+def parse_ptb64(data: bytes, bits_per_shot: int, num_shots: int) -> List[List[bool]]:
+    result = [[False] * bits_per_shot for _ in range(num_shots)]
+    group_byte_stride = bits_per_shot * 8
+    for shot_offset in range(num_shots):
+        shot_group = shot_offset // 64
+        shot_stripe = shot_offset % 64
+        for measure_index in range(bits_per_shot):
+            byte_offset = group_byte_stride*shot_group + measure_index * 8 + shot_stripe // 8
+            bit = (data[byte_offset] >> (shot_stripe % 8)) % 2 == 1
+            result[shot_offset][measure_index] = bit
+    return result
+```
+*Example ptb64 saving code (python):*
+```python
+from typing import List
+
+def save_ptb64(shots: List[List[bool]]):
+    output = b""
+    for shot_offset in range(0, len(shots), 64):
+        bits_per_shot = len(shots[0])
+        for measure_index in range(bits_per_shot):
+            v = 0
+            for k in reversed(range(min(64, len(shots) - shot_offset))):
+                v <<= 1
+                v += shots[shot_offset + k][measure_index]
+            output += v.to_bytes(8, 'little')
+    return output
+```
+
+# <a name="r8"></a>The `r8` Format
+
+The r8 format is a sparse binary format that stores shots as a series of lengths of runs between 1s.
+
+Each byte in the data indicates how many False bits there are before the next True bit. The maximum byte value (255) is
+special; it indicates to include 255 False bits but not follow them by a True bit. A shot always has a terminating True
+bit appended to it before encoding. Decoding of the shot ends (and the next shot begin) when this True bit just past the
+end of the shot data is reached.
+
+This format requires the reader to know the number of bits in each shot.
+
+This format is useful in contexts where the number of set bits is expected to be low, e.g. when sampling detection
+events.
+
+*Example of producing r8 format data using stim's python API:*
+
+    >>> import pathlib
+    >>> import stim
+    >>> import tempfile
+    >>> with tempfile.TemporaryDirectory() as d:
+    ...     path = str(pathlib.Path(d) / "tmp.dat")
+    ...     stim.Circuit("""
+    ...         X 1
+    ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
+    ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="r8")
+    ...     with open(path, 'rb') as f:
+    ...         print(' '.join(hex(e)[2:] for e in f.read()))
+    4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0 4 0 0 0 2 0 1 0
+
+    >>> with tempfile.TemporaryDirectory() as d:
+    ...     path = str(pathlib.Path(d) / "tmp.dat")
+    ...     stim.Circuit("""
+    ...         X 1
+    ...         M 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+    ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="r8")
+    ...     with open(path, 'rb') as f:
+    ...         print(' '.join(hex(e)[2:] for e in f.read()))
+    9 1f 9 1f 9 1f 9 1f 9 1f 9 1f 9 1f 9 1f 9 1f 9 1f
+
+*Example r8 parsing code (python)*:
+```python
+from typing import List
+
+def parse_r8(data: bytes, bits_per_shot: int) -> List[List[bool]]:
+    shots = []
+    shot = []
+    for byte in data:
+        shot += [False] * byte
+        if byte != 255:
+            shot.append(True)
+        if len(shot) > bits_per_shot:
+            assert len(shot) == bits_per_shot + 1 and shot[-1]
+            shot.pop()
+            shots.append(shot)
             shot = []
-            for byte in data:
-                shot += [False] * byte
-                if byte != 255:
-                    shot.append(True)
-                if len(shot) > bits_per_shot:
-                    assert len(shot) == bits_per_shot + 1 and shot[-1]
-                    shot.pop()
-                    shots.append(shot)
-                    shot = []
-            assert len(shot) == 0
-            return shots
-        ```
-        
-    - Sample saving code (python):
-    
-        ```python
-        from typing import List
-        
-        def save_r8(shots: List[List[bool]]) -> bytes:
-            output = b""
-            for shot in shots:
+    assert len(shot) == 0
+    return shots
+```
+*Example r8 saving code (python):*
+```python
+from typing import List
+
+def save_r8(shots: List[List[bool]]) -> bytes:
+    output = b""
+    for shot in shots:
+        gap = 0
+        for b in shot + [True]:
+            if b:
+                while gap >= 255:
+                    gap -= 255
+                    output += (255).to_bytes(1, 'big')
+                output += gap.to_bytes(1, 'big')
                 gap = 0
-                for b in shot + [True]:
-                    if b:
-                        while gap >= 255:
-                            gap -= 255
-                            output += (255).to_bytes(1, 'big')
-                        output += gap.to_bytes(1, 'big')
-                        gap = 0
-                    else:
-                        gap += 1
-            return output
-        ```
-        
-    
+            else:
+                gap += 1
+    return output
+```
+

--- a/glue/cirq/stimcirq/__init__.py
+++ b/glue/cirq/stimcirq/__init__.py
@@ -1,8 +1,8 @@
 from ._cirq_to_stim import cirq_circuit_to_stim_circuit
-from ._stim_sampler import StimSampler
-from ._stim_to_cirq import stim_circuit_to_cirq_circuit, MeasureAndOrResetGate, TwoQubitAsymmetricDepolarizingChannel
 from ._det_annotation import DetAnnotation
 from ._obs_annotation import CumulativeObservableAnnotation
+from ._stim_sampler import StimSampler
+from ._stim_to_cirq import stim_circuit_to_cirq_circuit, MeasureAndOrResetGate, TwoQubitAsymmetricDepolarizingChannel
 
 JSON_RESOLVER = {
     "CumulativeObservableAnnotation": CumulativeObservableAnnotation._from_json_helper,
@@ -13,11 +13,11 @@ JSON_RESOLVER = {
 
 # Workaround for doctest not searching imported objects.
 __test__ = {
-    "StimSampler": StimSampler,
     "cirq_circuit_to_stim_circuit": cirq_circuit_to_stim_circuit,
-    "stim_circuit_to_cirq_circuit": stim_circuit_to_cirq_circuit,
-    "MeasureAndOrResetGate": MeasureAndOrResetGate,
-    "TwoQubitAsymmetricDepolarizingChannel": TwoQubitAsymmetricDepolarizingChannel,
     "CumulativeObservableAnnotation": CumulativeObservableAnnotation,
     "DetAnnotation": DetAnnotation,
+    "MeasureAndOrResetGate": MeasureAndOrResetGate,
+    "stim_circuit_to_cirq_circuit": stim_circuit_to_cirq_circuit,
+    "StimSampler": StimSampler,
+    "TwoQubitAsymmetricDepolarizingChannel": TwoQubitAsymmetricDepolarizingChannel,
 }

--- a/glue/cirq/stimcirq/__init__.py
+++ b/glue/cirq/stimcirq/__init__.py
@@ -1,12 +1,23 @@
 from ._cirq_to_stim import cirq_circuit_to_stim_circuit
 from ._stim_sampler import StimSampler
-from ._stim_to_cirq import stim_circuit_to_cirq_circuit, MeasureAndOrReset, TwoQubitAsymmetricDepolarizingChannel
+from ._stim_to_cirq import stim_circuit_to_cirq_circuit, MeasureAndOrResetGate, TwoQubitAsymmetricDepolarizingChannel
+from ._det_annotation import DetAnnotation
+from ._obs_annotation import CumulativeObservableAnnotation
+
+JSON_RESOLVER = {
+    "CumulativeObservableAnnotation": CumulativeObservableAnnotation._from_json_helper,
+    "DetAnnotation": DetAnnotation._from_json_helper,
+    "MeasureAndOrResetGate": MeasureAndOrResetGate._from_json_helper,
+    "TwoQubitAsymmetricDepolarizingChannel": TwoQubitAsymmetricDepolarizingChannel._from_json_helper,
+}.get
 
 # Workaround for doctest not searching imported objects.
 __test__ = {
     "StimSampler": StimSampler,
     "cirq_circuit_to_stim_circuit": cirq_circuit_to_stim_circuit,
     "stim_circuit_to_cirq_circuit": stim_circuit_to_cirq_circuit,
-    "MeasureAndOrReset": MeasureAndOrReset,
+    "MeasureAndOrResetGate": MeasureAndOrResetGate,
     "TwoQubitAsymmetricDepolarizingChannel": TwoQubitAsymmetricDepolarizingChannel,
+    "CumulativeObservableAnnotation": CumulativeObservableAnnotation,
+    "DetAnnotation": DetAnnotation,
 }

--- a/glue/cirq/stimcirq/_cirq_to_stim.py
+++ b/glue/cirq/stimcirq/_cirq_to_stim.py
@@ -264,7 +264,7 @@ def _stim_append_pauli_measurement_gate(circuit: stim.Circuit, gate: cirq.PauliM
 
     # Convert to stim Pauli product targets.
     if len(targets) == 0:
-        raise NotImplementedError(f"{len(targets)=} == 0")
+        raise NotImplementedError(f"len(targets)={len(targets)} == 0")
     new_targets = []
     for t, p in zip(targets, obs.pauli_mask):
         if p == 1:

--- a/glue/cirq/stimcirq/_cirq_to_stim.py
+++ b/glue/cirq/stimcirq/_cirq_to_stim.py
@@ -274,7 +274,7 @@ def _stim_append_pauli_measurement_gate(circuit: stim.Circuit, gate: cirq.PauliM
         elif p == 3:
             t = stim.target_z(t)
         else:
-            raise NotImplementedError(f"{obs=!r}")
+            raise NotImplementedError(f"obs={obs!r}")
         new_targets.append(t)
         new_targets.append(stim.target_combiner())
     new_targets.pop()
@@ -284,7 +284,7 @@ def _stim_append_pauli_measurement_gate(circuit: stim.Circuit, gate: cirq.PauliM
         new_targets[0] |= stim.target_inv(new_targets[0])
         pass
     elif obs.coefficient != 1:
-        raise NotImplementedError(f"{obs.coefficient=!r} not in [1, -1]")
+        raise NotImplementedError(f"obs.coefficient={obs.coefficient!r} not in [1, -1]")
 
     circuit.append_operation("MPP",  new_targets)
 

--- a/glue/cirq/stimcirq/_det_annotation.py
+++ b/glue/cirq/stimcirq/_det_annotation.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, Dict, Iterable, List, Tuple
 
 import cirq
@@ -29,7 +27,7 @@ class DetAnnotation(cirq.Operation):
     def qubits(self) -> Tuple[cirq.Qid, ...]:
         return ()
 
-    def with_qubits(self, *new_qubits) -> DetAnnotation:
+    def with_qubits(self, *new_qubits) -> 'DetAnnotation':
         return self
 
     def _value_equality_values_(self) -> Any:
@@ -42,7 +40,7 @@ class DetAnnotation(cirq.Operation):
     @classmethod
     def _from_json_helper(
         cls, parity_keys: List[str], coordinate_metadata: List[float]
-    ) -> DetAnnotation:
+    ) -> 'DetAnnotation':
         return DetAnnotation(*parity_keys, coordinate_metadata=coordinate_metadata)
 
     def _json_dict_(self) -> Dict[str, Any]:

--- a/glue/cirq/stimcirq/_det_annotation.py
+++ b/glue/cirq/stimcirq/_det_annotation.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Tuple
+
+import cirq
+import stim
+
+
+@cirq.value_equality
+class DetAnnotation(cirq.Operation):
+    """Annotates that a particular combination of measurements is deterministic.
+
+    Creates a DETECTOR operation when converting to a stim circuit.
+    """
+
+    def __init__(self, *parity_keys: str, coordinate_metadata: Iterable[float] = ()):
+        """
+
+        Args:
+            parity_keys: The keys of some measurements with the property that their parity is always
+                the same under noiseless execution of the circuit.
+            coordinate_metadata: An optional location for the detector. This has no effect on the
+                function of the circuit, but can be used by plotting tools.
+        """
+        self.parity_keys = frozenset(parity_keys)
+        self.coordinate_metadata = tuple(coordinate_metadata)
+
+    @property
+    def qubits(self) -> Tuple[cirq.Qid, ...]:
+        return ()
+
+    def with_qubits(self, *new_qubits) -> DetAnnotation:
+        return self
+
+    def _value_equality_values_(self) -> Any:
+        return self.parity_keys, self.coordinate_metadata
+
+    def _circuit_diagram_info_(self, args: Any) -> str:
+        k = ",".join(repr(e) for e in sorted(self.parity_keys))
+        return f"Det({k})"
+
+    @classmethod
+    def _from_json_helper(
+        cls, parity_keys: List[str], coordinate_metadata: List[float]
+    ) -> DetAnnotation:
+        return DetAnnotation(*parity_keys, coordinate_metadata=coordinate_metadata)
+
+    def _json_dict_(self) -> Dict[str, Any]:
+        return {
+            'cirq_type': self.__class__.__name__,
+            'parity_keys': sorted(self.parity_keys),
+            'coordinate_metadata': self.coordinate_metadata,
+        }
+
+    def __repr__(self) -> str:
+        k = ", ".join(repr(e) for e in sorted(self.parity_keys))
+        return f'stimcirq.DetAnnotation({k}, coordinate_metadata={self.coordinate_metadata!r})'
+
+    def _decompose_(self):
+        return []
+
+    def _is_comment_(self) -> bool:
+        return True
+
+    def _stim_conversion_(
+        self,
+        edit_circuit: stim.Circuit,
+        edit_measurement_key_lengths: List[Tuple[str, int]],
+        **kwargs,
+    ):
+        # Ideally these references would all be resolved ahead of time, to avoid the redundant
+        # linear search overhead and also to avoid the detectors and measurements being interleaved
+        # instead of grouped (grouping measurements is helpful for stabilizer simulation). But that
+        # didn't happen and this is the context we're called in and we're going to make it work.
+
+        # Find indices of measurement record targets.
+        remaining = set(self.parity_keys)
+        rec_targets = []
+        for offset in range(len(edit_measurement_key_lengths)):
+            m_key, m_len = edit_measurement_key_lengths[-1 - offset]
+            if m_len != 1:
+                raise NotImplementedError(f"multi-qubit measurement {m_key!r}")
+            if m_key in remaining:
+                remaining.discard(m_key)
+                rec_targets.append(stim.target_rec(-1 - offset))
+                if not remaining:
+                    break
+        if remaining:
+            raise ValueError(
+                f"{self!r} was processed before measurements it referenced ({sorted(remaining)!r})."
+                f" Make sure the referenced measurements keys are actually in the circuit, and come"
+                f" in an earlier moment (or earlier in the same moment's operation order)."
+            )
+
+        edit_circuit.append_operation("DETECTOR", rec_targets, self.coordinate_metadata)

--- a/glue/cirq/stimcirq/_det_annotation_test.py
+++ b/glue/cirq/stimcirq/_det_annotation_test.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import cirq
 import numpy as np
 import pytest

--- a/glue/cirq/stimcirq/_det_annotation_test.py
+++ b/glue/cirq/stimcirq/_det_annotation_test.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import cirq
+import numpy as np
+import pytest
+import stim
+import stimcirq
+
+
+def test_stim_conversion():
+    a, b, c = cirq.LineQubit.range(3)
+
+    with pytest.raises(ValueError, match="earlier"):
+        stimcirq.cirq_circuit_to_stim_circuit(cirq.Circuit(cirq.Moment(stimcirq.DetAnnotation("unknown"))))
+    with pytest.raises(ValueError, match="earlier"):
+        stimcirq.cirq_circuit_to_stim_circuit(
+            cirq.Circuit(cirq.Moment(stimcirq.DetAnnotation("later"), cirq.measure(b, key="later")))
+        )
+    with pytest.raises(ValueError, match="earlier"):
+        stimcirq.cirq_circuit_to_stim_circuit(
+            cirq.Circuit(
+                cirq.Moment(stimcirq.DetAnnotation("later")), cirq.Moment(cirq.measure(b, key="later"))
+            )
+        )
+    assert stimcirq.cirq_circuit_to_stim_circuit(
+        cirq.Circuit(
+            cirq.Moment(cirq.measure(b, key="earlier")), cirq.Moment(stimcirq.DetAnnotation("earlier"))
+        )
+    ) == stim.Circuit(
+        """
+        QUBIT_COORDS(1) 0
+        M 0
+        TICK
+        DETECTOR rec[-1]
+        TICK
+    """
+    )
+    assert stimcirq.cirq_circuit_to_stim_circuit(
+        cirq.Circuit(cirq.Moment(cirq.measure(b, key="earlier"), stimcirq.DetAnnotation("earlier")))
+    ) == stim.Circuit(
+        """
+        QUBIT_COORDS(1) 0
+        M 0
+        DETECTOR rec[-1]
+        TICK
+    """
+    )
+
+    assert stimcirq.cirq_circuit_to_stim_circuit(
+        cirq.Circuit(
+            cirq.Moment(cirq.measure(a, key="a"), cirq.measure(b, key="b")),
+            cirq.Moment(stimcirq.DetAnnotation("a", "b", coordinate_metadata=(1, 2, 3.5))),
+        )
+    ) == stim.Circuit(
+        """
+        M 0 1
+        TICK
+        DETECTOR(1, 2, 3.5) rec[-1] rec[-2]
+        TICK
+    """
+    )
+
+    assert stimcirq.cirq_circuit_to_stim_circuit(
+        cirq.Circuit(
+            cirq.H(a),
+            cirq.CNOT(a, b),
+            cirq.CNOT(a, c),
+            cirq.Moment(
+                cirq.measure(a, key="a"),
+                cirq.measure(b, key="b"),
+                stimcirq.DetAnnotation("a", "b"),
+                cirq.measure(c, key="c"),
+                stimcirq.DetAnnotation("a", "c"),
+            ),
+        )
+    ) == stim.Circuit(
+        """
+        H 0
+        TICK
+        CNOT 0 1
+        TICK
+        CNOT 0 2
+        TICK
+        M 0 1
+        DETECTOR rec[-1] rec[-2]
+        M 2
+        DETECTOR rec[-1] rec[-3]
+        TICK
+    """
+    )
+
+
+def test_simulation():
+    a = cirq.LineQubit(0)
+    s = cirq.Simulator().sample(
+        cirq.Circuit(cirq.X(a), cirq.measure(a, key="a"), stimcirq.DetAnnotation("a")), repetitions=3
+    )
+    np.testing.assert_array_equal(s["a"], [1, 1, 1])
+
+
+def test_diagram():
+    a, b = cirq.LineQubit.range(2)
+    cirq.testing.assert_has_diagram(
+        cirq.Circuit(cirq.measure(a, key="a"), cirq.measure(b, key="b"), stimcirq.DetAnnotation("a", "b")),
+        """
+0: ───M('a')─────────
+
+1: ───M('b')─────────
+      Det('a','b')
+    """,
+    )
+
+
+def test_repr():
+    val = stimcirq.DetAnnotation("a", "b", coordinate_metadata=(1, 2))
+    assert eval(repr(val), {"stimcirq": stimcirq}) == val
+
+
+def test_equality():
+    eq = cirq.testing.EqualsTester()
+    eq.add_equality_group(stimcirq.DetAnnotation(), stimcirq.DetAnnotation())
+    eq.add_equality_group(stimcirq.DetAnnotation("a"))
+    eq.add_equality_group(
+        stimcirq.DetAnnotation("a", coordinate_metadata=[1, 2]),
+        stimcirq.DetAnnotation("a", coordinate_metadata=(1, 2)),
+    )
+    eq.add_equality_group(stimcirq.DetAnnotation("a", coordinate_metadata=(2, 1)))
+    eq.add_equality_group(stimcirq.DetAnnotation("b"))
+    eq.add_equality_group(stimcirq.DetAnnotation("a", "b"), stimcirq.DetAnnotation("b", "a"))
+
+
+def test_json_serialization():
+    c = cirq.Circuit(
+        stimcirq.DetAnnotation("a", "b"),
+        stimcirq.DetAnnotation(coordinate_metadata=(1, 2)),
+        stimcirq.DetAnnotation("d", "c", coordinate_metadata=(1, 2, 3)),
+    )
+    json = cirq.to_json(c)
+    c2 = cirq.read_json(
+        json_text=json,
+        resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER])
+    assert c == c2

--- a/glue/cirq/stimcirq/_measure_and_or_reset_gate.py
+++ b/glue/cirq/stimcirq/_measure_and_or_reset_gate.py
@@ -1,0 +1,121 @@
+from typing import List, Dict, Any
+
+import cirq
+import stim
+
+
+@cirq.value_equality
+class MeasureAndOrResetGate(cirq.SingleQubitGate):
+    def __init__(self, measure: bool, reset: bool, basis: str, invert_measure: bool, key: str, measure_flip_probability: float = 0):
+        self.measure = measure
+        self.reset = reset
+        self.basis = basis
+        self.invert_measure = invert_measure
+        self.key = key
+        self.measure_flip_probability = measure_flip_probability
+
+    def resolve(self,
+                target: cirq.Qid,
+                ) -> cirq.Operation:
+        if self.basis == 'Z' and self.measure and self.measure_flip_probability == 0 and not self.reset:
+            return cirq.MeasurementGate(
+                num_qubits=1,
+                key=self.key,
+                invert_mask=(1,) if self.invert_measure else (),
+            ).on(target)
+
+        return MeasureAndOrResetGate(
+            measure=self.measure,
+            reset=self.reset,
+            basis=self.basis,
+            invert_measure=self.invert_measure,
+            key=self.key,
+            measure_flip_probability=self.measure_flip_probability
+        ).on(target)
+
+    def _value_equality_values_(self):
+        return self.measure, self.reset, self.basis, self.invert_measure, self.key, self.measure_flip_probability
+
+    def _decompose_(self, qubits):
+        q, = qubits
+        if self.measure:
+            if self.basis == 'X':
+                yield cirq.H(q)
+            elif self.basis == 'Y':
+                yield cirq.X(q)**0.5
+            if self.measure_flip_probability:
+                raise NotImplementedError("Noisy measurement as a cirq operation.")
+            else:
+                yield cirq.measure(q, key=self.key, invert_mask=(True,) if self.invert_measure else ())
+        if self.reset:
+            yield cirq.ResetChannel().on(q)
+        if self.measure or self.reset:
+            if self.basis == 'X':
+                yield cirq.H(q)
+            elif self.basis == 'Y':
+                yield cirq.X(q)**-0.5
+
+    def _stim_op_name(self) -> str:
+        result = ''
+        if self.measure:
+            result += "M"
+        if self.reset:
+            result += "R"
+        if self.basis != 'Z':
+            result += self.basis
+        return result
+
+    def _stim_conversion_(
+            self,
+            edit_circuit: stim.Circuit,
+            targets: List[int],
+            **kwargs):
+        if self.invert_measure:
+            targets[0] = stim.target_inv(targets[0])
+        if self.measure_flip_probability:
+            edit_circuit.append_operation(self._stim_op_name(), targets, self.measure_flip_probability)
+        else:
+            edit_circuit.append_operation(self._stim_op_name(), targets)
+
+    def __str__(self) -> str:
+        result = self._stim_op_name()
+        if self.invert_measure:
+            result = "!" + result
+        if self.measure:
+            result += f"('{self.key}')"
+        if self.measure_flip_probability:
+            result += f"^{self.measure_flip_probability:%}"
+        return result
+
+    def __repr__(self):
+        return (f'stimcirq.MeasureAndOrResetGate('
+                f'measure={self.measure!r}, '
+                f'reset={self.reset!r}, '
+                f'basis={self.basis!r}, '
+                f'invert_measure={self.invert_measure!r}, '
+                f'key={self.key!r}, '
+                f'measure_flip_probability={self.measure_flip_probability!r})')
+
+    @classmethod
+    def _from_json_helper(
+        cls, measure: bool, reset: bool, basis: str, invert_measure: bool, key: str, measure_flip_probability: float,
+    ) -> 'MeasureAndOrResetGate':
+        return MeasureAndOrResetGate(
+            measure=measure,
+            reset=reset,
+            basis=basis,
+            invert_measure=invert_measure,
+            key=key,
+            measure_flip_probability=measure_flip_probability,
+        )
+
+    def _json_dict_(self) -> Dict[str, Any]:
+        return {
+            'cirq_type': self.__class__.__name__,
+            'measure': self.measure,
+            'reset': self.reset,
+            'basis': self.basis,
+            'invert_measure': self.invert_measure,
+            'key': self.key,
+            'measure_flip_probability': self.measure_flip_probability,
+        }

--- a/glue/cirq/stimcirq/_measure_and_or_reset_gate.py
+++ b/glue/cirq/stimcirq/_measure_and_or_reset_gate.py
@@ -6,6 +6,8 @@ import stim
 
 @cirq.value_equality
 class MeasureAndOrResetGate(cirq.SingleQubitGate):
+    """Handles explaining stim's MX/MY/MZ/MRX/MRY/MRZ/RX/RY/RZ gates to cirq."""
+
     def __init__(self, measure: bool, reset: bool, basis: str, invert_measure: bool, key: str, measure_flip_probability: float = 0):
         self.measure = measure
         self.reset = reset

--- a/glue/cirq/stimcirq/_measure_and_or_reset_gate_test.py
+++ b/glue/cirq/stimcirq/_measure_and_or_reset_gate_test.py
@@ -1,0 +1,34 @@
+import cirq
+
+import stimcirq
+
+
+def test_repr():
+    r = stimcirq.MeasureAndOrResetGate(
+        measure=True,
+        reset=True,
+        basis='Y',
+        key='result',
+        invert_measure=True,
+        measure_flip_probability=0.125,
+    )
+    assert eval(repr(r), {'stimcirq': stimcirq}) == r
+
+
+def test_json_serialization():
+    r = stimcirq.MeasureAndOrResetGate(
+        measure=True,
+        reset=True,
+        basis='Y',
+        key='result',
+        invert_measure=True,
+        measure_flip_probability=0.125,
+    )
+    c = cirq.Circuit(
+        r(cirq.LineQubit(1)),
+    )
+    json = cirq.to_json(c)
+    c2 = cirq.read_json(
+        json_text=json,
+        resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER])
+    assert c == c2

--- a/glue/cirq/stimcirq/_obs_annotation.py
+++ b/glue/cirq/stimcirq/_obs_annotation.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, Dict, List, Tuple
 
 import cirq
@@ -27,7 +25,7 @@ class CumulativeObservableAnnotation(cirq.Operation):
     def qubits(self) -> Tuple[cirq.Qid, ...]:
         return ()
 
-    def with_qubits(self, *new_qubits) -> CumulativeObservableAnnotation:
+    def with_qubits(self, *new_qubits) -> 'CumulativeObservableAnnotation':
         return self
 
     def _value_equality_values_(self) -> Any:
@@ -44,7 +42,7 @@ class CumulativeObservableAnnotation(cirq.Operation):
     @classmethod
     def _from_json_helper(
         cls, parity_keys: List[str], observable_index: int
-    ) -> CumulativeObservableAnnotation:
+    ) -> 'CumulativeObservableAnnotation':
         return CumulativeObservableAnnotation(*parity_keys, observable_index=observable_index)
 
     def _json_dict_(self) -> Dict[str, Any]:

--- a/glue/cirq/stimcirq/_obs_annotation.py
+++ b/glue/cirq/stimcirq/_obs_annotation.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+import cirq
+import stim
+
+
+@cirq.value_equality
+class CumulativeObservableAnnotation(cirq.Operation):
+    """Annotates that a particular combination of measurements is part of a logical observable.
+
+    Creates an OBSERVABLE_INCLUDE operation when converting to a stim circuit.
+    """
+
+    def __init__(self, *parity_keys: str, observable_index: int):
+        """
+
+        Args:
+            parity_keys: The keys of some measurements to include in the logical observable.
+            observable_index: A unique index for the logical observable.
+        """
+        self.parity_keys = frozenset(parity_keys)
+        self.observable_index = observable_index
+
+    @property
+    def qubits(self) -> Tuple[cirq.Qid, ...]:
+        return ()
+
+    def with_qubits(self, *new_qubits) -> CumulativeObservableAnnotation:
+        return self
+
+    def _value_equality_values_(self) -> Any:
+        return self.parity_keys, self.observable_index
+
+    def _circuit_diagram_info_(self, args: Any) -> str:
+        k = ",".join(repr(e) for e in sorted(self.parity_keys))
+        return f"Obs{self.observable_index}({k})"
+
+    def __repr__(self) -> str:
+        k = ", ".join(repr(e) for e in sorted(self.parity_keys))
+        return f'stimcirq.CumulativeObservableAnnotation({k}, observable_index={self.observable_index!r})'
+
+    @classmethod
+    def _from_json_helper(
+        cls, parity_keys: List[str], observable_index: int
+    ) -> CumulativeObservableAnnotation:
+        return CumulativeObservableAnnotation(*parity_keys, observable_index=observable_index)
+
+    def _json_dict_(self) -> Dict[str, Any]:
+        return {
+            'cirq_type': self.__class__.__name__,
+            'parity_keys': sorted(self.parity_keys),
+            'observable_index': self.observable_index,
+        }
+
+    def _decompose_(self):
+        return []
+
+    def _is_comment_(self) -> bool:
+        return True
+
+    def _stim_conversion_(
+        self,
+        edit_circuit: stim.Circuit,
+        edit_measurement_key_lengths: List[Tuple[str, int]],
+        **kwargs,
+    ):
+        # Ideally these references would all be resolved ahead of time, to avoid the redundant
+        # linear search overhead and also to avoid the detectors and measurements being interleaved
+        # instead of grouped (grouping measurements is helpful for stabilizer simulation). But that
+        # didn't happen and this is the context we're called in and we're going to make it work.
+
+        # Find indices of measurement record targets.
+        remaining = set(self.parity_keys)
+        rec_targets = []
+        for offset in range(len(edit_measurement_key_lengths)):
+            m_key, m_len = edit_measurement_key_lengths[-1 - offset]
+            if m_len != 1:
+                raise NotImplementedError(f"multi-qubit measurement {m_key!r}")
+            if m_key in remaining:
+                remaining.discard(m_key)
+                rec_targets.append(stim.target_rec(-1 - offset))
+                if not remaining:
+                    break
+        if remaining:
+            raise ValueError(
+                f"{self!r} was processed before measurements it referenced ({sorted(remaining)!r})."
+                f" Make sure the referenced measurements keys are actually in the circuit, and come"
+                f" in an earlier moment (or earlier in the same moment's operation order)."
+            )
+
+        edit_circuit.append_operation("OBSERVABLE_INCLUDE", rec_targets, self.observable_index)

--- a/glue/cirq/stimcirq/_obs_annotation_test.py
+++ b/glue/cirq/stimcirq/_obs_annotation_test.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import cirq
 import numpy as np
 import pytest

--- a/glue/cirq/stimcirq/_obs_annotation_test.py
+++ b/glue/cirq/stimcirq/_obs_annotation_test.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import cirq
+import numpy as np
+import pytest
+import stim
+import stimcirq
+
+
+def test_stim_conversion():
+    a, b, c = cirq.LineQubit.range(3)
+
+    with pytest.raises(ValueError, match="earlier"):
+        stimcirq.cirq_circuit_to_stim_circuit(
+            cirq.Circuit(cirq.Moment(stimcirq.CumulativeObservableAnnotation("unknown", observable_index=0)))
+        )
+    with pytest.raises(ValueError, match="earlier"):
+        stimcirq.cirq_circuit_to_stim_circuit(
+            cirq.Circuit(
+                cirq.Moment(
+                    stimcirq.CumulativeObservableAnnotation("later", observable_index=0),
+                    cirq.measure(b, key="later"),
+                )
+            )
+        )
+    with pytest.raises(ValueError, match="earlier"):
+        stimcirq.cirq_circuit_to_stim_circuit(
+            cirq.Circuit(
+                cirq.Moment(stimcirq.CumulativeObservableAnnotation("later", observable_index=0)),
+                cirq.Moment(cirq.measure(b, key="later")),
+            )
+        )
+    assert stimcirq.cirq_circuit_to_stim_circuit(
+        cirq.Circuit(
+            cirq.Moment(cirq.measure(b, key="earlier")),
+            cirq.Moment(stimcirq.CumulativeObservableAnnotation("earlier", observable_index=0)),
+        )
+    ) == stim.Circuit(
+        """
+        QUBIT_COORDS(1) 0
+        M 0
+        TICK
+        OBSERVABLE_INCLUDE(0) rec[-1]
+        TICK
+    """
+    )
+    assert stimcirq.cirq_circuit_to_stim_circuit(
+        cirq.Circuit(
+            cirq.Moment(
+                cirq.measure(b, key="earlier"),
+                stimcirq.CumulativeObservableAnnotation("earlier", observable_index=0),
+            )
+        )
+    ) == stim.Circuit(
+        """
+        QUBIT_COORDS(1) 0
+        M 0
+        OBSERVABLE_INCLUDE(0) rec[-1]
+        TICK
+    """
+    )
+
+    assert stimcirq.cirq_circuit_to_stim_circuit(
+        cirq.Circuit(
+            cirq.Moment(cirq.measure(a, key="a"), cirq.measure(b, key="b")),
+            cirq.Moment(stimcirq.CumulativeObservableAnnotation("a", "b", observable_index=2)),
+        )
+    ) == stim.Circuit(
+        """
+        M 0 1
+        TICK
+        OBSERVABLE_INCLUDE(2) rec[-1] rec[-2]
+        TICK
+    """
+    )
+
+    assert stimcirq.cirq_circuit_to_stim_circuit(
+        cirq.Circuit(
+            cirq.H(a),
+            cirq.CNOT(a, b),
+            cirq.CNOT(a, c),
+            cirq.Moment(
+                cirq.measure(a, key="a"),
+                cirq.measure(b, key="b"),
+                stimcirq.CumulativeObservableAnnotation("a", "b", observable_index=0),
+                cirq.measure(c, key="c"),
+                stimcirq.CumulativeObservableAnnotation("a", "c", observable_index=0),
+            ),
+        )
+    ) == stim.Circuit(
+        """
+        H 0
+        TICK
+        CNOT 0 1
+        TICK
+        CNOT 0 2
+        TICK
+        M 0 1
+        OBSERVABLE_INCLUDE(0) rec[-1] rec[-2]
+        M 2
+        OBSERVABLE_INCLUDE(0) rec[-1] rec[-3]
+        TICK
+    """
+    )
+
+
+def test_simulation():
+    a = cirq.LineQubit(0)
+    s = cirq.Simulator().sample(
+        cirq.Circuit(
+            cirq.X(a),
+            cirq.measure(a, key="a"),
+            stimcirq.CumulativeObservableAnnotation("a", observable_index=0),
+        ),
+        repetitions=3,
+    )
+    np.testing.assert_array_equal(s["a"], [1, 1, 1])
+
+
+def test_diagram():
+    a, b = cirq.LineQubit.range(2)
+    cirq.testing.assert_has_diagram(
+        cirq.Circuit(
+            cirq.measure(a, key="a"),
+            cirq.measure(b, key="b"),
+            stimcirq.CumulativeObservableAnnotation("a", "b", observable_index=2),
+        ),
+        """
+0: ───M('a')──────────
+
+1: ───M('b')──────────
+      Obs2('a','b')
+    """,
+    )
+
+
+def test_repr():
+    val = stimcirq.CumulativeObservableAnnotation("a", "b", observable_index=2)
+    assert eval(repr(val), {"stimcirq": stimcirq}) == val
+
+
+def test_equality():
+    eq = cirq.testing.EqualsTester()
+    eq.add_equality_group(
+        stimcirq.CumulativeObservableAnnotation(observable_index=0),
+        stimcirq.CumulativeObservableAnnotation(observable_index=0),
+    )
+    eq.add_equality_group(stimcirq.CumulativeObservableAnnotation(observable_index=1))
+    eq.add_equality_group(stimcirq.CumulativeObservableAnnotation("a", observable_index=0))
+    eq.add_equality_group(stimcirq.CumulativeObservableAnnotation("a", observable_index=1))
+    eq.add_equality_group(stimcirq.CumulativeObservableAnnotation("b", observable_index=0))
+    eq.add_equality_group(
+        stimcirq.CumulativeObservableAnnotation("a", "b", observable_index=0),
+        stimcirq.CumulativeObservableAnnotation("b", "a", observable_index=0),
+    )
+
+
+def test_json_serialization():
+    c = cirq.Circuit(
+        stimcirq.CumulativeObservableAnnotation("a", "b", observable_index=5),
+        stimcirq.CumulativeObservableAnnotation(observable_index=2),
+        stimcirq.CumulativeObservableAnnotation("d", "c", observable_index=5),
+    )
+    json = cirq.to_json(c)
+    c2 = cirq.read_json(
+        json_text=json,
+        resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER])
+    assert c == c2

--- a/glue/cirq/stimcirq/_stim_to_cirq.py
+++ b/glue/cirq/stimcirq/_stim_to_cirq.py
@@ -23,7 +23,7 @@ def _stim_targets_to_dense_pauli_string(targets: List[stim.GateTarget]) -> cirq.
         elif target.is_z_target:
             obs.pauli_mask[k] = 3
         else:
-            raise NotImplementedError(f"{target=!r}")
+            raise NotImplementedError(f"target={target!r}")
     return obs.frozen()
 
 
@@ -46,7 +46,7 @@ class CircuitTranslationTracker:
         targets: List[stim.GateTarget] = instruction.targets_copy()
         m = cirq.num_qubits(gate)
         if not all(t.is_qubit_target for t in targets) or len(targets) % m != 0:
-            raise NotImplementedError(f"{instruction=!r}")
+            raise NotImplementedError(f"instruction={instruction!r}")
         for k in range(0, len(targets), m):
             self.append_operation(gate(*[cirq.LineQubit(t.value) for t in targets[k:k+m]]))
 
@@ -57,7 +57,7 @@ class CircuitTranslationTracker:
     def process_pauli_channel_1(self, instruction: stim.CircuitInstruction) -> None:
         args = instruction.gate_args_copy()
         if len(args) != 3:
-            raise ValueError(f"len({args=!r}) != 3")
+            raise ValueError(f"len(args={args!r}) != 3")
         self.process_gate_instruction(
             cirq.AsymmetricDepolarizingChannel(p_x=args[0], p_y=args[1], p_z=args[2]),
             instruction)
@@ -65,7 +65,7 @@ class CircuitTranslationTracker:
     def process_pauli_channel_2(self, instruction: stim.CircuitInstruction) -> None:
         args = instruction.gate_args_copy()
         if len(args) != 15:
-            raise ValueError(f"len({args=!r}) != 15")
+            raise ValueError(f"len(args={args!r}) != 15")
         self.process_gate_instruction(
             TwoQubitAsymmetricDepolarizingChannel(args),
             instruction)
@@ -83,7 +83,7 @@ class CircuitTranslationTracker:
         targets: List[stim.GateTarget] = instruction.targets_copy()
         for t in targets:
             if not t.is_qubit_target:
-                raise NotImplementedError(f"{instruction=!r}")
+                raise NotImplementedError(f"instruction={instruction!r}")
             key = str(self.get_next_measure_id())
             self.append_operation(
                 MeasureAndOrResetGate(
@@ -110,7 +110,7 @@ class CircuitTranslationTracker:
                 elif isinstance(instruction, stim.CircuitRepeatBlock):
                     self.process_circuit(instruction.repeat_count, instruction.body_copy())
                 else:
-                    raise NotImplementedError(f"{instruction=!r}")
+                    raise NotImplementedError(f"instruction={instruction!r}")
 
     def output(self) -> cirq.Circuit:
         out = self.full_circuit + self.tick_circuit

--- a/glue/cirq/stimcirq/_two_qubit_asymmetric_depolarize.py
+++ b/glue/cirq/stimcirq/_two_qubit_asymmetric_depolarize.py
@@ -1,0 +1,68 @@
+from typing import List, Sequence, Dict, Any, Tuple
+
+import cirq
+import stim
+
+
+@cirq.value_equality
+class TwoQubitAsymmetricDepolarizingChannel(cirq.Gate):
+    """A two qubit error channel that applies Pauli pairs according to the given probability distribution.
+
+    The 15 probabilities are in IX, IY, ... ZY, ZZ order. II is skipped; it's the leftover.
+    """
+    def __init__(self, probabilities: Sequence[float]):
+        if len(probabilities) != 15:
+            raise ValueError(f"len({probabilities=}) != 15")
+        if sum(probabilities) > 1.000001:
+            raise ValueError(f"sum({probabilities=}) > 1")
+        self.probabilities = tuple(probabilities)
+
+    def _num_qubits_(self):
+        return 2
+
+    def _value_equality_values_(self):
+        return self.probabilities
+
+    def _has_mixture_(self):
+        return True
+
+    def _dense_mixture_(self):
+        result = [(1 - sum(self.probabilities), cirq.DensePauliString([0, 0]))]
+        result.extend([
+            (p, cirq.DensePauliString([((k + 1) >> 2) & 3, (k + 1) & 3]))
+            for k, p in enumerate(self.probabilities)
+        ])
+        return [(p, g) for p, g in result if p]
+
+    def _mixture_(self):
+        return [(p, cirq.unitary(g)) for p, g in self._dense_mixture_()]
+
+    def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs):
+        result = []
+        for p, d in self._dense_mixture_():
+            result.append(str(d)[1:] + ":" + args.format_real(p))
+        return "PauliMix(" + ",".join(result) + ")", "#2"
+
+    def _stim_conversion_(
+            self,
+            edit_circuit: stim.Circuit,
+            targets: List[int],
+            **kwargs):
+        edit_circuit.append_operation("PAULI_CHANNEL_2", targets, self.probabilities)
+
+    def __repr__(self):
+        return f"stimcirq.TwoQubitAsymmetricDepolarizingChannel({self.probabilities!r})"
+
+    @classmethod
+    def _from_json_helper(
+        cls, probabilities: List[float],
+    ) -> 'TwoQubitAsymmetricDepolarizingChannel':
+        return TwoQubitAsymmetricDepolarizingChannel(
+            probabilities=probabilities,
+        )
+
+    def _json_dict_(self) -> Dict[str, Any]:
+        return {
+            'cirq_type': self.__class__.__name__,
+            'probabilities': list(self.probabilities),
+        }

--- a/glue/cirq/stimcirq/_two_qubit_asymmetric_depolarize.py
+++ b/glue/cirq/stimcirq/_two_qubit_asymmetric_depolarize.py
@@ -12,9 +12,9 @@ class TwoQubitAsymmetricDepolarizingChannel(cirq.Gate):
     """
     def __init__(self, probabilities: Sequence[float]):
         if len(probabilities) != 15:
-            raise ValueError(f"len({probabilities=}) != 15")
+            raise ValueError(f"len(probabilities={probabilities}) != 15")
         if sum(probabilities) > 1.000001:
-            raise ValueError(f"sum({probabilities=}) > 1")
+            raise ValueError(f"sum(probabilities={probabilities}) > 1")
         self.probabilities = tuple(probabilities)
 
     def _num_qubits_(self):

--- a/glue/cirq/stimcirq/_two_qubit_asymmetric_depolarize_test.py
+++ b/glue/cirq/stimcirq/_two_qubit_asymmetric_depolarize_test.py
@@ -1,0 +1,39 @@
+import cirq
+
+import stimcirq
+
+
+def test_mixture():
+    r = stimcirq.TwoQubitAsymmetricDepolarizingChannel([0.125, 0, 0, 0, 0, 0, 0.375, 0, 0, 0, 0, 0, 0, 0.25, 0])
+    assert r._dense_mixture_() == [
+        (0.25, cirq.DensePauliString("II")),
+        (0.125, cirq.DensePauliString("IX")),
+        (0.375, cirq.DensePauliString("XZ")),
+        (0.25, cirq.DensePauliString("ZY")),
+    ]
+
+
+def test_diagram():
+    r = stimcirq.TwoQubitAsymmetricDepolarizingChannel([0.125, 0, 0, 0, 0, 0, 0.375, 0, 0, 0, 0, 0, 0, 0.25, 0])
+    cirq.testing.assert_has_diagram(cirq.Circuit(r.on(*cirq.LineQubit.range(2))), """
+0: ───PauliMix(II:0.25,IX:0.125,XZ:0.375,ZY:0.25)───
+      │
+1: ───#2────────────────────────────────────────────
+    """)
+
+
+def test_repr():
+    r = stimcirq.TwoQubitAsymmetricDepolarizingChannel([0.125, 0, 0, 0, 0, 0, 0.375, 0, 0, 0, 0, 0, 0, 0.25, 0])
+    assert eval(repr(r), {'stimcirq': stimcirq}) == r
+
+
+def test_json_serialization():
+    r = stimcirq.TwoQubitAsymmetricDepolarizingChannel([0.125, 0.1, 0, 0.23, 0, 0, 0.375, 0, 0, 0, 0, 0, 0, 0.25, 0])
+    c = cirq.Circuit(
+        r(cirq.LineQubit(0), cirq.LineQubit(1)),
+    )
+    json = cirq.to_json(c)
+    c2 = cirq.read_json(
+        json_text=json,
+        resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER])
+    assert c == c2

--- a/glue/cirq/stimcirq/_two_qubit_asymmetric_depolarize_test.py
+++ b/glue/cirq/stimcirq/_two_qubit_asymmetric_depolarize_test.py
@@ -28,7 +28,9 @@ def test_repr():
 
 
 def test_json_serialization():
-    r = stimcirq.TwoQubitAsymmetricDepolarizingChannel([0.125, 0.1, 0, 0.23, 0, 0, 0.375, 0, 0, 0, 0, 0, 0, 0.25, 0])
+    r = stimcirq.TwoQubitAsymmetricDepolarizingChannel([
+        0.0125, 0.1, 0, 0.23, 0, 0, 0.0375, 0, 0, 0, 0, 0, 0, 0.25, 0
+    ])
     c = cirq.Circuit(
         r(cirq.LineQubit(0), cirq.LineQubit(1)),
     )

--- a/src/stim/circuit/circuit_gate_target.pybind.cc
+++ b/src/stim/circuit/circuit_gate_target.pybind.cc
@@ -139,6 +139,10 @@ void pybind_circuit_gate_target(pybind11::module &m) {
 
     c.def(pybind11::self == pybind11::self, "Determines if two `stim.GateTarget`s are identical.");
     c.def(pybind11::self != pybind11::self, "Determines if two `stim.GateTarget`s are different.");
+    c.def("__hash__",
+          [](const GateTarget &self){
+              return pybind11::hash(pybind11::make_tuple("GateTarget", self.data));
+          });
     c.def(
         "__repr__",
         &GateTarget::repr,

--- a/src/stim/circuit/circuit_gate_target_pybind_test.py
+++ b/src/stim/circuit/circuit_gate_target_pybind_test.py
@@ -118,3 +118,11 @@ def test_properties():
 def test_repr(value):
     assert eval(repr(value), {'stim': stim}) == value
     assert repr(eval(repr(value), {'stim': stim})) == repr(value)
+
+
+def test_hashable():
+    a = stim.GateTarget(5)
+    b = stim.GateTarget(6)
+    c = stim.GateTarget(5)
+    assert hash(a) == hash(c)
+    assert len({a, b, c}) == 2

--- a/src/stim/circuit/circuit_instruction.pybind.cc
+++ b/src/stim/circuit/circuit_instruction.pybind.cc
@@ -55,7 +55,7 @@ std::string CircuitInstruction::repr() const {
     return result.str();
 }
 
-std::string CircuitInstruction::str() {
+std::string CircuitInstruction::str() const {
     std::stringstream result;
     result << Operation{&gate, {gate_args, targets}};
     return result.str();
@@ -157,4 +157,9 @@ void pybind_circuit_instruction(pybind11::module &m) {
         "__str__",
         &CircuitInstruction::str,
         "Returns a text description of the instruction as a stim circuit file line.");
+
+    c.def("__hash__",
+          [](const CircuitInstruction &self){
+              return pybind11::hash(pybind11::str(self.str()));
+          });
 }

--- a/src/stim/circuit/circuit_instruction.pybind.h
+++ b/src/stim/circuit/circuit_instruction.pybind.h
@@ -40,7 +40,7 @@ struct CircuitInstruction {
     bool operator!=(const CircuitInstruction &other) const;
 
     std::string repr() const;
-    std::string str();
+    std::string str() const;
 };
 
 #endif

--- a/src/stim/circuit/circuit_instruction_pybind_test.py
+++ b/src/stim/circuit/circuit_instruction_pybind_test.py
@@ -42,3 +42,11 @@ def test_repr(value):
 
 def test_str():
     assert str(stim.CircuitInstruction("X_ERROR", [stim.GateTarget(5)], [0.5])) == "X_ERROR(0.5) 5"
+
+
+def test_hashable():
+    a = stim.CircuitInstruction("X_ERROR", [stim.GateTarget(5)], [0.5])
+    b = stim.CircuitInstruction("DEPOLARIZE1", [stim.GateTarget(5)], [0.5])
+    c = stim.CircuitInstruction("X_ERROR", [stim.GateTarget(5)], [0.5])
+    assert hash(a) == hash(c)
+    assert len({a, b, c}) == 2

--- a/src/stim/dem/detector_error_model_instruction.pybind.cc
+++ b/src/stim/dem/detector_error_model_instruction.pybind.cc
@@ -197,4 +197,9 @@ void pybind_detector_error_model_instruction(pybind11::module &m) {
         "__repr__",
         &ExposedDemInstruction::repr,
         "Returns text that is a valid python expression evaluating to an equivalent `stim.DetectorErrorModel`.");
+
+    c.def("__hash__",
+          [](const ExposedDemInstruction &self){
+              return pybind11::hash(pybind11::str(self.str()));
+          });
 }

--- a/src/stim/dem/detector_error_model_instruction_pybind_test.py
+++ b/src/stim/dem/detector_error_model_instruction_pybind_test.py
@@ -79,3 +79,11 @@ def test_repr():
     assert eval(repr(v), {"stim": stim}) == v
     v = stim.DemInstruction("shift_detectors", [1.5, 2.5, 5.5], [6])
     assert eval(repr(v), {"stim": stim}) == v
+
+
+def test_hashable():
+    a = stim.DemInstruction("error", [0.25], [stim.target_relative_detector_id(3)])
+    b = stim.DemInstruction("error", [0.125], [stim.target_relative_detector_id(3)])
+    c = stim.DemInstruction("error", [0.25], [stim.target_relative_detector_id(3)])
+    assert hash(a) == hash(c)
+    assert len({a, b, c}) == 2

--- a/src/stim/dem/detector_error_model_target.pybind.cc
+++ b/src/stim/dem/detector_error_model_target.pybind.cc
@@ -218,6 +218,11 @@ void pybind_detector_error_model_target(pybind11::module &m) {
             Determines if the detector error model target is a separator (like "^" in a .dem file).
         )DOC")
             .data());
+
+    c.def("__hash__",
+          [](const ExposedDemTarget &self){
+              return pybind11::hash(pybind11::make_tuple("DemInstruction", self.data));
+          });
 }
 
 std::string ExposedDemTarget::repr() const {

--- a/src/stim/dem/detector_error_model_target_pybind_test.py
+++ b/src/stim/dem/detector_error_model_target_pybind_test.py
@@ -67,3 +67,11 @@ def test_static_constructors():
     assert stim.DemTarget.relative_detector_id(5) == stim.target_relative_detector_id(5)
     assert stim.DemTarget.logical_observable_id(5) == stim.target_logical_observable_id(5)
     assert stim.DemTarget.separator() == stim.target_separator()
+
+
+def test_hashable():
+    a = stim.DemTarget.relative_detector_id(3)
+    b = stim.DemTarget.logical_observable_id(5)
+    c = stim.DemTarget.relative_detector_id(3)
+    assert hash(a) == hash(c)
+    assert len({a, b, c}) == 2

--- a/src/stim/help.cc
+++ b/src/stim/help.cc
@@ -964,23 +964,19 @@ std::string generate_per_format_markdown(const FileFormatData &format_data, int 
     if (anchor) {
         out << "<a name=\"" << format_data.name << "\"></a>";
     }
-    out << "**`" << format_data.name << "`**\n";
+    out << "The `" << format_data.name << "` Format\n";
     out << format_data.help;
     out << "\n";
 
-    out << "- Sample parsing code (python):\n";
-    out.change_indent(+4);
+    out << "*Example " << format_data.name << " parsing code (python)*:\n";
     out << "```python";
     out << format_data.help_python_parse;
     out << "```\n";
-    out.change_indent(-4);
 
-    out << "- Sample saving code (python):\n";
-    out.change_indent(+4);
+    out << "*Example " << format_data.name << " saving code (python):*\n";
     out << "```python";
     out << format_data.help_python_save;
     out << "```\n";
-    out.change_indent(-4);
 
     out.flush();
     return out.settled;
@@ -991,7 +987,8 @@ std::map<std::string, std::string> generate_format_help_markdown() {
 
     std::stringstream all;
     all << "Result data formats supported by Stim\n";
-    all << "=====================================\n";
+
+    all << "\n# Index\n";
     for (const auto &kv : format_name_to_enum_map) {
         all << kv.first << "\n";
     }
@@ -1002,15 +999,38 @@ std::map<std::string, std::string> generate_format_help_markdown() {
     }
 
     all.str("");
-    all << R"MARKDOWN(# Result formats supported by Stim
+    all << R"MARKDOWN(# Introduction
 
+A *result format* is a way of representing bits from shots sampled from a circuit.
+It is some way of converting between a list-of-list-of-bits (a list-of-shots) and
+a flat string of bytes or characters.
+
+Generally, the result data formats supported by Stim are extremely minimalist.
+They do not contain metadata about which circuit was run,
+how many shots were taken,
+how many bits are in each shot,
+or even self-identifying information like a header with magic bytes.
+They produce *raw* data.
+Even details about which bits are measurements, which are detection events,
+and which are observable frame changes must be determined from context.
+
+The major driver for having multiple formats is context-dependent preferences for
+binary-vs-human-readable and dense-vs-sparse.
+For example, '`01`' is a dense text format and '`r8`' is a sparse binary format.
+Sometimes you want to be able to eyeball your data, so you want a text format.
+Other times you want maximum efficiency, so you want a binary format.
+Sometimes your data is high entropy, with as many 1s as 0s, so you use a dense format.
+Other times the data is highly biased, with 1s being much rarer and more interesting
+than 0s, so you use a sparse format.
+
+# Index
 )MARKDOWN";
     for (const auto &kv : format_name_to_enum_map) {
-        all << "- [" << kv.first << "](#" << kv.first << ")\n";
+        all << "- [The **" << kv.first << "** Format](#" << kv.first << ")\n";
     }
-    all << "\n";
+    all << "\n\n";
     for (const auto &kv : format_name_to_enum_map) {
-        all << "- " << generate_per_format_markdown(kv.second, 4, true) << "\n";
+        all << "# " << generate_per_format_markdown(kv.second, 0, true) << "\n";
     }
     result[std::string("FORMATS_MARKDOWN")] = all.str();
 

--- a/src/stim/io/stim_data_formats.cc
+++ b/src/stim/io/stim_data_formats.cc
@@ -9,14 +9,14 @@ extern const std::map<std::string, stim::FileFormatData> stim::format_name_to_en
             "01",
             SAMPLE_FORMAT_01,
             R"HELP(
-A human readable format that stores shots as lines of '0' and '1' characters.
+The 01 format is a dense human readable format that stores shots as lines of '0' and '1' characters.
 
 The data from each shot is terminated by a newline character '\n'. Each character in the line is a '0' (indicating
 False) or a '1' (indicating True) corresponding to a measurement result (or a detector result) from a circuit.
 
-This is the default format used when saving to files.
+This is the default format used by Stim, because it's the easiest to understand.
 
-Example:
+*Example of producing 01 format data using stim's python API:*
 
     >>> import pathlib
     >>> import stim
@@ -75,7 +75,7 @@ def parse_01(data: str) -> List[List[bool]]:
             "b8",
             SAMPLE_FORMAT_B8,
             R"HELP(
-A binary format that stores shots as bit-packed bytes.
+The b8 format is a dense binary format that stores shots as bit-packed bytes.
 
 Each shot is stored into ceil(n / 8) bytes, where n is the number of bits in the shot. Effectively, each shot is padded
 up to a multiple of 8 by appending False bits, so that shots always start on a byte boundary. Bits are packed into bytes
@@ -84,7 +84,7 @@ until the 128s bit which is the eighth bit).
 
 This format requires the reader to know the number of bits in each shot.
 
-Example:
+*Example of producing b8 format data using stim's python API:*
 
     >>> import pathlib
     >>> import stim
@@ -137,7 +137,7 @@ def parse_b8(data: bytes, bits_per_shot: int) -> List[List[bool]]:
             "ptb64",
             SAMPLE_FORMAT_PTB64,
             R"HELP(
-A binary format that stores shots as partially transposed bit-packed data.
+The ptb64 format is a dense SIMD-focused binary format that stores shots as partially transposed bit-packed data.
 
 Each 64 bit word (8 bytes) of the data contains bits from the same measurement result across 64 separate shots. The next
 8 bytes contain bits for the next measurement result from the 64 separate shots. This continues until the 8 bytes
@@ -154,7 +154,7 @@ This format requires the reader to know the number of shots that were taken.
 This format is generally more tedious to work with, but useful for achieving good performance on data processing tasks
 where it is possible to parallelize across shots using SIMD instructions.
 
-Example:
+*Example of producing ptb64 format data using stim's python API:*
 
     >>> import pathlib
     >>> import stim
@@ -208,7 +208,9 @@ def parse_ptb64(data: bytes, bits_per_shot: int, num_shots: int) -> List[List[bo
             "hits",
             SAMPLE_FORMAT_HITS,
             R"HELP(
-A human readable format that stores shots as a comma-separated list of integers indicating which bits were true.
+The hits format is a dense human readable format that stores shots as a comma-separated list of integers.
+Each integer indicates the position of a bit that was True.
+Positions that aren't mentioned had bits that were False.
 
 The data from each shot is terminated by a newline character '\n'. The line is a series of non-negative integers
 separated by commas, with each integer indicating a bit from the shot that was true.
@@ -220,7 +222,7 @@ the text data.
 This format is useful in contexts where the number of set bits is expected to be low, e.g. when sampling detection
 events.
 
-Example:
+*Example of producing hits format data using stim's python API:*
 
     >>> import pathlib
     >>> import stim
@@ -277,7 +279,7 @@ def parse_hits(data: str, bits_per_shot: int) -> List[List[bool]]:
             "r8",
             SAMPLE_FORMAT_R8,
             R"HELP(
-A binary format that stores shots as the length of runs between 1s.
+The r8 format is a sparse binary format that stores shots as a series of lengths of runs between 1s.
 
 Each byte in the data indicates how many False bits there are before the next True bit. The maximum byte value (255) is
 special; it indicates to include 255 False bits but not follow them by a True bit. A shot always has a terminating True
@@ -289,7 +291,7 @@ This format requires the reader to know the number of bits in each shot.
 This format is useful in contexts where the number of set bits is expected to be low, e.g. when sampling detection
 events.
 
-Example:
+*Example of producing r8 format data using stim's python API:*
 
     >>> import pathlib
     >>> import stim
@@ -359,7 +361,10 @@ def parse_r8(data: bytes, bits_per_shot: int) -> List[List[bool]]:
             "dets",
             SAMPLE_FORMAT_DETS,
             R"HELP(
-A human readable format that stores shots as lines starting with 'shot' and space-separated prefixed values like 'D5'.
+The dets format is a sparse human readable format that stores shots as lines starting with the word 'shot'
+and then containing space-separated prefixed values like 'D5' and 'L2'. Each value's prefix indicates whether
+it is a measurement (M), a detector (D), or observable frame change (L) and its integer indicates that
+the corresponding measurement/detection-event/frame-change was True instead of False.
 
 The data from each shot is started with the text 'shot' and terminated by a newline character '\n'. The rest of the
 line is a series of integers, separated by spaces and prefixed by a single letter. The prefix letter indicates the type
@@ -369,7 +374,7 @@ value. For example, "D1 D3 L0" indicates detectors 1 and 3 fired, and logical ob
 This format requires the reader to know the number of measurements/detectors/observables in each shot, if the reader
 wants to produce vectors of bits instead of sets.
 
-Example:
+*Example of producing dets format data using stim's python API:*
 
     >>> import pathlib
     >>> import stim


### PR DESCRIPTION
- Add support for converting MPP, DETECTOR, and OBSERVABLE_INCLUDE
- Add a json resolver for opt-in compatibility with cirq serialization
- Rewrite stim-to-cirq to use CircuitInstruction instead of the old flattened approach
- Move custom gates into their own files
- Refactor stim-to-cirq direction to use a CircuitTranslationTracker helper
- Substantially cleanup the stim-to-cirq handler dictionary
- Fix circuit/dem instructions and targets not being hashable
- Also, improve the result format documentation