### PR TITLE
Improve error decomposition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ venv/*
 .venv/*
 **/LastTest.log
 *.so
+.cmake/*

--- a/doc/usage_command_line.md
+++ b/doc/usage_command_line.md
@@ -5,8 +5,10 @@
 - **(mode)** [stim analyze_errors](#analyze_errors)
     - [--allow_gauge_detectors](#--allow_gauge_detectors)
     - [--approximate_disjoint_errors](#--approximate_disjoint_errors)
+    - [--block_decompose_from_introducing_remnant_edges](#--block_decompose_from_introducing_remnant_edges)
     - [--decompose_errors](#--decompose_errors)
     - [--fold_loops](#--fold_loops)
+    - [--ignore_decomposition_failures](#--ignore_decomposition_failures)
     - [--in](#--in)
     - [--out](#--out)
 - **(mode)** [stim detect](#detect)
@@ -97,8 +99,10 @@ Note: currently, the `ELSE_CORRELATED_ERROR` instruction is not supported by thi
 Flags used with this mode:
 - [--allow_gauge_detectors](#--allow_gauge_detectors)
 - [--approximate_disjoint_errors](#--approximate_disjoint_errors)
+- [--block_decompose_from_introducing_remnant_edges](#--block_decompose_from_introducing_remnant_edges)
 - [--decompose_errors](#--decompose_errors)
 - [--fold_loops](#--fold_loops)
+- [--ignore_decomposition_failures](#--ignore_decomposition_failures)
 - [--in](#--in)
 - [--out](#--out)
 
@@ -526,6 +530,20 @@ Flags used with this mode:
     When set to 0, the noise operations are not inserted.
     
     
+- <a name="--block_decomposition_from_introducing_remnant_edges"></a>**`--block_decomposition_from_introducing_remnant_edges`**
+    
+    Requires that both A B and C D be present elsewhere in the detector error model
+    in order to decompose A B C D into A B ^ C D. Normally, only one of A B or C D
+    needs to appear to allow this decomposition.
+    
+    Remnant edges can be a useful feature for ensuring decomposition succeeds, but
+    they can also reduce the effective code distance by giving the decoder single
+    edges that actually represent multiple errors in the circuit (resulting in the
+    decoder making misinformed choices when decoding).
+    
+    Irrelevant unless --decompose_errors is specified.
+    
+    
 - <a name="--circuit"></a>**`--circuit`**
     Specifies the circuit to use when converting measurement data to detector data.
     
@@ -601,6 +619,17 @@ Flags used with this mode:
     is any detector introduced after the loop, whose sensitivity region extends to before the loop, loop folding will fail.
     This is disastrous for loops with repetition counts in the billions, because in that case loop folding is the difference
     between the error analysis finishing in seconds instead of days.
+    
+    
+- <a name="--ignore_decomposition_failures"></a>**`--ignore_decomposition_failures`**
+    
+    When this flag is set, circuit errors that fail to decompose into graphlike
+    detector error model errors no longer cause the conversion process to abort.
+    Instead, the undecomposed error is inserted into the output. Whatever processes
+    the detector error model is then responsible for dealing with the undecomposed
+    errors (e.g. a tool may choose to simply ignore them).
+    
+    Irrelevant unless --decompose_errors is specified.
     
     
 - <a name="--in"></a>**`--in`**

--- a/src/stim.test.cc
+++ b/src/stim.test.cc
@@ -25,5 +25,5 @@ TEST(stim, include1) {
 }
 
 TEST(stim, include3) {
-    stim::ErrorAnalyzer::circuit_to_detector_error_model({}, false, false, false, false);
+    stim::ErrorAnalyzer::circuit_to_detector_error_model({}, false, false, false, 0.0, false, true);
 }

--- a/src/stim/benchmark_util.perf.h
+++ b/src/stim/benchmark_util.perf.h
@@ -63,14 +63,12 @@ struct RegisteredBenchmark {
 extern RegisteredBenchmark *running_benchmark;
 extern std::vector<RegisteredBenchmark> all_registered_benchmarks;
 
-#define BENCHMARK(name)                                                          \
-    void BENCH_##name##_METHOD();                                                \
-    struct BENCH_STARTUP_TYPE_##name {                                           \
-        BENCH_STARTUP_TYPE_##name() {                                            \
-            all_registered_benchmarks.push_back({#name, BENCH_##name##_METHOD}); \
-        }                                                                        \
-    };                                                                           \
-    static BENCH_STARTUP_TYPE_##name BENCH_STARTUP_INSTANCE_##name;              \
+#define BENCHMARK(name)                                                                                      \
+    void BENCH_##name##_METHOD();                                                                            \
+    struct BENCH_STARTUP_TYPE_##name {                                                                       \
+        BENCH_STARTUP_TYPE_##name() { all_registered_benchmarks.push_back({#name, BENCH_##name##_METHOD}); } \
+    };                                                                                                       \
+    static BENCH_STARTUP_TYPE_##name BENCH_STARTUP_INSTANCE_##name;                                          \
     void BENCH_##name##_METHOD()
 
 // HACK: Templating the body function type makes inlining significantly more likely.

--- a/src/stim/circuit/circuit_pybind_test.py
+++ b/src/stim/circuit/circuit_pybind_test.py
@@ -716,7 +716,7 @@ def test_shortest_graphlike_error_ignore():
         DETECTOR rec[-1]
     """)
     with pytest.raises(ValueError, match="Failed to decompose errors"):
-        c.shortest_graphlike_error()
+        c.shortest_graphlike_error(ignore_ungraphlike_errors=False)
     with pytest.raises(ValueError, match="Failed to find any graphlike logical errors"):
         c.shortest_graphlike_error(ignore_ungraphlike_errors=True)
 

--- a/src/stim/dem/detector_error_model.cc
+++ b/src/stim/dem/detector_error_model.cc
@@ -822,7 +822,13 @@ bool get_detector_coordinates_helper(
             // TODO: Finish in time proportional to len(instructions) + len(desired) instead of len(execution).
             for (uint64_t k = 0; k < reps; k++) {
                 if (get_detector_coordinates_helper(
-                    block, included_detector_indices, iter_desired_detector_index, coord_shift, detector_offset, out, false)) {
+                        block,
+                        included_detector_indices,
+                        iter_desired_detector_index,
+                        coord_shift,
+                        detector_offset,
+                        out,
+                        false)) {
                     return true;
                 }
             }

--- a/src/stim/dem/detector_error_model.test.cc
+++ b/src/stim/dem/detector_error_model.test.cc
@@ -681,24 +681,24 @@ TEST(detector_error_model, get_detector_coordinates_trivial) {
     dem = DetectorErrorModel(R"MODEL(
         detector(1, 2) D1
     )MODEL");
-    ASSERT_EQ(dem.get_detector_coordinates({0, 1}), (std::map<uint64_t, std::vector<double>>{
-        {0, {}},
-        {1, {1, 2}},
-    }));
-    ASSERT_THROW({
-        dem.get_detector_coordinates({2});
-    }, std::invalid_argument);
+    ASSERT_EQ(
+        dem.get_detector_coordinates({0, 1}),
+        (std::map<uint64_t, std::vector<double>>{
+            {0, {}},
+            {1, {1, 2}},
+        }));
+    ASSERT_THROW({ dem.get_detector_coordinates({2}); }, std::invalid_argument);
 
     dem = DetectorErrorModel(R"MODEL(
         error(0.25) D0 D1
     )MODEL");
-    ASSERT_EQ(dem.get_detector_coordinates({0, 1}), (std::map<uint64_t, std::vector<double>>{
-        {0, {}},
-        {1, {}},
-    }));
-    ASSERT_THROW({
-        dem.get_detector_coordinates({2});
-    }, std::invalid_argument);
+    ASSERT_EQ(
+        dem.get_detector_coordinates({0, 1}),
+        (std::map<uint64_t, std::vector<double>>{
+            {0, {}},
+            {1, {}},
+        }));
+    ASSERT_THROW({ dem.get_detector_coordinates({2}); }, std::invalid_argument);
 
     dem = DetectorErrorModel(R"MODEL(
         error(0.25) D0 D1
@@ -706,15 +706,15 @@ TEST(detector_error_model, get_detector_coordinates_trivial) {
         shift_detectors(5) 1
         detector(1, 2) D2
     )MODEL");
-    ASSERT_EQ(dem.get_detector_coordinates({0, 1, 2, 3}), (std::map<uint64_t, std::vector<double>>{
-        {0, {}},
-        {1, {1, 2, 3}},
-        {2, {}},
-        {3, {6, 2}},
-    }));
-    ASSERT_THROW({
-        dem.get_detector_coordinates({4});
-    }, std::invalid_argument);
+    ASSERT_EQ(
+        dem.get_detector_coordinates({0, 1, 2, 3}),
+        (std::map<uint64_t, std::vector<double>>{
+            {0, {}},
+            {1, {1, 2, 3}},
+            {2, {}},
+            {3, {6, 2}},
+        }));
+    ASSERT_THROW({ dem.get_detector_coordinates({4}); }, std::invalid_argument);
 }
 
 TEST(detector_error_model, final_detector_and_coord_shift) {

--- a/src/stim/help.cc
+++ b/src/stim/help.cc
@@ -404,12 +404,36 @@ Note: currently, the `ELSE_CORRELATED_ERROR` instruction is not supported by thi
         {
             "--allow_gauge_detectors",
             "--approximate_disjoint_errors",
+            "--block_decompose_from_introducing_remnant_edges",
+            "--ignore_decomposition_failures",
             "--decompose_errors",
             "--fold_loops",
             "--out",
             "--in",
         },
     };
+
+    flags["--ignore_decomposition_failures"] = R"PARAGRAPH(
+When this flag is set, circuit errors that fail to decompose into graphlike
+detector error model errors no longer cause the conversion process to abort.
+Instead, the undecomposed error is inserted into the output. Whatever processes
+the detector error model is then responsible for dealing with the undecomposed
+errors (e.g. a tool may choose to simply ignore them).
+
+Irrelevant unless --decompose_errors is specified.
+)PARAGRAPH";
+    flags["--block_decomposition_from_introducing_remnant_edges"] = R"PARAGRAPH(
+Requires that both A B and C D be present elsewhere in the detector error model
+in order to decompose A B C D into A B ^ C D. Normally, only one of A B or C D
+needs to appear to allow this decomposition.
+
+Remnant edges can be a useful feature for ensuring decomposition succeeds, but
+they can also reduce the effective code distance by giving the decoder single
+edges that actually represent multiple errors in the circuit (resulting in the
+decoder making misinformed choices when decoding).
+
+Irrelevant unless --decompose_errors is specified.
+)PARAGRAPH";
 
     flags["--fold_loops"] = R"PARAGRAPH(
 Allows the output error model to contain `repeat` blocks.

--- a/src/stim/main_namespaced.cc
+++ b/src/stim/main_namespaced.cc
@@ -208,10 +208,12 @@ int main_mode_analyze_errors(int argc, const char **argv) {
         {
             "--allow_gauge_detectors",
             "--approximate_disjoint_errors",
+            "--block_decompose_from_introducing_remnant_edges",
             "--decompose_errors",
             "--fold_loops",
-            "--out",
+            "--ignore_decomposition_failures",
             "--in",
+            "--out",
         },
         {"--analyze_errors", "--detector_hypergraph"},
         "analyze_errors",
@@ -220,6 +222,9 @@ int main_mode_analyze_errors(int argc, const char **argv) {
     bool decompose_errors = find_bool_argument("--decompose_errors", argc, argv);
     bool fold_loops = find_bool_argument("--fold_loops", argc, argv);
     bool allow_gauge_detectors = find_bool_argument("--allow_gauge_detectors", argc, argv);
+    bool ignore_decomposition_failures = find_bool_argument("--ignore_decomposition_failures", argc, argv);
+    bool block_decompose_from_introducing_remnant_edges =
+        find_bool_argument("--block_decompose_from_introducing_remnant_edges", argc, argv);
 
     const char *approximate_disjoint_errors_arg = find_argument("--approximate_disjoint_errors", argc, argv);
     float approximate_disjoint_errors_threshold = 0;
@@ -238,7 +243,13 @@ int main_mode_analyze_errors(int argc, const char **argv) {
         fclose(in);
     }
     out << ErrorAnalyzer::circuit_to_detector_error_model(
-               circuit, decompose_errors, fold_loops, allow_gauge_detectors, approximate_disjoint_errors_threshold)
+               circuit,
+               decompose_errors,
+               fold_loops,
+               allow_gauge_detectors,
+               approximate_disjoint_errors_threshold,
+               ignore_decomposition_failures,
+               block_decompose_from_introducing_remnant_edges)
         << "\n";
     return EXIT_SUCCESS;
 }

--- a/src/stim/mem/simd_bits_range_ref.h
+++ b/src/stim/mem/simd_bits_range_ref.h
@@ -17,10 +17,10 @@
 #ifndef _STIM_MEM_SIMD_BITS_RANGE_REF_H
 #define _STIM_MEM_SIMD_BITS_RANGE_REF_H
 
+#include <array>
 #include <iostream>
 #include <random>
 #include <vector>
-#include <array>
 
 #include "stim/mem/bit_ref.h"
 #include "stim/mem/simd_compat.h"

--- a/src/stim/py/base.pybind.h
+++ b/src/stim/py/base.pybind.h
@@ -48,6 +48,6 @@ pybind11::tuple tuple_tree(const std::vector<T> &val, size_t offset = 0) {
     return pybind11::make_tuple(val[offset], tuple_tree(val, offset + 1));
 }
 
-}
+}  // namespace stim_pybind
 
 #endif

--- a/src/stim/py/compiled_detector_sampler.pybind.cc
+++ b/src/stim/py/compiled_detector_sampler.pybind.cc
@@ -92,15 +92,14 @@ std::string CompiledDetectorSampler::repr() const {
     return result.str();
 }
 
-CompiledDetectorSampler stim_pybind::py_init_compiled_detector_sampler(const Circuit &circuit, const pybind11::object &seed) {
+CompiledDetectorSampler stim_pybind::py_init_compiled_detector_sampler(
+    const Circuit &circuit, const pybind11::object &seed) {
     return CompiledDetectorSampler(circuit, make_py_seeded_rng(seed));
 }
 
 pybind11::class_<CompiledDetectorSampler> stim_pybind::pybind_compiled_detector_sampler_class(pybind11::module &m) {
     return pybind11::class_<CompiledDetectorSampler>(
-        m,
-        "CompiledDetectorSampler",
-        "An analyzed stabilizer circuit whose detection events can be sampled quickly.");
+        m, "CompiledDetectorSampler", "An analyzed stabilizer circuit whose detection events can be sampled quickly.");
 }
 
 void stim_pybind::pybind_compiled_detector_sampler_methods(pybind11::class_<CompiledDetectorSampler> &c) {

--- a/src/stim/py/compiled_detector_sampler.pybind.h
+++ b/src/stim/py/compiled_detector_sampler.pybind.h
@@ -47,6 +47,6 @@ pybind11::class_<CompiledDetectorSampler> pybind_compiled_detector_sampler_class
 void pybind_compiled_detector_sampler_methods(pybind11::class_<CompiledDetectorSampler> &c);
 CompiledDetectorSampler py_init_compiled_detector_sampler(const stim::Circuit &circuit, const pybind11::object &seed);
 
-}
+}  // namespace stim_pybind
 
 #endif

--- a/src/stim/py/compiled_measurement_sampler.pybind.cc
+++ b/src/stim/py/compiled_measurement_sampler.pybind.cc
@@ -89,9 +89,7 @@ std::string CompiledMeasurementSampler::repr() const {
 
 pybind11::class_<CompiledMeasurementSampler> pybind_compiled_measurement_sampler_class(pybind11::module &m) {
     return pybind11::class_<CompiledMeasurementSampler>(
-        m,
-        "CompiledMeasurementSampler",
-        "An analyzed stabilizer circuit whose measurements can be sampled quickly.");
+        m, "CompiledMeasurementSampler", "An analyzed stabilizer circuit whose measurements can be sampled quickly.");
 }
 
 CompiledMeasurementSampler py_init_compiled_sampler(

--- a/src/stim/py/march.pybind.cc
+++ b/src/stim/py/march.pybind.cc
@@ -1,6 +1,6 @@
-#include <pybind11/pybind11.h>
-
 #include "stim/py/march.pybind.h"
+
+#include <pybind11/pybind11.h>
 
 #ifdef _WIN32
 //  Windows

--- a/src/stim/simulators/error_analyzer.perf.cc
+++ b/src/stim/simulators/error_analyzer.perf.cc
@@ -26,7 +26,7 @@ BENCHMARK(ErrorAnalyzer_surface_code_rotated_memory_z_d11_r100) {
     params.after_clifford_depolarization = 0.001;
     auto circuit = generate_surface_code_circuit(params).circuit;
     benchmark_go([&]() {
-        ErrorAnalyzer analyzer(circuit.count_detectors(), circuit.count_qubits(), false, false, false, 0.0);
+        ErrorAnalyzer analyzer(circuit.count_detectors(), circuit.count_qubits(), false, false, false, 0.0, false, true);
         analyzer.run_circuit(circuit);
     }).goal_millis(320);
 }
@@ -38,7 +38,7 @@ BENCHMARK(ErrorAnalyzer_surface_code_rotated_memory_z_d11_r100_find_reducible_er
     params.after_clifford_depolarization = 0.001;
     auto circuit = generate_surface_code_circuit(params).circuit;
     benchmark_go([&]() {
-        ErrorAnalyzer analyzer(circuit.count_detectors(), circuit.count_qubits(), true, false, false, 0.0);
+        ErrorAnalyzer analyzer(circuit.count_detectors(), circuit.count_qubits(), true, false, false, 0.0, false, true);
         analyzer.run_circuit(circuit);
     }).goal_millis(450);
 }
@@ -50,7 +50,7 @@ BENCHMARK(ErrorAnalyzer_surface_code_rotated_memory_z_d11_r100000000_find_loops)
     params.after_clifford_depolarization = 0.001;
     auto circuit = generate_surface_code_circuit(params).circuit;
     benchmark_go([&]() {
-        ErrorAnalyzer analyzer(circuit.count_detectors(), circuit.count_qubits(), false, true, false, 0.0);
+        ErrorAnalyzer analyzer(circuit.count_detectors(), circuit.count_qubits(), false, true, false, 0.0, false, true);
         analyzer.run_circuit(circuit);
     }).goal_millis(15);
 }

--- a/src/stim/simulators/error_analyzer.test.cc
+++ b/src/stim/simulators/error_analyzer.test.cc
@@ -34,7 +34,9 @@ TEST(ErrorAnalyzer, circuit_to_detector_error_model) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(0.25) D0
         )model"));
@@ -50,7 +52,9 @@ TEST(ErrorAnalyzer, circuit_to_detector_error_model) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(0.25) D0 L0
         )model"));
@@ -65,7 +69,9 @@ TEST(ErrorAnalyzer, circuit_to_detector_error_model) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(0.25) D0
         )model"));
@@ -80,7 +86,9 @@ TEST(ErrorAnalyzer, circuit_to_detector_error_model) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             detector D0
         )model"));
@@ -94,7 +102,9 @@ TEST(ErrorAnalyzer, circuit_to_detector_error_model) {
                     false,
                     false,
                     false,
-                    0.0)
+                    0.0,
+                    false,
+                    true)
                     .approx_equals(
                         DetectorErrorModel(R"model(
                 error(0.166666) D0
@@ -113,7 +123,9 @@ TEST(ErrorAnalyzer, circuit_to_detector_error_model) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(0.25) D0
             error(0.125) L3
@@ -131,7 +143,9 @@ TEST(ErrorAnalyzer, circuit_to_detector_error_model) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(0.25) D0
             error(0.125) L3
@@ -148,7 +162,9 @@ TEST(ErrorAnalyzer, circuit_to_detector_error_model) {
                     false,
                     false,
                     false,
-                    0.0)
+                    0.0,
+                    false,
+                    true)
                     .approx_equals(
                         DetectorErrorModel(R"model(
                 error(0.0718255) D0
@@ -173,7 +189,9 @@ TEST(ErrorAnalyzer, circuit_to_detector_error_model) {
                     false,
                     false,
                     false,
-                    0.0)
+                    0.0,
+                    false,
+                    true)
                     .approx_equals(
                         DetectorErrorModel(R"model(
                 error(0.019013) D0
@@ -210,7 +228,9 @@ TEST(ErrorAnalyzer, circuit_to_detector_error_model) {
                     true,
                     false,
                     false,
-                    0.0)
+                    0.0,
+                    false,
+                    true)
                     .approx_equals(
                         DetectorErrorModel(R"model(
                 error(0.019013) D0
@@ -255,7 +275,9 @@ TEST(ErrorAnalyzer, circuit_to_detector_error_model) {
                     true,
                     false,
                     true,
-                    0.0)
+                    0.0,
+                    false,
+                    true)
                     .approx_equals(
                         DetectorErrorModel(R"model(
                 error(0.071825) D0 D1
@@ -267,7 +289,7 @@ TEST(ErrorAnalyzer, circuit_to_detector_error_model) {
 
 TEST(ErrorAnalyzer, unitary_gates_match_frame_simulator) {
     FrameSimulator f(16, 16, SIZE_MAX, SHARED_TEST_RNG());
-    ErrorAnalyzer e(1, 16, false, false, false, 0.0);
+    ErrorAnalyzer e(1, 16, false, false, false, 0.0, false, true);
     for (size_t q = 0; q < 16; q++) {
         if (q & 1) {
             e.xs[q].xor_item({0});
@@ -330,7 +352,9 @@ TEST(ErrorAnalyzer, reversed_operation_order) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(0.25) D1
             detector D0
@@ -349,7 +373,9 @@ TEST(ErrorAnalyzer, reversed_operation_order) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(0.25) D0
             detector D1
@@ -369,7 +395,9 @@ TEST(ErrorAnalyzer, classical_error_propagation) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(0.125) D0
         )model"));
@@ -388,7 +416,9 @@ TEST(ErrorAnalyzer, classical_error_propagation) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(0.125) D0
         )model"));
@@ -407,7 +437,9 @@ TEST(ErrorAnalyzer, classical_error_propagation) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(0.125) D0
         )model"));
@@ -424,7 +456,9 @@ TEST(ErrorAnalyzer, classical_error_propagation) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(0.125) D0
         )model"));
@@ -441,7 +475,9 @@ TEST(ErrorAnalyzer, classical_error_propagation) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(0.125) D0
         )model"));
@@ -458,7 +494,9 @@ TEST(ErrorAnalyzer, classical_error_propagation) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(0.125) D0
         )model"));
@@ -480,7 +518,9 @@ TEST(ErrorAnalyzer, measure_reset_basis) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(0.25) D0
             error(0.25) D1
@@ -502,7 +542,9 @@ TEST(ErrorAnalyzer, measure_reset_basis) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(0.25) D1
             error(0.25) D2
@@ -523,7 +565,9 @@ TEST(ErrorAnalyzer, measure_reset_basis) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(0.25) D0
             error(0.25) D2
@@ -545,7 +589,9 @@ TEST(ErrorAnalyzer, measure_reset_basis) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(0.25) D0
             error(0.25) D1
@@ -567,7 +613,9 @@ TEST(ErrorAnalyzer, measure_reset_basis) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(0.25) D1
             error(0.25) D2
@@ -588,7 +636,9 @@ TEST(ErrorAnalyzer, measure_reset_basis) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(0.25) D0
             error(0.25) D2
@@ -611,7 +661,9 @@ TEST(ErrorAnalyzer, repeated_measure_reset) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(0.25) D2
             detector D0
@@ -634,7 +686,9 @@ TEST(ErrorAnalyzer, repeated_measure_reset) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(0.25) D2
             detector D0
@@ -657,7 +711,9 @@ TEST(ErrorAnalyzer, repeated_measure_reset) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(0.25) D2
             detector D0
@@ -683,7 +739,9 @@ TEST(ErrorAnalyzer, period_3_gates) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(1) D0
             error(1) D2
@@ -707,7 +765,9 @@ TEST(ErrorAnalyzer, period_3_gates) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(1) D1
             error(1) D2
@@ -731,7 +791,9 @@ TEST(ErrorAnalyzer, period_3_gates) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(1) D0
             error(1) D2
@@ -752,7 +814,9 @@ TEST(ErrorAnalyzer, detect_gauge_observables) {
             false,
             false,
             false,
-            0.0);
+            0.0,
+            false,
+            true);
     });
     ASSERT_ANY_THROW({
         ErrorAnalyzer::circuit_to_detector_error_model(
@@ -766,7 +830,9 @@ TEST(ErrorAnalyzer, detect_gauge_observables) {
             false,
             false,
             true,
-            0.0);
+            0.0,
+            false,
+            true);
     });
 }
 
@@ -783,7 +849,9 @@ TEST(ErrorAnalyzer, detect_gauge_detectors) {
             false,
             false,
             false,
-            0.0);
+            0.0,
+            false,
+            true);
     });
 
     ASSERT_ANY_THROW({
@@ -798,7 +866,9 @@ TEST(ErrorAnalyzer, detect_gauge_detectors) {
             false,
             false,
             false,
-            0.0);
+            0.0,
+            false,
+            true);
     });
 
     ASSERT_ANY_THROW({
@@ -812,7 +882,9 @@ TEST(ErrorAnalyzer, detect_gauge_detectors) {
             false,
             false,
             false,
-            0.0);
+            0.0,
+            false,
+            true);
     });
 
     ASSERT_ANY_THROW({
@@ -826,7 +898,9 @@ TEST(ErrorAnalyzer, detect_gauge_detectors) {
             false,
             false,
             false,
-            0.0);
+            0.0,
+            false,
+            true);
     });
 
     ASSERT_ANY_THROW({
@@ -840,7 +914,9 @@ TEST(ErrorAnalyzer, detect_gauge_detectors) {
             false,
             false,
             false,
-            0.0);
+            0.0,
+            false,
+            true);
     });
 
     ASSERT_ANY_THROW({
@@ -854,7 +930,9 @@ TEST(ErrorAnalyzer, detect_gauge_detectors) {
             false,
             false,
             false,
-            0.0);
+            0.0,
+            false,
+            true);
     });
 
     ASSERT_ANY_THROW({
@@ -868,7 +946,9 @@ TEST(ErrorAnalyzer, detect_gauge_detectors) {
             false,
             false,
             false,
-            0.0);
+            0.0,
+            false,
+            true);
     });
 
     ASSERT_ANY_THROW({
@@ -882,7 +962,9 @@ TEST(ErrorAnalyzer, detect_gauge_detectors) {
             false,
             false,
             false,
-            0.0);
+            0.0,
+            false,
+            true);
     });
 
     ASSERT_ANY_THROW({
@@ -895,7 +977,9 @@ TEST(ErrorAnalyzer, detect_gauge_detectors) {
             false,
             false,
             false,
-            0.0);
+            0.0,
+            false,
+            true);
     });
 }
 
@@ -913,7 +997,9 @@ TEST(ErrorAnalyzer, gauge_detectors) {
             false,
             false,
             true,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
                 error(0.5) D0 D1
             )model"));
@@ -932,7 +1018,9 @@ TEST(ErrorAnalyzer, gauge_detectors) {
             false,
             false,
             true,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(0.5) D0 D1
         )model"));
@@ -950,7 +1038,9 @@ TEST(ErrorAnalyzer, gauge_detectors) {
             false,
             false,
             true,
-            0.0),
+            0.0,
+            false,
+            true),
         R"model(
 error(0.5) D0 D1
 )model");
@@ -969,7 +1059,9 @@ error(0.5) D0 D1
             false,
             false,
             true,
-            0.0),
+            0.0,
+            false,
+            true),
         R"model(
 error(0.5) D0 D1
 )model");
@@ -988,7 +1080,9 @@ error(0.5) D0 D1
             false,
             false,
             true,
-            0.0),
+            0.0,
+            false,
+            true),
         R"model(
 error(0.5) D0 D1
 )model");
@@ -1006,7 +1100,9 @@ error(0.5) D0 D1
             false,
             false,
             true,
-            0.0),
+            0.0,
+            false,
+            true),
         R"model(
 error(0.5) D0 D1
 )model");
@@ -1025,7 +1121,9 @@ error(0.5) D0 D1
             false,
             false,
             true,
-            0.0),
+            0.0,
+            false,
+            true),
         R"model(
 error(0.5) D0 D1
 )model");
@@ -1044,7 +1142,9 @@ error(0.5) D0 D1
             false,
             false,
             true,
-            0.0),
+            0.0,
+            false,
+            true),
         R"model(
 error(0.5) D0 D1
 )model");
@@ -1062,7 +1162,9 @@ error(0.5) D0 D1
             false,
             false,
             true,
-            0.0),
+            0.0,
+            false,
+            true),
         R"model(
 error(0.5) D0 D1
 )model");
@@ -1081,7 +1183,9 @@ error(0.5) D0 D1
             false,
             false,
             true,
-            0.0),
+            0.0,
+            false,
+            true),
         R"model(
 error(0.5) D0 D1
 )model");
@@ -1119,7 +1223,7 @@ TEST(ErrorAnalyzer, composite_error_analysis) {
     auto encode = measure_stabilizers;
     auto decode = measure_stabilizers + detectors;
     ASSERT_TRUE(ErrorAnalyzer::circuit_to_detector_error_model(
-                    Circuit(encode + Circuit("DEPOLARIZE1(0.01) 4") + decode), true, false, false, 0.0)
+                    Circuit(encode + Circuit("DEPOLARIZE1(0.01) 4") + decode), true, false, false, 0.0, false, true)
                     .approx_equals(
                         DetectorErrorModel(R"model(
                 error(0.0033445) D0 D4
@@ -1131,7 +1235,7 @@ TEST(ErrorAnalyzer, composite_error_analysis) {
                         1e-6));
 
     ASSERT_TRUE(ErrorAnalyzer::circuit_to_detector_error_model(
-                    Circuit(encode + Circuit("DEPOLARIZE2(0.01) 4 5") + decode), true, false, false, 0.0)
+                    Circuit(encode + Circuit("DEPOLARIZE2(0.01) 4 5") + decode), true, false, false, 0.0, false, true)
                     .approx_equals(
                         DetectorErrorModel(R"model(
                 error(0.000669) D0 D2
@@ -1170,18 +1274,25 @@ TEST(ErrorAnalyzer, composite_error_analysis) {
         error(0.000669) D3 D5
     )model");
     ASSERT_TRUE(ErrorAnalyzer::circuit_to_detector_error_model(
-                    Circuit(encode + Circuit("DEPOLARIZE2(0.01) 4 5") + decode), false, false, false, 0.0)
+                    Circuit(encode + Circuit("DEPOLARIZE2(0.01) 4 5") + decode), false, false, false, 0.0, false, true)
                     .approx_equals(expected, 1e-5));
-    ASSERT_TRUE(
-        ErrorAnalyzer::circuit_to_detector_error_model(
-            Circuit(encode + Circuit("CNOT 4 5\nDEPOLARIZE2(0.01) 4 5\nCNOT 4 5") + decode), false, false, false, 0.0)
-            .approx_equals(expected, 1e-5));
+    ASSERT_TRUE(ErrorAnalyzer::circuit_to_detector_error_model(
+                    Circuit(encode + Circuit("CNOT 4 5\nDEPOLARIZE2(0.01) 4 5\nCNOT 4 5") + decode),
+                    false,
+                    false,
+                    false,
+                    0.0,
+                    false,
+                    true)
+                    .approx_equals(expected, 1e-5));
     ASSERT_TRUE(ErrorAnalyzer::circuit_to_detector_error_model(
                     Circuit(encode + Circuit("H_XY 4\nCNOT 4 5\nDEPOLARIZE2(0.01) 4 5\nCNOT 4 5\nH_XY 4") + decode),
                     false,
                     false,
                     false,
-                    0.0)
+                    0.0,
+                    false,
+                    true)
                     .approx_equals(expected, 1e-5));
 }
 
@@ -1210,7 +1321,9 @@ TEST(ErrorAnalyzer, loop_folding) {
             false,
             true,
             true,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"MODEL(
                 error(0.25) D0 L9
                 REPEAT 6172839493827159 {
@@ -1237,7 +1350,9 @@ TEST(ErrorAnalyzer, loop_folding) {
             false,
             true,
             true,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"MODEL(
             detector D0
             detector D1
@@ -1281,7 +1396,9 @@ TEST(ErrorAnalyzer, loop_folding) {
             false,
             true,
             true,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel((declare_detectors(0, 85) + R"MODEL(
             REPEAT 97210070768930 {
                 )MODEL" + declare_detectors(86, 86 + 127 - 1) +
@@ -1315,7 +1432,9 @@ TEST(ErrorAnalyzer, loop_folding_nested_loop) {
             false,
             true,
             true,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"MODEL(
                 REPEAT 999 {
                     REPEAT 1000 {
@@ -1338,7 +1457,7 @@ TEST(ErrorAnalyzer, loop_folding_rep_code_circuit) {
     params.after_clifford_depolarization = 0.001;
     auto circuit = generate_rep_code_circuit(params).circuit;
 
-    auto actual = ErrorAnalyzer::circuit_to_detector_error_model(circuit, true, true, false, 0.0);
+    auto actual = ErrorAnalyzer::circuit_to_detector_error_model(circuit, true, true, false, 0.0, false, true);
     auto expected = DetectorErrorModel(R"MODEL(
         error(0.000267) D0
         error(0.000267) D0 D1
@@ -1431,7 +1550,9 @@ TEST(ErrorAnalyzer, multi_round_gauge_detectors_dont_grow) {
             false,
             false,
             true,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"MODEL(
             error(0.5) D0 D1
             error(0.5) D2 D3
@@ -1469,7 +1590,9 @@ TEST(ErrorAnalyzer, multi_round_gauge_detectors_dont_grow) {
                     false,
                     false,
                     true,
-                    0.0)
+                    0.0,
+                    false,
+                    true)
                     .approx_equals(
                         DetectorErrorModel(R"MODEL(
             error(0.00667) D0
@@ -1549,7 +1672,9 @@ TEST(ErrorAnalyzer, multi_round_gauge_detectors_dont_grow) {
             false,
             true,
             true,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"MODEL(
             error(0.5) D0 D1
             error(0.5) D2 D3
@@ -1582,7 +1707,9 @@ TEST(ErrorAnalyzer, coordinate_tracking) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"MODEL(
             detector(1, 2) D0
             shift_detectors(10, 20) 0
@@ -1609,7 +1736,9 @@ TEST(ErrorAnalyzer, coordinate_tracking) {
             false,
             true,
             true,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"MODEL(
                 REPEAT 999 {
                     REPEAT 1000 {
@@ -1648,7 +1777,9 @@ TEST(ErrorAnalyzer, omit_vacuous_detector_observable_instructions) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(0.25) D0
         )model"));
@@ -1663,7 +1794,9 @@ TEST(ErrorAnalyzer, omit_vacuous_detector_observable_instructions) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(0.25) D0
             detector(1, 0) D0
@@ -1678,7 +1811,9 @@ TEST(ErrorAnalyzer, omit_vacuous_detector_observable_instructions) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             detector D0
         )model"));
@@ -1693,7 +1828,9 @@ TEST(ErrorAnalyzer, omit_vacuous_detector_observable_instructions) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             error(0.25) L0
         )model"));
@@ -1707,7 +1844,9 @@ TEST(ErrorAnalyzer, omit_vacuous_detector_observable_instructions) {
             false,
             false,
             false,
-            0.0),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"model(
             logical_observable L0
         )model"));
@@ -1727,20 +1866,28 @@ M 0
 DETECTOR rec[-1]
     )CIRCUIT");
 
-    ASSERT_ANY_THROW({ ErrorAnalyzer::circuit_to_detector_error_model(c1, false, false, false, 0); });
-    ASSERT_ANY_THROW({ ErrorAnalyzer::circuit_to_detector_error_model(c1, false, false, false, 0.3); });
-    ASSERT_ANY_THROW({ ErrorAnalyzer::circuit_to_detector_error_model(c2, false, false, false, 0); });
-    ASSERT_ANY_THROW({ ErrorAnalyzer::circuit_to_detector_error_model(c2, false, false, false, 0.3); });
-    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(c1, false, false, false, 0.38), DetectorErrorModel(R"MODEL(
+    ASSERT_ANY_THROW({ ErrorAnalyzer::circuit_to_detector_error_model(c1, false, false, false, 0, false, true); });
+    ASSERT_ANY_THROW({ ErrorAnalyzer::circuit_to_detector_error_model(c1, false, false, false, 0.3, false, true); });
+    ASSERT_ANY_THROW({ ErrorAnalyzer::circuit_to_detector_error_model(c2, false, false, false, 0, false, true); });
+    ASSERT_ANY_THROW({ ErrorAnalyzer::circuit_to_detector_error_model(c2, false, false, false, 0.3, false, true); });
+    ASSERT_EQ(
+        ErrorAnalyzer::circuit_to_detector_error_model(c1, false, false, false, 0.38, false, true),
+        DetectorErrorModel(R"MODEL(
             error(0.3125) D0
         )MODEL"));
-    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(c1, false, false, false, 1), DetectorErrorModel(R"MODEL(
+    ASSERT_EQ(
+        ErrorAnalyzer::circuit_to_detector_error_model(c1, false, false, false, 1, false, true),
+        DetectorErrorModel(R"MODEL(
             error(0.3125) D0
         )MODEL"));
-    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(c2, false, false, false, 0.38), DetectorErrorModel(R"MODEL(
+    ASSERT_EQ(
+        ErrorAnalyzer::circuit_to_detector_error_model(c2, false, false, false, 0.38, false, true),
+        DetectorErrorModel(R"MODEL(
             error(0.3125) D0
         )MODEL"));
-    ASSERT_EQ(ErrorAnalyzer::circuit_to_detector_error_model(c2, false, false, false, 1), DetectorErrorModel(R"MODEL(
+    ASSERT_EQ(
+        ErrorAnalyzer::circuit_to_detector_error_model(c2, false, false, false, 1, false, true),
+        DetectorErrorModel(R"MODEL(
             error(0.3125) D0
         )MODEL"));
 }
@@ -1778,7 +1925,13 @@ TEST(ErrorAnalyzer, pauli_channel_composite_errors) {
     auto encode = measure_stabilizers;
     auto decode = measure_stabilizers + detectors;
     ASSERT_TRUE(ErrorAnalyzer::circuit_to_detector_error_model(
-                    Circuit(encode + Circuit("PAULI_CHANNEL_1(0.01, 0.02, 0.03) 4") + decode), true, false, false, 0.1)
+                    Circuit(encode + Circuit("PAULI_CHANNEL_1(0.01, 0.02, 0.03) 4") + decode),
+                    true,
+                    false,
+                    false,
+                    0.1,
+                    false,
+                    true)
                     .approx_equals(
                         DetectorErrorModel(R"model(
                 error(0.03) D0 D4
@@ -1789,7 +1942,13 @@ TEST(ErrorAnalyzer, pauli_channel_composite_errors) {
             )model"),
                         1e-6));
     ASSERT_TRUE(ErrorAnalyzer::circuit_to_detector_error_model(
-                    Circuit(encode + Circuit("PAULI_CHANNEL_1(0.01, 0.02, 0.03) 5") + decode), true, false, false, 0.1)
+                    Circuit(encode + Circuit("PAULI_CHANNEL_1(0.01, 0.02, 0.03) 5") + decode),
+                    true,
+                    false,
+                    false,
+                    0.1,
+                    false,
+                    true)
                     .approx_equals(
                         DetectorErrorModel(R"model(
                 error(0.01) D1 D5
@@ -1810,7 +1969,9 @@ TEST(ErrorAnalyzer, pauli_channel_composite_errors) {
                     true,
                     false,
                     false,
-                    0.02)
+                    0.02,
+                    false,
+                    true)
                     .approx_equals(
                         DetectorErrorModel(R"model(
                 error(0.015) D0 D2          # ZZ
@@ -1842,7 +2003,9 @@ TEST(ErrorAnalyzer, duplicate_records_in_detectors) {
         false,
         false,
         false,
-        false);
+        false,
+        false,
+        true);
     auto m1 = ErrorAnalyzer::circuit_to_detector_error_model(
         Circuit(R"CIRCUIT(
             X_ERROR(0.25) 0
@@ -1852,7 +2015,9 @@ TEST(ErrorAnalyzer, duplicate_records_in_detectors) {
         false,
         false,
         false,
-        false);
+        false,
+        false,
+        true);
     auto m2 = ErrorAnalyzer::circuit_to_detector_error_model(
         Circuit(R"CIRCUIT(
             X_ERROR(0.25) 0
@@ -1862,7 +2027,9 @@ TEST(ErrorAnalyzer, duplicate_records_in_detectors) {
         false,
         false,
         false,
-        false);
+        false,
+        false,
+        true);
     auto m3 = ErrorAnalyzer::circuit_to_detector_error_model(
         Circuit(R"CIRCUIT(
             X_ERROR(0.25) 0
@@ -1872,7 +2039,9 @@ TEST(ErrorAnalyzer, duplicate_records_in_detectors) {
         false,
         false,
         false,
-        false);
+        false,
+        false,
+        true);
     ASSERT_EQ(m0, m2);
     ASSERT_EQ(m1, m3);
 }
@@ -1890,7 +2059,9 @@ TEST(ErrorAnalyzer, noisy_measurement_mx) {
             false,
             false,
             false,
-            false),
+            false,
+            false,
+            true),
         DetectorErrorModel(R"MODEL(
             error(0.125) D0
             detector D1
@@ -1911,7 +2082,9 @@ TEST(ErrorAnalyzer, noisy_measurement_mx) {
             false,
             false,
             false,
-            false),
+            false,
+            false,
+            true),
         DetectorErrorModel(R"MODEL(
             error(0.125) D0
             error(1) D0 D2
@@ -1933,7 +2106,9 @@ TEST(ErrorAnalyzer, noisy_measurement_my) {
             false,
             false,
             false,
-            false),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"MODEL(
             error(0.125) D0
             detector D1
@@ -1954,7 +2129,9 @@ TEST(ErrorAnalyzer, noisy_measurement_my) {
             false,
             false,
             false,
-            false),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"MODEL(
             error(0.125) D0
             error(1) D0 D2
@@ -1976,7 +2153,9 @@ TEST(ErrorAnalyzer, noisy_measurement_mz) {
             false,
             false,
             false,
-            false),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"MODEL(
             error(0.125) D0
             detector D1
@@ -1997,7 +2176,9 @@ TEST(ErrorAnalyzer, noisy_measurement_mz) {
             false,
             false,
             false,
-            false),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"MODEL(
             error(0.125) D0
             error(1) D0 D2
@@ -2019,7 +2200,9 @@ TEST(ErrorAnalyzer, noisy_measurement_mrx) {
             false,
             false,
             false,
-            false),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"MODEL(
             error(0.125) D0
             detector D1
@@ -2040,7 +2223,9 @@ TEST(ErrorAnalyzer, noisy_measurement_mrx) {
             false,
             false,
             false,
-            false),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"MODEL(
             error(0.875) D0
             error(0.875) D1
@@ -2062,7 +2247,9 @@ TEST(ErrorAnalyzer, noisy_measurement_mry) {
             false,
             false,
             false,
-            false),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"MODEL(
             error(0.125) D0
             detector D1
@@ -2083,7 +2270,9 @@ TEST(ErrorAnalyzer, noisy_measurement_mry) {
             false,
             false,
             false,
-            false),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"MODEL(
             error(0.875) D0
             error(0.875) D1
@@ -2105,7 +2294,9 @@ TEST(ErrorAnalyzer, noisy_measurement_mrz) {
             false,
             false,
             false,
-            false),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"MODEL(
             error(0.125) D0
             detector D1
@@ -2126,7 +2317,9 @@ TEST(ErrorAnalyzer, noisy_measurement_mrz) {
             false,
             false,
             false,
-            false),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"MODEL(
             error(0.875) D0
             error(0.875) D1
@@ -2166,7 +2359,9 @@ TEST(ErrorAnalyzer, context_clues_for_errors) {
                     false,
                     false,
                     false,
-                    false);
+                    0.0,
+                    false,
+                    true);
             }));
 
     ASSERT_EQ(
@@ -2190,7 +2385,9 @@ TEST(ErrorAnalyzer, context_clues_for_errors) {
                     false,
                     false,
                     false,
-                    false);
+                    0.0,
+                    false,
+                    true);
             }));
 }
 
@@ -2220,10 +2417,10 @@ TEST(ErrorAnalyzer, too_many_symptoms) {
         DETECTOR rec[-1]
     )CIRCUIT");
     ASSERT_EQ("", check_catch<std::invalid_argument>("max supported number of symptoms", [&] {
-                  ErrorAnalyzer::circuit_to_detector_error_model(symptoms_20, true, false, false, false);
+                  ErrorAnalyzer::circuit_to_detector_error_model(symptoms_20, true, false, false, 0.0, false, true);
               }));
     ASSERT_EQ("", check_catch<std::invalid_argument>("max supported number of symptoms", [&] {
-                  ErrorAnalyzer::circuit_to_detector_error_model(symptoms_20, false, false, false, false);
+                  ErrorAnalyzer::circuit_to_detector_error_model(symptoms_20, false, false, false, 0.0, false, true);
               }));
 }
 
@@ -2240,7 +2437,9 @@ TEST(ErrorAnalyzer, decompose_error_failures) {
                       true,
                       false,
                       false,
-                      false);
+                      0.0,
+                      false,
+                      true);
               }));
 
     ASSERT_EQ("", check_catch<std::invalid_argument>("decompose errors into graphlike components", [] {
@@ -2255,7 +2454,9 @@ TEST(ErrorAnalyzer, decompose_error_failures) {
                       true,
                       false,
                       false,
-                      false);
+                      0.0,
+                      false,
+                      true);
               }));
 
     ASSERT_EQ("", check_catch<std::invalid_argument>("failed to decompose is 'D0, D1, D2, L5'", [] {
@@ -2271,7 +2472,9 @@ TEST(ErrorAnalyzer, decompose_error_failures) {
                       true,
                       false,
                       false,
-                      false);
+                      0.0,
+                      false,
+                      true);
               }));
 }
 
@@ -2292,6 +2495,8 @@ TEST(ErrorAnalyzer, other_error_decomposition_fallback) {
             )CIRCUIT"),
             true,
             false,
+            false,
+            0.0,
             false,
             false),
         DetectorErrorModel(R"MODEL(
@@ -2314,6 +2519,8 @@ TEST(ErrorAnalyzer, other_error_decomposition_fallback) {
             true,
             false,
             false,
+            0.0,
+            false,
             false),
         DetectorErrorModel(R"MODEL(
             error(0.25) D2 D3
@@ -2334,6 +2541,8 @@ TEST(ErrorAnalyzer, other_error_decomposition_fallback) {
             )CIRCUIT"),
             true,
             false,
+            false,
+            0.0,
             false,
             false),
         DetectorErrorModel(R"MODEL(
@@ -2461,6 +2670,8 @@ TEST(ErrorAnalyzer, honeycomb_code_decomposes) {
         true,
         false,
         false,
+        0.0,
+        false,
         false);
 }
 
@@ -2476,7 +2687,9 @@ TEST(ErrorAnalyzer, measure_pauli_product_4body) {
             false,
             false,
             false,
-            false),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"MODEL(
             error(0.125) D0
         )MODEL"));
@@ -2490,7 +2703,9 @@ TEST(ErrorAnalyzer, measure_pauli_product_4body) {
             false,
             false,
             false,
-            false),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"MODEL(
             error(0.25) D0
         )MODEL"));
@@ -2508,7 +2723,9 @@ TEST(ErrorAnalyzer, ignores_sweep_controls) {
             false,
             false,
             false,
-            false),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"MODEL(
             error(0.25) D0
         )MODEL"));
@@ -2526,7 +2743,9 @@ TEST(ErrorAnalyzer, mpp_ordering) {
             false,
             false,
             false,
-            false),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"MODEL(
             detector D0
         )MODEL"));
@@ -2540,7 +2759,9 @@ TEST(ErrorAnalyzer, mpp_ordering) {
             false,
             false,
             false,
-            false),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"MODEL(
             detector D0
         )MODEL"));
@@ -2556,7 +2777,9 @@ TEST(ErrorAnalyzer, mpp_ordering) {
             false,
             false,
             false,
-            false),
+            0.0,
+            false,
+            true),
         DetectorErrorModel(R"MODEL(
             detector D0
         )MODEL"));
@@ -2573,7 +2796,9 @@ TEST(ErrorAnalyzer, mpp_ordering) {
                 false,
                 false,
                 false,
-                false);
+                0.0,
+                false,
+                true);
         },
         std::invalid_argument);
 
@@ -2589,7 +2814,9 @@ TEST(ErrorAnalyzer, mpp_ordering) {
                 false,
                 false,
                 false,
-                false);
+                0.0,
+                false,
+                true);
         },
         std::invalid_argument);
 }
@@ -2635,7 +2862,9 @@ Circuit stack trace:
                         false,
                         folding == 1,
                         false,
-                        false);
+                        0.0,
+                        false,
+                        true);
                 }));
 
         ASSERT_EQ(
@@ -2693,7 +2922,222 @@ Circuit stack trace:
                         false,
                         folding == 1,
                         false,
-                        false);
+                        0.0,
+                        false,
+                        true);
                 }));
     }
+}
+
+TEST(ErrorAnalyzer, brute_force_decomp_simple) {
+    MonotonicBuffer<DemTarget> buf;
+    std::map<FixedCapVector<DemTarget, 2>, ConstPointerRange<DemTarget>> known;
+    bool actual;
+    std::vector<DemTarget> problem{
+        DemTarget::relative_detector_id(0),
+        DemTarget::relative_detector_id(1),
+        DemTarget::relative_detector_id(2),
+    };
+    auto add = [&](uint32_t a, uint32_t b) {
+        DemTarget a2 = DemTarget::relative_detector_id(a);
+        DemTarget b2 = DemTarget::relative_detector_id(b);
+        FixedCapVector<DemTarget, 2> v;
+        v.push_back(a2);
+        if (b != UINT32_MAX) {
+            v.push_back(b2);
+        }
+        buf.append_tail({v.begin(), v.end()});
+        known[v] = buf.commit_tail();
+    };
+
+    actual = brute_force_decomposition_into_known_graphlike_errors({problem}, known, buf);
+    ASSERT_FALSE(actual);
+    ASSERT_TRUE(buf.tail.empty());
+
+    add(0, 2);
+
+    actual = brute_force_decomposition_into_known_graphlike_errors({problem}, known, buf);
+    ASSERT_FALSE(actual);
+    ASSERT_TRUE(buf.tail.empty());
+
+    add(1, UINT32_MAX);
+
+    actual = brute_force_decomposition_into_known_graphlike_errors({problem}, known, buf);
+    ASSERT_TRUE(actual);
+    ASSERT_EQ(buf.tail.size(), 5);
+    ASSERT_EQ(buf.tail[0], DemTarget::relative_detector_id(0));
+    ASSERT_EQ(buf.tail[1], DemTarget::relative_detector_id(2));
+    ASSERT_EQ(buf.tail[2], DemTarget::separator());
+    ASSERT_EQ(buf.tail[3], DemTarget::relative_detector_id(1));
+    ASSERT_EQ(buf.tail[4], DemTarget::separator());
+}
+
+TEST(ErrorAnalyzer, brute_force_decomp_introducing_obs_pair) {
+    MonotonicBuffer<DemTarget> buf;
+    std::map<FixedCapVector<DemTarget, 2>, ConstPointerRange<DemTarget>> known;
+    bool actual;
+    std::vector<DemTarget> problem{
+        DemTarget::relative_detector_id(0),
+        DemTarget::relative_detector_id(1),
+        DemTarget::relative_detector_id(2),
+    };
+    auto add = [&](uint32_t a, uint32_t b, bool obs) {
+        DemTarget a2 = DemTarget::relative_detector_id(a);
+        DemTarget b2 = DemTarget::relative_detector_id(b);
+        FixedCapVector<DemTarget, 2> v;
+        v.push_back(a2);
+        if (b != UINT32_MAX) {
+            v.push_back(b2);
+        }
+        buf.append_tail({v.begin(), v.end()});
+        if (obs) {
+            buf.append_tail(DemTarget::observable_id(5));
+        }
+        known[v] = buf.commit_tail();
+    };
+
+    actual = brute_force_decomposition_into_known_graphlike_errors({problem}, known, buf);
+    ASSERT_FALSE(actual);
+    ASSERT_TRUE(buf.tail.empty());
+
+    add(0, 2, true);
+
+    actual = brute_force_decomposition_into_known_graphlike_errors({problem}, known, buf);
+    ASSERT_FALSE(actual);
+    ASSERT_TRUE(buf.tail.empty());
+
+    add(1, UINT32_MAX, false);
+    actual = brute_force_decomposition_into_known_graphlike_errors({problem}, known, buf);
+    ASSERT_FALSE(actual);
+    ASSERT_TRUE(buf.tail.empty());
+
+    add(1, UINT32_MAX, true);
+    actual = brute_force_decomposition_into_known_graphlike_errors({problem}, known, buf);
+    ASSERT_TRUE(actual);
+    ASSERT_EQ(buf.tail.size(), 7);
+    ASSERT_EQ(buf.tail[0], DemTarget::relative_detector_id(0));
+    ASSERT_EQ(buf.tail[1], DemTarget::relative_detector_id(2));
+    ASSERT_EQ(buf.tail[2], DemTarget::observable_id(5));
+    ASSERT_EQ(buf.tail[3], DemTarget::separator());
+    ASSERT_EQ(buf.tail[4], DemTarget::relative_detector_id(1));
+    ASSERT_EQ(buf.tail[5], DemTarget::observable_id(5));
+    ASSERT_EQ(buf.tail[6], DemTarget::separator());
+}
+
+TEST(ErrorAnalyzer, brute_force_decomp_with_obs) {
+    MonotonicBuffer<DemTarget> buf;
+    std::map<FixedCapVector<DemTarget, 2>, ConstPointerRange<DemTarget>> known;
+    bool actual;
+    std::vector<DemTarget> problem{
+        DemTarget::relative_detector_id(0),
+        DemTarget::relative_detector_id(1),
+        DemTarget::relative_detector_id(2),
+        DemTarget::observable_id(5),
+    };
+    auto add = [&](uint32_t a, uint32_t b, bool obs) {
+        DemTarget a2 = DemTarget::relative_detector_id(a);
+        DemTarget b2 = DemTarget::relative_detector_id(b);
+        FixedCapVector<DemTarget, 2> v;
+        v.push_back(a2);
+        if (b != UINT32_MAX) {
+            v.push_back(b2);
+        }
+        buf.append_tail({v.begin(), v.end()});
+        if (obs) {
+            buf.append_tail(DemTarget::observable_id(5));
+        }
+        known[v] = buf.commit_tail();
+    };
+
+    actual = brute_force_decomposition_into_known_graphlike_errors({problem}, known, buf);
+    ASSERT_FALSE(actual);
+    ASSERT_TRUE(buf.tail.empty());
+
+    add(0, 2, true);
+
+    actual = brute_force_decomposition_into_known_graphlike_errors({problem}, known, buf);
+    ASSERT_FALSE(actual);
+    ASSERT_TRUE(buf.tail.empty());
+
+    add(1, UINT32_MAX, false);
+    actual = brute_force_decomposition_into_known_graphlike_errors({problem}, known, buf);
+    ASSERT_TRUE(actual);
+    ASSERT_EQ(buf.tail.size(), 6);
+    ASSERT_EQ(buf.tail[0], DemTarget::relative_detector_id(0));
+    ASSERT_EQ(buf.tail[1], DemTarget::relative_detector_id(2));
+    ASSERT_EQ(buf.tail[2], DemTarget::observable_id(5));
+    ASSERT_EQ(buf.tail[3], DemTarget::separator());
+    ASSERT_EQ(buf.tail[4], DemTarget::relative_detector_id(1));
+    ASSERT_EQ(buf.tail[5], DemTarget::separator());
+
+    buf.discard_tail();
+    add(0, 2, false);
+    actual = brute_force_decomposition_into_known_graphlike_errors({problem}, known, buf);
+    ASSERT_FALSE(actual);
+    ASSERT_TRUE(buf.tail.empty());
+
+    add(1, UINT32_MAX, true);
+    actual = brute_force_decomposition_into_known_graphlike_errors({problem}, known, buf);
+    ASSERT_TRUE(actual);
+    ASSERT_EQ(buf.tail.size(), 6);
+    ASSERT_EQ(buf.tail[0], DemTarget::relative_detector_id(0));
+    ASSERT_EQ(buf.tail[1], DemTarget::relative_detector_id(2));
+    ASSERT_EQ(buf.tail[2], DemTarget::separator());
+    ASSERT_EQ(buf.tail[3], DemTarget::relative_detector_id(1));
+    ASSERT_EQ(buf.tail[4], DemTarget::observable_id(5));
+    ASSERT_EQ(buf.tail[5], DemTarget::separator());
+}
+
+TEST(ErrorAnalyzer, ignore_failures) {
+    stim::Circuit circuit(Circuit(R"CIRCUIT(
+        X_ERROR(0.25) 0
+        MR 0
+        DETECTOR rec[-1]
+        DETECTOR rec[-1]
+        DETECTOR rec[-1]
+
+        X_ERROR(0.125) 0 1 2
+        CORRELATED_ERROR(0.25) X0 X1 X2
+        M 0 1 2
+        DETECTOR rec[-1]
+        DETECTOR rec[-2]
+        DETECTOR rec[-3]
+    )CIRCUIT"));
+
+    ASSERT_THROW(
+        { ErrorAnalyzer::circuit_to_detector_error_model(circuit, true, false, false, 0.0, false, false); },
+        std::invalid_argument);
+
+    ASSERT_EQ(
+        ErrorAnalyzer::circuit_to_detector_error_model(circuit, true, false, false, 0.0, true, false),
+        DetectorErrorModel(R"MODEL(
+            error(0.25) D0 D1 D2
+            error(0.125) D3
+            error(0.25) D3 ^ D4 ^ D5
+            error(0.125) D4
+            error(0.125) D5
+        )MODEL"));
+}
+
+TEST(ErrorAnalyzer, block_remnant_edge) {
+    stim::Circuit circuit(Circuit(R"CIRCUIT(
+        X_ERROR(0.125) 0
+        CORRELATED_ERROR(0.25) X0 X1
+        M 0 1
+        DETECTOR rec[-1]
+        DETECTOR rec[-1]
+        DETECTOR rec[-2]
+        DETECTOR rec[-2]
+    )CIRCUIT"));
+
+    ASSERT_THROW(
+        { ErrorAnalyzer::circuit_to_detector_error_model(circuit, true, false, false, 0.0, false, true); },
+        std::invalid_argument);
+
+    ASSERT_EQ(
+        ErrorAnalyzer::circuit_to_detector_error_model(circuit, true, false, false, 0.0, false, false),
+        DetectorErrorModel(R"MODEL(
+            error(0.125) D2 D3
+            error(0.25) D2 D3 ^ D0 D1
+        )MODEL"));
 }

--- a/src/stim/simulators/error_matcher.cc
+++ b/src/stim/simulators/error_matcher.cc
@@ -23,7 +23,7 @@ using namespace stim;
 
 ErrorMatcher::ErrorMatcher(
     const Circuit &circuit, const DetectorErrorModel *init_filter, bool reduce_to_one_representative_error)
-    : error_analyzer(circuit.count_detectors(), circuit.count_qubits(), false, false, true, 1),
+    : error_analyzer(circuit.count_detectors(), circuit.count_qubits(), false, false, true, 1, false, false),
       cur_loc(),
       output_map(),
       allow_adding_new_dem_errors_to_output_map(init_filter == nullptr),

--- a/src/stim/simulators/min_distance.perf.cc
+++ b/src/stim/simulators/min_distance.perf.cc
@@ -27,7 +27,7 @@ BENCHMARK(find_graphlike_logical_error_surface_code_d25) {
     params.after_reset_flip_probability = 0.001;
     params.before_round_data_depolarization = 0.001;
     auto circuit = generate_surface_code_circuit(params).circuit;
-    auto model = ErrorAnalyzer::circuit_to_detector_error_model(circuit, true, true, false, false);
+    auto model = ErrorAnalyzer::circuit_to_detector_error_model(circuit, true, true, false, 0.0, false, true);
 
     size_t total = 0;
     benchmark_go([&]() {

--- a/src/stim/simulators/min_distance.test.cc
+++ b/src/stim/simulators/min_distance.test.cc
@@ -154,8 +154,8 @@ TEST(shortest_graphlike_undetectable_logical_error, surface_code) {
     params.after_reset_flip_probability = 0.001;
     params.before_round_data_depolarization = 0.001;
     auto circuit = generate_surface_code_circuit(params).circuit;
-    auto graphlike_model = ErrorAnalyzer::circuit_to_detector_error_model(circuit, true, true, false, false);
-    auto ungraphlike_model = ErrorAnalyzer::circuit_to_detector_error_model(circuit, false, true, false, false);
+    auto graphlike_model = ErrorAnalyzer::circuit_to_detector_error_model(circuit, true, true, false, 0.0, false, true);
+    auto ungraphlike_model = ErrorAnalyzer::circuit_to_detector_error_model(circuit, false, true, false, 0.0, false, true);
 
     ASSERT_EQ(stim::shortest_graphlike_undetectable_logical_error(graphlike_model, false).instructions.size(), 5);
 
@@ -172,7 +172,7 @@ TEST(shortest_graphlike_undetectable_logical_error, repetition_code) {
     CircuitGenParameters params(10, 7, "memory");
     params.before_round_data_depolarization = 0.01;
     auto circuit = generate_rep_code_circuit(params).circuit;
-    auto graphlike_model = ErrorAnalyzer::circuit_to_detector_error_model(circuit, true, true, false, false);
+    auto graphlike_model = ErrorAnalyzer::circuit_to_detector_error_model(circuit, true, true, false, 0.0, false, true);
 
     ASSERT_EQ(stim::shortest_graphlike_undetectable_logical_error(graphlike_model, false).instructions.size(), 7);
 }

--- a/src/stim/simulators/tableau_simulator.pybind.cc
+++ b/src/stim/simulators/tableau_simulator.pybind.cc
@@ -22,7 +22,8 @@
 using namespace stim;
 using namespace stim_pybind;
 
-PyTableauSimulator::PyTableauSimulator(std::shared_ptr<std::mt19937_64> rng) : TableauSimulator(*rng), rng_reference(rng) {
+PyTableauSimulator::PyTableauSimulator(std::shared_ptr<std::mt19937_64> rng)
+    : TableauSimulator(*rng), rng_reference(rng) {
 }
 
 struct TempViewableData {

--- a/src/stim/simulators/vector_simulator.cc
+++ b/src/stim/simulators/vector_simulator.cc
@@ -107,7 +107,8 @@ void VectorSimulator::apply(const PauliStringRef &gate, size_t qubit_offset) {
     }
 }
 
-VectorSimulator VectorSimulator::from_stabilizers(const std::vector<PauliStringRef> &stabilizers, std::mt19937_64 &rng) {
+VectorSimulator VectorSimulator::from_stabilizers(
+    const std::vector<PauliStringRef> &stabilizers, std::mt19937_64 &rng) {
     size_t num_qubits = stabilizers.empty() ? 0 : stabilizers[0].num_qubits;
     VectorSimulator result(num_qubits);
 


### PR DESCRIPTION
- Add `block_decompose_from_introducing_remnant_edges` option
- Add `ignore_decomposition_failures` option
- Make decomposition do a much stronger brute force search to avoid introducing remnant edges unless needed
- Autoformat
- Add `.cmake` directory to .gitignore
- BREAKING CHANGE: changed default value of `stim.Circuit.shortest_graphlike_error:ignore_ungraphlike_errors` from False to True

Fixes https://github.com/quantumlib/Stim/issues/202