### PR TITLE
Iterate on sinter's design

### DIFF
--- a/glue/sample/README.md
+++ b/glue/sample/README.md
@@ -100,13 +100,17 @@ def main():
     fig, ax = plt.subplots(1, 1)
     sinter.plot_error_rate(
         ax=ax,
-        samples=samples,
-        curve_func=lambda e: sinter.DataPointId(
-            curve_label=f"Rotated Surface Code d={e.json_metadata['d']}",
-            x=e.json_metadata['p'],
-        ),
-        xaxis='[log]Physical Error Rate'
+        stats=samples,
+        curve_func=lambda stat: f"Rotated Surface Code d={stat.json_metadata['d']}",
+        x_func=lambda stat: stat.json_metadata['p'],
     )
+    ax.loglog()
+    ax.set_ylim(1e-5, 1)
+    ax.grid()
+    ax.set_title('Logical Error Rate vs Physical Error Rate')
+    ax.set_ylabel('Logical Error Probability (per shot)')
+    ax.set_xlabel('Physical Error Rate')
+    ax.legend()
 
     # Save to file and also open in a window.
     fig.savefig('plot.png')

--- a/glue/sample/src/sinter/__init__.py
+++ b/glue/sample/src/sinter/__init__.py
@@ -8,6 +8,9 @@ from sinter.collection import (
 from sinter.csv_out import (
     CSV_HEADER,
 )
+from sinter.existing_data import (
+    stats_from_csv_files,
+)
 from sinter.probability_util import (
     binomial_relative_likelihood_range,
 )

--- a/glue/sample/src/sinter/__init__.py
+++ b/glue/sample/src/sinter/__init__.py
@@ -18,7 +18,7 @@ from sinter.plotting import (
     better_sorted_str_terms,
     plot_discard_rate,
     plot_error_rate,
-    DataPointId,
+    group_by,
 )
 from sinter.task import (
     Task,

--- a/glue/sample/src/sinter/collection_tracker_for_single_task.py
+++ b/glue/sample/src/sinter/collection_tracker_for_single_task.py
@@ -8,10 +8,13 @@ from sinter.worker import WorkIn
 from sinter.worker import WorkOut
 
 
+DEFAULT_MAX_BATCH_SECONDS = 120
+
+
 class CollectionTrackerForSingleTask:
     def __init__(self, *, task: Task):
         self.task = task
-        self.task_summary = task.to_case_executable().to_summary()
+        self.task_summary = task.to_executable_task().to_summary()
         self.finished_stats = task.previous_stats
         self.deployed_shots = 0
         self.deployed_processes = 0
@@ -96,7 +99,7 @@ class CollectionTrackerForSingleTask:
         # If no maximum on batch size is specified, default to 30s maximum.
         max_batch_seconds = self.task.max_batch_seconds
         if max_batch_seconds is None and self.task.max_batch_size is None:
-            max_batch_seconds = 10
+            max_batch_seconds = DEFAULT_MAX_BATCH_SECONDS
 
         # Try not to exceed max batch duration.
         if max_batch_seconds is not None:
@@ -117,7 +120,7 @@ class CollectionTrackerForSingleTask:
         self.deployed_processes += 1
         return WorkIn(
             key=None,
-            task=self.task.to_case_executable(),
+            task=self.task.to_executable_task(),
             summary=self.task_summary,
             num_shots=num_shots,
         )

--- a/glue/sample/src/sinter/decoding.py
+++ b/glue/sample/src/sinter/decoding.py
@@ -25,8 +25,10 @@ DECODER_METHODS: Dict[str, Callable] = {
 def _post_select(data: np.ndarray, *, post_mask: Optional[np.ndarray] = None) -> Tuple[int, np.ndarray]:
     if post_mask is None:
         return 0, data
-    assert post_mask.shape == (data.shape[1],)
-    assert post_mask.dtype == np.uint8
+    if post_mask.shape != (data.shape[1],):
+        raise ValueError(f"post_mask.shape={post_mask.shape} != (data.shape[1]={data.shape[1]},)")
+    if post_mask.dtype != np.uint8:
+        raise ValueError(f"post_mask.dtype={post_mask.dtype} != np.uint8")
     discarded = np.any(data & post_mask, axis=1)
     num_discards = np.count_nonzero(discarded)
     return num_discards, data[~discarded]

--- a/glue/sample/src/sinter/existing_data.py
+++ b/glue/sample/src/sinter/existing_data.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, Union
+from typing import Any, Dict, Union, List, TYPE_CHECKING
 
 import pandas as pd
 
@@ -7,6 +7,9 @@ from sinter.task_stats import TaskStats
 from sinter.executable_task import ExecutableTask
 from sinter.task_summary import TaskSummary
 from sinter.decoding import AnonTaskStats
+
+if TYPE_CHECKING:
+    import sinter
 
 
 class ExistingData:
@@ -68,3 +71,10 @@ class ExistingData:
                 seconds=row['seconds'],
             )
         return result
+
+
+def stats_from_csv_files(*paths_or_files: Any) -> List['sinter.TaskStats']:
+    result = ExistingData()
+    for p in paths_or_files:
+        result += ExistingData.from_file(p)
+    return list(result.data.values())

--- a/glue/sample/src/sinter/plotting.py
+++ b/glue/sample/src/sinter/plotting.py
@@ -227,8 +227,8 @@ def plot_error_rate(
                 if 0 < highlight_likelihood_ratio < 1:
                     xs_range.append(x)
                     low, high = binomial_relative_likelihood_range(num_shots=num_kept,
-                                                                    num_hits=stats.errors,
-                                                                    likelihood_ratio=highlight_likelihood_ratio)
+                                                                   num_hits=stats.errors,
+                                                                   likelihood_ratio=highlight_likelihood_ratio)
                     ys_low.append(low)
                     ys_high.append(high)
         all_ys += ys

--- a/glue/sample/src/sinter/plotting_test.py
+++ b/glue/sample/src/sinter/plotting_test.py
@@ -1,0 +1,43 @@
+import io
+
+from matplotlib import pyplot as plt
+
+import sinter
+
+
+def test_plotting_does_not_crash():
+    data = io.BytesIO()
+    data.write("""
+  shots,errors,discards,seconds,decoder,strong_id,json_metadata
+1000000, 837,0,36.6,pymatching,9f7e20c54fec45b6aef7491b774dd5c0a3b9a005aa82faf5b9c051d6e40d60a9,"{""d"":3,""p"":0.001}"
+  53498,1099,0,6.52,pymatching,3f40432443a99b933fb548b831fb54e7e245d9d73a35c03ea5a2fb2ce270f8c8,"{""d"":3,""p"":0.005}"
+  16269,1023,0,3.23,pymatching,17b2e0c99560d20307204494ac50e31b33e50721b4ebae99d9e3577ae7248874,"{""d"":3,""p"":0.01}"
+1000000, 151,0,77.3,pymatching,e179a18739201250371ffaae0197d8fa19d26b58dfc2942f9f1c85568645387a,"{""d"":5,""p"":0.001}"
+  11363,1068,0,12.5,pymatching,a4dec28934a033215ff1389651a26114ecc22016a6e122008830cf7dd04ba5ad,"{""d"":5,""p"":0.01}"
+  61569,1001,0,24.5,pymatching,2fefcc356752482fb4c6d912c228f6d18762f5752796c668b6abeb7775f5de92,"{""d"":5,""p"":0.005}"
+    """.encode('UTF-8'))
+    data.seek(0)
+    stats = sinter.stats_from_csv_files(data)
+
+    fig, ax = plt.subplots(1, 1)
+    sinter.plot_error_rate(
+        ax=ax,
+        stats=stats,
+        curve_func=lambda e: f"Rotated Surface Code d={e.json_metadata['d']}",
+        x_func=lambda e: e.json_metadata['p'],
+        plot_args_func=lambda k, e: {'marker': "ov*sp^<>8PhH+xXDd|"[k]},
+    )
+    sinter.plot_discard_rate(
+        ax=ax,
+        stats=stats,
+        curve_func=lambda e: f"Rotated Surface Code d={e.json_metadata['d']}",
+        x_func=lambda e: e.json_metadata['p'],
+        plot_args_func=lambda k, e: {'marker': "ov*sp^<>8PhH+xXDd|"[k]},
+    )
+
+
+def test_group_by():
+    assert sinter.group_by([1, 2, 3], key=lambda i: i == 2) == {False: [1, 3], True: [2]}
+    assert sinter.group_by(range(10), key=lambda i: i % 3) == {0: [0, 3, 6, 9], 1: [1, 4, 7], 2: [2, 5, 8]}
+    assert sinter.group_by([], key=lambda i: 0) == {}
+    assert sinter.group_by([1, 2, 3, 1], key=lambda i: 0) == {0: [1, 2, 3, 1]}

--- a/glue/sample/src/sinter/task.py
+++ b/glue/sample/src/sinter/task.py
@@ -103,7 +103,15 @@ class Task:
 
         self.previous_stats = previous_stats
         if existing_data is not None:
-            self.previous_stats += existing_data.stats_for(self.to_case_executable())
+            self.previous_stats += existing_data.stats_for(self.to_executable_task())
+
+    def strong_id(self) -> str:
+        """A cryptographically unique identifier for this task.
+
+        Doesn't depend on properties related to how many shots to take (such as
+        max_batch_size).
+        """
+        return self.to_executable_task().strong_id()
 
     def with_merged_options(self,
              *,
@@ -131,7 +139,11 @@ class Task:
             existing_data=existing_data,
         )
 
-    def to_case_executable(self) -> ExecutableTask:
+    def to_executable_task(self) -> ExecutableTask:
+        """Strips off properties that are not needed in order to take a shot.
+
+        Omits things like max_errors but keeps things like the circuit.
+        """
         if self.decoder is None:
             raise ValueError('decoder is None')
         return ExecutableTask(


### PR DESCRIPTION
- Refactor `sinter.plot_error_rate` and `sinter.plot_discard_rate` to make them more flexible
    - Stop setting properties like the title, ylim, loglog to avoid interfering with what caller wants.
    - Remove sinter.DataPointId; split x_func argument out of curve_func argument
    - Replace sinter.CurveStats with sinter.group_by
- Increase default max batch seconds from 30s to 120s
- Rename `to_case_executable` to `to_executable_task`
- Add more safety checks around the poststelection mask
- Fix postselection mask size inconsistently including observables or not
- Add `sinter.Task.strong_id` convenience method