### PR TITLE
Use cirq.ResultDict in StimSampler when available

### DIFF
--- a/glue/cirq/stimcirq/_stim_sampler.py
+++ b/glue/cirq/stimcirq/_stim_sampler.py
@@ -5,6 +5,12 @@ import cirq
 from ._cirq_to_stim import cirq_circuit_to_stim_data
 
 
+try:
+    ResultImpl = cirq.ResultDict  # For cirq >= 0.14
+except AttributeError:
+    ResultImpl = cirq.Result  # For cirq < 0.14
+
+
 class StimSampler(cirq.Sampler):
     """Samples stabilizer circuits using Stim.
 
@@ -33,6 +39,6 @@ class StimSampler(cirq.Sampler):
                 p = k
                 k += length
                 measurements[key] = samples[:, p:k]
-            trial_results.append(cirq.Result(params=param_resolver, measurements=measurements))
+            trial_results.append(ResultImpl(params=param_resolver, measurements=measurements))
 
         return trial_results


### PR DESCRIPTION
The `cirq.Result` constructor is deprecated as of https://github.com/quantumlib/Cirq/pull/4806. Instead, we should use a concrete type like `cirq.ResultDict`. This changes `StimSampler` to use `cirq.ResultDict` when available, to avoid deprecation warnings.

I'm also curious to know what is the support policy for stimcirq supporting different pyle versions. This workaround can be removed whenever support for cirq < 0.14 is dropped.