### PR TITLE
Make `stim.Circuit.append` more convenient

### DIFF
--- a/src/stim/circuit/circuit.cc
+++ b/src/stim/circuit/circuit.cc
@@ -122,13 +122,13 @@ void validate_gate(const Gate &gate, ConstPointerRange<GateTarget> targets, Cons
     if (gate.arg_count == ARG_COUNT_SYGIL_ZERO_OR_ONE) {
         if (args.size() > 1) {
             throw std::invalid_argument(
-                "Gate " + std::string(gate.name) + " was given " + std::to_string(args.size()) + " arguments (" +
-                comma_sep(args).str() + ") but takes 0 or 1 arguments.");
+                "Gate " + std::string(gate.name) + " was given " + std::to_string(args.size()) + " parens arguments (" +
+                comma_sep(args).str() + ") but takes 0 or 1 parens arguments.");
         }
     } else if (args.size() != gate.arg_count && gate.arg_count != ARG_COUNT_SYGIL_ANY) {
         throw std::invalid_argument(
-            "Gate " + std::string(gate.name) + " was given " + std::to_string(args.size()) + " arguments (" +
-            comma_sep(args).str() + ") but takes " + std::to_string(gate.arg_count) + " arguments.");
+            "Gate " + std::string(gate.name) + " was given " + std::to_string(args.size()) + " parens arguments (" +
+            comma_sep(args).str() + ") but takes " + std::to_string(gate.arg_count) + " parens arguments.");
     }
 
     if ((gate.flags & GATE_TAKES_NO_TARGETS) && !targets.empty()) {

--- a/src/stim/circuit/circuit_gate_target.pybind.cc
+++ b/src/stim/circuit/circuit_gate_target.pybind.cc
@@ -19,7 +19,7 @@
 
 using namespace stim;
 
-GateTarget obj_to_gate_target(const pybind11::object &obj) {
+GateTarget handle_to_gate_target(const pybind11::handle &obj) {
     try {
         return pybind11::cast<GateTarget>(obj);
     } catch (const pybind11::cast_error &ex) {
@@ -30,6 +30,10 @@ GateTarget obj_to_gate_target(const pybind11::object &obj) {
     }
     throw std::invalid_argument(
         "target argument wasn't a qubit index, a result from a `stim.target_*` method, or a `stim.GateTarget`.");
+}
+
+GateTarget obj_to_gate_target(const pybind11::object &obj) {
+    return handle_to_gate_target(obj);
 }
 
 void pybind_circuit_gate_target(pybind11::module &m) {

--- a/src/stim/circuit/circuit_gate_target.pybind.h
+++ b/src/stim/circuit/circuit_gate_target.pybind.h
@@ -23,5 +23,6 @@
 
 void pybind_circuit_gate_target(pybind11::module &m);
 stim::GateTarget obj_to_gate_target(const pybind11::object &obj);
+stim::GateTarget handle_to_gate_target(const pybind11::handle &obj);
 
 #endif


### PR DESCRIPTION
- Add `stim.Circuit.append` alias for `stim.Circuit.append_operation`
- Make it an error to pass 0 instead of 1 parens arguments into `stim.Circuit.append` (e.g. for X_ERROR gate)
    - `stim.append_operation` has to allow this for backwards compatibility
- Allow single targets to be passed not in a list, e.g. `stim.append("H", 0)`