### PR TITLE
Mitigate rng state duplication from multiprocessing forking state

### DIFF
--- a/glue/sample/setup.py
+++ b/glue/sample/setup.py
@@ -26,7 +26,7 @@ setup(
     author_email='craig.gidney@gmail.com',
     license='Apache 2',
     packages=['simmer'],
-    package_dir = {'': 'src'},
+    package_dir={'': 'src'},
     description='Samples Stim circuits.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/glue/sample/src/simmer/collection_work_manager.py
+++ b/glue/sample/src/simmer/collection_work_manager.py
@@ -27,10 +27,8 @@ class CollectionWorkManager:
     def __init__(self,
                  to_do: Iterator[CollectionCaseTracker],
                  max_shutdown_wait_seconds: float):
-        self.results_queue = multiprocessing.Queue()
-        self.problem_queue = multiprocessing.Queue()
-        self.results_queue.cancel_join_thread()
-        self.problem_queue.cancel_join_thread()
+        self.results_queue: Optional[multiprocessing.Queue] = None
+        self.problem_queue: Optional[multiprocessing.Queue] = None
         self.max_shutdown_wait_seconds = max_shutdown_wait_seconds
 
         self.workers: List[multiprocessing.Process] = []
@@ -43,25 +41,26 @@ class CollectionWorkManager:
         self.next_job_id = 0
 
     def start_workers(self, num_workers: int) -> None:
-        if multiprocessing.get_start_method() != 'spawn':
-            raise ValueError("""
-multiprocessing.get_start_method() != 'spawn'
+        current_method = multiprocessing.get_start_method()
+        try:
+            # To ensure the child processes do not accidentally share ANY state
+            # related to, we use 'spawn' instead of 'fork'.
+            multiprocessing.set_start_method('spawn', force=True)
+            # Create queues after setting start method to work around a deadlock
+            # bug that occurs otherwise.
+            self.results_queue = multiprocessing.Queue()
+            self.problem_queue = multiprocessing.Queue()
+            self.results_queue.cancel_join_thread()
+            self.problem_queue.cancel_join_thread()
 
-To ensure the child processes do not accidentally share ANY state related to
-generating random numbers, simmer REQUIRES you to have called
-
-multiprocessing.set_start_method('spawn', force=True)
-
-before attempting to collect data. It's also recommended that the entrypoint
-file do as little work as possible when __name__ == '__mp_main__'.
-            """)
-
-        for _ in range(num_workers):
-            w = multiprocessing.Process(
-                target=worker_loop,
-                args=(self.problem_queue, self.results_queue))
-            self.workers.append(w)
-            w.start()
+            for _ in range(num_workers):
+                w = multiprocessing.Process(
+                    target=worker_loop,
+                    args=(self.problem_queue, self.results_queue))
+                self.workers.append(w)
+                w.start()
+        finally:
+            multiprocessing.set_start_method(current_method, force=True)
 
     def __enter__(self):
         return self

--- a/glue/sample/src/simmer/collection_work_manager.py
+++ b/glue/sample/src/simmer/collection_work_manager.py
@@ -43,6 +43,19 @@ class CollectionWorkManager:
         self.next_job_id = 0
 
     def start_workers(self, num_workers: int) -> None:
+        if multiprocessing.get_start_method() != 'spawn':
+            raise ValueError("""
+multiprocessing.get_start_method() != 'spawn'
+
+To ensure the child processes do not accidentally share ANY state related to
+generating random numbers, simmer REQUIRES you to have called
+
+multiprocessing.set_start_method('spawn', force=True)
+
+before attempting to collect data. It's also recommended that the entrypoint
+file do as little work as possible when __name__ == '__mp_main__'.
+            """)
+
         for _ in range(num_workers):
             w = multiprocessing.Process(
                 target=worker_loop,

--- a/glue/sample/src/simmer/main.py
+++ b/glue/sample/src/simmer/main.py
@@ -1,10 +1,6 @@
 import sys
 from typing import Optional, List
 
-from simmer.main_combine import main_combine
-from simmer.main_collect import main_collect
-from simmer.main_plot import main_plot
-
 
 def main(*, command_line_args: Optional[List[str]] = None):
     if command_line_args is None:
@@ -12,10 +8,13 @@ def main(*, command_line_args: Optional[List[str]] = None):
 
     mode = command_line_args[0] if command_line_args else None
     if mode == 'combine':
+        from simmer.main_combine import main_combine
         return main_combine(command_line_args=command_line_args[1:])
     if mode == 'collect':
+        from simmer.main_collect import main_collect
         return main_collect(command_line_args=command_line_args[1:])
     if mode == 'plot':
+        from simmer.main_plot import main_plot
         return main_plot(command_line_args=command_line_args[1:])
     if command_line_args and not command_line_args[0].startswith('-'):
         print(f"\033[31mUnrecognized command: simmer {command_line_args[0]}\033[0m\n", file=sys.stderr)
@@ -27,7 +26,6 @@ def main(*, command_line_args: Optional[List[str]] = None):
           f"    simmer plot\n"
           f"", file=sys.stderr)
     sys.exit(1)
-
 
 
 if __name__ == '__main__':

--- a/glue/sample/src/simmer/main_collect.py
+++ b/glue/sample/src/simmer/main_collect.py
@@ -1,6 +1,7 @@
 import argparse
 import contextlib
 import hashlib
+import multiprocessing
 import sys
 from typing import Iterator, Any, Tuple, Optional, List
 
@@ -150,6 +151,8 @@ def open_merge_file(path: str) -> Tuple[Any, ExistingData]:
 
 
 def main_collect(*, command_line_args: List[str]):
+    multiprocessing.set_start_method('spawn', force=True)
+
     with contextlib.ExitStack() as ctx:
         args = parse_args(args=command_line_args)
 

--- a/glue/sample/src/simmer/main_collect.py
+++ b/glue/sample/src/simmer/main_collect.py
@@ -1,7 +1,6 @@
 import argparse
 import contextlib
 import hashlib
-import multiprocessing
 import sys
 from typing import Iterator, Any, Tuple, Optional, List
 
@@ -151,8 +150,6 @@ def open_merge_file(path: str) -> Tuple[Any, ExistingData]:
 
 
 def main_collect(*, command_line_args: List[str]):
-    multiprocessing.set_start_method('spawn', force=True)
-
     with contextlib.ExitStack() as ctx:
         args = parse_args(args=command_line_args)
 

--- a/src/stim/circuit/circuit.h
+++ b/src/stim/circuit/circuit.h
@@ -35,7 +35,7 @@
 namespace stim {
 
 // Change this number from time to time to ensure people don't rely on seeds across versions.
-constexpr uint64_t INTENTIONAL_VERSION_SEED_INCOMPATIBILITY = 0xDEADBEEF1235ULL;
+constexpr uint64_t INTENTIONAL_VERSION_SEED_INCOMPATIBILITY = 0xDEADBEEF1236ULL;
 
 uint64_t op_data_rep_count(const OperationData &data);
 

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -31,6 +31,7 @@
 #include "stim/simulators/min_distance.h"
 
 using namespace stim;
+using namespace stim_pybind;
 
 std::string circuit_repr(const Circuit &self) {
     if (self.operations.empty()) {

--- a/src/stim/circuit/circuit_gate_target.pybind.cc
+++ b/src/stim/circuit/circuit_gate_target.pybind.cc
@@ -18,6 +18,7 @@
 #include "stim/py/base.pybind.h"
 
 using namespace stim;
+using namespace stim_pybind;
 
 GateTarget handle_to_gate_target(const pybind11::handle &obj) {
     try {

--- a/src/stim/circuit/circuit_instruction.pybind.cc
+++ b/src/stim/circuit/circuit_instruction.pybind.cc
@@ -20,6 +20,7 @@
 #include "stim/str_util.h"
 
 using namespace stim;
+using namespace stim_pybind;
 
 CircuitInstruction::CircuitInstruction(
     const char *name, const std::vector<pybind11::object> &init_targets, const std::vector<double> &gate_args)

--- a/src/stim/circuit/circuit_repeat_block.pybind.cc
+++ b/src/stim/circuit/circuit_repeat_block.pybind.cc
@@ -20,6 +20,7 @@
 #include "stim/py/base.pybind.h"
 
 using namespace stim;
+using namespace stim_pybind;
 
 CircuitRepeatBlock::CircuitRepeatBlock(uint64_t repeat_count, stim::Circuit body)
     : repeat_count(repeat_count), body(body) {

--- a/src/stim/dem/detector_error_model.pybind.cc
+++ b/src/stim/dem/detector_error_model.pybind.cc
@@ -22,6 +22,7 @@
 #include "stim/simulators/min_distance.h"
 
 using namespace stim;
+using namespace stim_pybind;
 
 std::string detector_error_model_repr(const DetectorErrorModel &self) {
     if (self.instructions.empty()) {

--- a/src/stim/dem/detector_error_model_instruction.pybind.cc
+++ b/src/stim/dem/detector_error_model_instruction.pybind.cc
@@ -18,6 +18,7 @@
 #include "stim/py/base.pybind.h"
 
 using namespace stim;
+using namespace stim_pybind;
 
 DemInstruction ExposedDemInstruction::as_dem_instruction() const {
     return DemInstruction{arguments, targets, type};

--- a/src/stim/dem/detector_error_model_repeat_block.pybind.cc
+++ b/src/stim/dem/detector_error_model_repeat_block.pybind.cc
@@ -19,6 +19,7 @@
 #include "stim/py/base.pybind.h"
 
 using namespace stim;
+using namespace stim_pybind;
 
 void pybind_detector_error_model_repeat_block(pybind11::module &m) {
     auto c = pybind11::class_<ExposedDemRepeatBlock>(

--- a/src/stim/dem/detector_error_model_target.pybind.cc
+++ b/src/stim/dem/detector_error_model_target.pybind.cc
@@ -18,6 +18,7 @@
 #include "stim/py/base.pybind.h"
 
 using namespace stim;
+using namespace stim_pybind;
 
 void pybind_detector_error_model_target(pybind11::module &m) {
     auto c = pybind11::class_<ExposedDemTarget>(

--- a/src/stim/py/base.pybind.cc
+++ b/src/stim/py/base.pybind.cc
@@ -20,14 +20,9 @@
 
 using namespace stim;
 
-static std::shared_ptr<std::mt19937_64> shared_rng;
-
-std::shared_ptr<std::mt19937_64> PYBIND_SHARED_RNG(const pybind11::object &seed) {
-    if (seed.is(pybind11::none())) {
-        if (!shared_rng) {
-            shared_rng = std::make_shared<std::mt19937_64>(std::move(externally_seeded_rng()));
-        }
-        return shared_rng;
+std::shared_ptr<std::mt19937_64> stim_pybind::make_py_seeded_rng(const pybind11::object &seed) {
+    if (seed.is_none()) {
+        return std::make_shared<std::mt19937_64>(externally_seeded_rng());
     }
 
     try {
@@ -38,7 +33,7 @@ std::shared_ptr<std::mt19937_64> PYBIND_SHARED_RNG(const pybind11::object &seed)
     }
 }
 
-std::string clean_doc_string(const char *c) {
+std::string stim_pybind::clean_doc_string(const char *c) {
     // Skip leading empty lines.
     while (*c == '\n') {
         c++;
@@ -71,7 +66,7 @@ std::string clean_doc_string(const char *c) {
     return result;
 }
 
-bool normalize_index_or_slice(
+bool stim_pybind::normalize_index_or_slice(
     const pybind11::object &index_or_slice,
     size_t length,
     pybind11::ssize_t *start,
@@ -105,7 +100,7 @@ bool normalize_index_or_slice(
     return true;
 }
 
-SampleFormat format_to_enum(const std::string &format) {
+SampleFormat stim_pybind::format_to_enum(const std::string &format) {
     auto found_format = format_name_to_enum_map.find(format);
     if (found_format == format_name_to_enum_map.end()) {
         std::stringstream msg;

--- a/src/stim/py/base.pybind.h
+++ b/src/stim/py/base.pybind.h
@@ -24,7 +24,9 @@
 #include "stim/circuit/circuit.h"
 #include "stim/io/stim_data_formats.h"
 
-std::shared_ptr<std::mt19937_64> PYBIND_SHARED_RNG(const pybind11::object &seed);
+namespace stim_pybind {
+
+std::shared_ptr<std::mt19937_64> make_py_seeded_rng(const pybind11::object &seed);
 std::string clean_doc_string(const char *c);
 stim::SampleFormat format_to_enum(const std::string &format);
 bool normalize_index_or_slice(
@@ -44,6 +46,8 @@ pybind11::tuple tuple_tree(const std::vector<T> &val, size_t offset = 0) {
         return pybind11::make_tuple(val[offset]);
     }
     return pybind11::make_tuple(val[offset], tuple_tree(val, offset + 1));
+}
+
 }
 
 #endif

--- a/src/stim/py/compiled_detector_sampler.pybind.cc
+++ b/src/stim/py/compiled_detector_sampler.pybind.cc
@@ -21,6 +21,7 @@
 #include "stim/simulators/tableau_simulator.h"
 
 using namespace stim;
+using namespace stim_pybind;
 
 CompiledDetectorSampler::CompiledDetectorSampler(Circuit circuit, std::shared_ptr<std::mt19937_64> prng)
     : dets_obs(circuit), circuit(std::move(circuit)), prng(prng) {
@@ -91,11 +92,11 @@ std::string CompiledDetectorSampler::repr() const {
     return result.str();
 }
 
-CompiledDetectorSampler py_init_compiled_detector_sampler(const Circuit &circuit, const pybind11::object &seed) {
-    return CompiledDetectorSampler(circuit, PYBIND_SHARED_RNG(seed));
+CompiledDetectorSampler stim_pybind::py_init_compiled_detector_sampler(const Circuit &circuit, const pybind11::object &seed) {
+    return CompiledDetectorSampler(circuit, make_py_seeded_rng(seed));
 }
 
-pybind11::class_<CompiledDetectorSampler> pybind_compiled_detector_sampler_class(pybind11::module &m) {
+pybind11::class_<CompiledDetectorSampler> stim_pybind::pybind_compiled_detector_sampler_class(pybind11::module &m) {
     return pybind11::class_<CompiledDetectorSampler>(
         m,
         "CompiledDetectorSampler",
@@ -103,7 +104,7 @@ pybind11::class_<CompiledDetectorSampler> pybind_compiled_detector_sampler_class
         "An analyzed stabilizer circuit whose detection events can be sampled quickly.");
 }
 
-void pybind_compiled_detector_sampler_methods(pybind11::class_<CompiledDetectorSampler> &c) {
+void stim_pybind::pybind_compiled_detector_sampler_methods(pybind11::class_<CompiledDetectorSampler> &c) {
     c.def(
         pybind11::init(&py_init_compiled_detector_sampler),
         pybind11::arg("circuit"),

--- a/src/stim/py/compiled_detector_sampler.pybind.h
+++ b/src/stim/py/compiled_detector_sampler.pybind.h
@@ -22,6 +22,8 @@
 #include "stim/circuit/circuit.h"
 #include "stim/mem/simd_bits.h"
 
+namespace stim_pybind {
+
 struct CompiledDetectorSampler {
     const stim::DetectorsAndObservables dets_obs;
     const stim::Circuit circuit;
@@ -44,5 +46,7 @@ struct CompiledDetectorSampler {
 pybind11::class_<CompiledDetectorSampler> pybind_compiled_detector_sampler_class(pybind11::module &m);
 void pybind_compiled_detector_sampler_methods(pybind11::class_<CompiledDetectorSampler> &c);
 CompiledDetectorSampler py_init_compiled_detector_sampler(const stim::Circuit &circuit, const pybind11::object &seed);
+
+}
 
 #endif

--- a/src/stim/py/compiled_measurement_sampler.pybind.cc
+++ b/src/stim/py/compiled_measurement_sampler.pybind.cc
@@ -21,6 +21,7 @@
 #include "stim/simulators/tableau_simulator.h"
 
 using namespace stim;
+using namespace stim_pybind;
 
 CompiledMeasurementSampler::CompiledMeasurementSampler(
     simd_bits ref_sample, Circuit circuit, bool skip_reference_sample, std::shared_ptr<std::mt19937_64> prng)
@@ -98,7 +99,7 @@ CompiledMeasurementSampler py_init_compiled_sampler(
     const Circuit &circuit, bool skip_reference_sample, const pybind11::object &seed) {
     simd_bits ref_sample = skip_reference_sample ? simd_bits(circuit.count_measurements())
                                                  : TableauSimulator::reference_sample_circuit(circuit);
-    return CompiledMeasurementSampler(ref_sample, circuit, skip_reference_sample, PYBIND_SHARED_RNG(seed));
+    return CompiledMeasurementSampler(ref_sample, circuit, skip_reference_sample, make_py_seeded_rng(seed));
 }
 
 void pybind_compiled_measurement_sampler_methods(pybind11::class_<CompiledMeasurementSampler> &c) {

--- a/src/stim/py/stim.pybind.cc
+++ b/src/stim/py/stim.pybind.cc
@@ -33,6 +33,7 @@
 #define str(s) #s
 
 using namespace stim;
+using namespace stim_pybind;
 
 uint32_t target_rec(int32_t lookback) {
     if (lookback >= 0 || lookback <= -(1 << 24)) {

--- a/src/stim/simulators/matched_error.pybind.cc
+++ b/src/stim/simulators/matched_error.pybind.cc
@@ -22,6 +22,7 @@
 #include "stim/simulators/matched_error.h"
 
 using namespace stim;
+using namespace stim_pybind;
 
 std::string CircuitErrorLocationStackFrame_repr(const CircuitErrorLocationStackFrame &self) {
     std::stringstream out;

--- a/src/stim/simulators/measurements_to_detection_events.pybind.cc
+++ b/src/stim/simulators/measurements_to_detection_events.pybind.cc
@@ -22,6 +22,7 @@
 #include "stim/simulators/tableau_simulator.h"
 
 using namespace stim;
+using namespace stim_pybind;
 
 CompiledMeasurementsToDetectionEventsConverter::CompiledMeasurementsToDetectionEventsConverter(
     simd_bits ref_sample, Circuit circuit, bool skip_reference_sample)

--- a/src/stim/simulators/tableau_simulator.cc
+++ b/src/stim/simulators/tableau_simulator.cc
@@ -25,7 +25,7 @@ TableauSimulator::TableauSimulator(std::mt19937_64 &rng, size_t num_qubits, int8
     : inv_state(Tableau::identity(num_qubits)),
       rng(rng),
       sign_bias(sign_bias),
-      measurement_record(record),
+      measurement_record(std::move(record)),
       last_correlated_error_occurred(false) {
 }
 

--- a/src/stim/simulators/tableau_simulator.pybind.h
+++ b/src/stim/simulators/tableau_simulator.pybind.h
@@ -17,6 +17,13 @@
 
 #include <pybind11/pybind11.h>
 
+#include "stim/simulators/tableau_simulator.h"
+
+struct PyTableauSimulator : stim::TableauSimulator {
+    std::shared_ptr<std::mt19937_64> rng_reference;
+    explicit PyTableauSimulator(std::shared_ptr<std::mt19937_64> rng);
+};
+
 void pybind_tableau_simulator(pybind11::module &m);
 
 #endif

--- a/src/stim/simulators/vector_simulator.cc
+++ b/src/stim/simulators/vector_simulator.cc
@@ -107,14 +107,14 @@ void VectorSimulator::apply(const PauliStringRef &gate, size_t qubit_offset) {
     }
 }
 
-VectorSimulator VectorSimulator::from_stabilizers(const std::vector<PauliStringRef> stabilizers, std::mt19937_64 &rng) {
+VectorSimulator VectorSimulator::from_stabilizers(const std::vector<PauliStringRef> &stabilizers, std::mt19937_64 &rng) {
     size_t num_qubits = stabilizers.empty() ? 0 : stabilizers[0].num_qubits;
     VectorSimulator result(num_qubits);
 
     // Create an initial state $|A\rangle^{\otimes n}$ which overlaps with all possible stabilizers.
     std::uniform_real_distribution<float> dist(-1.0, +1.0);
-    for (size_t k = 0; k < result.state.size(); k++) {
-        result.state[k] = {dist(rng), dist(rng)};
+    for (auto &s : result.state) {
+        s = {dist(rng), dist(rng)};
     }
 
     // Project out the non-overlapping parts.

--- a/src/stim/simulators/vector_simulator.h
+++ b/src/stim/simulators/vector_simulator.h
@@ -39,7 +39,7 @@ struct VectorSimulator {
     ///
     /// Assumes the stabilizers commute. Works by generating a random state vector and projecting onto
     /// each of the given stabilizers. Global phase will vary.
-    static VectorSimulator from_stabilizers(const std::vector<PauliStringRef> stabilizers, std::mt19937_64 &rng);
+    static VectorSimulator from_stabilizers(const std::vector<PauliStringRef> &stabilizers, std::mt19937_64 &rng);
 
     /// Applies a unitary operation to the given qubits, updating the state vector.
     void apply(const std::vector<std::vector<std::complex<float>>> &matrix, const std::vector<size_t> &qubits);

--- a/src/stim/stabilizers/pauli_string.pybind.cc
+++ b/src/stim/stabilizers/pauli_string.pybind.cc
@@ -21,6 +21,7 @@
 #include "stim/stabilizers/tableau.pybind.h"
 
 using namespace stim;
+using namespace stim_pybind;
 
 PyPauliString::PyPauliString(const PauliStringRef val, bool imag) : value(val), imag(imag) {
 }
@@ -341,7 +342,7 @@ void pybind_pauli_string(pybind11::module &m) {
     c.def_static(
         "random",
         [](size_t num_qubits, bool allow_imaginary) {
-            std::shared_ptr<std::mt19937_64> rng = PYBIND_SHARED_RNG(pybind11::none());
+            auto rng = make_py_seeded_rng(pybind11::none());
             return PyPauliString(PauliString::random(num_qubits, *rng), allow_imaginary ? ((*rng)() & 1) : false);
         },
         pybind11::arg("num_qubits"),

--- a/src/stim/stabilizers/tableau.pybind.cc
+++ b/src/stim/stabilizers/tableau.pybind.cc
@@ -21,6 +21,7 @@
 #include "stim/stabilizers/tableau.h"
 
 using namespace stim;
+using namespace stim_pybind;
 
 void pybind_tableau(pybind11::module &m) {
     auto c = pybind11::class_<Tableau>(
@@ -86,7 +87,7 @@ void pybind_tableau(pybind11::module &m) {
     c.def_static(
         "random",
         [](size_t num_qubits) {
-            return Tableau::random(num_qubits, *PYBIND_SHARED_RNG(pybind11::none()));
+            return Tableau::random(num_qubits, *make_py_seeded_rng(pybind11::none()));
         },
         pybind11::arg("num_qubits"),
         clean_doc_string(u8R"DOC(


### PR DESCRIPTION
- Samplers created without a specified seed now always reseed from external entropy, instead of falling back to a shared rng
- This fixes an issue where forking the process multiple times and then sampling a circuit within each child processes would return identical samples, which could occur when using python multiprocessing
- Add stim_pybind namespace and use it in some files
- As a second layer of defense, simmer also now forces multiprocessing to create workers using "spawn" mode, which avoids forking memory

Fixes https://github.com/quantumlib/Stim/issues/207