### PR TITLE
Remove usage of deprecated `cirq.SingleQubitGate`

### DIFF
--- a/glue/cirq/stimcirq/_measure_and_or_reset_gate.py
+++ b/glue/cirq/stimcirq/_measure_and_or_reset_gate.py
@@ -5,7 +5,7 @@ import stim
 
 
 @cirq.value_equality
-class MeasureAndOrResetGate(cirq.SingleQubitGate):
+class MeasureAndOrResetGate(cirq.Gate):
     """Handles explaining stim's MX/MY/MZ/MRX/MRY/MRZ/RX/RY/RZ gates to cirq."""
 
     def __init__(
@@ -23,6 +23,9 @@ class MeasureAndOrResetGate(cirq.SingleQubitGate):
         self.invert_measure = invert_measure
         self.key = key
         self.measure_flip_probability = measure_flip_probability
+
+    def _num_qubits_(self) -> int:
+        return 1
 
     def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs) -> str:
         return str(self)

--- a/glue/cirq/stimcirq/_stim_sampler_test.py
+++ b/glue/cirq/stimcirq/_stim_sampler_test.py
@@ -33,21 +33,28 @@ def test_custom_gates():
     s = stimcirq.StimSampler()
     a, b, c, d = cirq.LineQubit.range(4)
 
-    class GoodGate(cirq.SingleQubitGate):
+    class GoodGate(cirq.Gate):
         def _num_qubits_(self) -> int:
             return 1
 
         def _decompose_(self, qubits):
             return [cirq.X.on_each(*qubits)]
 
-    class IndirectlyGoodGate(cirq.SingleQubitGate):
+    class IndirectlyGoodGate(cirq.Gate):
+        def _num_qubits_(self) -> int:
+            return 1
+
         def _decompose_(self, qubits):
             return [GoodGate().on_each(*qubits)]
 
-    class BadGate(cirq.SingleQubitGate):
-        pass
+    class BadGate(cirq.Gate):
+        def _num_qubits_(self) -> int:
+            return 1
 
-    class IndirectlyBadGate(cirq.SingleQubitGate):
+    class IndirectlyBadGate(cirq.Gate):
+        def _num_qubits_(self) -> int:
+            return 1
+
         def _decompose_(self):
             return [BadGate()]
 


### PR DESCRIPTION
SingleQubitGate was deprecated in https://github.com/quantumlib/Cirq/pull/5272 and is scheduled for removal. Remove usage of it by defining `_num_qubits_` explicitly to fix deprecation warnings when using stim with nightly cirq.