### PR TITLE
Add support for sweep targets to stimcirq

### DIFF
--- a/glue/cirq/stimcirq/__init__.py
+++ b/glue/cirq/stimcirq/__init__.py
@@ -3,13 +3,16 @@ from ._det_annotation import DetAnnotation
 from ._obs_annotation import CumulativeObservableAnnotation
 from ._stim_sampler import StimSampler
 from ._stim_to_cirq import stim_circuit_to_cirq_circuit, MeasureAndOrResetGate, TwoQubitAsymmetricDepolarizingChannel
+from ._sweep_pauli import SweepPauli
 
-JSON_RESOLVER = {
+JSON_RESOLVERS_DICT = {
     "CumulativeObservableAnnotation": CumulativeObservableAnnotation._from_json_helper,
     "DetAnnotation": DetAnnotation._from_json_helper,
     "MeasureAndOrResetGate": MeasureAndOrResetGate._from_json_helper,
-    "TwoQubitAsymmetricDepolarizingChannel": TwoQubitAsymmetricDepolarizingChannel._from_json_helper,
-}.get
+    "TwoQubitAsymmetricDepolarizingChannel": TwoQubitAsymmetricDepolarizingChannel,
+    "SweepPauli": SweepPauli,
+}
+JSON_RESOLVER = JSON_RESOLVERS_DICT.get
 
 # Workaround for doctest not searching imported objects.
 __test__ = {
@@ -19,5 +22,6 @@ __test__ = {
     "MeasureAndOrResetGate": MeasureAndOrResetGate,
     "stim_circuit_to_cirq_circuit": stim_circuit_to_cirq_circuit,
     "StimSampler": StimSampler,
+    "SweepPauli": SweepPauli,
     "TwoQubitAsymmetricDepolarizingChannel": TwoQubitAsymmetricDepolarizingChannel,
 }

--- a/glue/cirq/stimcirq/_sweep_pauli.py
+++ b/glue/cirq/stimcirq/_sweep_pauli.py
@@ -27,7 +27,7 @@ class SweepPauli(cirq.Gate):
             pauli: The cirq Pauli operation to apply when the bit is True.
         """
         if cirq_sweep_symbol is None:
-            cirq_sweep_symbol = f"sweep_{stim_sweep_bit_index}"
+            cirq_sweep_symbol = f"sweep[{stim_sweep_bit_index}]"
         self.stim_sweep_bit_index = stim_sweep_bit_index
         self.cirq_sweep_symbol = cirq_sweep_symbol
         self.pauli = pauli

--- a/glue/cirq/stimcirq/_sweep_pauli.py
+++ b/glue/cirq/stimcirq/_sweep_pauli.py
@@ -1,0 +1,78 @@
+from typing import Any, Dict, List, Optional, Union
+
+import cirq
+import stim
+import sympy
+
+
+@cirq.value_equality
+class SweepPauli(cirq.Gate):
+    """A Pauli gate included depending on sweep data, with compatibility across stim and cirq.
+
+    Includes a sweep bit index for stim and a sweep symbol for cirq.
+    Creates sweep-controlled operations like `CX sweep[5] 0` when converting to a stim circuit.
+    """
+
+    def __init__(
+        self,
+        *,
+        stim_sweep_bit_index: int,
+        cirq_sweep_symbol: Optional[Union[str, sympy.Symbol]] = None,
+        pauli: cirq.Pauli,
+    ):
+        r"""
+        Args:
+            stim_sweep_bit_index: The bit position, in some unspecified array, controlling the Pauli.
+            cirq_sweep_symbol: The symbol used by cirq. Defaults to f"sweep_{sweep_bit_index}".
+            pauli: The cirq Pauli operation to apply when the bit is True.
+        """
+        if cirq_sweep_symbol is None:
+            cirq_sweep_symbol = f"sweep_{stim_sweep_bit_index}"
+        self.stim_sweep_bit_index = stim_sweep_bit_index
+        self.cirq_sweep_symbol = cirq_sweep_symbol
+        self.pauli = pauli
+
+    def _decomposed_into_pauli(self) -> cirq.Gate:
+        return self.pauli ** self.cirq_sweep_symbol
+
+    def _resolve_parameters_(self, resolver: cirq.ParamResolver, recursive: bool) -> cirq.Gate:
+        new_value = resolver.value_of(self.cirq_sweep_symbol, recursive=recursive)
+        if new_value == self.cirq_sweep_symbol:
+            return self
+        return self.pauli ** new_value
+
+    def _is_parameterized_(self) -> bool:
+        return True
+
+    def _decompose_(self, qubits) -> cirq.OP_TREE:
+        return self.pauli.on(*qubits) ** self.cirq_sweep_symbol
+
+    def _num_qubits_(self) -> int:
+        return 1
+
+    def _value_equality_values_(self) -> Any:
+        return self.pauli, self.stim_sweep_bit_index, self.cirq_sweep_symbol
+
+    def _circuit_diagram_info_(self, args: Any) -> str:
+        return f"{self.pauli}^sweep[{self.stim_sweep_bit_index}]='{self.cirq_sweep_symbol}'"
+
+    def _json_dict_(self) -> Dict[str, Any]:
+        return {
+            'cirq_type': self.__class__.__name__,
+            'pauli': self.pauli,
+            'stim_sweep_bit_index': self.stim_sweep_bit_index,
+            'cirq_sweep_symbol': self.cirq_sweep_symbol,
+        }
+
+    def __repr__(self) -> str:
+        return (
+            f'stimcirq.SweepPauli('
+            f'pauli={self.pauli!r}, '
+            f'stim_sweep_bit_index={self.stim_sweep_bit_index!r}, '
+            f'cirq_sweep_symbol={self.cirq_sweep_symbol!r})'
+        )
+
+    def _stim_conversion_(self, edit_circuit: stim.Circuit, targets: List[int], **kwargs):
+        edit_circuit.append_operation(
+            f"C{self.pauli}", [stim.target_sweep_bit(self.stim_sweep_bit_index)] + targets
+        )

--- a/glue/cirq/stimcirq/_sweep_pauli_test.py
+++ b/glue/cirq/stimcirq/_sweep_pauli_test.py
@@ -1,0 +1,93 @@
+import cirq
+import numpy as np
+import stim
+import stimcirq
+
+
+def test_repr():
+    cirq.testing.assert_equivalent_repr(
+        stimcirq.SweepPauli(stim_sweep_bit_index=1, pauli=cirq.X, cirq_sweep_symbol="a"),
+        global_vals={"stimcirq": stimcirq},
+    )
+    cirq.testing.assert_equivalent_repr(
+        stimcirq.SweepPauli(stim_sweep_bit_index=2, pauli=cirq.Y, cirq_sweep_symbol="b"),
+        global_vals={"stimcirq": stimcirq},
+    )
+
+
+def test_stim_conversion():
+    actual = stimcirq.cirq_circuit_to_stim_circuit(
+        cirq.Circuit(
+            stimcirq.SweepPauli(stim_sweep_bit_index=5, pauli=cirq.X, cirq_sweep_symbol="init_66").on(
+                cirq.GridQubit(1, 3)
+            ),
+            stimcirq.SweepPauli(stim_sweep_bit_index=7, pauli=cirq.Y, cirq_sweep_symbol="init_63").on(
+                cirq.GridQubit(2, 4)
+            ),
+            stimcirq.SweepPauli(stim_sweep_bit_index=5, pauli=cirq.Z, cirq_sweep_symbol="init_66").on(
+                cirq.GridQubit(2, 4)
+            ),
+        )
+    )
+    assert actual == stim.Circuit("""
+        QUBIT_COORDS(1, 3) 0
+        QUBIT_COORDS(2, 4) 1
+        CX sweep[5] 0
+        CY sweep[7] 1
+        TICK
+        CZ sweep[5] 1
+        TICK
+    """)
+
+
+def test_cirq_compatibility():
+    circuit = cirq.Circuit(
+        stimcirq.SweepPauli(stim_sweep_bit_index=5, pauli=cirq.X, cirq_sweep_symbol="xx").on(cirq.LineQubit(0)),
+        cirq.measure(cirq.LineQubit(0), key="k"),
+    )
+    np.testing.assert_array_equal(
+        cirq.Simulator().sample(circuit, params={"xx": 0}, repetitions=3)["k"], [0, 0, 0]
+    )
+    np.testing.assert_array_equal(
+        cirq.Simulator().sample(circuit, params={"xx": 1}, repetitions=3)["k"], [1, 1, 1]
+    )
+
+    circuit = cirq.Circuit(
+        stimcirq.SweepPauli(stim_sweep_bit_index=5, pauli=cirq.Z, cirq_sweep_symbol="xx").on(cirq.LineQubit(0)),
+        cirq.measure(cirq.LineQubit(0), key="k"),
+    )
+    np.testing.assert_array_equal(
+        cirq.Simulator().sample(circuit, params={"xx": 0}, repetitions=3)["k"], [0, 0, 0]
+    )
+    np.testing.assert_array_equal(
+        cirq.Simulator().sample(circuit, params={"xx": 1}, repetitions=3)["k"], [0, 0, 0]
+    )
+
+    circuit = cirq.Circuit(
+        cirq.H(cirq.LineQubit(0)),
+        stimcirq.SweepPauli(stim_sweep_bit_index=5, pauli=cirq.Z, cirq_sweep_symbol="xx").on(cirq.LineQubit(0)),
+        cirq.H(cirq.LineQubit(0)),
+        cirq.measure(cirq.LineQubit(0), key="k"),
+    )
+    np.testing.assert_array_equal(
+        cirq.Simulator().sample(circuit, params={"xx": 0}, repetitions=3)["k"], [0, 0, 0]
+    )
+    np.testing.assert_array_equal(
+        cirq.Simulator().sample(circuit, params={"xx": 1}, repetitions=3)["k"], [1, 1, 1]
+    )
+
+
+def test_json_serialization():
+    c = cirq.Circuit(
+        stimcirq.SweepPauli(stim_sweep_bit_index=5, pauli=cirq.X, cirq_sweep_symbol="init_66").on(
+            cirq.GridQubit(1, 3)
+        ),
+        stimcirq.SweepPauli(stim_sweep_bit_index=7, pauli=cirq.Y, cirq_sweep_symbol="init_63").on(
+            cirq.GridQubit(2, 4)
+        ),
+    )
+    json = cirq.to_json(c)
+    c2 = cirq.read_json(
+        json_text=json,
+        resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER])
+    assert c == c2

--- a/glue/cirq/stimcirq/_two_qubit_asymmetric_depolarize.py
+++ b/glue/cirq/stimcirq/_two_qubit_asymmetric_depolarize.py
@@ -53,14 +53,6 @@ class TwoQubitAsymmetricDepolarizingChannel(cirq.Gate):
     def __repr__(self):
         return f"stimcirq.TwoQubitAsymmetricDepolarizingChannel({self.probabilities!r})"
 
-    @classmethod
-    def _from_json_helper(
-        cls, probabilities: List[float],
-    ) -> 'TwoQubitAsymmetricDepolarizingChannel':
-        return TwoQubitAsymmetricDepolarizingChannel(
-            probabilities=probabilities,
-        )
-
     def _json_dict_(self) -> Dict[str, Any]:
         return {
             'cirq_type': self.__class__.__name__,


### PR DESCRIPTION
- Add `stimcirq.SweepPauli` for representing the configuration-controlled gates
    - Has a stim sweep bit index and a cirq sweep symbol, for cross compatibility
