### PR TITLE
add preprocessor clauses for bare support for aarch64

### DIFF
--- a/src/stim/py/march.pybind.cc
+++ b/src/stim/py/march.pybind.cc
@@ -4,6 +4,14 @@
 //  Windows
 #include <intrin.h>
 #define cpuid(info, x) __cpuidex(info, x, 0)
+#elif (defined(__arm64__) && defined(__APPLE__)) || defined(__aarch64__)
+// macOS ARM64 (dummied out)
+void cpuid(int info[4], int infoType) {
+    info[0] = 0;
+    info[1] = 0;
+    info[2] = 0;
+    info[3] = 0;
+}
 #else
 //  GCC Intrinsics
 #include <cpuid.h>


### PR DESCRIPTION
Stim includes some C preprocessor logic which assists in looking up processor intrinsics for specialized / accelerated operator evaluation. Currently, the logic forks on x86 Windows / x86 not-Windows, which breaks on modern Apple devices with ARM64 processors. This PR adds basic support for these processors by adding an extra (dummy) clause to the preprocessor logic, but it does not supply any specialized support for ARM64 features.

This borrows from the ARM64 clause here: https://opensource.apple.com/source/WTF/WTF-7601.1.46.42/wtf/Platform.h.auto.html .