### PR TITLE
Simmer polish and implicit setup.py readme encoding fix

### DIFF
--- a/glue/cirq/setup.py
+++ b/glue/cirq/setup.py
@@ -14,7 +14,7 @@
 
 from setuptools import setup
 
-with open('README.md') as f:
+with open('README.md', encoding='UTF-8') as f:
     long_description = f.read()
 
 version = '1.9.dev0'

--- a/glue/sample/README.md
+++ b/glue/sample/README.md
@@ -25,14 +25,16 @@ import stim
 
 for p in [0.001, 0.005, 0.01]:
     for d in [3, 5]:
-        for rot in ['rotated', 'unrotated']:
-            with open(f'surface_code_circuits/{rot}_d{d}_p{p}.stim', 'w') as f:
-                c = stim.Circuit.generated(
-                    rounds=d,
-                    distance=d,
-                    after_clifford_depolarization=p,
-                    code_task=f'surface_code:{rot}_memory_x')
-                print(c, file=f)
+        with open(f'surface_code_circuits/{d}_{p}_.stim', 'w') as f:
+            c = stim.Circuit.generated(
+                rounds=d,
+                distance=d,
+                after_clifford_depolarization=p,
+                after_reset_flip_probability=p,
+                before_measure_flip_probability=p,
+                before_round_data_depolarization=p,
+                code_task=f'surface_code:rotated_memory_x')
+            print(c, file=f)
 
 "
 ```
@@ -56,6 +58,7 @@ instead of overwriting it.
 simmer collect \
     -processes 4 \
     -circuits surface_code_circuits/*.stim \
+    -metadata_func "(v := path.split('/')[-1].split('_')) and {'d': int(v[0]), 'p': float(v[1])}" \
     -decoders pymatching \
     -max_shots 1_000_000 \
     -max_errors 1000 \
@@ -105,8 +108,8 @@ This is done in a flexible but very hacky way, by specifying a python expression
 ```bash
 simmer plot \
     -in surface_code_stats.csv \
-    -group_func "' '.join(custom['path'].split('/')[-1].split('_')[:2])" \
-    -x_func "'0.' + custom['path'].split('/')[-1].split('_')[-1].split('.')[1]" \
+    -group_func "'Rotated Surface Code d=' + str(metadata['d'])" \
+    -x_func "metadata['p']" \
     -fig_size 1024 1024 \
     -xaxis "[log]Physical Error Rate" \
     -out surface_code_figure.png \

--- a/glue/sample/setup.py
+++ b/glue/sample/setup.py
@@ -14,9 +14,9 @@
 
 from setuptools import setup
 
-with open('README.md') as f:
+with open('README.md', encoding='UTF-8') as f:
     long_description = f.read()
-with open('requirements.txt') as f:
+with open('requirements.txt', encoding='UTF-8') as f:
     requirements = [line.split()[0] for line in f.read().splitlines()]
 
 setup(

--- a/glue/sample/src/simmer/collection_work_manager.py
+++ b/glue/sample/src/simmer/collection_work_manager.py
@@ -24,7 +24,6 @@ class CollectionWorkManager:
         self.active_collectors: Dict[int, CollectionTrackerForSingleTask] = {}
         self.tasks: Iterator[Task] = tasks
         self.next_collector_key: int = 0
-        self.started_count = 0
         self.finished_count = 0
         self.deployed_jobs: Dict[int, WorkIn] = {}
         self.next_job_id = 0
@@ -128,10 +127,10 @@ class CollectionWorkManager:
             collector = CollectionTrackerForSingleTask(
                     task=task, additional_existing_data=self.additional_existing_data)
             if collector.is_done():
+                self.finished_count += 1
                 continue
             self.next_collector_key += 1
             self.active_collectors[key] = collector
-            self.started_count += 1
             yield key, collector
         if not prefer_started:
             yield from self.active_collectors.items()

--- a/glue/sample/src/simmer/main_combine.py
+++ b/glue/sample/src/simmer/main_combine.py
@@ -1,3 +1,4 @@
+import sys
 from typing import List
 
 from simmer.csv_out import CSV_HEADER
@@ -5,9 +6,12 @@ from simmer.existing_data import ExistingData
 
 
 def main_combine(*, command_line_args: List[str]):
-    total = ExistingData()
-    for path in command_line_args:
-        total += ExistingData.from_file(path)
+    if command_line_args:
+        total = ExistingData()
+        for path in command_line_args:
+            total += ExistingData.from_file(path)
+    else:
+        total = ExistingData.from_file(sys.stdin)
 
     print(CSV_HEADER)
     for value in total.data.values():

--- a/glue/sample/src/simmer/main_test.py
+++ b/glue/sample/src/simmer/main_test.py
@@ -7,6 +7,19 @@ import stim
 
 from simmer.main import main
 from simmer.main_combine import ExistingData
+from simmer.main_plot import better_sorted_str_terms, split_by
+
+
+def test_split_by():
+    assert split_by('abcdefcccghi', lambda e: e == 'c') == [list('ab'), list('c'), list('def'), list('ccc'), list('ghi')]
+
+
+def test_better_sorted_str_terms():
+    assert better_sorted_str_terms('a') == ('a',)
+    assert better_sorted_str_terms('abc') == ('abc',)
+    assert better_sorted_str_terms('a1b2') == ('a', 1, 'b', 2)
+    assert better_sorted_str_terms('a1.5b2') == ('a', 1.5, 'b', 2)
+    assert better_sorted_str_terms('a1.5.3b2') == ('a', (1, 5, 3), 'b', 2)
 
 
 def test_main_collect():

--- a/glue/sample/src/simmer/task.py
+++ b/glue/sample/src/simmer/task.py
@@ -23,8 +23,8 @@ class Task:
                  json_metadata: JSON_TYPE = None,
 
                  # Information related to how to take samples from the problem.
-                 max_shots: int,
-                 max_errors: int,
+                 max_shots: Optional[int] = None,
+                 max_errors: Optional[int] = None,
                  start_batch_size: int = 100,
                  max_batch_size: Optional[int] = None,
                  max_batch_seconds: Optional[float] = None,
@@ -46,11 +46,12 @@ class Task:
                 the problem. Must be JSON serializable. For example, this could
                 be a dictionary with "physical_error_rate" and "code_distance"
                 keys.
-            max_shots: Stops the sampling process after this many samples have
-                been taken from the circuit.
-            max_errors: Stops the sampling process after this many errors have
-                been seen in samples taken from the circuit. The actual number
-                sampled errors may be larger due to batching.
+            max_shots: Defaults to None (unused). Stops the sampling process
+                after this many samples have been taken from the circuit.
+            max_errors: Defaults to None (unused). Stops the sampling process
+                after this many errors have been seen in samples taken from the
+                circuit. The actual number sampled errors may be larger due to
+                batching.
             start_batch_size: Defaults to 100. The very first shots taken from
                 the circuit will use a batch of this size, and no other batches
                 will be taken in parallel. Once this initial fact finding batch
@@ -70,10 +71,12 @@ class Task:
                 a batch might take, instead of having to wait for new shots to
                 reveal this information again.
         """
-        if max_shots < 0:
-            raise ValueError(f'max_shots={max_shots} < 0')
-        if max_errors < 0:
-            raise ValueError(f'max_errors={max_errors} < 0')
+        if max_shots is None and max_errors is None:
+            raise ValueError(f'max_shots is None and max_errors is None. Must specify one or the other.')
+        if max_shots is not None and max_shots < 0:
+            raise ValueError(f'max_shots is not None and max_shots={max_shots} < 0')
+        if max_errors is not None and max_errors < 0:
+            raise ValueError(f'max_errors is not None and max_errors={max_errors} < 0')
         if start_batch_size <= 0:
             raise ValueError(f'start_batch_size={start_batch_size} <= 0')
         if max_batch_size is not None and max_batch_size <= 0:

--- a/glue/zx/setup.py
+++ b/glue/zx/setup.py
@@ -14,7 +14,7 @@
 
 from setuptools import setup
 
-with open('README.md') as f:
+with open('README.md', encoding='UTF-8') as f:
     long_description = f.read()
 
 version = '1.9.dev0'

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ stim_avx2 = Extension(
     ],
 )
 
-with open('glue/python/README.md') as f:
+with open('glue/python/README.md', encoding='UTF-8') as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
- Specify encoding when reading readme for long_description of python wheel
- Add `-metadata_func` option to `simmer collect`
- Make `-max_error` or `-max_shot` optional for `simmer collect`
- Fix already-done tasks not being counted as finished in `simmer collect` progress message
- Use `compile` on function expressions given by command line
- Make `simmer combine` read from stdin when given no arguments
- Add `-filter_func` argument to `-simmer_plot`
- Improve curve sort ordering to do numbers numerically instead of alphabetically

Fixes https://github.com/quantumlib/Stim/issues/214
Fixes https://github.com/quantumlib/Stim/issues/212