### PR TITLE
Iterate on sinter work assignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,5 @@ venv/*
 .venv/*
 **/LastTest.log
 *.so
+.clwb/*
 .cmake/*

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,9 +3,9 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 http_archive(
     name = "gtest",
-    sha256 = "ff7a82736e158c077e76188232eac77913a15dac0b22508c390ab3f88e6d6d86",
-    strip_prefix = "googletest-b6cd405286ed8635ece71c72f118e659f4ade3fb",
-    urls = ["https://github.com/google/googletest/archive/b6cd405286ed8635ece71c72f118e659f4ade3fb.zip"],  # 2019-01-07
+    sha256 = "353571c2440176ded91c2de6d6cd88ddd41401d14692ec1f99e35d013feda55a",
+    strip_prefix = "googletest-release-1.11.0",
+    urls = ["https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip"],
 )
 
 http_archive(

--- a/glue/python/src/stim/__init__.py
+++ b/glue/python/src/stim/__init__.py
@@ -22,6 +22,7 @@ del _tmp
 def _pytest_pycharm_pybind_repr_bug_workaround(cls):
     f = cls.__repr__
     cls.__repr__ = lambda e: f(e)
+    cls.__repr__.__doc__ = f.__doc__
 
 
 _pytest_pycharm_pybind_repr_bug_workaround(Circuit)

--- a/glue/python/src/stim/__init__.py
+++ b/glue/python/src/stim/__init__.py
@@ -4,7 +4,6 @@ This is the entrypoint when running `import stim`.
 It does runtime detection of CPU features, and based on that imports the fastest pre-built C++ extension that only uses
 compatible instructions. Importing a different one can result in runtime segfaults that crash the python interpreter.
 """
-
 import stim._detect_machine_architecture as _tmp
 
 _tmp = _tmp._UNSTABLE_detect_march()
@@ -17,5 +16,16 @@ elif _tmp == 'sse2':
 else:
     from stim._stim_polyfill import *
     from stim._stim_polyfill import _UNSTABLE_raw_gate_data, _UNSTABLE_raw_format_data, __version__
-
 del _tmp
+
+
+def _pytest_pycharm_pybind_repr_bug_workaround(cls):
+    f = cls.__repr__
+    cls.__repr__ = lambda e: f(e)
+
+
+_pytest_pycharm_pybind_repr_bug_workaround(Circuit)
+_pytest_pycharm_pybind_repr_bug_workaround(DetectorErrorModel)
+_pytest_pycharm_pybind_repr_bug_workaround(Tableau)
+_pytest_pycharm_pybind_repr_bug_workaround(PauliString)
+del _pytest_pycharm_pybind_repr_bug_workaround

--- a/glue/sample/src/sinter/__init__.py
+++ b/glue/sample/src/sinter/__init__.py
@@ -1,3 +1,6 @@
+from sinter.anon_task_stats import (
+    AnonTaskStats,
+)
 from sinter.collection import (
     collect,
     iter_collect,
@@ -5,7 +8,11 @@ from sinter.collection import (
 from sinter.csv_out import (
     CSV_HEADER,
 )
+from sinter.probability_util import (
+    binomial_relative_likelihood_range,
+)
 from sinter.plotting import (
+    better_sorted_str_terms,
     plot_discard_rate,
     plot_error_rate,
     DataPointId,
@@ -15,4 +22,7 @@ from sinter.task import (
 )
 from sinter.task_stats import (
     TaskStats,
+)
+from sinter.task_summary import (
+    TaskSummary,
 )

--- a/glue/sample/src/sinter/collection_test.py
+++ b/glue/sample/src/sinter/collection_test.py
@@ -29,7 +29,7 @@ def test_iter_collect():
         ],
         print_progress=False,
     ):
-        result[sample.json_metadata['p']] += sample.to_case_stats()
+        result[sample.json_metadata['p']] += sample.to_anon_stats()
     assert len(result) == 4
     for k, v in result.items():
         assert v.shots >= 1000 or v.errors >= 100
@@ -95,7 +95,7 @@ def test_iter_collect_list():
         ],
         print_progress=False,
     ):
-        result[sample.json_metadata['p']] += sample.to_case_stats()
+        result[sample.json_metadata['p']] += sample.to_anon_stats()
     assert len(result) == 4
     for k, v in result.items():
         assert v.shots >= 1000 or v.errors >= 100

--- a/glue/sample/src/sinter/collection_work_manager.py
+++ b/glue/sample/src/sinter/collection_work_manager.py
@@ -176,14 +176,15 @@ class CollectionWorkManager:
     def provide_more_work(self) -> Optional[WorkIn]:
         iter_collectors = self._iter_draw_collectors(
                 prefer_started=len(self.active_collectors) >= 2)
-        for collector_index, collector in iter_collectors:
-            w = collector.provide_more_work()
-            if w is not None:
-                assert w.key is None
-                return WorkIn(key=collector_index,
-                              task=w.task,
-                              summary=w.summary,
-                              num_shots=w.num_shots)
+        for desperate in False, True:
+            for collector_index, collector in iter_collectors:
+                w = collector.provide_more_work(desperate=desperate)
+                if w is not None:
+                    assert w.key is None
+                    return WorkIn(key=collector_index,
+                                  task=w.task,
+                                  summary=w.summary,
+                                  num_shots=w.num_shots)
         return None
 
     def status(self, *, num_circuits: Optional[int]) -> str:

--- a/glue/sample/src/sinter/decoding_internal.py
+++ b/glue/sample/src/sinter/decoding_internal.py
@@ -34,7 +34,7 @@ def decode_using_internal_decoder(*,
         dets_format='b8',
         dets_filepath=dets_file,
         ignore_distance_1_errors=True,
-        ignore_undecomposed_errors=False,
+        ignore_undecomposed_errors=True,
         use_correlated_decoding=use_correlated_decoding,
     )
 

--- a/glue/sample/src/sinter/existing_data.py
+++ b/glue/sample/src/sinter/existing_data.py
@@ -15,14 +15,14 @@ class ExistingData:
 
     def stats_for(self, case: Union[ExecutableTask, TaskSummary]) -> AnonTaskStats:
         if isinstance(case, ExecutableTask):
-            key = case.to_strong_id()
+            key = case.strong_id()
         elif isinstance(case, TaskSummary):
             key = case.strong_id
         else:
             raise NotImplementedError(f'{type(case)}')
         if key not in self.data:
             return AnonTaskStats()
-        return self.data[key].to_case_stats()
+        return self.data[key].to_anon_stats()
 
     def add_sample(self, sample: TaskStats) -> None:
         k = sample.strong_id

--- a/glue/sample/src/sinter/main_plot.py
+++ b/glue/sample/src/sinter/main_plot.py
@@ -133,7 +133,7 @@ def plot(
             total.add_sample(sample)
     total.data = {k: v
                   for k, v in total.data.items()
-                  if bool(filter_func(v.to_case_summary()))}
+                  if bool(filter_func(v.to_task_summary()))}
 
     if not include_error_rate_plot and not include_discard_rate_plot:
         include_error_rate_plot = True

--- a/glue/sample/src/sinter/plotting.py
+++ b/glue/sample/src/sinter/plotting.py
@@ -6,7 +6,7 @@ import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 
 from sinter.anon_task_stats import AnonTaskStats
-from sinter.probability_util import binominal_relative_likelihood_range
+from sinter.probability_util import binomial_relative_likelihood_range
 from sinter.task_summary import TaskSummary
 
 if TYPE_CHECKING:
@@ -85,18 +85,18 @@ class CurveStats:
     @staticmethod
     def from_samples(samples: Iterable['sinter.TaskStats'],
                      *,
-                     curve_func: Callable[[TaskSummary], Optional[DataPointId]],
-                     ) -> List['CurveStats']:
+                     curve_func: Callable[['sinter.TaskSummary'], Optional['sinter.DataPointId']],
+                     ) -> List['sinter.CurveStats']:
         pairs: DefaultDict[Any, List[Tuple[float, AnonTaskStats]]] = collections.defaultdict(list)
 
         seen_appearance_ids = set()
         for sample in samples:
-            curve = curve_func(sample.to_case_summary())
+            curve = curve_func(sample.to_task_summary())
             if curve is not None:
                 aid = curve.effective_appearance_id()
                 seen_appearance_ids.add(aid)
                 key = curve.curve_label, aid, curve.hidden
-                stats = sample.to_case_stats()
+                stats = sample.to_anon_stats()
                 pairs[key].append((curve.x, stats))
 
         appearance_id_to_int = {
@@ -133,7 +133,7 @@ def plot_discard_rate(
         *,
         ax: plt.Axes,
         samples: 'Iterable[sinter.TaskStats]',
-        curve_func: Callable[[TaskSummary], Optional[DataPointId]],
+        curve_func: Callable[['sinter.TaskSummary'], Optional['sinter.DataPointId']],
         highlight_likelihood_ratio: Optional[float] = 1e-3,
         xaxis: str,
 ) -> None:
@@ -166,7 +166,7 @@ def plot_discard_rate(
                 xs.append(x)
                 ys.append(stats.discards / stats.shots)
                 if 0 < highlight_likelihood_ratio < 1:
-                    low, high = binominal_relative_likelihood_range(
+                    low, high = binomial_relative_likelihood_range(
                         num_shots=stats.shots,
                         num_hits=stats.discards,
                         likelihood_ratio=highlight_likelihood_ratio)
@@ -192,7 +192,7 @@ def plot_error_rate(
         *,
         ax: plt.Axes,
         samples: 'Iterable[sinter.TaskStats]',
-        curve_func: Callable[[TaskSummary], Optional[DataPointId]],
+        curve_func: Callable[['sinter.TaskSummary'], Optional['sinter.DataPointId']],
         highlight_likelihood_ratio: Optional[float] = 1e-3,
         xaxis: str = '',
 ) -> None:
@@ -215,15 +215,18 @@ def plot_error_rate(
     for curve in curves:
         xs = []
         ys = []
+        xs_range = []
         ys_low = []
         ys_high = []
         for x, stats in zip(curve.xs, curve.stats):
             num_kept = stats.shots - stats.discards
             if num_kept:
-                xs.append(x)
-                ys.append(stats.errors / num_kept)
+                if stats.errors:
+                    xs.append(x)
+                    ys.append(stats.errors / num_kept)
                 if 0 < highlight_likelihood_ratio < 1:
-                    low, high = binominal_relative_likelihood_range(num_shots=num_kept,
+                    xs_range.append(x)
+                    low, high = binomial_relative_likelihood_range(num_shots=num_kept,
                                                                     num_hits=stats.errors,
                                                                     likelihood_ratio=highlight_likelihood_ratio)
                     ys_low.append(low)
@@ -239,7 +242,7 @@ def plot_error_rate(
                     color=curve.color,
                     zorder=100)
             if 0 < highlight_likelihood_ratio < 1:
-                ax.fill_between(xs,
+                ax.fill_between(xs_range,
                                 ys_low,
                                 ys_high,
                                 color=curve.color,

--- a/glue/sample/src/sinter/probability_util.py
+++ b/glue/sample/src/sinter/probability_util.py
@@ -169,15 +169,21 @@ def least_squares_slope_range(*,
     return low_slope, fit.slope, high_slope
 
 
-def binominal_relative_likelihood_range(
+def binomial_relative_likelihood_range(
         *,
         num_shots: int,
         num_hits: int,
         likelihood_ratio: float) -> Tuple[float, float]:
-    """Compute relative-likelihood bounds.
+    """Compute the (min, max) probabilities within the given ratio of the max likelihood hypothesis.
 
-    Returns the min/max error rates whose Bayes factors are within the given ratio of the maximum
-    likelihood estimate.
+    Args:
+        num_shots: The number of samples that were taken.
+        num_hits: The number of hits that were seen in the samples.
+        likelihood_ratio: Should be larger than 1. The maximum Bayes factor between hypotheses and
+            the max likelihood hypothesis.
+
+    Returns:
+        A (min_hypothesis_probability, max_hypothesis_probability) tuple.
     """
     if num_shots == 0:
         return 0, 1

--- a/glue/sample/src/sinter/probability_util_test.py
+++ b/glue/sample/src/sinter/probability_util_test.py
@@ -6,7 +6,7 @@ import pytest
 
 from .probability_util import (
     binary_search, log_binomial, log_factorial, least_squares_output_range, least_squares_slope_range,
-    binary_intercept, least_squares_through_point, binominal_relative_likelihood_range,
+    binary_intercept, least_squares_through_point, binomial_relative_likelihood_range,
 )
 
 
@@ -119,27 +119,27 @@ def test_least_squares_slope_range():
 
 def test_likely_error_rate_bounds_shrink_towards_half():
     np.testing.assert_allclose(
-        binominal_relative_likelihood_range(num_shots=10 ** 5, num_hits=10 ** 5 / 2, likelihood_ratio=1e-3),
+        binomial_relative_likelihood_range(num_shots=10 ** 5, num_hits=10 ** 5 / 2, likelihood_ratio=1e-3),
         (0.494122, 0.505878),
         rtol=1e-4,
     )
     np.testing.assert_allclose(
-        binominal_relative_likelihood_range(num_shots=10 ** 4, num_hits=10 ** 4 / 2, likelihood_ratio=1e-3),
+        binomial_relative_likelihood_range(num_shots=10 ** 4, num_hits=10 ** 4 / 2, likelihood_ratio=1e-3),
         (0.481422, 0.518578),
         rtol=1e-4,
     )
     np.testing.assert_allclose(
-        binominal_relative_likelihood_range(num_shots=10 ** 4, num_hits=10 ** 4 / 2, likelihood_ratio=1e-2),
+        binomial_relative_likelihood_range(num_shots=10 ** 4, num_hits=10 ** 4 / 2, likelihood_ratio=1e-2),
         (0.48483, 0.51517),
         rtol=1e-4,
     )
     np.testing.assert_allclose(
-        binominal_relative_likelihood_range(num_shots=1000, num_hits=500, likelihood_ratio=1e-3),
+        binomial_relative_likelihood_range(num_shots=1000, num_hits=500, likelihood_ratio=1e-3),
         (0.44143, 0.55857),
         rtol=1e-4,
     )
     np.testing.assert_allclose(
-        binominal_relative_likelihood_range(num_shots=100, num_hits=50, likelihood_ratio=1e-3),
+        binomial_relative_likelihood_range(num_shots=100, num_hits=50, likelihood_ratio=1e-3),
         (0.3204, 0.6796),
         rtol=1e-4,
     )
@@ -154,7 +154,7 @@ def test_likely_error_rate_bounds_shrink_towards_half():
     (10**6, 100, 1e-2),
 ])
 def test_likely_error_rate_bounds_vs_log_binomial(n: int, c: int, ratio: float):
-    a, b = binominal_relative_likelihood_range(num_shots=n, num_hits=n - c, likelihood_ratio=ratio)
+    a, b = binomial_relative_likelihood_range(num_shots=n, num_hits=n - c, likelihood_ratio=ratio)
 
     raw = log_binomial(p=(n - c) / n, n=n, hits=n - c)
     low = log_binomial(p=a, n=n, hits=n - c)

--- a/glue/sample/src/sinter/task_stats.py
+++ b/glue/sample/src/sinter/task_stats.py
@@ -1,6 +1,8 @@
+from typing import Tuple
 import dataclasses
 
 from sinter.anon_task_stats import AnonTaskStats
+from sinter.probability_util import binomial_relative_likelihood_range
 from sinter.task_summary import JSON_TYPE, TaskSummary
 from sinter.csv_out import csv_line
 
@@ -21,7 +23,7 @@ class TaskStats:
     seconds: float
 
     def __add__(self, other: 'TaskStats') -> 'TaskStats':
-        assert self.to_case_summary() == other.to_case_summary()
+        assert self.to_task_summary() == other.to_task_summary()
         return TaskStats(
             decoder=self.decoder,
             strong_id=self.strong_id,
@@ -32,14 +34,14 @@ class TaskStats:
             seconds=self.seconds + other.seconds,
         )
 
-    def to_case_summary(self) -> TaskSummary:
+    def to_task_summary(self) -> TaskSummary:
         return TaskSummary(
             strong_id=self.strong_id,
             decoder=self.decoder,
             json_metadata=self.json_metadata,
         )
 
-    def to_case_stats(self) -> AnonTaskStats:
+    def to_anon_stats(self) -> AnonTaskStats:
         return AnonTaskStats(
             shots=self.shots,
             errors=self.errors,


### PR DESCRIPTION
- Bump googletest version in Bazel workspace
- Add workaround for pytest+pycharm+pybind working together to fail at making `assert circuit1 == circuit2` print a useful failure message
- Expose better_sorted_strm_terms, binomial_relative_likelihood_range, TaskSummary, AnonTaskStats from sinter
- Add a second 'desperate=True' pass for assigning work
- Don't plot points at negative infinity in log error rate plots
- Added methods for looking at what defines the strong_id