### PR TITLE
Add stimcirq support for converting `REPEAT` blocks into `cirq.CircuitOperation`s

### DIFF
--- a/glue/cirq/stimcirq/__init__.py
+++ b/glue/cirq/stimcirq/__init__.py
@@ -1,16 +1,22 @@
 from ._cirq_to_stim import cirq_circuit_to_stim_circuit
 from ._det_annotation import DetAnnotation
 from ._obs_annotation import CumulativeObservableAnnotation
+from ._shift_coords_annotation import ShiftCoordsAnnotation
 from ._stim_sampler import StimSampler
-from ._stim_to_cirq import stim_circuit_to_cirq_circuit, MeasureAndOrResetGate, TwoQubitAsymmetricDepolarizingChannel
+from ._stim_to_cirq import (
+    MeasureAndOrResetGate,
+    stim_circuit_to_cirq_circuit,
+    TwoQubitAsymmetricDepolarizingChannel,
+)
 from ._sweep_pauli import SweepPauli
 
 JSON_RESOLVERS_DICT = {
-    "CumulativeObservableAnnotation": CumulativeObservableAnnotation._from_json_helper,
-    "DetAnnotation": DetAnnotation._from_json_helper,
-    "MeasureAndOrResetGate": MeasureAndOrResetGate._from_json_helper,
-    "TwoQubitAsymmetricDepolarizingChannel": TwoQubitAsymmetricDepolarizingChannel,
+    "CumulativeObservableAnnotation": CumulativeObservableAnnotation,
+    "DetAnnotation": DetAnnotation,
+    "MeasureAndOrResetGate": MeasureAndOrResetGate,
+    "ShiftCoordsAnnotation": ShiftCoordsAnnotation,
     "SweepPauli": SweepPauli,
+    "TwoQubitAsymmetricDepolarizingChannel": TwoQubitAsymmetricDepolarizingChannel,
 }
 JSON_RESOLVER = JSON_RESOLVERS_DICT.get
 
@@ -20,6 +26,7 @@ __test__ = {
     "CumulativeObservableAnnotation": CumulativeObservableAnnotation,
     "DetAnnotation": DetAnnotation,
     "MeasureAndOrResetGate": MeasureAndOrResetGate,
+    "ShiftCoordsAnnotation": ShiftCoordsAnnotation,
     "stim_circuit_to_cirq_circuit": stim_circuit_to_cirq_circuit,
     "StimSampler": StimSampler,
     "SweepPauli": SweepPauli,

--- a/glue/cirq/stimcirq/_cirq_to_stim.py
+++ b/glue/cirq/stimcirq/_cirq_to_stim.py
@@ -359,7 +359,7 @@ class CirqToStimHelper:
         self.flatten = False
 
     def process_circuit_operation_into_repeat_block(self, op: cirq.CircuitOperation) -> None:
-        if self.flatten:
+        if self.flatten or op.repetitions == 1:
             self.process_operations(cirq.decompose_once(op))
             return
 

--- a/glue/cirq/stimcirq/_cirq_to_stim.py
+++ b/glue/cirq/stimcirq/_cirq_to_stim.py
@@ -1,16 +1,15 @@
-from typing import Callable, cast, Dict, Iterable, List, Optional, Sequence, Tuple, Type
-
 import functools
 import itertools
 import math
+from typing import Callable, cast, Dict, Iterable, List, Optional, Sequence, Tuple, Type
 
 import cirq
 import stim
 
 
-def cirq_circuit_to_stim_circuit(circuit: cirq.Circuit,
-                                 *,
-                                 qubit_to_index_dict: Optional[Dict[cirq.Qid, int]] = None) -> stim.Circuit:
+def cirq_circuit_to_stim_circuit(
+    circuit: cirq.Circuit, *, qubit_to_index_dict: Optional[Dict[cirq.Qid, int]] = None
+) -> stim.Circuit:
     """Converts a cirq circuit into an equivalent stim circuit.
 
     Not all circuits can be converted. In order for a circuit to be convertible, all of its operations must be
@@ -100,21 +99,19 @@ def cirq_circuit_to_stim_data(
     """Converts a Cirq circuit into a Stim circuit and also metadata about where measurements go."""
     if q2i is None:
         q2i = {q: i for i, q in enumerate(sorted(circuit.all_qubits()))}
-    out = stim.Circuit()
-    key_out: List[Tuple[str, int]] = []
+    helper = CirqToStimHelper()
+    helper.q2i = q2i
 
     for q in sorted(circuit.all_qubits()):
         if isinstance(q, cirq.LineQubit):
             i = q2i[q]
             if i != q.x:
-                out.append_operation("QUBIT_COORDS", [i], [q.x])
+                helper.out.append_operation("QUBIT_COORDS", [i], [q.x])
         elif isinstance(q, cirq.GridQubit):
-            out.append_operation("QUBIT_COORDS", [q2i[q]], [q.row, q.col])
+            helper.out.append_operation("QUBIT_COORDS", [q2i[q]], [q.row, q.col])
 
-    for moment in circuit:
-        _c2s_helper(moment, q2i, out, key_out)
-        out.append_operation("TICK", [])
-    return out, key_out
+    helper.process_moments(circuit)
+    return helper.out, helper.key_out
 
 
 StimTypeHandler = Callable[[stim.Circuit, cirq.Gate, List[int]], None]
@@ -189,12 +186,12 @@ def gate_to_stim_append_func() -> Dict[cirq.Gate, Callable[[stim.Circuit, List[i
         cirq.X.controlled(1): use("CX"),
         cirq.Y.controlled(1): use("CY"),
         cirq.Z.controlled(1): use("CZ"),
-        cirq.XX**0.5: use("SQRT_XX"),
-        cirq.YY**0.5: use("SQRT_YY"),
-        cirq.ZZ**0.5: use("SQRT_ZZ"),
-        cirq.XX**-0.5: use("SQRT_XX_DAG"),
-        cirq.YY**-0.5: use("SQRT_YY_DAG"),
-        cirq.ZZ**-0.5: use("SQRT_ZZ_DAG"),
+        cirq.XX ** 0.5: use("SQRT_XX"),
+        cirq.YY ** 0.5: use("SQRT_YY"),
+        cirq.ZZ ** 0.5: use("SQRT_ZZ"),
+        cirq.XX ** -0.5: use("SQRT_XX_DAG"),
+        cirq.YY ** -0.5: use("SQRT_YY_DAG"),
+        cirq.ZZ ** -0.5: use("SQRT_ZZ_DAG"),
         # All 24 cirq.SingleQubitCliffordGate instances.
         sqcg(x, y): use("SQRT_X_DAG"),
         sqcg(x, ny): use("SQRT_X"),
@@ -237,7 +234,9 @@ def gate_type_to_stim_append_func() -> Dict[Type[cirq.Gate], StimTypeHandler]:
         cirq.ControlledGate: cast(StimTypeHandler, _stim_append_controlled_gate),
         cirq.DensePauliString: cast(StimTypeHandler, _stim_append_dense_pauli_string_gate),
         cirq.MutableDensePauliString: cast(StimTypeHandler, _stim_append_dense_pauli_string_gate),
-        cirq.AsymmetricDepolarizingChannel: cast(StimTypeHandler, _stim_append_asymmetric_depolarizing_channel),
+        cirq.AsymmetricDepolarizingChannel: cast(
+            StimTypeHandler, _stim_append_asymmetric_depolarizing_channel
+        ),
         cirq.BitFlipChannel: lambda c, g, t: c.append_operation(
             "X_ERROR", t, cast(cirq.BitFlipChannel, g).p
         ),
@@ -252,14 +251,18 @@ def gate_type_to_stim_append_func() -> Dict[Type[cirq.Gate], StimTypeHandler]:
     }
 
 
-def _stim_append_measurement_gate(circuit: stim.Circuit, gate: cirq.MeasurementGate, targets: List[int]):
+def _stim_append_measurement_gate(
+    circuit: stim.Circuit, gate: cirq.MeasurementGate, targets: List[int]
+):
     for i, b in enumerate(gate.invert_mask):
         if b:
             targets[i] = stim.target_inv(targets[i])
-    circuit.append_operation("M",  targets)
+    circuit.append_operation("M", targets)
 
 
-def _stim_append_pauli_measurement_gate(circuit: stim.Circuit, gate: cirq.PauliMeasurementGate, targets: List[int]):
+def _stim_append_pauli_measurement_gate(
+    circuit: stim.Circuit, gate: cirq.PauliMeasurementGate, targets: List[int]
+):
     obs: cirq.DensePauliString = gate.observable()
 
     # Convert to stim Pauli product targets.
@@ -286,17 +289,21 @@ def _stim_append_pauli_measurement_gate(circuit: stim.Circuit, gate: cirq.PauliM
     elif obs.coefficient != 1:
         raise NotImplementedError(f"obs.coefficient={obs.coefficient!r} not in [1, -1]")
 
-    circuit.append_operation("MPP",  new_targets)
+    circuit.append_operation("MPP", new_targets)
 
 
-def _stim_append_dense_pauli_string_gate(c: stim.Circuit, g: cirq.BaseDensePauliString, t: List[int]):
+def _stim_append_dense_pauli_string_gate(
+    c: stim.Circuit, g: cirq.BaseDensePauliString, t: List[int]
+):
     gates = [None, "X", "Y", "Z"]
     for p, k in zip(g.pauli_mask, t):
         if p:
             c.append_operation(gates[p], [k])
 
 
-def _stim_append_asymmetric_depolarizing_channel(c: stim.Circuit, g: cirq.AsymmetricDepolarizingChannel, t: List[int]):
+def _stim_append_asymmetric_depolarizing_channel(
+    c: stim.Circuit, g: cirq.AsymmetricDepolarizingChannel, t: List[int]
+):
     c.append_operation("PAULI_CHANNEL_1", t, [g.p_x, g.p_y, g.p_z])
 
 
@@ -335,64 +342,100 @@ def _stim_append_random_gate_channel(c: stim.Circuit, g: cirq.RandomGateChannel,
         c.append_operation(f"{g.sub_gate}_ERROR", t, g.probability)
     elif isinstance(g.sub_gate, cirq.DensePauliString):
         target_p = [None, stim.target_x, stim.target_y, stim.target_z]
-        pauli_targets = [
-            target_p[p](t)
-            for t, p in zip(t, g.sub_gate.pauli_mask)
-        ]
+        pauli_targets = [target_p[p](t) for t, p in zip(t, g.sub_gate.pauli_mask)]
         c.append_operation(f"CORRELATED_ERROR", pauli_targets, g.probability)
     else:
-        raise NotImplementedError(f"Don't know how to turn probabilistic {g!r} into Stim operations.")
+        raise NotImplementedError(
+            f"Don't know how to turn probabilistic {g!r} into Stim operations."
+        )
 
 
-def _c2s_helper(
-    operations: Iterable[cirq.Operation], q2i: Dict[cirq.Qid, int], out: stim.Circuit,
-    key_out: List[Tuple[str, int]]
-):
-    g2f = gate_to_stim_append_func()
-    t2f = gate_type_to_stim_append_func()
-    for op in operations:
-        gate = op.gate
-        targets = [q2i[q] for q in op.qubits]
+class CirqToStimHelper:
+    def __init__(self):
+        self.key_out: List[Tuple[str, int]] = []
+        self.out = stim.Circuit()
+        self.q2i = {}
+        self.have_seen_loop = False
+        self.flatten = False
 
-        custom_method = getattr(op, '_stim_conversion_', getattr(gate, '_stim_conversion_', None))
-        if custom_method is not None:
-            custom_method(
-                dont_forget_your_star_star_kwargs=True,
-                edit_circuit=out,
-                edit_measurement_key_lengths=key_out,
-                targets=targets)
-            continue
+    def process_circuit_operation_into_repeat_block(self, op: cirq.CircuitOperation) -> None:
+        if self.flatten:
+            self.process_operations(cirq.decompose_once(op))
+            return
 
-        # Special case measurement, because of its metadata.
-        if isinstance(gate, cirq.PauliMeasurementGate):
-            key_out.append((gate.key, len(targets)))
-            _stim_append_pauli_measurement_gate(out, gate, targets)
-            continue
-        if isinstance(gate, cirq.MeasurementGate):
-            key_out.append((gate.key, len(targets)))
-            _stim_append_measurement_gate(out, gate, targets)
-            continue
+        child = CirqToStimHelper()
+        child.key_out = self.key_out
+        child.q2i = self.q2i
+        child.have_seen_loop = True
+        self.have_seen_loop = True
+        child.process_moments(op.circuit)
+        self.out += child.out * op.repetitions
 
-        # Look for recognized gate values like cirq.H.
-        val_append_func = g2f.get(gate)
-        if val_append_func is not None:
-            val_append_func(out, targets)
-            continue
+    def process_operations(self, operations: Iterable[cirq.Operation]) -> None:
+        g2f = gate_to_stim_append_func()
+        t2f = gate_type_to_stim_append_func()
+        for op in operations:
+            assert isinstance(op, cirq.Operation)
+            gate = op.gate
+            targets = [self.q2i[q] for q in op.qubits]
 
-        # Look for recognized gate types like cirq.DepolarizingChannel.
-        type_append_func = t2f.get(type(gate))
-        if type_append_func is not None:
-            type_append_func(out, gate, targets)
-            continue
+            custom_method = getattr(
+                op, '_stim_conversion_', getattr(gate, '_stim_conversion_', None)
+            )
+            if custom_method is not None:
+                custom_method(
+                    dont_forget_your_star_star_kwargs=True,
+                    edit_circuit=self.out,
+                    edit_measurement_key_lengths=self.key_out,
+                    targets=targets,
+                    have_seen_loop=self.have_seen_loop,
+                )
+                continue
 
-        # Ask unrecognized operations to decompose themselves into simpler operations.
-        try:
-            _c2s_helper(cirq.decompose_once(op), q2i, out, key_out)
-        except TypeError as ex:
-            raise TypeError(
-                f"Don't know how to translate {op!r} into stim gates.\n"
-                f"- It doesn't have a _decompose_ method that returns stim-compatible operations.\n"
-                f"- It doesn't have a _stim_conversion_ method.\n"
-            ) from ex
+            if isinstance(op, cirq.CircuitOperation):
+                self.process_circuit_operation_into_repeat_block(op)
+                continue
 
-    return out
+            # Special case measurement, because of its metadata.
+            if isinstance(gate, cirq.PauliMeasurementGate):
+                self.key_out.append((gate.key, len(targets)))
+                _stim_append_pauli_measurement_gate(self.out, gate, targets)
+                continue
+            if isinstance(gate, cirq.MeasurementGate):
+                self.key_out.append((gate.key, len(targets)))
+                _stim_append_measurement_gate(self.out, gate, targets)
+                continue
+
+            # Look for recognized gate values like cirq.H.
+            val_append_func = g2f.get(gate)
+            if val_append_func is not None:
+                val_append_func(self.out, targets)
+                continue
+
+            # Look for recognized gate types like cirq.DepolarizingChannel.
+            type_append_func = t2f.get(type(gate))
+            if type_append_func is not None:
+                type_append_func(self.out, gate, targets)
+                continue
+
+            # Ask unrecognized operations to decompose themselves into simpler operations.
+            try:
+                self.process_operations(cirq.decompose_once(op))
+            except TypeError as ex:
+                raise TypeError(
+                    f"Don't know how to translate {op!r} into stim gates.\n"
+                    f"- It doesn't have a _decompose_ method that returns stim-compatible operations.\n"
+                    f"- It doesn't have a _stim_conversion_ method.\n"
+                ) from ex
+
+    def process_moment(self, moment: cirq.Moment):
+        length_before = len(self.out)
+        self.process_operations(moment)
+
+        # Append a TICK, unless it was already handled by an internal REPEAT block.
+        if length_before == len(self.out) or not isinstance(self.out[-1], stim.CircuitRepeatBlock):
+            self.out.append_operation("TICK", [])
+
+    def process_moments(self, moments: Iterable[cirq.Moment]):
+        for moment in moments:
+            self.process_moment(moment)

--- a/glue/cirq/stimcirq/_cirq_to_stim.py
+++ b/glue/cirq/stimcirq/_cirq_to_stim.py
@@ -368,7 +368,7 @@ class CirqToStimHelper:
         child.q2i = self.q2i
         child.have_seen_loop = True
         self.have_seen_loop = True
-        child.process_moments(op.circuit)
+        child.process_moments(op.transform_qubits(lambda q: op.qubit_map.get(q, q)).circuit)
         self.out += child.out * op.repetitions
 
     def process_operations(self, operations: Iterable[cirq.Operation]) -> None:

--- a/glue/cirq/stimcirq/_cirq_to_stim_test.py
+++ b/glue/cirq/stimcirq/_cirq_to_stim_test.py
@@ -1,15 +1,11 @@
-from typing import Dict, Tuple, Sequence, List, Union
+from typing import Dict, List, Sequence, Tuple, Union
 
 import cirq
 import numpy as np
 import pytest
 import stim
-
 import stimcirq
-from stimcirq._cirq_to_stim import (
-    cirq_circuit_to_stim_data,
-    gate_to_stim_append_func,
-)
+from stimcirq._cirq_to_stim import cirq_circuit_to_stim_data, gate_to_stim_append_func
 
 
 def solve_tableau(gate: cirq.Gate) -> Dict[cirq.PauliString, cirq.PauliString]:
@@ -109,7 +105,9 @@ def test_more_unitary_gate_conversions():
         assert_unitary_gate_converts_correctly((p * cirq.DensePauliString("IXYZ")).controlled(1))
 
     a, b = cirq.LineQubit.range(2)
-    c, _ = cirq_circuit_to_stim_data(cirq.Circuit(cirq.H(a), cirq.CNOT(a, b), cirq.measure(a, b), cirq.reset(a)))
+    c, _ = cirq_circuit_to_stim_data(
+        cirq.Circuit(cirq.H(a), cirq.CNOT(a, b), cirq.measure(a, b), cirq.reset(a))
+    )
     assert (
         str(c).strip()
         == """
@@ -148,11 +146,13 @@ ROUND_TRIP_NOISY_GATES = [
     cirq.AsymmetricDepolarizingChannel(p_x=0, p_y=0.1, p_z=0),
     cirq.AsymmetricDepolarizingChannel(p_x=0, p_y=0, p_z=0.1),
     *[
-        stimcirq.TwoQubitAsymmetricDepolarizingChannel(cirq.one_hot(index=k, shape=15, value=0.1, dtype=np.float64))
+        stimcirq.TwoQubitAsymmetricDepolarizingChannel(
+            cirq.one_hot(index=k, shape=15, value=0.1, dtype=np.float64)
+        )
         for k in range(15)
     ],
-    stimcirq.TwoQubitAsymmetricDepolarizingChannel([k/300 for k in range(1, 16)]),
-    stimcirq.TwoQubitAsymmetricDepolarizingChannel([0]*15),
+    stimcirq.TwoQubitAsymmetricDepolarizingChannel([k / 300 for k in range(1, 16)]),
+    stimcirq.TwoQubitAsymmetricDepolarizingChannel([0] * 15),
 ]
 
 
@@ -171,7 +171,9 @@ def test_frame_simulator_sampling_noisy_gates_agrees_with_cirq_data(gate: cirq.G
     expected_rates = cirq.final_density_matrix(circuit).diagonal().real
 
     # Convert test circuit to Stim and sample from it.
-    stim_circuit, _ = cirq_circuit_to_stim_data(circuit + cirq.measure(*sorted(circuit.all_qubits())[::-1]))
+    stim_circuit, _ = cirq_circuit_to_stim_data(
+        circuit + cirq.measure(*sorted(circuit.all_qubits())[::-1])
+    )
     sample_count = 10000
     samples = stim_circuit.compile_sampler().sample_bit_packed(sample_count).flat
     unique, counts = np.unique(samples, return_counts=True)
@@ -208,7 +210,9 @@ def test_tableau_simulator_sampling_noisy_gates_agrees_with_cirq_data(gate: cirq
     expected_rates = cirq.final_density_matrix(circuit).diagonal().real
 
     # Convert test circuit to Stim and sample from it.
-    stim_circuit, _ = cirq_circuit_to_stim_data(circuit + cirq.measure(*sorted(circuit.all_qubits())[::-1]))
+    stim_circuit, _ = cirq_circuit_to_stim_data(
+        circuit + cirq.measure(*sorted(circuit.all_qubits())[::-1])
+    )
     sample_count = 10000
     samples = []
     for _ in range(sample_count):
@@ -242,13 +246,15 @@ def test_cirq_circuit_to_stim_circuit_custom_stim_method():
             return 1
 
         def _measure_keys_(self):
-            return "custom",
+            return ("custom",)
 
-        def _stim_conversion_(self,
-                              edit_circuit: stim.Circuit,
-                              edit_measurement_key_lengths: List[Tuple[str, int]],
-                              targets: Sequence[int],
-                              **kwargs):
+        def _stim_conversion_(
+            self,
+            edit_circuit: stim.Circuit,
+            edit_measurement_key_lengths: List[Tuple[str, int]],
+            targets: Sequence[int],
+            **kwargs,
+        ):
             edit_measurement_key_lengths.append(("custom", 2))
             edit_circuit.append_operation("M", [stim.target_inv(targets[0])])
             edit_circuit.append_operation("M", [targets[0]])
@@ -275,7 +281,9 @@ def test_cirq_circuit_to_stim_circuit_custom_stim_method():
     )
 
     stim_circuit = stimcirq.cirq_circuit_to_stim_circuit(cirq_circuit)
-    assert str(stim_circuit).strip() == """
+    assert (
+        str(stim_circuit).strip()
+        == """
 M 0 1 2
 TICK
 DETECTOR rec[-2]
@@ -284,6 +292,7 @@ M !1 1
 DETECTOR rec[-1]
 TICK
     """.strip()
+    )
 
     class BadGate(cirq.Gate):
         def num_qubits(self) -> int:
@@ -306,5 +315,7 @@ TICK
 def test_custom_qubit_indexing():
     a = cirq.NamedQubit("a")
     b = cirq.NamedQubit("b")
-    actual = stimcirq.cirq_circuit_to_stim_circuit(cirq.Circuit(cirq.CNOT(a, b)), qubit_to_index_dict={a: 10, b: 15})
+    actual = stimcirq.cirq_circuit_to_stim_circuit(
+        cirq.Circuit(cirq.CNOT(a, b)), qubit_to_index_dict={a: 10, b: 15}
+    )
     assert actual == stim.Circuit('CX 10 15\nTICK')

--- a/glue/cirq/stimcirq/_det_annotation.py
+++ b/glue/cirq/stimcirq/_det_annotation.py
@@ -11,16 +11,25 @@ class DetAnnotation(cirq.Operation):
     Creates a DETECTOR operation when converting to a stim circuit.
     """
 
-    def __init__(self, *parity_keys: str, coordinate_metadata: Iterable[float] = ()):
+    def __init__(
+        self,
+        *,
+        parity_keys: Iterable[str] = (),
+        relative_keys: Iterable[int] = (),
+        coordinate_metadata: Iterable[float] = (),
+    ):
         """
 
         Args:
             parity_keys: The keys of some measurements with the property that their parity is always
                 the same under noiseless execution of the circuit.
+            relative_keys: Refers to measurements relative to this operation. For example,
+                relative key -1 is the previous measurement. All entries must be negative.
             coordinate_metadata: An optional location for the detector. This has no effect on the
                 function of the circuit, but can be used by plotting tools.
         """
         self.parity_keys = frozenset(parity_keys)
+        self.relative_keys = frozenset(relative_keys)
         self.coordinate_metadata = tuple(coordinate_metadata)
 
     @property
@@ -34,25 +43,28 @@ class DetAnnotation(cirq.Operation):
         return self.parity_keys, self.coordinate_metadata
 
     def _circuit_diagram_info_(self, args: Any) -> str:
-        k = ",".join(repr(e) for e in sorted(self.parity_keys))
+        items: List[str] = [repr(e) for e in sorted(self.parity_keys)]
+        items += [f'rec[{e}]' for e in sorted(self.relative_keys)]
+        k = ",".join(str(e) for e in items)
         return f"Det({k})"
 
-    @classmethod
-    def _from_json_helper(
-        cls, parity_keys: List[str], coordinate_metadata: List[float]
-    ) -> 'DetAnnotation':
-        return DetAnnotation(*parity_keys, coordinate_metadata=coordinate_metadata)
-
     def _json_dict_(self) -> Dict[str, Any]:
-        return {
+        result = {
             'cirq_type': self.__class__.__name__,
             'parity_keys': sorted(self.parity_keys),
             'coordinate_metadata': self.coordinate_metadata,
         }
+        if self.relative_keys:
+            result['relative_keys'] = sorted(self.relative_keys)
+        return result
 
     def __repr__(self) -> str:
-        k = ", ".join(repr(e) for e in sorted(self.parity_keys))
-        return f'stimcirq.DetAnnotation({k}, coordinate_metadata={self.coordinate_metadata!r})'
+        return (
+            f'stimcirq.DetAnnotation('
+            f'parity_keys={sorted(self.parity_keys)}, '
+            f'relative_keys={sorted(self.relative_keys)}, '
+            f'coordinate_metadata={self.coordinate_metadata!r})'
+        )
 
     def _decompose_(self):
         return []
@@ -64,6 +76,7 @@ class DetAnnotation(cirq.Operation):
         self,
         edit_circuit: stim.Circuit,
         edit_measurement_key_lengths: List[Tuple[str, int]],
+        have_seen_loop: bool = False,
         **kwargs,
     ):
         # Ideally these references would all be resolved ahead of time, to avoid the redundant
@@ -71,9 +84,14 @@ class DetAnnotation(cirq.Operation):
         # instead of grouped (grouping measurements is helpful for stabilizer simulation). But that
         # didn't happen and this is the context we're called in and we're going to make it work.
 
+        if have_seen_loop and self.parity_keys:
+            raise NotImplementedError(
+                "Measurement key conversion is not reliable when loops are present."
+            )
+
         # Find indices of measurement record targets.
         remaining = set(self.parity_keys)
-        rec_targets = []
+        rec_targets = [stim.target_rec(k) for k in sorted(self.relative_keys, reverse=True)]
         for offset in range(len(edit_measurement_key_lengths)):
             m_key, m_len = edit_measurement_key_lengths[-1 - offset]
             if m_len != 1:

--- a/glue/cirq/stimcirq/_det_annotation_test.py
+++ b/glue/cirq/stimcirq/_det_annotation_test.py
@@ -9,20 +9,28 @@ def test_stim_conversion():
     a, b, c = cirq.LineQubit.range(3)
 
     with pytest.raises(ValueError, match="earlier"):
-        stimcirq.cirq_circuit_to_stim_circuit(cirq.Circuit(cirq.Moment(stimcirq.DetAnnotation("unknown"))))
-    with pytest.raises(ValueError, match="earlier"):
         stimcirq.cirq_circuit_to_stim_circuit(
-            cirq.Circuit(cirq.Moment(stimcirq.DetAnnotation("later"), cirq.measure(b, key="later")))
+            cirq.Circuit(cirq.Moment(stimcirq.DetAnnotation(parity_keys=["unknown"])))
         )
     with pytest.raises(ValueError, match="earlier"):
         stimcirq.cirq_circuit_to_stim_circuit(
             cirq.Circuit(
-                cirq.Moment(stimcirq.DetAnnotation("later")), cirq.Moment(cirq.measure(b, key="later"))
+                cirq.Moment(
+                    stimcirq.DetAnnotation(parity_keys=["later"]), cirq.measure(b, key="later")
+                )
+            )
+        )
+    with pytest.raises(ValueError, match="earlier"):
+        stimcirq.cirq_circuit_to_stim_circuit(
+            cirq.Circuit(
+                cirq.Moment(stimcirq.DetAnnotation(parity_keys=["later"])),
+                cirq.Moment(cirq.measure(b, key="later")),
             )
         )
     assert stimcirq.cirq_circuit_to_stim_circuit(
         cirq.Circuit(
-            cirq.Moment(cirq.measure(b, key="earlier")), cirq.Moment(stimcirq.DetAnnotation("earlier"))
+            cirq.Moment(cirq.measure(b, key="earlier")),
+            cirq.Moment(stimcirq.DetAnnotation(parity_keys=["earlier"])),
         )
     ) == stim.Circuit(
         """
@@ -34,7 +42,11 @@ def test_stim_conversion():
     """
     )
     assert stimcirq.cirq_circuit_to_stim_circuit(
-        cirq.Circuit(cirq.Moment(cirq.measure(b, key="earlier"), stimcirq.DetAnnotation("earlier")))
+        cirq.Circuit(
+            cirq.Moment(
+                cirq.measure(b, key="earlier"), stimcirq.DetAnnotation(parity_keys=["earlier"])
+            )
+        )
     ) == stim.Circuit(
         """
         QUBIT_COORDS(1) 0
@@ -47,7 +59,9 @@ def test_stim_conversion():
     assert stimcirq.cirq_circuit_to_stim_circuit(
         cirq.Circuit(
             cirq.Moment(cirq.measure(a, key="a"), cirq.measure(b, key="b")),
-            cirq.Moment(stimcirq.DetAnnotation("a", "b", coordinate_metadata=(1, 2, 3.5))),
+            cirq.Moment(
+                stimcirq.DetAnnotation(parity_keys=["a", "b"], coordinate_metadata=(1, 2, 3.5))
+            ),
         )
     ) == stim.Circuit(
         """
@@ -66,9 +80,9 @@ def test_stim_conversion():
             cirq.Moment(
                 cirq.measure(a, key="a"),
                 cirq.measure(b, key="b"),
-                stimcirq.DetAnnotation("a", "b"),
+                stimcirq.DetAnnotation(parity_keys=["a", "b"]),
                 cirq.measure(c, key="c"),
-                stimcirq.DetAnnotation("a", "c"),
+                stimcirq.DetAnnotation(parity_keys=["a", "c"]),
             ),
         )
     ) == stim.Circuit(
@@ -91,7 +105,10 @@ def test_stim_conversion():
 def test_simulation():
     a = cirq.LineQubit(0)
     s = cirq.Simulator().sample(
-        cirq.Circuit(cirq.X(a), cirq.measure(a, key="a"), stimcirq.DetAnnotation("a")), repetitions=3
+        cirq.Circuit(
+            cirq.X(a), cirq.measure(a, key="a"), stimcirq.DetAnnotation(parity_keys=["a"])
+        ),
+        repetitions=3,
     )
     np.testing.assert_array_equal(s["a"], [1, 1, 1])
 
@@ -99,42 +116,49 @@ def test_simulation():
 def test_diagram():
     a, b = cirq.LineQubit.range(2)
     cirq.testing.assert_has_diagram(
-        cirq.Circuit(cirq.measure(a, key="a"), cirq.measure(b, key="b"), stimcirq.DetAnnotation("a", "b")),
+        cirq.Circuit(
+            cirq.measure(a, key="a"),
+            cirq.measure(b, key="b"),
+            stimcirq.DetAnnotation(parity_keys=["a", "b"]),
+        ),
         """
-0: ───M('a')─────────
+0: ---M('a')---------
 
-1: ───M('b')─────────
+1: ---M('b')---------
       Det('a','b')
-    """,
+        """,
+        use_unicode_characters=False,
     )
 
 
 def test_repr():
-    val = stimcirq.DetAnnotation("a", "b", coordinate_metadata=(1, 2))
+    val = stimcirq.DetAnnotation(parity_keys=["a", "b"], coordinate_metadata=(1, 2))
     assert eval(repr(val), {"stimcirq": stimcirq}) == val
 
 
 def test_equality():
     eq = cirq.testing.EqualsTester()
     eq.add_equality_group(stimcirq.DetAnnotation(), stimcirq.DetAnnotation())
-    eq.add_equality_group(stimcirq.DetAnnotation("a"))
+    eq.add_equality_group(stimcirq.DetAnnotation(parity_keys=["a"]))
     eq.add_equality_group(
-        stimcirq.DetAnnotation("a", coordinate_metadata=[1, 2]),
-        stimcirq.DetAnnotation("a", coordinate_metadata=(1, 2)),
+        stimcirq.DetAnnotation(parity_keys=["a"], coordinate_metadata=[1, 2]),
+        stimcirq.DetAnnotation(parity_keys=["a"], coordinate_metadata=(1, 2)),
     )
-    eq.add_equality_group(stimcirq.DetAnnotation("a", coordinate_metadata=(2, 1)))
-    eq.add_equality_group(stimcirq.DetAnnotation("b"))
-    eq.add_equality_group(stimcirq.DetAnnotation("a", "b"), stimcirq.DetAnnotation("b", "a"))
+    eq.add_equality_group(stimcirq.DetAnnotation(parity_keys=["a"], coordinate_metadata=(2, 1)))
+    eq.add_equality_group(stimcirq.DetAnnotation(parity_keys=["b"]))
+    eq.add_equality_group(
+        stimcirq.DetAnnotation(parity_keys=["a", "b"]),
+        stimcirq.DetAnnotation(parity_keys=["b", "a"]),
+    )
 
 
 def test_json_serialization():
     c = cirq.Circuit(
-        stimcirq.DetAnnotation("a", "b"),
+        stimcirq.DetAnnotation(parity_keys=["a", "b"]),
+        stimcirq.DetAnnotation(parity_keys=["a", "b"], relative_keys=[-3, -5]),
         stimcirq.DetAnnotation(coordinate_metadata=(1, 2)),
-        stimcirq.DetAnnotation("d", "c", coordinate_metadata=(1, 2, 3)),
+        stimcirq.DetAnnotation(parity_keys=["d", "c"], coordinate_metadata=(1, 2, 3)),
     )
     json = cirq.to_json(c)
-    c2 = cirq.read_json(
-        json_text=json,
-        resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER])
+    c2 = cirq.read_json(json_text=json, resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER])
     assert c == c2

--- a/glue/cirq/stimcirq/_measure_and_or_reset_gate_test.py
+++ b/glue/cirq/stimcirq/_measure_and_or_reset_gate_test.py
@@ -1,5 +1,4 @@
 import cirq
-
 import stimcirq
 
 
@@ -24,11 +23,7 @@ def test_json_serialization():
         invert_measure=True,
         measure_flip_probability=0.125,
     )
-    c = cirq.Circuit(
-        r(cirq.LineQubit(1)),
-    )
+    c = cirq.Circuit(r(cirq.LineQubit(1)))
     json = cirq.to_json(c)
-    c2 = cirq.read_json(
-        json_text=json,
-        resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER])
+    c2 = cirq.read_json(json_text=json, resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER])
     assert c == c2

--- a/glue/cirq/stimcirq/_obs_annotation.py
+++ b/glue/cirq/stimcirq/_obs_annotation.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, Iterable, List, Tuple
 
 import cirq
 import stim
@@ -11,14 +11,23 @@ class CumulativeObservableAnnotation(cirq.Operation):
     Creates an OBSERVABLE_INCLUDE operation when converting to a stim circuit.
     """
 
-    def __init__(self, *parity_keys: str, observable_index: int):
+    def __init__(
+        self,
+        *,
+        parity_keys: Iterable[str] = (),
+        relative_keys: Iterable[int] = (),
+        observable_index: int,
+    ):
         """
 
         Args:
             parity_keys: The keys of some measurements to include in the logical observable.
+            relative_keys: Refers to measurements relative to this operation. For example,
+                relative key -1 is the previous measurement. All entries must be negative.
             observable_index: A unique index for the logical observable.
         """
         self.parity_keys = frozenset(parity_keys)
+        self.relative_keys = frozenset(relative_keys)
         self.observable_index = observable_index
 
     @property
@@ -32,25 +41,28 @@ class CumulativeObservableAnnotation(cirq.Operation):
         return self.parity_keys, self.observable_index
 
     def _circuit_diagram_info_(self, args: Any) -> str:
-        k = ",".join(repr(e) for e in sorted(self.parity_keys))
+        items: List[str] = [repr(e) for e in sorted(self.parity_keys)]
+        items += [f'rec[{e}]' for e in sorted(self.relative_keys)]
+        k = ",".join(str(e) for e in items)
         return f"Obs{self.observable_index}({k})"
 
     def __repr__(self) -> str:
-        k = ", ".join(repr(e) for e in sorted(self.parity_keys))
-        return f'stimcirq.CumulativeObservableAnnotation({k}, observable_index={self.observable_index!r})'
-
-    @classmethod
-    def _from_json_helper(
-        cls, parity_keys: List[str], observable_index: int
-    ) -> 'CumulativeObservableAnnotation':
-        return CumulativeObservableAnnotation(*parity_keys, observable_index=observable_index)
+        return (
+            f'stimcirq.CumulativeObservableAnnotation('
+            f'parity_keys={sorted(self.parity_keys)}, '
+            f'relative_keys={sorted(self.relative_keys)}, '
+            f'observable_index={self.observable_index!r})'
+        )
 
     def _json_dict_(self) -> Dict[str, Any]:
-        return {
+        result = {
             'cirq_type': self.__class__.__name__,
             'parity_keys': sorted(self.parity_keys),
             'observable_index': self.observable_index,
         }
+        if self.relative_keys:
+            result['relative_keys'] = sorted(self.relative_keys)
+        return result
 
     def _decompose_(self):
         return []
@@ -62,6 +74,7 @@ class CumulativeObservableAnnotation(cirq.Operation):
         self,
         edit_circuit: stim.Circuit,
         edit_measurement_key_lengths: List[Tuple[str, int]],
+        have_seen_loop: bool = False,
         **kwargs,
     ):
         # Ideally these references would all be resolved ahead of time, to avoid the redundant
@@ -69,9 +82,14 @@ class CumulativeObservableAnnotation(cirq.Operation):
         # instead of grouped (grouping measurements is helpful for stabilizer simulation). But that
         # didn't happen and this is the context we're called in and we're going to make it work.
 
+        if have_seen_loop and self.parity_keys:
+            raise NotImplementedError(
+                "Measurement key conversion is not reliable when loops are present."
+            )
+
         # Find indices of measurement record targets.
         remaining = set(self.parity_keys)
-        rec_targets = []
+        rec_targets = [stim.target_rec(k) for k in sorted(self.relative_keys, reverse=True)]
         for offset in range(len(edit_measurement_key_lengths)):
             m_key, m_len = edit_measurement_key_lengths[-1 - offset]
             if m_len != 1:

--- a/glue/cirq/stimcirq/_obs_annotation_test.py
+++ b/glue/cirq/stimcirq/_obs_annotation_test.py
@@ -10,13 +10,21 @@ def test_stim_conversion():
 
     with pytest.raises(ValueError, match="earlier"):
         stimcirq.cirq_circuit_to_stim_circuit(
-            cirq.Circuit(cirq.Moment(stimcirq.CumulativeObservableAnnotation("unknown", observable_index=0)))
+            cirq.Circuit(
+                cirq.Moment(
+                    stimcirq.CumulativeObservableAnnotation(
+                        parity_keys=["unknown"], observable_index=0
+                    )
+                )
+            )
         )
     with pytest.raises(ValueError, match="earlier"):
         stimcirq.cirq_circuit_to_stim_circuit(
             cirq.Circuit(
                 cirq.Moment(
-                    stimcirq.CumulativeObservableAnnotation("later", observable_index=0),
+                    stimcirq.CumulativeObservableAnnotation(
+                        parity_keys=["later"], observable_index=0
+                    ),
                     cirq.measure(b, key="later"),
                 )
             )
@@ -24,14 +32,20 @@ def test_stim_conversion():
     with pytest.raises(ValueError, match="earlier"):
         stimcirq.cirq_circuit_to_stim_circuit(
             cirq.Circuit(
-                cirq.Moment(stimcirq.CumulativeObservableAnnotation("later", observable_index=0)),
+                cirq.Moment(
+                    stimcirq.CumulativeObservableAnnotation(
+                        parity_keys=["later"], observable_index=0
+                    )
+                ),
                 cirq.Moment(cirq.measure(b, key="later")),
             )
         )
     assert stimcirq.cirq_circuit_to_stim_circuit(
         cirq.Circuit(
             cirq.Moment(cirq.measure(b, key="earlier")),
-            cirq.Moment(stimcirq.CumulativeObservableAnnotation("earlier", observable_index=0)),
+            cirq.Moment(
+                stimcirq.CumulativeObservableAnnotation(parity_keys=["earlier"], observable_index=0)
+            ),
         )
     ) == stim.Circuit(
         """
@@ -46,7 +60,9 @@ def test_stim_conversion():
         cirq.Circuit(
             cirq.Moment(
                 cirq.measure(b, key="earlier"),
-                stimcirq.CumulativeObservableAnnotation("earlier", observable_index=0),
+                stimcirq.CumulativeObservableAnnotation(
+                    parity_keys=["earlier"], observable_index=0
+                ),
             )
         )
     ) == stim.Circuit(
@@ -61,7 +77,9 @@ def test_stim_conversion():
     assert stimcirq.cirq_circuit_to_stim_circuit(
         cirq.Circuit(
             cirq.Moment(cirq.measure(a, key="a"), cirq.measure(b, key="b")),
-            cirq.Moment(stimcirq.CumulativeObservableAnnotation("a", "b", observable_index=2)),
+            cirq.Moment(
+                stimcirq.CumulativeObservableAnnotation(parity_keys=["a", "b"], observable_index=2)
+            ),
         )
     ) == stim.Circuit(
         """
@@ -80,9 +98,9 @@ def test_stim_conversion():
             cirq.Moment(
                 cirq.measure(a, key="a"),
                 cirq.measure(b, key="b"),
-                stimcirq.CumulativeObservableAnnotation("a", "b", observable_index=0),
+                stimcirq.CumulativeObservableAnnotation(parity_keys=["a", "b"], observable_index=0),
                 cirq.measure(c, key="c"),
-                stimcirq.CumulativeObservableAnnotation("a", "c", observable_index=0),
+                stimcirq.CumulativeObservableAnnotation(parity_keys=["a", "c"], observable_index=0),
             ),
         )
     ) == stim.Circuit(
@@ -108,7 +126,7 @@ def test_simulation():
         cirq.Circuit(
             cirq.X(a),
             cirq.measure(a, key="a"),
-            stimcirq.CumulativeObservableAnnotation("a", observable_index=0),
+            stimcirq.CumulativeObservableAnnotation(parity_keys=["a"], observable_index=0),
         ),
         repetitions=3,
     )
@@ -121,19 +139,20 @@ def test_diagram():
         cirq.Circuit(
             cirq.measure(a, key="a"),
             cirq.measure(b, key="b"),
-            stimcirq.CumulativeObservableAnnotation("a", "b", observable_index=2),
+            stimcirq.CumulativeObservableAnnotation(parity_keys=["a", "b"], observable_index=2),
         ),
         """
-0: ───M('a')──────────
+0: ---M('a')----------
 
-1: ───M('b')──────────
+1: ---M('b')----------
       Obs2('a','b')
-    """,
+        """,
+        use_unicode_characters=False,
     )
 
 
 def test_repr():
-    val = stimcirq.CumulativeObservableAnnotation("a", "b", observable_index=2)
+    val = stimcirq.CumulativeObservableAnnotation(parity_keys=["a", "b"], observable_index=2)
     assert eval(repr(val), {"stimcirq": stimcirq}) == val
 
 
@@ -144,23 +163,30 @@ def test_equality():
         stimcirq.CumulativeObservableAnnotation(observable_index=0),
     )
     eq.add_equality_group(stimcirq.CumulativeObservableAnnotation(observable_index=1))
-    eq.add_equality_group(stimcirq.CumulativeObservableAnnotation("a", observable_index=0))
-    eq.add_equality_group(stimcirq.CumulativeObservableAnnotation("a", observable_index=1))
-    eq.add_equality_group(stimcirq.CumulativeObservableAnnotation("b", observable_index=0))
     eq.add_equality_group(
-        stimcirq.CumulativeObservableAnnotation("a", "b", observable_index=0),
-        stimcirq.CumulativeObservableAnnotation("b", "a", observable_index=0),
+        stimcirq.CumulativeObservableAnnotation(parity_keys=["a"], observable_index=0)
+    )
+    eq.add_equality_group(
+        stimcirq.CumulativeObservableAnnotation(parity_keys=["a"], observable_index=1)
+    )
+    eq.add_equality_group(
+        stimcirq.CumulativeObservableAnnotation(parity_keys=["b"], observable_index=0)
+    )
+    eq.add_equality_group(
+        stimcirq.CumulativeObservableAnnotation(parity_keys=["a", "b"], observable_index=0),
+        stimcirq.CumulativeObservableAnnotation(parity_keys=["b", "a"], observable_index=0),
     )
 
 
 def test_json_serialization():
     c = cirq.Circuit(
-        stimcirq.CumulativeObservableAnnotation("a", "b", observable_index=5),
+        stimcirq.CumulativeObservableAnnotation(parity_keys=["a", "b"], observable_index=5),
+        stimcirq.CumulativeObservableAnnotation(
+            parity_keys=["a", "b"], relative_keys=[-1, -3], observable_index=5
+        ),
         stimcirq.CumulativeObservableAnnotation(observable_index=2),
-        stimcirq.CumulativeObservableAnnotation("d", "c", observable_index=5),
+        stimcirq.CumulativeObservableAnnotation(parity_keys=["d", "c"], observable_index=5),
     )
     json = cirq.to_json(c)
-    c2 = cirq.read_json(
-        json_text=json,
-        resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER])
+    c2 = cirq.read_json(json_text=json, resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER])
     assert c == c2

--- a/glue/cirq/stimcirq/_shift_coords_annotation.py
+++ b/glue/cirq/stimcirq/_shift_coords_annotation.py
@@ -1,0 +1,49 @@
+from typing import Any, Dict, Iterable, List, Tuple
+
+import cirq
+import stim
+
+
+@cirq.value_equality
+class ShiftCoordsAnnotation(cirq.Operation):
+    """Annotates that the qubit/detector coordinate origin is being moved.
+
+    Creates a SHIFT_COORDS operation when converting to a stim circuit.
+    """
+
+    def __init__(self, shift: Iterable[float]):
+        """
+
+        Args:
+            shift: How much to shift each coordinate..
+        """
+        self.shift = tuple(shift)
+
+    @property
+    def qubits(self) -> Tuple[cirq.Qid, ...]:
+        return ()
+
+    def with_qubits(self, *new_qubits) -> 'ShiftCoordsAnnotation':
+        return self
+
+    def _value_equality_values_(self) -> Any:
+        return self.shift
+
+    def _circuit_diagram_info_(self, args: Any) -> str:
+        k = ",".join(repr(e) for e in self.shift)
+        return f"ShiftCoords({k})"
+
+    def _json_dict_(self) -> Dict[str, Any]:
+        return {'cirq_type': self.__class__.__name__, 'shift': self.shift}
+
+    def __repr__(self) -> str:
+        return f'stimcirq.ShiftCoordsAnnotation({self.shift!r})'
+
+    def _decompose_(self):
+        return []
+
+    def _is_comment_(self) -> bool:
+        return True
+
+    def _stim_conversion_(self, edit_circuit: stim.Circuit, **kwargs):
+        edit_circuit.append_operation("SHIFT_COORDS", [], self.shift)

--- a/glue/cirq/stimcirq/_shift_coords_annotation_test.py
+++ b/glue/cirq/stimcirq/_shift_coords_annotation_test.py
@@ -1,0 +1,80 @@
+import cirq
+import numpy as np
+import pytest
+import stim
+import stimcirq
+
+
+def test_conversion():
+    stim_circuit = stim.Circuit(
+        """
+        M 0
+        DETECTOR(4) rec[-1]
+        SHIFT_COORDS(1, 2, 3)
+        DETECTOR(5) rec[-1]
+        TICK
+    """
+    )
+    cirq_circuit = cirq.Circuit(
+        cirq.measure(cirq.LineQubit(0)),
+        stimcirq.DetAnnotation(parity_keys=["0"], coordinate_metadata=[4]),
+        stimcirq.ShiftCoordsAnnotation((1, 2, 3)),
+        stimcirq.DetAnnotation(parity_keys=["0"], coordinate_metadata=[5]),
+    )
+    assert stimcirq.cirq_circuit_to_stim_circuit(cirq_circuit) == stim_circuit
+    assert stimcirq.stim_circuit_to_cirq_circuit(stim_circuit) == cirq_circuit
+    assert stimcirq.stim_circuit_to_cirq_circuit(stim_circuit, flatten=False) == cirq_circuit
+    assert stimcirq.stim_circuit_to_cirq_circuit(stim_circuit, flatten=True) == cirq.Circuit(
+        cirq.measure(cirq.LineQubit(0)),
+        stimcirq.DetAnnotation(parity_keys=["0"], coordinate_metadata=[4]),
+        stimcirq.DetAnnotation(parity_keys=["0"], coordinate_metadata=[6]),
+    )
+
+
+def test_simulation():
+    a = cirq.LineQubit(0)
+    s = cirq.Simulator().sample(
+        cirq.Circuit(
+            cirq.X(a), cirq.measure(a, key="a"), stimcirq.ShiftCoordsAnnotation((1, 2, 3))
+        ),
+        repetitions=3,
+    )
+    np.testing.assert_array_equal(s["a"], [1, 1, 1])
+
+
+def test_diagram():
+    a, b = cirq.LineQubit.range(2)
+    cirq.testing.assert_has_diagram(
+        cirq.Circuit(
+            cirq.measure(a, key="a"),
+            cirq.measure(b, key="b"),
+            stimcirq.ShiftCoordsAnnotation([1, 2, 3]),
+        ),
+        """
+0: ---M('a')---------------
+
+1: ---M('b')---------------
+      ShiftCoords(1,2,3)
+        """,
+        use_unicode_characters=False,
+    )
+
+
+def test_repr():
+    val = stimcirq.ShiftCoordsAnnotation([1, 2, 3])
+    assert eval(repr(val), {"stimcirq": stimcirq}) == val
+
+
+def test_equality():
+    eq = cirq.testing.EqualsTester()
+    eq.add_equality_group(stimcirq.ShiftCoordsAnnotation([]))
+    eq.add_equality_group(
+        stimcirq.ShiftCoordsAnnotation([1, 2]), stimcirq.ShiftCoordsAnnotation((1, 2))
+    )
+
+
+def test_json_serialization():
+    c = cirq.Circuit(stimcirq.ShiftCoordsAnnotation([1, 2, 3]))
+    json = cirq.to_json(c)
+    c2 = cirq.read_json(json_text=json, resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER])
+    assert c == c2

--- a/glue/cirq/stimcirq/_stim_sampler.py
+++ b/glue/cirq/stimcirq/_stim_sampler.py
@@ -17,10 +17,7 @@ class StimSampler(cirq.Sampler):
     """
 
     def run_sweep(
-        self,
-        program: cirq.Circuit,
-        params: cirq.Sweepable,
-        repetitions: int = 1,
+        self, program: cirq.Circuit, params: cirq.Sweepable, repetitions: int = 1
     ) -> List[cirq.Result]:
         trial_results: List[cirq.Result] = []
         for param_resolver in cirq.to_resolvers(params):

--- a/glue/cirq/stimcirq/_stim_sampler_test.py
+++ b/glue/cirq/stimcirq/_stim_sampler_test.py
@@ -1,7 +1,6 @@
 import cirq
 import numpy as np
 import pytest
-
 import stimcirq
 
 
@@ -80,18 +79,20 @@ def test_custom_measurement():
             return 1
 
         def _decompose_(self, qubits):
-            q, = qubits
+            (q,) = qubits
             return [cirq.H(q), cirq.measure(q, key=self.key), cirq.H(q)]
 
     s = stimcirq.StimSampler()
     a, b = cirq.LineQubit.range(2)
-    out = s.sample(cirq.Circuit(
-        cirq.H(a),
-        cirq.X(b),
-        cirq.H(b),
-        XBasisMeasurement("a").on(a),
-        XBasisMeasurement("b").on(b),
-    ))
+    out = s.sample(
+        cirq.Circuit(
+            cirq.H(a),
+            cirq.X(b),
+            cirq.H(b),
+            XBasisMeasurement("a").on(a),
+            XBasisMeasurement("b").on(b),
+        )
+    )
     np.testing.assert_array_equal(out["a"], [0])
     np.testing.assert_array_equal(out["b"], [1])
 

--- a/glue/cirq/stimcirq/_stim_to_cirq.py
+++ b/glue/cirq/stimcirq/_stim_to_cirq.py
@@ -107,7 +107,7 @@ class CircuitTranslationTracker:
         self.process_gate_instruction(TwoQubitAsymmetricDepolarizingChannel(args), instruction)
 
     def process_repeat_block(self, block: stim.CircuitRepeatBlock):
-        if self.flatten:
+        if self.flatten or block.repeat_count == 1:
             self.process_circuit(block.repeat_count, block.body_copy())
             return
 

--- a/glue/cirq/stimcirq/_stim_to_cirq.py
+++ b/glue/cirq/stimcirq/_stim_to_cirq.py
@@ -44,6 +44,23 @@ def _stim_targets_to_dense_pauli_string(
     return obs.frozen()
 
 
+def _proper_transform_circuit_qubits(circuit: cirq.AbstractCircuit, remap: Dict[cirq.Qid, cirq.Qid]) -> cirq.Circuit:
+    # Note: doing this the hard way because cirq.CircuitOperation otherwise remembers the old indices in
+    # its `remap` entry, instead of completely expunging those indices.
+    return cirq.Circuit(
+        cirq.Moment(
+            cirq.CircuitOperation(
+                circuit=_proper_transform_circuit_qubits(op.circuit, remap).freeze(),
+                repetitions=op.repetitions,
+            )
+            if isinstance(op, cirq.CircuitOperation)
+            else op.with_qubits(*[remap[q] for q in op.qubits])
+            for op in moment
+        )
+        for moment in circuit
+    )
+
+
 class CircuitTranslationTracker:
     def __init__(self, flatten: bool):
         self.qubit_coords: Dict[int, cirq.Qid] = {}
@@ -162,7 +179,9 @@ class CircuitTranslationTracker:
 
             # Only remap if there are no collisions.
             if len(set(remap.values())) == len(remap):
-                out = out.transform_qubits(remap.__getitem__)
+                # Note: doing this the hard way because cirq.CircuitOperation otherwise remembers the old indices in
+                # its `remap` entry, instead of completely expunging those indices.
+                out = _proper_transform_circuit_qubits(out, remap)
 
         return out
 

--- a/glue/cirq/stimcirq/_stim_to_cirq.py
+++ b/glue/cirq/stimcirq/_stim_to_cirq.py
@@ -1,6 +1,19 @@
 import collections
 import functools
-from typing import Callable, Dict, List, Tuple, Union, Iterator, cast, Sequence, Iterable, Set, Any, DefaultDict
+from typing import (
+    Any,
+    Callable,
+    cast,
+    DefaultDict,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
 
 import cirq
 import stim
@@ -8,11 +21,14 @@ import stim
 from ._det_annotation import DetAnnotation
 from ._measure_and_or_reset_gate import MeasureAndOrResetGate
 from ._obs_annotation import CumulativeObservableAnnotation
+from ._shift_coords_annotation import ShiftCoordsAnnotation
 from ._sweep_pauli import SweepPauli
 from ._two_qubit_asymmetric_depolarize import TwoQubitAsymmetricDepolarizingChannel
 
 
-def _stim_targets_to_dense_pauli_string(targets: List[stim.GateTarget]) -> cirq.BaseDensePauliString:
+def _stim_targets_to_dense_pauli_string(
+    targets: List[stim.GateTarget],
+) -> cirq.BaseDensePauliString:
     obs = cirq.MutableDensePauliString("I" * len(targets))
     for k, target in enumerate(targets):
         if target.is_inverted_result_target:
@@ -29,12 +45,14 @@ def _stim_targets_to_dense_pauli_string(targets: List[stim.GateTarget]) -> cirq.
 
 
 class CircuitTranslationTracker:
-    def __init__(self):
+    def __init__(self, flatten: bool):
         self.qubit_coords: Dict[int, cirq.Qid] = {}
         self.origin: DefaultDict[float] = collections.defaultdict(float)
         self.num_measurements_seen = 0
         self.full_circuit = cirq.Circuit()
         self.tick_circuit = cirq.Circuit()
+        self.flatten = flatten
+        self.have_seen_loop = False
 
     def get_next_measure_id(self) -> int:
         self.num_measurements_seen += 1
@@ -43,13 +61,15 @@ class CircuitTranslationTracker:
     def append_operation(self, op: cirq.Operation) -> None:
         self.tick_circuit.append(op, strategy=cirq.InsertStrategy.INLINE)
 
-    def process_gate_instruction(self, gate: cirq.Gate, instruction: stim.CircuitInstruction) -> None:
+    def process_gate_instruction(
+        self, gate: cirq.Gate, instruction: stim.CircuitInstruction
+    ) -> None:
         targets: List[stim.GateTarget] = instruction.targets_copy()
         m = cirq.num_qubits(gate)
         if not all(t.is_qubit_target for t in targets) or len(targets) % m != 0:
             raise NotImplementedError(f"instruction={instruction!r}")
         for k in range(0, len(targets), m):
-            self.append_operation(gate(*[cirq.LineQubit(t.value) for t in targets[k:k+m]]))
+            self.append_operation(gate(*[cirq.LineQubit(t.value) for t in targets[k : k + m]]))
 
     def process_tick(self, instruction: stim.CircuitInstruction) -> None:
         self.full_circuit += self.tick_circuit or cirq.Moment()
@@ -60,22 +80,43 @@ class CircuitTranslationTracker:
         if len(args) != 3:
             raise ValueError(f"len(args={args!r}) != 3")
         self.process_gate_instruction(
-            cirq.AsymmetricDepolarizingChannel(p_x=args[0], p_y=args[1], p_z=args[2]),
-            instruction)
+            cirq.AsymmetricDepolarizingChannel(p_x=args[0], p_y=args[1], p_z=args[2]), instruction
+        )
 
     def process_pauli_channel_2(self, instruction: stim.CircuitInstruction) -> None:
         args = instruction.gate_args_copy()
         if len(args) != 15:
             raise ValueError(f"len(args={args!r}) != 15")
-        self.process_gate_instruction(
-            TwoQubitAsymmetricDepolarizingChannel(args),
-            instruction)
+        self.process_gate_instruction(TwoQubitAsymmetricDepolarizingChannel(args), instruction)
 
-    def process_measurement_instruction(self,
-                                        instruction: stim.CircuitInstruction,
-                                        measure: bool,
-                                        reset: bool,
-                                        basis: str) -> None:
+    def process_repeat_block(self, block: stim.CircuitRepeatBlock):
+        if self.flatten:
+            self.process_circuit(block.repeat_count, block.body_copy())
+            return
+
+        self.have_seen_loop = True
+        child = CircuitTranslationTracker(flatten=self.flatten)
+        child.origin = self.origin.copy()
+        child.num_measurements_seen = self.num_measurements_seen
+        child.qubit_coords = self.qubit_coords.copy()
+        child.have_seen_loop = True
+        child.process_circuit(1, block.body_copy())
+        self.append_operation(
+            cirq.CircuitOperation(
+                cirq.FrozenCircuit(child.full_circuit + child.tick_circuit),
+                repetitions=block.repeat_count,
+            )
+        )
+        self.qubit_coords = child.qubit_coords
+        self.num_measurements_seen += (
+            child.num_measurements_seen - self.num_measurements_seen
+        ) * block.repeat_count
+        for k, v in child.origin.items():
+            self.origin[k] += (v - self.origin[k]) * block.repeat_count
+
+    def process_measurement_instruction(
+        self, instruction: stim.CircuitInstruction, measure: bool, reset: bool, basis: str
+    ) -> None:
         args = instruction.gate_args_copy()
         flip_probability = 0
         if args:
@@ -94,12 +135,10 @@ class CircuitTranslationTracker:
                     invert_measure=t.is_inverted_result_target,
                     key=key,
                     measure_flip_probability=flip_probability,
-                ).resolve(cirq.LineQubit(t.value)))
+                ).resolve(cirq.LineQubit(t.value))
+            )
 
-    def process_circuit(
-            self,
-            repetitions: int,
-            circuit: stim.Circuit) -> None:
+    def process_circuit(self, repetitions: int, circuit: stim.Circuit) -> None:
         handler_table = CircuitTranslationTracker.get_handler_table()
         for _ in range(repetitions):
             for instruction in circuit:
@@ -109,7 +148,7 @@ class CircuitTranslationTracker:
                         raise NotImplementedError(f"{instruction!r}")
                     handler(self, instruction)
                 elif isinstance(instruction, stim.CircuitRepeatBlock):
-                    self.process_circuit(instruction.repeat_count, instruction.body_copy())
+                    self.process_repeat_block(instruction)
                 else:
                     raise NotImplementedError(f"instruction={instruction!r}")
 
@@ -118,8 +157,7 @@ class CircuitTranslationTracker:
 
         if self.qubit_coords:
             remap: Dict[cirq.Qid, cirq.Qid] = {
-                q: self.qubit_coords.get(cast(cirq.LineQubit, q).x, q)
-                for q in out.all_qubits()
+                q: self.qubit_coords.get(cast(cirq.LineQubit, q).x, q) for q in out.all_qubits()
             }
 
             # Only remap if there are no collisions.
@@ -147,7 +185,8 @@ class CircuitTranslationTracker:
             key = str(self.get_next_measure_id())
             if obs.coefficient == -1:
                 raise NotImplementedError(
-                    "Converting inverted MPP blocked by https://github.com/quantumlib/Cirq/issues/4814")
+                    "Converting inverted MPP blocked by https://github.com/quantumlib/Cirq/issues/4814"
+                )
             self.append_operation(cirq.PauliMeasurementGate(obs, key=key).on(*qubits))
 
     def process_correlated_error(self, instruction: stim.CircuitInstruction) -> None:
@@ -155,9 +194,15 @@ class CircuitTranslationTracker:
         probability = args[0] if args else 0
         targets = instruction.targets_copy()
         qubits = [cirq.LineQubit(t.value) for t in targets]
-        self.append_operation(_stim_targets_to_dense_pauli_string(targets).on(*qubits).with_probability(probability))
+        self.append_operation(
+            _stim_targets_to_dense_pauli_string(targets).on(*qubits).with_probability(probability)
+        )
 
-    def coords_after_offset(self, relative_coords: List[float]) -> List[Union[float, int]]:
+    def coords_after_offset(
+        self, relative_coords: List[float], *, even_if_flattening: bool = False
+    ) -> List[Union[float, int]]:
+        if not self.flatten and not even_if_flattening:
+            return list(relative_coords)
         result = []
         for k in range(len(relative_coords)):
             t = relative_coords[k] + self.origin[k]
@@ -166,23 +211,33 @@ class CircuitTranslationTracker:
             result.append(t)
         return result
 
+    def resolve_measurement_record_keys(
+        self, targets: Iterable[stim.GateTarget]
+    ) -> Tuple[List[str], List[int]]:
+        if self.have_seen_loop:
+            return [], [t.value for t in targets]
+        else:
+            return [str(self.num_measurements_seen + t.value) for t in targets], []
+
     def process_detector(self, instruction: stim.CircuitInstruction) -> None:
         coords = self.coords_after_offset(instruction.gate_args_copy())
-        targets = instruction.targets_copy()
-        measurement_keys = [str(self.num_measurements_seen + t.value) for t in targets]
-        self.append_operation(DetAnnotation(*measurement_keys, coordinate_metadata=coords))
+        keys, rels = self.resolve_measurement_record_keys(instruction.targets_copy())
+        self.append_operation(
+            DetAnnotation(parity_keys=keys, relative_keys=rels, coordinate_metadata=coords)
+        )
 
     def process_observable_include(self, instruction: stim.CircuitInstruction) -> None:
         args = instruction.gate_args_copy()
         index = 0 if not args else int(args[0])
-        targets = instruction.targets_copy()
-        measurement_keys = [str(self.num_measurements_seen + t.value) for t in targets]
-        self.append_operation(CumulativeObservableAnnotation(
-            *measurement_keys,
-            observable_index=index))
+        keys, rels = self.resolve_measurement_record_keys(instruction.targets_copy())
+        self.append_operation(
+            CumulativeObservableAnnotation(
+                parity_keys=keys, relative_keys=rels, observable_index=index
+            )
+        )
 
     def process_qubit_coords(self, instruction: stim.CircuitInstruction) -> None:
-        coords = self.coords_after_offset(instruction.gate_args_copy())
+        coords = self.coords_after_offset(instruction.gate_args_copy(), even_if_flattening=True)
         for t in instruction.targets_copy():
             if len(coords) == 1:
                 self.qubit_coords[t.value] = cirq.LineQubit(*coords)
@@ -190,14 +245,19 @@ class CircuitTranslationTracker:
                 self.qubit_coords[t.value] = cirq.GridQubit(*coords)
 
     def process_shift_coords(self, instruction: stim.CircuitInstruction) -> None:
-        for k, a in enumerate(instruction.gate_args_copy()):
+        args = instruction.gate_args_copy()
+        if not self.flatten:
+            self.append_operation(ShiftCoordsAnnotation(args))
+        for k, a in enumerate(args):
             self.origin[k] += a
 
     class OneToOneGateHandler:
         def __init__(self, gate: cirq.Gate):
             self.gate = gate
 
-        def __call__(self, tracker: 'CircuitTranslationTracker', instruction: stim.CircuitInstruction) -> None:
+        def __call__(
+            self, tracker: 'CircuitTranslationTracker', instruction: stim.CircuitInstruction
+        ) -> None:
             tracker.process_gate_instruction(gate=self.gate, instruction=instruction)
 
     class SweepableGateHandler:
@@ -205,7 +265,9 @@ class CircuitTranslationTracker:
             self.pauli_gate = pauli_gate
             self.gate = gate
 
-        def __call__(self, tracker: 'CircuitTranslationTracker', instruction: stim.CircuitInstruction) -> None:
+        def __call__(
+            self, tracker: 'CircuitTranslationTracker', instruction: stim.CircuitInstruction
+        ) -> None:
             targets: List[stim.GateTarget] = instruction.targets_copy()
             for k in range(0, len(targets), 2):
                 a = targets[k]
@@ -216,15 +278,19 @@ class CircuitTranslationTracker:
                     if b.is_sweep_bit_target:
                         a, b = b, a
                     assert not a.is_inverted_result_target
-                    tracker.append_operation(SweepPauli(
-                        stim_sweep_bit_index=a.value,
-                        cirq_sweep_symbol=f'sweep[{a.value}]',
-                        pauli=self.pauli_gate,
-                    ).on(cirq.LineQubit(b.value)))
+                    tracker.append_operation(
+                        SweepPauli(
+                            stim_sweep_bit_index=a.value,
+                            cirq_sweep_symbol=f'sweep[{a.value}]',
+                            pauli=self.pauli_gate,
+                        ).on(cirq.LineQubit(b.value))
+                    )
                 else:
                     if not a.is_qubit_target or not b.is_qubit_target:
                         raise NotImplementedError(f"instruction={instruction!r}")
-                    tracker.append_operation(self.gate(cirq.LineQubit(a.value), cirq.LineQubit(b.value)))
+                    tracker.append_operation(
+                        self.gate(cirq.LineQubit(a.value), cirq.LineQubit(b.value))
+                    )
 
     class OneToOneMeasurementHandler:
         def __init__(self, *, reset: bool, measure: bool, basis: str):
@@ -232,31 +298,40 @@ class CircuitTranslationTracker:
             self.measure = measure
             self.basis = basis
 
-        def __call__(self, tracker: 'CircuitTranslationTracker', instruction: stim.CircuitInstruction) -> None:
+        def __call__(
+            self, tracker: 'CircuitTranslationTracker', instruction: stim.CircuitInstruction
+        ) -> None:
             tracker.process_measurement_instruction(
-                measure=self.measure,
-                reset=self.reset,
-                basis=self.basis,
-                instruction=instruction)
+                measure=self.measure, reset=self.reset, basis=self.basis, instruction=instruction
+            )
 
     class OneToOneNoisyGateHandler:
         def __init__(self, prob_to_gate: Callable[[float], cirq.Gate]):
             self.prob_to_gate = prob_to_gate
 
-        def __call__(self, tracker: 'CircuitTranslationTracker', instruction: stim.CircuitInstruction) -> None:
-            tracker.process_gate_instruction(self.prob_to_gate(instruction.gate_args_copy()[0]), instruction)
+        def __call__(
+            self, tracker: 'CircuitTranslationTracker', instruction: stim.CircuitInstruction
+        ) -> None:
+            tracker.process_gate_instruction(
+                self.prob_to_gate(instruction.gate_args_copy()[0]), instruction
+            )
 
     @staticmethod
     @functools.lru_cache(maxsize=1)
-    def get_handler_table() -> Dict[str, Callable[['CircuitTranslationTracker', stim.Circuit], None]]:
+    def get_handler_table() -> Dict[
+        str, Callable[['CircuitTranslationTracker', stim.Circuit], None]
+    ]:
         gate = CircuitTranslationTracker.OneToOneGateHandler
         measure_gate = CircuitTranslationTracker.OneToOneMeasurementHandler
         noise = CircuitTranslationTracker.OneToOneNoisyGateHandler
         sweep_gate = CircuitTranslationTracker.SweepableGateHandler
 
         def not_impl(message) -> Callable[[Any], None]:
-            def handler(tracker: CircuitTranslationTracker, instruction: stim.CircuitInstruction) -> None:
+            def handler(
+                tracker: CircuitTranslationTracker, instruction: stim.CircuitInstruction
+            ) -> None:
                 raise NotImplementedError(message)
+
             return handler
 
         return {
@@ -269,36 +344,52 @@ class CircuitTranslationTracker:
             "MRY": measure_gate(measure=True, reset=True, basis='Y'),
             "MRZ": measure_gate(measure=True, reset=True, basis='Z'),
             "R": gate(cirq.ResetChannel()),
-            "RX": gate(MeasureAndOrResetGate(measure=False, reset=True, basis='X', invert_measure=False, key='')),
-            "RY": gate(MeasureAndOrResetGate(measure=False, reset=True, basis='Y', invert_measure=False, key='')),
+            "RX": gate(
+                MeasureAndOrResetGate(
+                    measure=False, reset=True, basis='X', invert_measure=False, key=''
+                )
+            ),
+            "RY": gate(
+                MeasureAndOrResetGate(
+                    measure=False, reset=True, basis='Y', invert_measure=False, key=''
+                )
+            ),
             "RZ": gate(cirq.ResetChannel()),
             "I": gate(cirq.I),
             "X": gate(cirq.X),
             "Y": gate(cirq.Y),
             "Z": gate(cirq.Z),
-            "H_XY": gate(cirq.SingleQubitCliffordGate.from_xz_map(x_to=(cirq.Y, False), z_to=(cirq.Z, True))),
+            "H_XY": gate(
+                cirq.SingleQubitCliffordGate.from_xz_map(x_to=(cirq.Y, False), z_to=(cirq.Z, True))
+            ),
             "H": gate(cirq.H),
             "H_XZ": gate(cirq.H),
-            "H_YZ": gate(cirq.SingleQubitCliffordGate.from_xz_map(x_to=(cirq.X, True), z_to=(cirq.Y, False))),
-            "SQRT_X": gate(cirq.X**0.5),
-            "SQRT_X_DAG": gate(cirq.X**-0.5),
-            "SQRT_Y": gate(cirq.Y**0.5),
-            "SQRT_Y_DAG": gate(cirq.Y**-0.5),
-            "C_XYZ": gate(cirq.SingleQubitCliffordGate.from_xz_map(x_to=(cirq.Y, False), z_to=(cirq.X, False))),
-            "C_ZYX": gate(cirq.SingleQubitCliffordGate.from_xz_map(x_to=(cirq.Z, False), z_to=(cirq.Y, False))),
-            "SQRT_XX": gate(cirq.XX**0.5),
-            "SQRT_YY": gate(cirq.YY**0.5),
-            "SQRT_ZZ": gate(cirq.ZZ**0.5),
-            "SQRT_XX_DAG": gate(cirq.XX**-0.5),
-            "SQRT_YY_DAG": gate(cirq.YY**-0.5),
-            "SQRT_ZZ_DAG": gate(cirq.ZZ**-0.5),
+            "H_YZ": gate(
+                cirq.SingleQubitCliffordGate.from_xz_map(x_to=(cirq.X, True), z_to=(cirq.Y, False))
+            ),
+            "SQRT_X": gate(cirq.X ** 0.5),
+            "SQRT_X_DAG": gate(cirq.X ** -0.5),
+            "SQRT_Y": gate(cirq.Y ** 0.5),
+            "SQRT_Y_DAG": gate(cirq.Y ** -0.5),
+            "C_XYZ": gate(
+                cirq.SingleQubitCliffordGate.from_xz_map(x_to=(cirq.Y, False), z_to=(cirq.X, False))
+            ),
+            "C_ZYX": gate(
+                cirq.SingleQubitCliffordGate.from_xz_map(x_to=(cirq.Z, False), z_to=(cirq.Y, False))
+            ),
+            "SQRT_XX": gate(cirq.XX ** 0.5),
+            "SQRT_YY": gate(cirq.YY ** 0.5),
+            "SQRT_ZZ": gate(cirq.ZZ ** 0.5),
+            "SQRT_XX_DAG": gate(cirq.XX ** -0.5),
+            "SQRT_YY_DAG": gate(cirq.YY ** -0.5),
+            "SQRT_ZZ_DAG": gate(cirq.ZZ ** -0.5),
             "S": gate(cirq.S),
-            "S_DAG": gate(cirq.S**-1),
+            "S_DAG": gate(cirq.S ** -1),
             "SQRT_Z": gate(cirq.S),
-            "SQRT_Z_DAG": gate(cirq.S**-1),
+            "SQRT_Z_DAG": gate(cirq.S ** -1),
             "SWAP": gate(cirq.SWAP),
             "ISWAP": gate(cirq.ISWAP),
-            "ISWAP_DAG": gate(cirq.ISWAP**-1),
+            "ISWAP_DAG": gate(cirq.ISWAP ** -1),
             "XCX": gate(cirq.PauliInteractionGate(cirq.X, False, cirq.X, False)),
             "XCY": gate(cirq.PauliInteractionGate(cirq.X, False, cirq.Y, False)),
             "XCZ": sweep_gate(cirq.X, cirq.PauliInteractionGate(cirq.X, False, cirq.Z, False)),
@@ -319,7 +410,9 @@ class CircuitTranslationTracker:
             "Z_ERROR": noise(cirq.Z.with_probability),
             "PAULI_CHANNEL_1": CircuitTranslationTracker.process_pauli_channel_1,
             "PAULI_CHANNEL_2": CircuitTranslationTracker.process_pauli_channel_2,
-            "ELSE_CORRELATED_ERROR": not_impl("Converting ELSE_CORRELATED_ERROR to cirq is not supported."),
+            "ELSE_CORRELATED_ERROR": not_impl(
+                "Converting ELSE_CORRELATED_ERROR to cirq is not supported."
+            ),
             "REPEAT": not_impl("[handled special]"),
             "TICK": CircuitTranslationTracker.process_tick,
             "SHIFT_COORDS": CircuitTranslationTracker.process_shift_coords,
@@ -332,7 +425,7 @@ class CircuitTranslationTracker:
         }
 
 
-def stim_circuit_to_cirq_circuit(circuit: stim.Circuit) -> cirq.Circuit:
+def stim_circuit_to_cirq_circuit(circuit: stim.Circuit, *, flatten: bool = False) -> cirq.Circuit:
     """Converts a stim circuit into an equivalent cirq circuit.
 
     Qubit indices are turned into cirq.LineQubit instances. Measurements are
@@ -348,6 +441,10 @@ def stim_circuit_to_cirq_circuit(circuit: stim.Circuit) -> cirq.Circuit:
 
     Args:
         circuit: The stim circuit to convert into a cirq circuit.
+        flatten: Defaults to False. When set to True, REPEAT blocks are removed by
+            explicitly repeating their instructions multiple times. Also,
+            SHIFT_COORDS instructions are removed by appropriately adjusting the
+            coordinate metadata of later instructions.
 
     Returns:
         The converted circuit.
@@ -367,6 +464,6 @@ def stim_circuit_to_cirq_circuit(circuit: stim.Circuit) -> cirq.Circuit:
                   │
         1: ───────X──────────────────!M('0')───
     """
-    tracker = CircuitTranslationTracker()
+    tracker = CircuitTranslationTracker(flatten=flatten)
     tracker.process_circuit(repetitions=1, circuit=circuit)
     return tracker.output()

--- a/glue/cirq/stimcirq/_stim_to_cirq_test.py
+++ b/glue/cirq/stimcirq/_stim_to_cirq_test.py
@@ -567,3 +567,20 @@ def test_convert_repeat_measurements():
     )
     assert stimcirq.stim_circuit_to_cirq_circuit(stim_circuit) == cirq_circuit
     assert stimcirq.cirq_circuit_to_stim_circuit(cirq_circuit) == stim_circuit
+
+
+def test_single_repeat_loops_always_flattened():
+    assert stimcirq.stim_circuit_to_cirq_circuit(stim.Circuit(
+        """
+        REPEAT 1 {
+            H 0
+        }
+        """)) == cirq.Circuit(cirq.H(cirq.LineQubit(0)))
+    assert stimcirq.cirq_circuit_to_stim_circuit(cirq.Circuit(
+        cirq.CircuitOperation(
+            cirq.FrozenCircuit(
+                cirq.H(cirq.LineQubit(0)),
+            ),
+            repetitions=1,
+        ),
+    )) == stim.Circuit("H 0\nTICK")

--- a/glue/cirq/stimcirq/_stim_to_cirq_test.py
+++ b/glue/cirq/stimcirq/_stim_to_cirq_test.py
@@ -1,17 +1,19 @@
 import inspect
 import itertools
-from typing import Tuple, Union, Callable, Any, cast
+from typing import Any, Callable, cast, Tuple, Union
 
 import cirq
 import pytest
 import stim
-
 import stimcirq
+
 from ._stim_to_cirq import CircuitTranslationTracker
 
 
 def test_stim_circuit_to_cirq_circuit():
-    circuit = stimcirq.stim_circuit_to_cirq_circuit(stim.Circuit("""
+    circuit = stimcirq.stim_circuit_to_cirq_circuit(
+        stim.Circuit(
+            """
         X 0
         CNOT 0 1
         X_ERROR(0.125) 0 1
@@ -20,43 +22,48 @@ def test_stim_circuit_to_cirq_circuit():
         M !1
         TICK
         MR 0 !1
-    """))
+    """
+        )
+    )
     a, b, c = cirq.LineQubit.range(3)
     assert circuit == cirq.Circuit(
         cirq.Moment(cirq.X(a)),
         cirq.Moment(cirq.CNOT(a, b)),
+        cirq.Moment(cirq.X.with_probability(0.125).on(a), cirq.X.with_probability(0.125).on(b)),
+        cirq.Moment(cirq.PauliString({a: cirq.X, b: cirq.Y, c: cirq.Z}).with_probability(0.25)),
+        cirq.Moment(cirq.measure(b, key="0")),
+        cirq.Moment(cirq.measure(b, key="1", invert_mask=(True,))),
         cirq.Moment(
-            cirq.X.with_probability(0.125).on(a),
-            cirq.X.with_probability(0.125).on(b),
-        ),
-        cirq.Moment(
-            cirq.PauliString({a: cirq.X, b: cirq.Y, c: cirq.Z}).with_probability(0.25),
-        ),
-        cirq.Moment(
-            cirq.measure(b, key="0"),
-        ),
-        cirq.Moment(
-            cirq.measure(b, key="1", invert_mask=(True,)),
-        ),
-        cirq.Moment(
-            stimcirq.MeasureAndOrResetGate(measure=True, reset=True, basis='Z', invert_measure=False, key='2').on(a),
-            stimcirq.MeasureAndOrResetGate(measure=True, reset=True, basis='Z', invert_measure=True, key='3').on(b),
+            stimcirq.MeasureAndOrResetGate(
+                measure=True, reset=True, basis='Z', invert_measure=False, key='2'
+            ).on(a),
+            stimcirq.MeasureAndOrResetGate(
+                measure=True, reset=True, basis='Z', invert_measure=True, key='3'
+            ).on(b),
         ),
     )
 
 
-def assert_circuits_are_equivalent_and_convert(cirq_circuit: cirq.Circuit, stim_circuit: stim.Circuit):
+def assert_circuits_are_equivalent_and_convert(
+    cirq_circuit: cirq.Circuit, stim_circuit: stim.Circuit
+):
     assert cirq_circuit == stimcirq.stim_circuit_to_cirq_circuit(stim_circuit)
     assert stim_circuit == stimcirq.cirq_circuit_to_stim_circuit(cirq_circuit)
 
 
-@pytest.mark.parametrize("name", [
-    k
-    for k, v in CircuitTranslationTracker.get_handler_table().items()
-    if isinstance(v, CircuitTranslationTracker.OneToOneGateHandler)
-])
+@pytest.mark.parametrize(
+    "name",
+    [
+        k
+        for k, v in CircuitTranslationTracker.get_handler_table().items()
+        if isinstance(v, CircuitTranslationTracker.OneToOneGateHandler)
+    ],
+)
 def test_gates_converted_using_OneToOneGateHandler(name: str):
-    handler = cast(CircuitTranslationTracker.OneToOneGateHandler, CircuitTranslationTracker.get_handler_table()[name])
+    handler = cast(
+        CircuitTranslationTracker.OneToOneGateHandler,
+        CircuitTranslationTracker.get_handler_table()[name],
+    )
     gate = handler.gate
     n = cirq.num_qubits(gate)
     qs = cirq.LineQubit.range(n)
@@ -67,13 +74,19 @@ def test_gates_converted_using_OneToOneGateHandler(name: str):
     assert_circuits_are_equivalent_and_convert(cirq_original, stim_original)
 
 
-@pytest.mark.parametrize("name", [
-    k
-    for k, v in CircuitTranslationTracker.get_handler_table().items()
-    if isinstance(v, CircuitTranslationTracker.SweepableGateHandler)
-])
+@pytest.mark.parametrize(
+    "name",
+    [
+        k
+        for k, v in CircuitTranslationTracker.get_handler_table().items()
+        if isinstance(v, CircuitTranslationTracker.SweepableGateHandler)
+    ],
+)
 def test_gates_converted_using_SweepableGateHandler(name: str):
-    handler = cast(CircuitTranslationTracker.SweepableGateHandler, CircuitTranslationTracker.get_handler_table()[name])
+    handler = cast(
+        CircuitTranslationTracker.SweepableGateHandler,
+        CircuitTranslationTracker.get_handler_table()[name],
+    )
     gate = handler.gate
     n = cirq.num_qubits(gate)
     qs = cirq.LineQubit.range(n)
@@ -86,10 +99,11 @@ def test_gates_converted_using_SweepableGateHandler(name: str):
 
     # With sweeping.
     q = qs[0]
-    cirq_original = cirq.Circuit(stimcirq.SweepPauli(
-        stim_sweep_bit_index=3,
-        cirq_sweep_symbol="sweep[3]",
-        pauli=handler.pauli_gate).on(q))
+    cirq_original = cirq.Circuit(
+        stimcirq.SweepPauli(
+            stim_sweep_bit_index=3, cirq_sweep_symbol="sweep[3]", pauli=handler.pauli_gate
+        ).on(q)
+    )
     if name.startswith("C") or name.startswith("Z"):
         stim_original = stim.Circuit(f"{name} sweep[3] 0\nTICK")
         assert_circuits_are_equivalent_and_convert(cirq_original, stim_original)
@@ -99,13 +113,22 @@ def test_gates_converted_using_SweepableGateHandler(name: str):
         assert stimcirq.stim_circuit_to_cirq_circuit(stim_original) == cirq_original
 
 
-@pytest.mark.parametrize("name,probability", itertools.product([
-    k
-    for k, v in CircuitTranslationTracker.get_handler_table().items()
-    if isinstance(v, CircuitTranslationTracker.OneToOneNoisyGateHandler)
-], [0, 0.125]))
+@pytest.mark.parametrize(
+    "name,probability",
+    itertools.product(
+        [
+            k
+            for k, v in CircuitTranslationTracker.get_handler_table().items()
+            if isinstance(v, CircuitTranslationTracker.OneToOneNoisyGateHandler)
+        ],
+        [0, 0.125],
+    ),
+)
 def test_gates_converted_using_OneToOneNoisyGateHandler(name: str, probability: float):
-    handler = cast(CircuitTranslationTracker.OneToOneNoisyGateHandler, CircuitTranslationTracker.get_handler_table()[name])
+    handler = cast(
+        CircuitTranslationTracker.OneToOneNoisyGateHandler,
+        CircuitTranslationTracker.get_handler_table()[name],
+    )
     gate = handler.prob_to_gate(probability)
     n = cirq.num_qubits(gate)
     qs = cirq.LineQubit.range(n)
@@ -116,22 +139,40 @@ def test_gates_converted_using_OneToOneNoisyGateHandler(name: str, probability: 
     assert_circuits_are_equivalent_and_convert(cirq_original, stim_original)
 
 
-@pytest.mark.parametrize("name,invert,probability", itertools.product([
-    k
-    for k, v in CircuitTranslationTracker.get_handler_table().items()
-    if isinstance(v, CircuitTranslationTracker.OneToOneMeasurementHandler)
-], [False, True], [0, 0.125]))
-def test_gates_converted_using_OneToOneMeasurementHandler(name: str, invert: bool, probability: float):
-    handler = cast(CircuitTranslationTracker.OneToOneMeasurementHandler, CircuitTranslationTracker.get_handler_table()[name])
+@pytest.mark.parametrize(
+    "name,invert,probability",
+    itertools.product(
+        [
+            k
+            for k, v in CircuitTranslationTracker.get_handler_table().items()
+            if isinstance(v, CircuitTranslationTracker.OneToOneMeasurementHandler)
+        ],
+        [False, True],
+        [0, 0.125],
+    ),
+)
+def test_gates_converted_using_OneToOneMeasurementHandler(
+    name: str, invert: bool, probability: float
+):
+    handler = cast(
+        CircuitTranslationTracker.OneToOneMeasurementHandler,
+        CircuitTranslationTracker.get_handler_table()[name],
+    )
     if handler.basis == 'Z' and not handler.reset and not probability:
-        cirq_original = cirq.Circuit(cirq.measure(cirq.LineQubit(5), key="0", invert_mask=(1,) * invert))
+        cirq_original = cirq.Circuit(
+            cirq.measure(cirq.LineQubit(5), key="0", invert_mask=(1,) * invert)
+        )
     else:
-        cirq_original = cirq.Circuit(stimcirq.MeasureAndOrResetGate(basis=handler.basis,
-                                                                    key="0",
-                                                                    invert_measure=invert,
-                                                                    reset=handler.reset,
-                                                                    measure_flip_probability=probability,
-                                                                    measure=handler.measure).on(cirq.LineQubit(5)))
+        cirq_original = cirq.Circuit(
+            stimcirq.MeasureAndOrResetGate(
+                basis=handler.basis,
+                key="0",
+                invert_measure=invert,
+                reset=handler.reset,
+                measure_flip_probability=probability,
+                measure=handler.measure,
+            ).on(cirq.LineQubit(5))
+        )
     inverted = "!" if invert else ""
     p_str = f"({probability})" if probability else ""
     stim_original = stim.Circuit(f"QUBIT_COORDS(5) 0\n{name}{p_str} {inverted}0\nTICK")
@@ -156,7 +197,9 @@ def test_round_trip_preserves_moment_structure():
 
 def test_circuit_diagram():
     cirq.testing.assert_has_diagram(
-        stimcirq.stim_circuit_to_cirq_circuit(stim.Circuit("""
+        stimcirq.stim_circuit_to_cirq_circuit(
+            stim.Circuit(
+                """
             M 0
             MX 0
             MY 0
@@ -169,9 +212,14 @@ def test_circuit_diagram():
             MRX 0
             MRY 0
             MRZ 0
-        """)), """
-0: ───M───MX('1')───MY('2')───M('3')───R───RX───RY───R───MR('4')───MRX('5')───MRY('6')───MR('7')───
-        """)
+        """
+            )
+        ),
+        """
+0: ---M---MX('1')---MY('2')---M('3')---R---RX---RY---R---MR('4')---MRX('5')---MRY('6')---MR('7')---
+        """,
+        use_unicode_characters=False,
+    )
 
 
 def test_all_known_gates_explicitly_handled():
@@ -191,7 +239,8 @@ def test_line_grid_qubit_round_trip():
         cirq.Y(cirq.GridQubit(-2, 5)),
     )
     s = stimcirq.cirq_circuit_to_stim_circuit(c)
-    assert s == stim.Circuit("""
+    assert s == stim.Circuit(
+        """
         QUBIT_COORDS(-2, 5) 0
         QUBIT_COORDS(2, 3.5) 1
         QUBIT_COORDS(101) 2
@@ -201,7 +250,8 @@ def test_line_grid_qubit_round_trip():
         X 1
         Y 0
         TICK
-    """)
+    """
+    )
     c2 = stimcirq.stim_circuit_to_cirq_circuit(s)
     for q in c2.all_qubits():
         if q == cirq.LineQubit(101):
@@ -210,16 +260,28 @@ def test_line_grid_qubit_round_trip():
             assert isinstance(cast(cirq.GridQubit, q).row, int)
     assert c2 == c
 
-    assert stimcirq.stim_circuit_to_cirq_circuit(stim.Circuit("""
+    assert (
+        stimcirq.stim_circuit_to_cirq_circuit(
+            stim.Circuit(
+                """
         QUBIT_COORDS(10) 0
         SHIFT_COORDS(1, 2, 3)
         QUBIT_COORDS(20, 30) 1
         H 0 1
-    """)) == cirq.Circuit(cirq.H(cirq.LineQubit(10)), cirq.H(cirq.GridQubit(21, 32)))
+    """
+            )
+        )
+        == cirq.Circuit(
+            stimcirq.ShiftCoordsAnnotation([1, 2, 3]),
+            cirq.H(cirq.LineQubit(10)),
+            cirq.H(cirq.GridQubit(21, 32)),
+        )
+    )
 
 
 def test_noisy_measurements():
-    s = stim.Circuit("""
+    s = stim.Circuit(
+        """
         MX(0.125) 0
         MY(0.125) 1
         MZ(0.125) 2
@@ -227,58 +289,111 @@ def test_noisy_measurements():
         MRY(0.125) 4
         MRZ(0.25) 5
         TICK
-    """)
+    """
+    )
     c = stimcirq.stim_circuit_to_cirq_circuit(s)
     assert c == cirq.Circuit(
-        stimcirq.MeasureAndOrResetGate(measure=True, reset=False, basis='X', invert_measure=False, key='0', measure_flip_probability=0.125).on(cirq.LineQubit(0)),
-        stimcirq.MeasureAndOrResetGate(measure=True, reset=False, basis='Y', invert_measure=False, key='1', measure_flip_probability=0.125).on(cirq.LineQubit(1)),
-        stimcirq.MeasureAndOrResetGate(measure=True, reset=False, basis='Z', invert_measure=False, key='2', measure_flip_probability=0.125).on(cirq.LineQubit(2)),
-        stimcirq.MeasureAndOrResetGate(measure=True, reset=True, basis='X', invert_measure=False, key='3', measure_flip_probability=0.125).on(cirq.LineQubit(3)),
-        stimcirq.MeasureAndOrResetGate(measure=True, reset=True, basis='Y', invert_measure=False, key='4', measure_flip_probability=0.125).on(cirq.LineQubit(4)),
-        stimcirq.MeasureAndOrResetGate(measure=True, reset=True, basis='Z', invert_measure=False, key='5', measure_flip_probability=0.25).on(cirq.LineQubit(5)),
+        stimcirq.MeasureAndOrResetGate(
+            measure=True,
+            reset=False,
+            basis='X',
+            invert_measure=False,
+            key='0',
+            measure_flip_probability=0.125,
+        ).on(cirq.LineQubit(0)),
+        stimcirq.MeasureAndOrResetGate(
+            measure=True,
+            reset=False,
+            basis='Y',
+            invert_measure=False,
+            key='1',
+            measure_flip_probability=0.125,
+        ).on(cirq.LineQubit(1)),
+        stimcirq.MeasureAndOrResetGate(
+            measure=True,
+            reset=False,
+            basis='Z',
+            invert_measure=False,
+            key='2',
+            measure_flip_probability=0.125,
+        ).on(cirq.LineQubit(2)),
+        stimcirq.MeasureAndOrResetGate(
+            measure=True,
+            reset=True,
+            basis='X',
+            invert_measure=False,
+            key='3',
+            measure_flip_probability=0.125,
+        ).on(cirq.LineQubit(3)),
+        stimcirq.MeasureAndOrResetGate(
+            measure=True,
+            reset=True,
+            basis='Y',
+            invert_measure=False,
+            key='4',
+            measure_flip_probability=0.125,
+        ).on(cirq.LineQubit(4)),
+        stimcirq.MeasureAndOrResetGate(
+            measure=True,
+            reset=True,
+            basis='Z',
+            invert_measure=False,
+            key='5',
+            measure_flip_probability=0.25,
+        ).on(cirq.LineQubit(5)),
     )
     assert stimcirq.cirq_circuit_to_stim_circuit(c) == s
     cirq.testing.assert_equivalent_repr(c, global_vals={'stimcirq': stimcirq})
 
 
 def test_convert_mpp():
-    s = stim.Circuit("""
+    s = stim.Circuit(
+        """
         MPP X2*Y5*Z3
         TICK
         MPP X1 Y2 Z3*Z4
         X 0
         TICK
-    """)
+    """
+    )
     c = cirq.Circuit(
         cirq.Moment(
             cirq.PauliMeasurementGate(cirq.DensePauliString("XYZ", coefficient=+1), key='0').on(
-                cirq.LineQubit(2), cirq.LineQubit(5), cirq.LineQubit(3)),
+                cirq.LineQubit(2), cirq.LineQubit(5), cirq.LineQubit(3)
+            )
         ),
         cirq.Moment(
             cirq.PauliMeasurementGate(cirq.DensePauliString("X"), key='1').on(cirq.LineQubit(1)),
             cirq.PauliMeasurementGate(cirq.DensePauliString("Y"), key='2').on(cirq.LineQubit(2)),
-            cirq.PauliMeasurementGate(cirq.DensePauliString("ZZ"), key='3').on(cirq.LineQubit(3), cirq.LineQubit(4)),
+            cirq.PauliMeasurementGate(cirq.DensePauliString("ZZ"), key='3').on(
+                cirq.LineQubit(3), cirq.LineQubit(4)
+            ),
             cirq.X(cirq.LineQubit(0)),
         ),
     )
     assert_circuits_are_equivalent_and_convert(c, s)
-    cirq.testing.assert_has_diagram(c, """
-0: ───────────────X───────────
+    cirq.testing.assert_has_diagram(
+        c,
+        """
+0: ---------------X-----------
 
-1: ───────────────M(X)────────
+1: ---------------M(X)--------
 
-2: ───M(X)('0')───M(Y)────────
-      │
-3: ───M(Z)────────M(Z)('3')───
-      │           │
-4: ───┼───────────M(Z)────────
-      │
-5: ───M(Y)────────────────────
-        """)
+2: ---M(X)('0')---M(Y)--------
+      |
+3: ---M(Z)--------M(Z)('3')---
+      |           |
+4: ---|-----------M(Z)--------
+      |
+5: ---M(Y)--------------------
+        """,
+        use_unicode_characters=False,
+    )
 
 
 def test_convert_detector():
-    s = stim.Circuit("""
+    s = stim.Circuit(
+        """
         H 0
         TICK
         CNOT 0 1
@@ -286,7 +401,8 @@ def test_convert_detector():
         M 0 1
         DETECTOR(2, 3, 5) rec[-1] rec[-2]
         TICK
-    """)
+    """
+    )
     a, b = cirq.LineQubit.range(2)
     c = cirq.Circuit(
         cirq.H(a),
@@ -294,20 +410,25 @@ def test_convert_detector():
         cirq.Moment(
             cirq.measure(a, key='0'),
             cirq.measure(b, key='1'),
-            stimcirq.DetAnnotation('0', '1', coordinate_metadata=(2, 3, 5)),
+            stimcirq.DetAnnotation(parity_keys=['0', '1'], coordinate_metadata=(2, 3, 5)),
         ),
     )
-    cirq.testing.assert_has_diagram(c, """
-0: ───H───@───M──────────────
-          │
-1: ───────X───M──────────────
+    cirq.testing.assert_has_diagram(
+        c,
+        """
+0: ---H---@---M--------------
+          |
+1: -------X---M--------------
               Det('0','1')
-        """)
+        """,
+        use_unicode_characters=False,
+    )
     assert_circuits_are_equivalent_and_convert(c, s)
 
 
 def test_convert_observable():
-    s = stim.Circuit("""
+    s = stim.Circuit(
+        """
         H 0
         TICK
         CNOT 0 1
@@ -315,7 +436,8 @@ def test_convert_observable():
         M 0 1
         OBSERVABLE_INCLUDE(5) rec[-1] rec[-2]
         TICK
-    """)
+    """
+    )
     a, b = cirq.LineQubit.range(2)
     c = cirq.Circuit(
         cirq.H(a),
@@ -323,39 +445,123 @@ def test_convert_observable():
         cirq.Moment(
             cirq.measure(a, key='0'),
             cirq.measure(b, key='1'),
-            stimcirq.CumulativeObservableAnnotation('0', '1', observable_index=5),
+            stimcirq.CumulativeObservableAnnotation(parity_keys=['0', '1'], observable_index=5),
         ),
     )
-    cirq.testing.assert_has_diagram(c, """
-0: ───H───@───M───────────────
-          │
-1: ───────X───M───────────────
+    cirq.testing.assert_has_diagram(
+        c,
+        """
+0: ---H---@---M---------------
+          |
+1: -------X---M---------------
               Obs5('0','1')
-        """)
+        """,
+        use_unicode_characters=False,
+    )
     assert_circuits_are_equivalent_and_convert(c, s)
 
 
 def test_sweep_target():
-    stim_circuit = stim.Circuit("""
+    stim_circuit = stim.Circuit(
+        """
         CX sweep[2] 0
         CY sweep[3] 1
         CZ sweep[5] 2 sweep[7] 3
         TICK
-    """)
+    """
+    )
     a, b, c, d = cirq.LineQubit.range(4)
     cirq_circuit = cirq.Circuit(
-        stimcirq.SweepPauli(stim_sweep_bit_index=2, cirq_sweep_symbol="sweep[2]", pauli=cirq.X).on(a),
-        stimcirq.SweepPauli(stim_sweep_bit_index=3, cirq_sweep_symbol="sweep[3]", pauli=cirq.Y).on(b),
-        stimcirq.SweepPauli(stim_sweep_bit_index=5, cirq_sweep_symbol="sweep[5]", pauli=cirq.Z).on(c),
-        stimcirq.SweepPauli(stim_sweep_bit_index=7, cirq_sweep_symbol="sweep[7]", pauli=cirq.Z).on(d),
+        stimcirq.SweepPauli(stim_sweep_bit_index=2, cirq_sweep_symbol="sweep[2]", pauli=cirq.X).on(
+            a
+        ),
+        stimcirq.SweepPauli(stim_sweep_bit_index=3, cirq_sweep_symbol="sweep[3]", pauli=cirq.Y).on(
+            b
+        ),
+        stimcirq.SweepPauli(stim_sweep_bit_index=5, cirq_sweep_symbol="sweep[5]", pauli=cirq.Z).on(
+            c
+        ),
+        stimcirq.SweepPauli(stim_sweep_bit_index=7, cirq_sweep_symbol="sweep[7]", pauli=cirq.Z).on(
+            d
+        ),
     )
-    cirq.testing.assert_has_diagram(cirq_circuit, """
-0: ───X^sweep[2]='sweep[2]'───
+    cirq.testing.assert_has_diagram(
+        cirq_circuit,
+        """
+0: ---X^sweep[2]='sweep[2]'---
 
-1: ───Y^sweep[3]='sweep[3]'───
+1: ---Y^sweep[3]='sweep[3]'---
 
-2: ───Z^sweep[5]='sweep[5]'───
+2: ---Z^sweep[5]='sweep[5]'---
 
-3: ───Z^sweep[7]='sweep[7]'───
-        """)
+3: ---Z^sweep[7]='sweep[7]'---
+        """,
+        use_unicode_characters=False,
+    )
     assert_circuits_are_equivalent_and_convert(cirq_circuit, stim_circuit)
+
+
+def test_convert_repeat_simple():
+    stim_circuit = stim.Circuit(
+        """
+        REPEAT 1000000 {
+            H 0
+            TICK
+            CNOT 0 1
+            TICK
+        }
+        M 0
+        TICK
+    """
+    )
+    a, b = cirq.LineQubit.range(2)
+    cirq_circuit = cirq.Circuit(
+        cirq.CircuitOperation(cirq.FrozenCircuit(cirq.H(a), cirq.CNOT(a, b)), repetitions=1000000),
+        cirq.measure(a, key="0"),
+    )
+    assert stimcirq.stim_circuit_to_cirq_circuit(stim_circuit) == cirq_circuit
+    assert stimcirq.cirq_circuit_to_stim_circuit(cirq_circuit) == stim_circuit
+
+
+def test_convert_repeat_measurements():
+    stim_circuit = stim.Circuit(
+        """
+        REPEAT 1000000 {
+            H 0
+            TICK
+            CNOT 0 1
+            TICK
+            M 0 1
+            DETECTOR(5) rec[-1] rec[-2]
+            SHIFT_COORDS(2)
+            TICK
+        }
+        M 0
+        DETECTOR(7) rec[-1] rec[-3]
+        TICK
+    """
+    )
+    a, b = cirq.LineQubit.range(2)
+    cirq_circuit = cirq.Circuit(
+        cirq.Moment(
+            cirq.CircuitOperation(
+                cirq.FrozenCircuit(
+                    cirq.Moment(cirq.H(a)),
+                    cirq.Moment(cirq.CNOT(a, b)),
+                    cirq.Moment(
+                        cirq.measure(a, key=cirq.MeasurementKey("0")),
+                        cirq.measure(b, key=cirq.MeasurementKey("1")),
+                        stimcirq.DetAnnotation(relative_keys=[-1, -2], coordinate_metadata=[5]),
+                        stimcirq.ShiftCoordsAnnotation([2]),
+                    ),
+                ),
+                repetitions=1000000,
+            )
+        ),
+        cirq.Moment(
+            cirq.measure(a, key="2000000"),
+            stimcirq.DetAnnotation(relative_keys=[-1, -3], coordinate_metadata=[7]),
+        ),
+    )
+    assert stimcirq.stim_circuit_to_cirq_circuit(stim_circuit) == cirq_circuit
+    assert stimcirq.cirq_circuit_to_stim_circuit(cirq_circuit) == stim_circuit

--- a/glue/cirq/stimcirq/_stim_to_cirq_test.py
+++ b/glue/cirq/stimcirq/_stim_to_cirq_test.py
@@ -526,6 +526,8 @@ def test_convert_repeat_simple():
 def test_convert_repeat_measurements():
     stim_circuit = stim.Circuit(
         """
+        QUBIT_COORDS(2, 3) 0
+        QUBIT_COORDS(4, 5) 1
         REPEAT 1000000 {
             H 0
             TICK
@@ -541,7 +543,7 @@ def test_convert_repeat_measurements():
         TICK
     """
     )
-    a, b = cirq.LineQubit.range(2)
+    a, b = cirq.GridQubit(2, 3), cirq.GridQubit(4, 5)
     cirq_circuit = cirq.Circuit(
         cirq.Moment(
             cirq.CircuitOperation(

--- a/glue/cirq/stimcirq/_sweep_pauli.py
+++ b/glue/cirq/stimcirq/_sweep_pauli.py
@@ -21,6 +21,7 @@ class SweepPauli(cirq.Gate):
         pauli: cirq.Pauli,
     ):
         r"""
+
         Args:
             stim_sweep_bit_index: The bit position, in some unspecified array, controlling the Pauli.
             cirq_sweep_symbol: The symbol used by cirq. Defaults to f"sweep_{sweep_bit_index}".

--- a/glue/cirq/stimcirq/_sweep_pauli_test.py
+++ b/glue/cirq/stimcirq/_sweep_pauli_test.py
@@ -18,18 +18,19 @@ def test_repr():
 def test_stim_conversion():
     actual = stimcirq.cirq_circuit_to_stim_circuit(
         cirq.Circuit(
-            stimcirq.SweepPauli(stim_sweep_bit_index=5, pauli=cirq.X, cirq_sweep_symbol="init_66").on(
-                cirq.GridQubit(1, 3)
-            ),
-            stimcirq.SweepPauli(stim_sweep_bit_index=7, pauli=cirq.Y, cirq_sweep_symbol="init_63").on(
-                cirq.GridQubit(2, 4)
-            ),
-            stimcirq.SweepPauli(stim_sweep_bit_index=5, pauli=cirq.Z, cirq_sweep_symbol="init_66").on(
-                cirq.GridQubit(2, 4)
-            ),
+            stimcirq.SweepPauli(
+                stim_sweep_bit_index=5, pauli=cirq.X, cirq_sweep_symbol="init_66"
+            ).on(cirq.GridQubit(1, 3)),
+            stimcirq.SweepPauli(
+                stim_sweep_bit_index=7, pauli=cirq.Y, cirq_sweep_symbol="init_63"
+            ).on(cirq.GridQubit(2, 4)),
+            stimcirq.SweepPauli(
+                stim_sweep_bit_index=5, pauli=cirq.Z, cirq_sweep_symbol="init_66"
+            ).on(cirq.GridQubit(2, 4)),
         )
     )
-    assert actual == stim.Circuit("""
+    assert actual == stim.Circuit(
+        """
         QUBIT_COORDS(1, 3) 0
         QUBIT_COORDS(2, 4) 1
         CX sweep[5] 0
@@ -37,12 +38,15 @@ def test_stim_conversion():
         TICK
         CZ sweep[5] 1
         TICK
-    """)
+    """
+    )
 
 
 def test_cirq_compatibility():
     circuit = cirq.Circuit(
-        stimcirq.SweepPauli(stim_sweep_bit_index=5, pauli=cirq.X, cirq_sweep_symbol="xx").on(cirq.LineQubit(0)),
+        stimcirq.SweepPauli(stim_sweep_bit_index=5, pauli=cirq.X, cirq_sweep_symbol="xx").on(
+            cirq.LineQubit(0)
+        ),
         cirq.measure(cirq.LineQubit(0), key="k"),
     )
     np.testing.assert_array_equal(
@@ -53,7 +57,9 @@ def test_cirq_compatibility():
     )
 
     circuit = cirq.Circuit(
-        stimcirq.SweepPauli(stim_sweep_bit_index=5, pauli=cirq.Z, cirq_sweep_symbol="xx").on(cirq.LineQubit(0)),
+        stimcirq.SweepPauli(stim_sweep_bit_index=5, pauli=cirq.Z, cirq_sweep_symbol="xx").on(
+            cirq.LineQubit(0)
+        ),
         cirq.measure(cirq.LineQubit(0), key="k"),
     )
     np.testing.assert_array_equal(
@@ -65,7 +71,9 @@ def test_cirq_compatibility():
 
     circuit = cirq.Circuit(
         cirq.H(cirq.LineQubit(0)),
-        stimcirq.SweepPauli(stim_sweep_bit_index=5, pauli=cirq.Z, cirq_sweep_symbol="xx").on(cirq.LineQubit(0)),
+        stimcirq.SweepPauli(stim_sweep_bit_index=5, pauli=cirq.Z, cirq_sweep_symbol="xx").on(
+            cirq.LineQubit(0)
+        ),
         cirq.H(cirq.LineQubit(0)),
         cirq.measure(cirq.LineQubit(0), key="k"),
     )
@@ -87,7 +95,5 @@ def test_json_serialization():
         ),
     )
     json = cirq.to_json(c)
-    c2 = cirq.read_json(
-        json_text=json,
-        resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER])
+    c2 = cirq.read_json(json_text=json, resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER])
     assert c == c2

--- a/glue/cirq/stimcirq/_two_qubit_asymmetric_depolarize.py
+++ b/glue/cirq/stimcirq/_two_qubit_asymmetric_depolarize.py
@@ -1,4 +1,4 @@
-from typing import List, Sequence, Dict, Any, Tuple
+from typing import Any, Dict, List, Sequence, Tuple
 
 import cirq
 import stim
@@ -6,10 +6,12 @@ import stim
 
 @cirq.value_equality
 class TwoQubitAsymmetricDepolarizingChannel(cirq.Gate):
-    """A two qubit error channel that applies Pauli pairs according to the given probability distribution.
+    """A two qubit error channel that applies Pauli pairs according to the given probability
+    distribution.
 
     The 15 probabilities are in IX, IY, ... ZY, ZZ order. II is skipped; it's the leftover.
     """
+
     def __init__(self, probabilities: Sequence[float]):
         if len(probabilities) != 15:
             raise ValueError(f"len(probabilities={probabilities}) != 15")
@@ -28,10 +30,12 @@ class TwoQubitAsymmetricDepolarizingChannel(cirq.Gate):
 
     def _dense_mixture_(self):
         result = [(1 - sum(self.probabilities), cirq.DensePauliString([0, 0]))]
-        result.extend([
-            (p, cirq.DensePauliString([((k + 1) >> 2) & 3, (k + 1) & 3]))
-            for k, p in enumerate(self.probabilities)
-        ])
+        result.extend(
+            [
+                (p, cirq.DensePauliString([((k + 1) >> 2) & 3, (k + 1) & 3]))
+                for k, p in enumerate(self.probabilities)
+            ]
+        )
         return [(p, g) for p, g in result if p]
 
     def _mixture_(self):
@@ -43,18 +47,11 @@ class TwoQubitAsymmetricDepolarizingChannel(cirq.Gate):
             result.append(str(d)[1:] + ":" + args.format_real(p))
         return "PauliMix(" + ",".join(result) + ")", "#2"
 
-    def _stim_conversion_(
-            self,
-            edit_circuit: stim.Circuit,
-            targets: List[int],
-            **kwargs):
+    def _stim_conversion_(self, edit_circuit: stim.Circuit, targets: List[int], **kwargs):
         edit_circuit.append_operation("PAULI_CHANNEL_2", targets, self.probabilities)
 
     def __repr__(self):
         return f"stimcirq.TwoQubitAsymmetricDepolarizingChannel({self.probabilities!r})"
 
     def _json_dict_(self) -> Dict[str, Any]:
-        return {
-            'cirq_type': self.__class__.__name__,
-            'probabilities': list(self.probabilities),
-        }
+        return {'cirq_type': self.__class__.__name__, 'probabilities': list(self.probabilities)}

--- a/glue/cirq/stimcirq/_two_qubit_asymmetric_depolarize_test.py
+++ b/glue/cirq/stimcirq/_two_qubit_asymmetric_depolarize_test.py
@@ -1,10 +1,11 @@
 import cirq
-
 import stimcirq
 
 
 def test_mixture():
-    r = stimcirq.TwoQubitAsymmetricDepolarizingChannel([0.125, 0, 0, 0, 0, 0, 0.375, 0, 0, 0, 0, 0, 0, 0.25, 0])
+    r = stimcirq.TwoQubitAsymmetricDepolarizingChannel(
+        [0.125, 0, 0, 0, 0, 0, 0.375, 0, 0, 0, 0, 0, 0, 0.25, 0]
+    )
     assert r._dense_mixture_() == [
         (0.25, cirq.DensePauliString("II")),
         (0.125, cirq.DensePauliString("IX")),
@@ -14,28 +15,32 @@ def test_mixture():
 
 
 def test_diagram():
-    r = stimcirq.TwoQubitAsymmetricDepolarizingChannel([0.125, 0, 0, 0, 0, 0, 0.375, 0, 0, 0, 0, 0, 0, 0.25, 0])
-    cirq.testing.assert_has_diagram(cirq.Circuit(r.on(*cirq.LineQubit.range(2))), """
-0: ───PauliMix(II:0.25,IX:0.125,XZ:0.375,ZY:0.25)───
-      │
-1: ───#2────────────────────────────────────────────
-    """)
+    r = stimcirq.TwoQubitAsymmetricDepolarizingChannel(
+        [0.125, 0, 0, 0, 0, 0, 0.375, 0, 0, 0, 0, 0, 0, 0.25, 0]
+    )
+    cirq.testing.assert_has_diagram(
+        cirq.Circuit(r.on(*cirq.LineQubit.range(2))),
+        """
+0: ---PauliMix(II:0.25,IX:0.125,XZ:0.375,ZY:0.25)---
+      |
+1: ---#2--------------------------------------------
+        """,
+        use_unicode_characters=False,
+    )
 
 
 def test_repr():
-    r = stimcirq.TwoQubitAsymmetricDepolarizingChannel([0.125, 0, 0, 0, 0, 0, 0.375, 0, 0, 0, 0, 0, 0, 0.25, 0])
+    r = stimcirq.TwoQubitAsymmetricDepolarizingChannel(
+        [0.125, 0, 0, 0, 0, 0, 0.375, 0, 0, 0, 0, 0, 0, 0.25, 0]
+    )
     assert eval(repr(r), {'stimcirq': stimcirq}) == r
 
 
 def test_json_serialization():
-    r = stimcirq.TwoQubitAsymmetricDepolarizingChannel([
-        0.0125, 0.1, 0, 0.23, 0, 0, 0.0375, 0, 0, 0, 0, 0, 0, 0.25, 0
-    ])
-    c = cirq.Circuit(
-        r(cirq.LineQubit(0), cirq.LineQubit(1)),
+    r = stimcirq.TwoQubitAsymmetricDepolarizingChannel(
+        [0.0125, 0.1, 0, 0.23, 0, 0, 0.0375, 0, 0, 0, 0, 0, 0, 0.25, 0]
     )
+    c = cirq.Circuit(r(cirq.LineQubit(0), cirq.LineQubit(1)))
     json = cirq.to_json(c)
-    c2 = cirq.read_json(
-        json_text=json,
-        resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER])
+    c2 = cirq.read_json(json_text=json, resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER])
     assert c == c2


### PR DESCRIPTION
- Add support for relative indices (as opposed to measurement keys) to Det and Obs annotations
- Add `stimcirq.ShiftCoordsAnnotation`
- Add some guard rails for measurement keys crossing loop boundaries
- Add `flatten` option to `stimcirq.stim_circuit_to_cirq_circuit`
- Add `MeasureAndOrResetGate._circuit_diagram_info_`
- Run an autoformatter on stimcirq