### PR TITLE
Expose read/write functionality to python

### DIFF
--- a/src/stim/io/measure_record_batch_writer.cc
+++ b/src/stim/io/measure_record_batch_writer.cc
@@ -27,6 +27,9 @@ MeasureRecordBatchWriter::MeasureRecordBatchWriter(FILE *out, size_t num_shots, 
     if (num_shots > 768) {
         throw std::out_of_range("num_shots > 768 (safety check to ensure staying away from linux file handle limit)");
     }
+    if (output_format == SAMPLE_FORMAT_PTB64 && num_shots % 64 != 0) {
+        throw std::out_of_range("Number of shots must be a multiple of 64 to use output format ptb64.");
+    }
     auto f = output_format;
     auto s = num_shots;
     if (output_format == SAMPLE_FORMAT_PTB64) {

--- a/src/stim/io/measure_record_reader.cc
+++ b/src/stim/io/measure_record_reader.cc
@@ -20,24 +20,6 @@
 
 using namespace stim;
 
-// Returns true if keyword is found at current position. Returns false if EOF is found at current
-// position. Throws otherwise. Uses next output variable for the next character or EOF.
-bool maybe_consume_keyword(FILE *in, const std::string &keyword, int &next) {
-    next = getc(in);
-    if (next == EOF) {
-        return false;
-    }
-
-    for (char c : keyword) {
-        if (c != next) {
-            throw std::runtime_error("Failed to find expected string \"" + keyword + "\"");
-        }
-        next = getc(in);
-    }
-
-    return true;
-}
-
 bool stim::read_uint64(FILE *in, uint64_t &value, int &next, bool include_next) {
     if (!include_next) {
         next = getc(in);
@@ -95,28 +77,14 @@ std::unique_ptr<MeasureRecordReader> MeasureRecordReader::make(
             return std::unique_ptr<MeasureRecordReader>(
                 new MeasureRecordReaderFormatHits(in, num_measurements, num_detectors, num_observables));
         case SAMPLE_FORMAT_PTB64:
-            throw std::invalid_argument("SAMPLE_FORMAT_PTB64 incompatible with SingleMeasurementRecord");
+            return std::unique_ptr<MeasureRecordReader>(
+                new MeasureRecordReaderFormatPTB64(in, num_measurements, num_detectors, num_observables));
         case SAMPLE_FORMAT_R8:
             return std::unique_ptr<MeasureRecordReader>(
                 new MeasureRecordReaderFormatR8(in, num_measurements, num_detectors, num_observables));
         default:
             throw std::invalid_argument("Sample format not recognized by SingleMeasurementRecord");
     }
-}
-
-size_t MeasureRecordReader::read_bits_into_bytes(PointerRange<uint8_t> out_buffer) {
-    size_t n = 0;
-    for (uint8_t &b : out_buffer) {
-        b = 0;
-        for (size_t k = 0; k < 8; k++) {
-            if (is_end_of_record()) {
-                return n;
-            }
-            b |= uint8_t(read_bit()) << k;
-            ++n;
-        }
-    }
-    return n;
 }
 
 size_t MeasureRecordReader::bits_per_record() const {
@@ -149,9 +117,7 @@ void MeasureRecordReader::move_obs_in_shots_to_mask_assuming_sorted(SparseShot &
 MeasureRecordReaderFormat01::MeasureRecordReaderFormat01(
     FILE *in, size_t num_measurements, size_t num_detectors, size_t num_observables)
     : MeasureRecordReader(num_measurements, num_detectors, num_observables),
-      in(in),
-      payload('\n'),
-      position(bits_per_record()) {
+      in(in) {
 }
 
 bool MeasureRecordReaderFormat01::start_and_read_entire_record(simd_bits_range_ref dirty_out_buffer) {
@@ -175,54 +141,6 @@ bool MeasureRecordReaderFormat01::start_and_read_entire_record(SparseShot &clear
     return result;
 }
 
-bool MeasureRecordReaderFormat01::read_bit() {
-    if (payload == EOF) {
-        throw std::out_of_range("Attempt to read past end-of-file");
-    }
-    if (payload == '\n' || position >= bits_per_record()) {
-        throw std::out_of_range("Attempt to read past end-of-record");
-    }
-    if (payload != '0' && payload != '1') {
-        throw std::runtime_error("Expected '0' or '1' because input format was specified as '01'");
-    }
-
-    bool bit = payload == '1';
-    payload = getc(in);
-    ++position;
-    return bit;
-}
-
-bool MeasureRecordReaderFormat01::next_record() {
-    while (payload != EOF && payload != '\n') {
-        payload = getc(in);
-        if (position++ > bits_per_record()) {
-            throw std::runtime_error(
-                "Line was too long for input file in 01 format. Expected " + std::to_string(bits_per_record()) +
-                " characters but got " + std::to_string(position));
-        }
-    }
-
-    return start_record();
-}
-
-bool MeasureRecordReaderFormat01::start_record() {
-    payload = getc(in);
-    position = 0;
-    return payload != EOF;
-}
-
-bool MeasureRecordReaderFormat01::is_end_of_record() {
-    bool payload_ended = (payload == EOF || payload == '\n');
-    bool expected_end = position >= bits_per_record();
-    if (payload_ended && !expected_end) {
-        throw std::invalid_argument("Record data (in 01 format) ended early, before expected length.");
-    }
-    if (!payload_ended && expected_end) {
-        throw std::invalid_argument("Record data (in 01 format) did not end by the expected length.");
-    }
-    return payload_ended;
-}
-
 bool MeasureRecordReaderFormat01::expects_empty_serialized_data_for_each_shot() const {
     return false;
 }
@@ -232,108 +150,51 @@ bool MeasureRecordReaderFormat01::expects_empty_serialized_data_for_each_shot() 
 MeasureRecordReaderFormatB8::MeasureRecordReaderFormatB8(
     FILE *in, size_t num_measurements, size_t num_detectors, size_t num_observables)
     : MeasureRecordReader(num_measurements, num_detectors, num_observables),
-      in(in),
-      payload(0),
-      bits_available(0),
-      position(bits_per_record()) {
+      in(in) {
 }
 
 bool MeasureRecordReaderFormatB8::start_and_read_entire_record(simd_bits_range_ref dirty_out_buffer) {
-    return start_and_read_entire_record_helper([&](size_t byte_index, uint8_t byte) {
-        dirty_out_buffer.u8[byte_index] = (uint8_t)byte;
-    });
+    size_t n = bits_per_record();
+    size_t nb = (n + 7) >> 3;
+    size_t nr = fread(dirty_out_buffer.u8, 1, nb, in);
+    if (nr == 0) {
+        return false;
+    }
+    if (nr != nb) {
+        throw std::invalid_argument(
+            "b8 data ended in middle of record at byte position " + std::to_string(nr) +
+            ".\n"
+            "Expected bytes per record was " +
+            std::to_string(nb) + " (" + std::to_string(n) + " bits padded).");
+    }
+    return true;
 }
 
 bool MeasureRecordReaderFormatB8::start_and_read_entire_record(SparseShot &cleared_out) {
-    bool result = start_and_read_entire_record_helper([&](size_t byte_index, uint8_t byte) {
-        size_t bit_offset = byte_index << 3;
+    size_t n = bits_per_record();
+    size_t nb = (n + 7) >> 3;
+    for (size_t k = 0; k < nb; k++) {
+        int b = getc(in);
+        if (b == EOF) {
+            if (k == 0) {
+                return false;
+            }
+            throw std::invalid_argument(
+                "b8 data ended in middle of record at byte position " + std::to_string(k) +
+                ".\n"
+                "Expected bytes per record was " +
+                std::to_string(nb) + " (" + std::to_string(n) + " bits padded).");
+        }
+
+        size_t bit_offset = k << 3;
         for (size_t r = 0; r < 8; r++) {
-            if (byte & (1 << r)) {
+            if (b & (1 << r)) {
                 cleared_out.hits.push_back(bit_offset + r);
             }
         }
-    });
+    }
     move_obs_in_shots_to_mask_assuming_sorted(cleared_out);
-    return result;
-}
-
-size_t MeasureRecordReaderFormatB8::read_bits_into_bytes(PointerRange<uint8_t> out_buffer) {
-    if (out_buffer.empty()) {
-        return 0;
-    }
-    if (position >= bits_per_record()) {
-        return 0;
-    }
-
-    if (bits_available & 7) {
-        // Partial read from before still had trailing bits.
-        return MeasureRecordReader::read_bits_into_bytes(out_buffer);
-    }
-
-    size_t total_read = 0;
-    if (bits_available) {
-        *out_buffer.ptr_start = payload & 0xFF;
-        out_buffer.ptr_start++;
-        bits_available = 0;
-        position += 8;
-        total_read += 8;
-    }
-
-    size_t n_bits = std::min<size_t>(8 * out_buffer.size(), bits_per_record() - position);
-    size_t n_bytes = (n_bits + 7) / 8;
-    n_bytes = fread(out_buffer.ptr_start, sizeof(uint8_t), n_bytes, in);
-    n_bits = std::min<size_t>(8 * n_bytes, n_bits);
-    position += n_bits;
-    total_read += n_bits;
-
-    return total_read;
-}
-
-bool MeasureRecordReaderFormatB8::read_bit() {
-    if (position >= bits_per_record()) {
-        throw std::out_of_range("Attempt to read past end-of-record");
-    }
-
-    maybe_update_payload();
-
-    if (payload == EOF) {
-        throw std::out_of_range("Attempt to read past end-of-file");
-    }
-
-    bool b = payload & 1;
-    payload >>= 1;
-    --bits_available;
-    ++position;
-    return b;
-}
-
-bool MeasureRecordReaderFormatB8::next_record() {
-    while (!is_end_of_record()) {
-        read_bit();
-    }
-    return start_record();
-}
-
-bool MeasureRecordReaderFormatB8::start_record() {
-    position = 0;
-    bits_available = 0;
-    payload = 0;
-    maybe_update_payload();
-    return payload != EOF;
-}
-
-bool MeasureRecordReaderFormatB8::is_end_of_record() {
-    return position >= bits_per_record();
-}
-
-void MeasureRecordReaderFormatB8::maybe_update_payload() {
-    if (bits_available > 0) {
-        return;
-    }
-    payload = getc(in);
-    if (payload != EOF) {
-        bits_available = 8;
-    }
+    return true;
 }
 
 bool MeasureRecordReaderFormatB8::expects_empty_serialized_data_for_each_shot() const {
@@ -345,15 +206,17 @@ bool MeasureRecordReaderFormatB8::expects_empty_serialized_data_for_each_shot() 
 MeasureRecordReaderFormatHits::MeasureRecordReaderFormatHits(
     FILE *in, size_t num_measurements, size_t num_detectors, size_t num_observables)
     : MeasureRecordReader(num_measurements, num_detectors, num_observables),
-      in(in),
-      buffer(bits_per_record()),
-      position_in_buffer(bits_per_record()) {
+      in(in) {
 }
 
 bool MeasureRecordReaderFormatHits::start_and_read_entire_record(simd_bits_range_ref dirty_out_buffer) {
+    size_t m = bits_per_record();
     dirty_out_buffer.prefix_ref(bits_per_record()).clear();
     return start_and_read_entire_record_helper([&](size_t bit_index) {
-        dirty_out_buffer[bit_index] = true;
+        if (bit_index >= m) {
+            throw std::invalid_argument("hit index is too large.");
+        }
+        dirty_out_buffer[bit_index] ^= true;
     });
 }
 
@@ -372,51 +235,6 @@ bool MeasureRecordReaderFormatHits::start_and_read_entire_record(SparseShot &cle
     });
 }
 
-bool MeasureRecordReaderFormatHits::read_bit() {
-    if (position_in_buffer >= bits_per_record()) {
-        throw std::invalid_argument("Read past end of buffer.");
-    }
-    return buffer[position_in_buffer++];
-}
-
-bool MeasureRecordReaderFormatHits::next_record() {
-    return start_record();
-}
-
-bool MeasureRecordReaderFormatHits::start_record() {
-    int c = getc(in);
-    if (c == EOF) {
-        return false;
-    }
-    buffer.clear();
-    position_in_buffer = 0;
-    bool is_first = true;
-    while (c != '\n') {
-        uint64_t value;
-        if (!read_uint64(in, value, c, is_first)) {
-            throw std::runtime_error(
-                "Integer didn't start immediately at start of line or after comma in 'hits' format.");
-        }
-        if (c != ',' && c != '\n') {
-            throw std::runtime_error(
-                "'hits' format requires  integers to be followed by a comma or newline, but got a '" +
-                std::to_string(c) + "'.");
-        }
-        if (value >= bits_per_record()) {
-            throw std::runtime_error(
-                "Bits per record is " + std::to_string(bits_per_record()) + " but got a hit value " +
-                std::to_string(value) + ".");
-        }
-        buffer[(size_t)value] ^= true;
-        is_first = false;
-    }
-    return true;
-}
-
-bool MeasureRecordReaderFormatHits::is_end_of_record() {
-    return position_in_buffer >= bits_per_record();
-}
-
 bool MeasureRecordReaderFormatHits::expects_empty_serialized_data_for_each_shot() const {
     return false;
 }
@@ -426,45 +244,6 @@ bool MeasureRecordReaderFormatHits::expects_empty_serialized_data_for_each_shot(
 MeasureRecordReaderFormatR8::MeasureRecordReaderFormatR8(
     FILE *in, size_t num_measurements, size_t num_detectors, size_t num_observables)
     : MeasureRecordReader(num_measurements, num_detectors, num_observables), in(in) {
-}
-
-size_t MeasureRecordReaderFormatR8::read_bits_into_bytes(PointerRange<uint8_t> out_buffer) {
-    size_t n = 0;
-    for (uint8_t &b : out_buffer) {
-        b = 0;
-        if (buffered_0s >= 8) {
-            position += 8;
-            buffered_0s -= 8;
-            n += 8;
-            continue;
-        }
-        for (size_t k = 0; k < 8; k++) {
-            if (is_end_of_record()) {
-                return n;
-            }
-            b |= uint8_t(read_bit()) << k;
-            ++n;
-        }
-    }
-    return n;
-}
-
-bool MeasureRecordReaderFormatR8::read_bit() {
-    if (!buffered_0s && !buffered_1s) {
-        bool read_any = maybe_buffer_data();
-        assert(read_any);
-    }
-    if (buffered_0s) {
-        buffered_0s--;
-        position++;
-        return false;
-    } else if (buffered_1s) {
-        buffered_1s--;
-        position++;
-        return true;
-    } else {
-        throw std::invalid_argument("Read past end-of-record.");
-    }
 }
 
 bool MeasureRecordReaderFormatR8::start_and_read_entire_record(simd_bits_range_ref dirty_out_buffer) {
@@ -480,68 +259,6 @@ bool MeasureRecordReaderFormatR8::start_and_read_entire_record(SparseShot &clear
     });
     move_obs_in_shots_to_mask_assuming_sorted(cleared_out);
     return result;
-}
-bool MeasureRecordReaderFormatR8::next_record() {
-    while (!is_end_of_record()) {
-        read_bit();
-    }
-    return start_record();
-}
-
-bool MeasureRecordReaderFormatR8::start_record() {
-    position = 0;
-    have_seen_terminal_1 = false;
-    return maybe_buffer_data();
-}
-
-bool MeasureRecordReaderFormatR8::is_end_of_record() {
-    return position == bits_per_record() && have_seen_terminal_1;
-}
-
-bool MeasureRecordReaderFormatR8::maybe_buffer_data() {
-    assert(buffered_0s == 0);
-    assert(buffered_1s == 0);
-    if (is_end_of_record()) {
-        throw std::invalid_argument("Attempted to read past end-of-record.");
-    }
-
-    // Count zeroes until a one is found.
-    int r;
-    do {
-        r = getc(in);
-        if (r == EOF) {
-            if (buffered_0s == 0 && position == 0) {
-                return false;  // No next record.
-            }
-            throw std::invalid_argument("r8 data ended on a continuation (a 0xFF byte) which is not allowed.");
-        }
-        buffered_0s += r;
-    } while (r == 0xFF);
-    buffered_1s = 1;
-
-    // Check if the 1 is the one at end of data.
-    size_t total_data = position + buffered_0s + buffered_1s;
-    if (total_data == bits_per_record()) {
-        int t = getc(in);
-        if (t == EOF) {
-            throw std::invalid_argument(
-                "r8 data ended too early. "
-                "The extracted data ended in a 1, but there was no corresponding 0x00 terminator byte for the expected "
-                "'fake encoded 1 just after the end of the data' before the input ended.");
-        } else if (t != 0) {
-            throw std::invalid_argument(
-                "r8 data ended too early. "
-                "The extracted data ended in a 1, but there was no corresponding 0x00 terminator byte for the expected "
-                "'fake encoded 1 just after the end of the data' before any additional data.");
-        }
-        have_seen_terminal_1 = true;
-    } else if (total_data == bits_per_record() + 1) {
-        have_seen_terminal_1 = true;
-        buffered_1s = 0;
-    } else if (total_data > bits_per_record() + 1) {
-        throw std::invalid_argument("r8 data encoded a jump past the expected end of encoded data.");
-    }
-    return true;
 }
 
 bool MeasureRecordReaderFormatR8::expects_empty_serialized_data_for_each_shot() const {
@@ -571,73 +288,89 @@ bool MeasureRecordReaderFormatDets::start_and_read_entire_record(SparseShot &cle
 MeasureRecordReaderFormatDets::MeasureRecordReaderFormatDets(
     FILE *in, size_t num_measurements, size_t num_detectors, size_t num_observables)
     : MeasureRecordReader(num_measurements, num_detectors, num_observables),
-      in(in),
-      buffer(num_measurements + num_detectors + num_observables),
-      position_in_buffer(num_measurements + num_detectors + num_observables) {
-}
-
-bool MeasureRecordReaderFormatDets::read_bit() {
-    if (position_in_buffer >= bits_per_record()) {
-        throw std::invalid_argument("Read past end of buffer.");
-    }
-    return buffer[position_in_buffer++];
-}
-
-bool MeasureRecordReaderFormatDets::next_record() {
-    return start_record();
-}
-
-bool MeasureRecordReaderFormatDets::start_record() {
-    int c;
-    if (!maybe_consume_keyword(in, "shot", c)) {
-        return false;
-    }
-    buffer.clear();
-    position_in_buffer = 0;
-    while (true) {
-        bool had_spacing = c == ' ';
-        while (c == ' ') {
-            c = getc(in);
-        }
-        if (c == '\n' || c == EOF) {
-            break;
-        }
-        if (!had_spacing) {
-            throw std::invalid_argument("DETS values must be separated by spaces.");
-        }
-        size_t offset;
-        size_t size;
-        char prefix = c;
-        if (prefix == 'M') {
-            offset = 0;
-            size = num_measurements;
-        } else if (prefix == 'D') {
-            offset = num_measurements;
-            size = num_detectors;
-        } else if (prefix == 'L') {
-            offset = num_measurements + num_detectors;
-            size = num_observables;
-        } else {
-            throw std::invalid_argument("Unrecognized DETS prefix: '" + std::to_string(c) + "'");
-        }
-        uint64_t number;
-        if (!read_uint64(in, number, c)) {
-            throw std::invalid_argument("DETS prefix '" + std::to_string(c) + "' wasn't not followed by an integer.");
-        }
-        if (number >= size) {
-            throw std::invalid_argument(
-                "Got '" + std::to_string(c) + std::to_string(number) + "' but expected num values of that type is " +
-                std::to_string(size) + ".");
-        }
-        buffer[(size_t)(offset + number)] ^= true;
-    }
-    return true;
-}
-
-bool MeasureRecordReaderFormatDets::is_end_of_record() {
-    return position_in_buffer == bits_per_record();
+      in(in) {
 }
 
 bool MeasureRecordReaderFormatDets::expects_empty_serialized_data_for_each_shot() const {
     return false;
+}
+
+MeasureRecordReaderFormatPTB64::MeasureRecordReaderFormatPTB64(FILE *in, size_t num_measurements, size_t num_detectors, size_t num_observables)
+    : MeasureRecordReader(num_measurements, num_detectors, num_observables),
+      in(in),
+      buf((bits_per_record() + 63) / 64 * 64 * 64),
+      num_unread_shots_in_buf(0) {
+}
+
+bool MeasureRecordReaderFormatPTB64::load_cache() {
+    size_t n = bits_per_record();
+    size_t nb = bits_per_record() * (64 / 8);
+    size_t nr = fread(buf.u8, 1, nb, in);
+    if (nr == 0) {
+        num_unread_shots_in_buf = 0;
+        return false;
+    }
+    if (nr != nb) {
+        throw std::invalid_argument(
+            "ptb64 data ended in middle of 64 record group at byte position " + std::to_string(nr) +
+            ".\n"
+            "Expected bytes per 64 records was " +
+            std::to_string(nb) + " (" + std::to_string(n) + " bits padded).");
+    }
+
+    // Convert from bit interleaving to uint64_t interleaving.
+    for (size_t k = 0; k < n; k += 64) {
+        inplace_transpose_64x64(buf.u64 + k);
+    }
+
+    num_unread_shots_in_buf = 64;
+    return true;
+}
+
+bool MeasureRecordReaderFormatPTB64::start_and_read_entire_record(simd_bits_range_ref dirty_out_buffer) {
+    if (num_unread_shots_in_buf == 0) {
+        load_cache();
+    }
+    if (num_unread_shots_in_buf == 0) {
+        return false;
+    }
+
+    size_t offset = 64 - num_unread_shots_in_buf;
+    size_t n64 = (bits_per_record() + 63) / 64;
+    for (size_t k = 0; k < n64; k++) {
+        dirty_out_buffer.u64[k] = buf.u64[k*64 + offset];
+    }
+    num_unread_shots_in_buf -= 1;
+    return true;
+}
+
+bool MeasureRecordReaderFormatPTB64::start_and_read_entire_record(SparseShot &cleared_out) {
+    if (num_unread_shots_in_buf == 0) {
+        load_cache();
+    }
+    if (num_unread_shots_in_buf == 0) {
+        return false;
+    }
+
+    size_t offset = 64 - num_unread_shots_in_buf;
+    size_t n = bits_per_record();
+    size_t n64 = (n + 63) / 64;
+    for (size_t k = 0; k < n64; k++) {
+        uint64_t v = buf.u64[k*64 + offset];
+        if (v) {
+            size_t nb = std::min(size_t{64}, n - k*64);
+            for (size_t b = 0; b < nb; b++) {
+                if (v & (uint64_t{1} << b)) {
+                    cleared_out.hits.push_back(k*64 + b);
+                }
+            }
+        }
+    }
+    num_unread_shots_in_buf -= 1;
+    move_obs_in_shots_to_mask_assuming_sorted(cleared_out);
+    return true;
+}
+
+bool MeasureRecordReaderFormatPTB64::expects_empty_serialized_data_for_each_shot() const {
+    return bits_per_record() == 0;
 }

--- a/src/stim/io/measure_record_reader.h
+++ b/src/stim/io/measure_record_reader.h
@@ -58,14 +58,6 @@ struct MeasureRecordReader {
         size_t num_observables = 0);
     virtual ~MeasureRecordReader() = default;
 
-    /// Reads and returns one measurement result. If no result is available, exception is thrown.
-    /// If is_end_of_record() just returned false, then a result is available and no exception is thrown.
-    virtual bool read_bit() = 0;
-    /// Reads multiple measurement results. Returns the number of results read. If no results are available,
-    /// zero is returned. Read terminates when data is filled up or when the current record ends. Note that
-    /// records encoded in HITS and DETS file formats never end.
-    virtual size_t read_bits_into_bytes(PointerRange<uint8_t> out_buffer);
-
     /// Determines whether or not there is no actual data written for each shot.
     ///
     /// For example, sampling a circuit with no measurements produces no bytes of data
@@ -99,22 +91,6 @@ struct MeasureRecordReader {
     ///         The reader is not at the start of a record.
     virtual size_t read_records_into(
         simd_bit_table &out, bool major_index_is_shot_index, size_t max_shots = UINT32_MAX);
-
-    /// Advances the reader to the next record (i.e. the next sequence of 0s and 1s). Skips the remainder
-    /// of the current record and an end-of-record marker (such as a newline). Returns true if a new record
-    /// has been found. Returns false if end of file has been reached.
-    virtual bool next_record() = 0;
-
-    /// Checks if there is another record present. The reader must be between records.
-    ///
-    /// Returns:
-    //      True: there is another record to read and we have begun reading it.
-    //      False: there are no more records to read.
-    virtual bool start_record() = 0;
-
-    /// Returns true when the current record has ended. Beyond this point read_bit() throws an exception
-    /// and read_bits_into_bytes() returns no data. Note that records in file formats HITS and DETS never end.
-    virtual bool is_end_of_record() = 0;
 
     /// Reads an entire record from start to finish, returning False if there are no more records.
     /// The data from the record is bit packed into a simd_bits.
@@ -151,17 +127,27 @@ struct MeasureRecordReader {
     void move_obs_in_shots_to_mask_assuming_sorted(SparseShot &shot);
 };
 
+struct MeasureRecordReaderFormatPTB64 : MeasureRecordReader {
+    FILE *in;
+    // This buffer stores partially transposed shots.
+    // The uint64_t for index k of shot s is stored in the buffer at offset k*64 + s.
+    simd_bits buf;
+    size_t num_unread_shots_in_buf;
+
+    MeasureRecordReaderFormatPTB64(FILE *in, size_t num_measurements, size_t num_detectors, size_t num_observables);
+
+    bool start_and_read_entire_record(simd_bits_range_ref dirty_out_buffer) override;
+    bool start_and_read_entire_record(SparseShot &cleared_out) override;
+    bool expects_empty_serialized_data_for_each_shot() const override;
+ private:
+    bool load_cache();
+};
+
 struct MeasureRecordReaderFormat01 : MeasureRecordReader {
     FILE *in;
-    int payload;
-    size_t position;
 
     MeasureRecordReaderFormat01(FILE *in, size_t num_measurements, size_t num_detectors, size_t num_observables);
 
-    bool read_bit() override;
-    bool next_record() override;
-    bool start_record() override;
-    bool is_end_of_record() override;
     bool start_and_read_entire_record(simd_bits_range_ref dirty_out_buffer) override;
     bool start_and_read_entire_record(SparseShot &cleared_out) override;
     bool expects_empty_serialized_data_for_each_shot() const override;
@@ -206,57 +192,19 @@ struct MeasureRecordReaderFormat01 : MeasureRecordReader {
 
 struct MeasureRecordReaderFormatB8 : MeasureRecordReader {
     FILE *in;
-    int payload;
-    uint8_t bits_available;
-    size_t position;
 
     MeasureRecordReaderFormatB8(FILE *in, size_t num_measurements, size_t num_detectors, size_t num_observables);
 
-    size_t read_bits_into_bytes(PointerRange<uint8_t> out_buffer) override;
-    bool read_bit() override;
-    bool next_record() override;
-    bool start_record() override;
-    bool is_end_of_record() override;
     bool start_and_read_entire_record(simd_bits_range_ref dirty_out_buffer) override;
     bool start_and_read_entire_record(SparseShot &cleared_out) override;
     bool expects_empty_serialized_data_for_each_shot() const override;
-
-   private:
-    void maybe_update_payload();
-
-    template <typename HANDLE_BYTE>
-    bool start_and_read_entire_record_helper(HANDLE_BYTE handle_byte) {
-        size_t n = bits_per_record();
-        size_t nb = (n + 7) >> 3;
-        for (size_t k = 0; k < nb; k++) {
-            int b = getc(in);
-            if (b == EOF) {
-                if (k == 0) {
-                    return false;
-                }
-                throw std::invalid_argument(
-                    "b8 data ended in middle of record at byte position " + std::to_string(k) +
-                    ".\n"
-                    "Expected bytes per record was " +
-                    std::to_string(nb) + " (" + std::to_string(n) + " bits padded).");
-            }
-            handle_byte(k, (uint8_t)b);
-        }
-        return true;
-    }
 };
 
 struct MeasureRecordReaderFormatHits : MeasureRecordReader {
     FILE *in;
-    simd_bits buffer;
-    size_t position_in_buffer;
 
     MeasureRecordReaderFormatHits(FILE *in, size_t num_measurements, size_t num_detectors, size_t num_observables);
 
-    bool read_bit() override;
-    bool next_record() override;
-    bool start_record() override;
-    bool is_end_of_record() override;
     bool start_and_read_entire_record(simd_bits_range_ref dirty_out_buffer) override;
     bool start_and_read_entire_record(SparseShot &cleared_out) override;
     bool expects_empty_serialized_data_for_each_shot() const override;
@@ -291,24 +239,14 @@ struct MeasureRecordReaderFormatHits : MeasureRecordReader {
 
 struct MeasureRecordReaderFormatR8 : MeasureRecordReader {
     FILE *in;
-    size_t position = 0;
-    bool have_seen_terminal_1 = false;
-    size_t buffered_0s = 0;
-    size_t buffered_1s = 0;
 
     MeasureRecordReaderFormatR8(FILE *in, size_t num_measurements, size_t num_detectors, size_t num_observables);
 
-    size_t read_bits_into_bytes(PointerRange<uint8_t> out_buffer) override;
-    bool read_bit() override;
-    bool next_record() override;
-    bool start_record() override;
-    bool is_end_of_record() override;
     bool start_and_read_entire_record(simd_bits_range_ref dirty_out_buffer) override;
     bool start_and_read_entire_record(SparseShot &cleared_out) override;
     bool expects_empty_serialized_data_for_each_shot() const override;
 
    private:
-    bool maybe_buffer_data();
     template <typename HANDLE_HIT>
     bool start_and_read_entire_record_helper(HANDLE_HIT handle_hit) {
         int next_char = getc(in);
@@ -344,16 +282,10 @@ struct MeasureRecordReaderFormatR8 : MeasureRecordReader {
 
 struct MeasureRecordReaderFormatDets : MeasureRecordReader {
     FILE *in;
-    simd_bits buffer;
-    size_t position_in_buffer;
 
     MeasureRecordReaderFormatDets(
         FILE *in, size_t num_measurements, size_t num_detectors = 0, size_t num_observables = 0);
 
-    bool read_bit() override;
-    bool next_record() override;
-    bool start_record() override;
-    bool is_end_of_record() override;
     bool start_and_read_entire_record(simd_bits_range_ref dirty_out_buffer) override;
     bool start_and_read_entire_record(SparseShot &cleared_out) override;
     bool expects_empty_serialized_data_for_each_shot() const override;

--- a/src/stim/io/measure_record_reader.test.cc
+++ b/src/stim/io/measure_record_reader.test.cc
@@ -30,35 +30,10 @@ FILE *tmpfile_with_contents(const std::string &contents) {
     if (written != contents.size()) {
         int en = errno;
         std::cerr << "Failed to write to tmpfile: " << strerror(en) << std::endl;
-        return nullptr;
+        throw std::invalid_argument("Failed to write to tmpfile");
     }
     rewind(tmp);
     return tmp;
-}
-
-bool maybe_consume_keyword(FILE *in, const std::string &keyword, int &next);
-
-TEST(maybe_consume_keyword, FoundKeyword) {
-    int next = 0;
-    FILE *tmp = tmpfile_with_contents("shot\n");
-    ASSERT_NE(tmp, nullptr);
-    ASSERT_TRUE(maybe_consume_keyword(tmp, "shot", next));
-    ASSERT_EQ(next, '\n');
-}
-
-TEST(maybe_consume_keyword, NotFoundKeyword) {
-    int next = 0;
-    FILE *tmp = tmpfile_with_contents("hit\n");
-    ASSERT_NE(tmp, nullptr);
-    ASSERT_THROW({ maybe_consume_keyword(tmp, "shot", next); }, std::runtime_error);
-}
-
-TEST(maybe_consume_keyword, FoundEOF) {
-    int next = 0;
-    FILE *tmp = tmpfile_with_contents("");
-    ASSERT_NE(tmp, nullptr);
-    ASSERT_FALSE(maybe_consume_keyword(tmp, "shot", next));
-    ASSERT_EQ(next, EOF);
 }
 
 TEST(read_unsigned_int, BasicUsage) {
@@ -79,143 +54,60 @@ TEST(read_unsigned_int, ValueTooBig) {
     ASSERT_THROW({ read_uint64(tmp, value, next); }, std::runtime_error);
 }
 
+void assert_contents_load_correctly(SampleFormat format, const std::string &contents) {
+    FILE *tmp = tmpfile_with_contents(contents);
+    auto reader = MeasureRecordReader::make(tmp, format, 18);
+    simd_bits buf(18);
+    reader->start_and_read_entire_record(buf);
+    ASSERT_EQ(buf[0], 0);
+    ASSERT_EQ(buf[1], 0);
+    ASSERT_EQ(buf[2], 0);
+    ASSERT_EQ(buf[3], 1);
+    ASSERT_EQ(buf[4], 1);
+    ASSERT_EQ(buf[5], 1);
+    ASSERT_EQ(buf[6], 1);
+    ASSERT_EQ(buf[7], 1);
+    ASSERT_EQ(buf[8], 0);
+    ASSERT_EQ(buf[9], 0);
+    ASSERT_EQ(buf[10], 0);
+    ASSERT_EQ(buf[11], 0);
+    ASSERT_EQ(buf[12], 1);
+    ASSERT_EQ(buf[13], 1);
+    ASSERT_EQ(buf[14], 1);
+    ASSERT_EQ(buf[15], 1);
+    ASSERT_EQ(buf[16], 1);
+    ASSERT_EQ(buf[17], 1);
+
+    rewind(tmp);
+    SparseShot sparse;
+    reader->start_and_read_entire_record(sparse);
+    ASSERT_EQ(sparse.hits, (std::vector<uint64_t>{3, 4, 5, 6, 7, 12, 13, 14, 15, 16, 17}));
+}
+
 TEST(MeasureRecordReader, Format01) {
-    // We'll read the data like this:  |-0xF8-|0|-0xF8-|1|
-    FILE *tmp = tmpfile_with_contents("000111110000111111\n");
-    ASSERT_NE(tmp, nullptr);
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_01, 18);
-    ASSERT_TRUE(reader->start_record());
-    ASSERT_FALSE(reader->is_end_of_record());
-    // bits 0..7 == 0xF8
-    uint8_t bytes[]{0};
-    ASSERT_EQ(8, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(0xF8, bytes[0]);
-    // bit 8 == 0
-    ASSERT_FALSE(reader->read_bit());
-    // bits 9..16 == 0xF8
-    bytes[0] = 0;
-    ASSERT_EQ(8, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(0xF8, bytes[0]);
-    // bit 17 == 1
-    ASSERT_TRUE(reader->read_bit());
-    ASSERT_TRUE(reader->is_end_of_record());
+    assert_contents_load_correctly(SAMPLE_FORMAT_01, "000111110000111111\n");
 }
 
 TEST(MeasureRecordReader, FormatB8) {
-    FILE *tmp = tmpfile_with_contents("\xF8\xF0\x03");
-    ASSERT_NE(tmp, nullptr);
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_B8, 18);
-    ASSERT_TRUE(reader->start_record());
-    ASSERT_FALSE(reader->is_end_of_record());
-    // bits 0..7 == 0xF8
-    uint8_t bytes[]{0};
-    ASSERT_EQ(8, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(0xF8, bytes[0]);
-    // bit 8 == 0
-    ASSERT_FALSE(reader->read_bit());
-    // bits 9..16 == 0xF8
-    bytes[0] = 0;
-    ASSERT_EQ(8, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(0xF8, bytes[0]);
-    // bit 17 == 1
-    ASSERT_TRUE(reader->read_bit());
-    ASSERT_TRUE(reader->is_end_of_record());
+    assert_contents_load_correctly(SAMPLE_FORMAT_B8, "\xF8\xF0\x03");
 }
 
 TEST(MeasureRecordReader, FormatHits) {
-    FILE *tmp = tmpfile_with_contents("3,4,5,6,7,12,13,14,15,16,17\n");
-    ASSERT_NE(tmp, nullptr);
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_HITS, 18);
-    ASSERT_TRUE(reader->start_record());
-    ASSERT_FALSE(reader->is_end_of_record());
-    // bits 0..7 == 0xF8
-    uint8_t bytes[]{0};
-    ASSERT_EQ(8, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(0xF8, bytes[0]);
-    // bit 8 == 0
-    ASSERT_FALSE(reader->read_bit());
-    // bits 9..16 == 0xF8
-    bytes[0] = 0;
-    ASSERT_EQ(8, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(0xF8, bytes[0]);
-    // bit 17 == 1
-    ASSERT_TRUE(reader->read_bit());
-    ASSERT_TRUE(reader->is_end_of_record());
+    assert_contents_load_correctly(SAMPLE_FORMAT_HITS, "3,4,5,6,7,12,13,14,15,16,17\n");
 }
 
 TEST(MeasureRecordReader, FormatR8) {
     char tmp_data[]{3, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0};
-    FILE *tmp = tmpfile_with_contents(std::string(std::begin(tmp_data), std::end(tmp_data)));
-    ASSERT_NE(tmp, nullptr);
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_R8, 18);
-    ASSERT_FALSE(reader->is_end_of_record());
-    // bits 0..7 == 0xF8
-    uint8_t bytes[]{0};
-    ASSERT_EQ(8, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(0xF8, bytes[0]);
-    // bit 8 == 0
-    ASSERT_FALSE(reader->read_bit());
-    // bits 9..16 == 0xF8
-    bytes[0] = 0;
-    ASSERT_EQ(8, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(0xF8, bytes[0]);
-    // bit 17 == 1
-    ASSERT_TRUE(reader->read_bit());
-    ASSERT_TRUE(reader->is_end_of_record());
+    assert_contents_load_correctly(SAMPLE_FORMAT_R8, std::string(std::begin(tmp_data), std::end(tmp_data)));
 }
 
 TEST(MeasureRecordReader, FormatR8_LongGap) {
     FILE *tmp = tmpfile_with_contents("\xFF\xFF\x02\x20");
-    ASSERT_NE(tmp, nullptr);
     auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_R8, 8 * 64 + 32 + 1);
-    ASSERT_FALSE(reader->is_end_of_record());
-    uint8_t bytes[]{1, 2, 3, 4, 5, 6, 7, 8};
-    for (int i = 0; i < 8; ++i) {
-        ASSERT_EQ(64, reader->read_bits_into_bytes({bytes, bytes + 8}));
-        for (int j = 0; j < 8; ++j) {
-            ASSERT_EQ(0, bytes[j]);
-            bytes[j] = 123;
-        }
-    }
-    ASSERT_TRUE(reader->read_bit());
-    ASSERT_EQ(32, reader->read_bits_into_bytes({bytes, bytes + 4}));
-    ASSERT_EQ(0, bytes[0]);
-    ASSERT_EQ(0, bytes[1]);
-    ASSERT_EQ(0, bytes[2]);
-    ASSERT_EQ(0, bytes[3]);
-    ASSERT_TRUE(reader->is_end_of_record());
-
-    // Read past end of record.
-    ASSERT_THROW({ reader->read_bit(); }, std::invalid_argument);
-    // No next record.
-    ASSERT_FALSE(reader->next_record());
-}
-
-TEST(MeasureRecordReader, FormatDets) {
-    FILE *tmp = tmpfile_with_contents("shot D3 D4 D5 D6 D7 D12 D13 D14 D15 D16 L1\n");
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, 0, 17, 2);
-    ASSERT_TRUE(reader->start_record());
-    ASSERT_FALSE(reader->is_end_of_record());
-
-    // Detection events:
-    // bits 0..7 == 0xF8
-    uint8_t bytes[]{0};
-    ASSERT_EQ(8, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(0xF8, bytes[0]);
-    // bit 8 == 0
-    ASSERT_FALSE(reader->read_bit());
-    // bits 9..16 == 0xF8
-    bytes[0] = 0;
-    ASSERT_EQ(8, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(0xF8, bytes[0]);
-
-    // Logical observables:
-    // bit 0 == 0
-    ASSERT_FALSE(reader->read_bit());
-    // bit 1 == 1
-    ASSERT_TRUE(reader->read_bit());
-
-    ASSERT_TRUE(reader->is_end_of_record());
+    SparseShot sparse;
+    ASSERT_TRUE(reader->start_and_read_entire_record(sparse));
+    ASSERT_EQ(sparse.hits, (std::vector<uint64_t>{255 + 255 + 2}));
+    ASSERT_FALSE(reader->start_and_read_entire_record(sparse));
 }
 
 FILE *write_records(ConstPointerRange<uint8_t> data, SampleFormat format) {
@@ -228,8 +120,14 @@ FILE *write_records(ConstPointerRange<uint8_t> data, SampleFormat format) {
 
 size_t read_records_as_bytes(FILE *in, PointerRange<uint8_t> buf, SampleFormat format, size_t bits_per_record) {
     auto reader = MeasureRecordReader::make(in, format, bits_per_record);
-    EXPECT_TRUE(reader->start_record());
-    return reader->read_bits_into_bytes(buf);
+    if (buf.size() * 8 < reader->bits_per_record()) {
+        throw std::invalid_argument("buf too small");
+    }
+    simd_bits buf2(reader->bits_per_record());
+    bool success = reader->start_and_read_entire_record(buf2);
+    EXPECT_TRUE(success);
+    memcpy(buf.ptr_start, buf2.u8, (reader->bits_per_record() + 7) / 8);
+    return reader->bits_per_record();
 }
 
 TEST(MeasureRecordReader, Format01_WriteRead) {
@@ -284,38 +182,6 @@ TEST(MeasureRecordReader, FormatHits_WriteRead) {
     }
 }
 
-TEST(MeasureRecordReader, FormatHits_OutOfOrder) {
-    FILE *tmp = tmpfile_with_contents("5,3\n");
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_HITS, 8, 0, 0);
-    ASSERT_TRUE(reader->start_record());
-    ASSERT_FALSE(reader->read_bit());
-    ASSERT_FALSE(reader->read_bit());
-    ASSERT_FALSE(reader->read_bit());
-    ASSERT_TRUE(reader->read_bit());
-    ASSERT_FALSE(reader->read_bit());
-    ASSERT_TRUE(reader->read_bit());
-    ASSERT_FALSE(reader->read_bit());
-    ASSERT_FALSE(reader->read_bit());
-    ASSERT_TRUE(reader->is_end_of_record());
-    ASSERT_FALSE(reader->start_record());
-}
-
-TEST(MeasureRecordReader, FormatDets_OutOfOrder) {
-    FILE *tmp = tmpfile_with_contents("shot L2 D3 D1\n");
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, 0, 4, 4);
-    ASSERT_TRUE(reader->start_record());
-    ASSERT_FALSE(reader->read_bit());
-    ASSERT_TRUE(reader->read_bit());
-    ASSERT_FALSE(reader->read_bit());
-    ASSERT_TRUE(reader->read_bit());
-    ASSERT_FALSE(reader->read_bit());
-    ASSERT_FALSE(reader->read_bit());
-    ASSERT_TRUE(reader->read_bit());
-    ASSERT_FALSE(reader->read_bit());
-    ASSERT_TRUE(reader->is_end_of_record());
-    ASSERT_FALSE(reader->start_record());
-}
-
 TEST(MeasureRecordReader, FormatDets_WriteRead) {
     uint8_t src[]{0, 1, 2, 3, 4, 0xFF, 0xBF, 0xFE, 80, 0, 0, 1, 20};
     constexpr size_t num_bytes = sizeof(src) / sizeof(uint8_t);
@@ -348,33 +214,25 @@ TEST(MeasureRecordReader, Format01_WriteRead_MultipleRecords) {
 
     rewind(tmp);
 
-    uint8_t buf[num_bytes];
     auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_01, bits_per_record);
-    ASSERT_TRUE(reader->start_record());
 
-    memset(buf, 0, num_bytes);
-    ASSERT_EQ(bits_per_record, reader->read_bits_into_bytes({buf, buf + num_bytes}));
+    simd_bits buf(num_bytes * 8);
+    ASSERT_TRUE(reader->start_and_read_entire_record(buf));
     for (size_t i = 0; i < num_bytes; ++i) {
-        ASSERT_EQ(buf[i], record1[i]);
+        ASSERT_EQ(buf.u8[i], record1[i]);
     }
-    ASSERT_TRUE(reader->is_end_of_record());
-    ASSERT_TRUE(reader->next_record());
 
-    memset(buf, 0, num_bytes);
-    ASSERT_EQ(bits_per_record, reader->read_bits_into_bytes({buf, buf + num_bytes}));
+    ASSERT_TRUE(reader->start_and_read_entire_record(buf));
     for (size_t i = 0; i < num_bytes; ++i) {
-        ASSERT_EQ(buf[i], record2[i]);
+        ASSERT_EQ(buf.u8[i], record2[i]);
     }
-    ASSERT_TRUE(reader->is_end_of_record());
-    ASSERT_TRUE(reader->next_record());
 
-    memset(buf, 0, num_bytes);
-    ASSERT_EQ(bits_per_record, reader->read_bits_into_bytes({buf, buf + num_bytes}));
+    ASSERT_TRUE(reader->start_and_read_entire_record(buf));
     for (size_t i = 0; i < num_bytes; ++i) {
-        ASSERT_EQ(buf[i], record3[i]);
+        ASSERT_EQ(buf.u8[i], record3[i]);
     }
-    ASSERT_TRUE(reader->is_end_of_record());
-    ASSERT_FALSE(reader->next_record());
+
+    ASSERT_FALSE(reader->start_and_read_entire_record(buf));
 }
 
 TEST(MeasureRecordReader, FormatHits_WriteRead_MultipleRecords) {
@@ -395,33 +253,24 @@ TEST(MeasureRecordReader, FormatHits_WriteRead_MultipleRecords) {
 
     rewind(tmp);
 
-    uint8_t buf[num_bytes];
     auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_HITS, bits_per_record);
-    ASSERT_TRUE(reader->start_record());
-
-    memset(buf, 0, num_bytes);
-    ASSERT_EQ(bits_per_record, reader->read_bits_into_bytes({buf, buf + num_bytes}));
+    simd_bits buf(num_bytes * 8);
+    ASSERT_TRUE(reader->start_and_read_entire_record(buf));
     for (size_t i = 0; i < num_bytes; ++i) {
-        ASSERT_EQ(buf[i], record1[i]);
+        ASSERT_EQ(buf.u8[i], record1[i]);
     }
-    ASSERT_TRUE(reader->is_end_of_record());
-    ASSERT_TRUE(reader->next_record());
 
-    memset(buf, 0, num_bytes);
-    ASSERT_EQ(bits_per_record, reader->read_bits_into_bytes({buf, buf + num_bytes}));
+    ASSERT_TRUE(reader->start_and_read_entire_record(buf));
     for (size_t i = 0; i < num_bytes; ++i) {
-        ASSERT_EQ(buf[i], record2[i]);
+        ASSERT_EQ(buf.u8[i], record2[i]);
     }
-    ASSERT_TRUE(reader->is_end_of_record());
-    ASSERT_TRUE(reader->next_record());
 
-    memset(buf, 0, num_bytes);
-    ASSERT_EQ(bits_per_record, reader->read_bits_into_bytes({buf, buf + num_bytes}));
+    ASSERT_TRUE(reader->start_and_read_entire_record(buf));
     for (size_t i = 0; i < num_bytes; ++i) {
-        ASSERT_EQ(buf[i], record3[i]);
+        ASSERT_EQ(buf.u8[i], record3[i]);
     }
-    ASSERT_TRUE(reader->is_end_of_record());
-    ASSERT_FALSE(reader->next_record());
+
+    ASSERT_FALSE(reader->start_and_read_entire_record(buf));
 }
 
 TEST(MeasureRecordReader, FormatDets_WriteRead_MultipleRecords) {
@@ -442,319 +291,134 @@ TEST(MeasureRecordReader, FormatDets_WriteRead_MultipleRecords) {
 
     rewind(tmp);
 
-    uint8_t buf[num_bytes];
     auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, bits_per_record);
-    ASSERT_TRUE(reader->start_record());
-
-    memset(buf, 0, num_bytes);
-    ASSERT_EQ(bits_per_record, reader->read_bits_into_bytes({buf, buf + num_bytes}));
+    simd_bits buf(num_bytes * 8);
+    ASSERT_TRUE(reader->start_and_read_entire_record(buf));
     for (size_t i = 0; i < num_bytes; ++i) {
-        ASSERT_EQ(buf[i], record1[i]);
+        ASSERT_EQ(buf.u8[i], record1[i]);
     }
-    ASSERT_TRUE(reader->is_end_of_record());
-    ASSERT_TRUE(reader->next_record());
 
-    memset(buf, 0, num_bytes);
-    ASSERT_EQ(bits_per_record, reader->read_bits_into_bytes({buf, buf + num_bytes}));
+    ASSERT_TRUE(reader->start_and_read_entire_record(buf));
     for (size_t i = 0; i < num_bytes; ++i) {
-        ASSERT_EQ(buf[i], record2[i]);
+        ASSERT_EQ(buf.u8[i], record2[i]);
     }
-    ASSERT_TRUE(reader->is_end_of_record());
-    ASSERT_TRUE(reader->next_record());
 
-    memset(buf, 0, num_bytes);
-    ASSERT_EQ(bits_per_record, reader->read_bits_into_bytes({buf, buf + num_bytes}));
+    ASSERT_TRUE(reader->start_and_read_entire_record(buf));
     for (size_t i = 0; i < num_bytes; ++i) {
-        ASSERT_EQ(buf[i], record3[i]);
+        ASSERT_EQ(buf.u8[i], record3[i]);
     }
-    ASSERT_TRUE(reader->is_end_of_record());
-    ASSERT_FALSE(reader->next_record());
+
+    ASSERT_FALSE(reader->start_and_read_entire_record(buf));
 }
 
 TEST(MeasureRecordReader, Format01_MultipleRecords) {
-    FILE *tmp = tmpfile_with_contents("111011001\n01000000\n101100011");
+    FILE *tmp = tmpfile_with_contents("111011001\n010000000\n101100011\n");
     ASSERT_NE(tmp, nullptr);
     auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_01, 9);
-    ASSERT_TRUE(reader->start_record());
-    ASSERT_FALSE(reader->is_end_of_record());
-    // first record
-    uint8_t bytes[]{0};
-    ASSERT_EQ(8, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(0x37, bytes[0]);
-    ASSERT_FALSE(reader->is_end_of_record());
-    ASSERT_TRUE(reader->read_bit());
-    ASSERT_TRUE(reader->is_end_of_record());
-    // second_record
-    ASSERT_TRUE(reader->next_record());
-    ASSERT_FALSE(reader->read_bit());
-    ASSERT_TRUE(reader->read_bit());
-    ASSERT_FALSE(reader->read_bit());
-    ASSERT_FALSE(reader->is_end_of_record());
-    // third record
-    ASSERT_TRUE(reader->next_record());
-    bytes[0] = 0;
-    ASSERT_EQ(8, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(0x8D, bytes[0]);
-    ASSERT_TRUE(reader->read_bit());
-    ASSERT_TRUE(reader->is_end_of_record());
-    // no more records
-    ASSERT_FALSE(reader->next_record());
-}
-
-TEST(MeasureRecordReader, Format01_MultipleShortRecords) {
-    FILE *tmp = tmpfile_with_contents("10\n01\n10\n");
-    ASSERT_NE(tmp, nullptr);
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_01, 2);
-    ASSERT_TRUE(reader->start_record());
-    ASSERT_FALSE(reader->is_end_of_record());
-    // first record
-    uint8_t bytes[]{0};
-    ASSERT_EQ(2, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(1, bytes[0]);
-    ASSERT_TRUE(reader->is_end_of_record());
-    // second_record
-    ASSERT_TRUE(reader->next_record());
-    ASSERT_FALSE(reader->read_bit());
-    ASSERT_TRUE(reader->read_bit());
-    ASSERT_TRUE(reader->is_end_of_record());
-    // third record
-    ASSERT_TRUE(reader->next_record());
-    bytes[0] = 0;
-    ASSERT_EQ(2, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(1, bytes[0]);
-    ASSERT_TRUE(reader->is_end_of_record());
-    // no more records
-    ASSERT_FALSE(reader->next_record());
-}
-
-TEST(MeasureRecordReader, FormatHits_MultipleRecords) {
-    FILE *tmp = tmpfile_with_contents("0,1,2,4,5,8\n1\n0\n");
-    ASSERT_NE(tmp, nullptr);
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_HITS, 9);
-    ASSERT_TRUE(reader->start_record());
-    ASSERT_FALSE(reader->is_end_of_record());
-    // first record
-    uint8_t bytes[]{0};
-    ASSERT_EQ(8, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(0x37, bytes[0]);
-    ASSERT_FALSE(reader->is_end_of_record());
-    ASSERT_TRUE(reader->read_bit());
-    ASSERT_TRUE(reader->is_end_of_record());
-    // second_record
-    ASSERT_TRUE(reader->next_record());
-    ASSERT_FALSE(reader->read_bit());
-    ASSERT_TRUE(reader->read_bit());
-    ASSERT_FALSE(reader->read_bit());
-    ASSERT_FALSE(reader->is_end_of_record());
-    // third record
-    ASSERT_TRUE(reader->next_record());
-    bytes[0] = 0;
-    ASSERT_EQ(8, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(1, bytes[0]);
-    ASSERT_FALSE(reader->read_bit());
-    ASSERT_TRUE(reader->is_end_of_record());
-    // no more records
-    ASSERT_FALSE(reader->next_record());
-}
-
-TEST(MeasureRecordReader, FormatHits_MultipleShortRecords) {
-    FILE *tmp = tmpfile_with_contents("0\n1\n0\n\n");
-    ASSERT_NE(tmp, nullptr);
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_HITS, 2);
-    ASSERT_TRUE(reader->start_record());
-    ASSERT_FALSE(reader->is_end_of_record());
-    // first record
-    uint8_t bytes[]{0};
-    ASSERT_EQ(2, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(1, bytes[0]);
-    ASSERT_TRUE(reader->is_end_of_record());
-    // second_record
-    ASSERT_TRUE(reader->next_record());
-    ASSERT_FALSE(reader->read_bit());
-    ASSERT_TRUE(reader->read_bit());
-    ASSERT_TRUE(reader->is_end_of_record());
-    // third record
-    ASSERT_TRUE(reader->next_record());
-    bytes[0] = 0;
-    ASSERT_EQ(2, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(1, bytes[0]);
-    ASSERT_TRUE(reader->is_end_of_record());
-    // fourth record
-    ASSERT_TRUE(reader->next_record());
-    bytes[0] = 0xFF;
-    ASSERT_EQ(2, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(0, bytes[0]);
-    ASSERT_TRUE(reader->is_end_of_record());
-    // no more records
-    ASSERT_FALSE(reader->next_record());
-}
-
-TEST(MeasureRecordReader, FormatDets_MultipleRecords) {
-    FILE *tmp = tmpfile_with_contents("shot M0 M1 M2 M4 M5 M8\nshot M1\nshot M0\n");
-    ASSERT_NE(tmp, nullptr);
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, 9);
-    ASSERT_TRUE(reader->start_record());
-    ASSERT_FALSE(reader->is_end_of_record());
-    // first record
-    uint8_t bytes[]{0};
-    ASSERT_EQ(8, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(0x37, bytes[0]);
-    ASSERT_TRUE(reader->read_bit());
-    ASSERT_TRUE(reader->is_end_of_record());
-    // second_record
-    ASSERT_TRUE(reader->next_record());
-    ASSERT_FALSE(reader->read_bit());
-    ASSERT_TRUE(reader->read_bit());
-    ASSERT_FALSE(reader->is_end_of_record());
-    // third record
-    ASSERT_TRUE(reader->next_record());
-    bytes[0] = 0;
-    ASSERT_EQ(8, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(1, bytes[0]);
-    ASSERT_FALSE(reader->read_bit());
-    ASSERT_TRUE(reader->is_end_of_record());
-    // no more records
-    ASSERT_FALSE(reader->next_record());
+    simd_bits buf(9);
+    ASSERT_TRUE(reader->start_and_read_entire_record(buf));
+    ASSERT_TRUE(reader->start_and_read_entire_record(buf));
+    ASSERT_TRUE(reader->start_and_read_entire_record(buf));
+    ASSERT_FALSE(reader->start_and_read_entire_record(buf));
 }
 
 TEST(MeasureRecordReader, FormatDets_MultipleShortRecords) {
     FILE *tmp = tmpfile_with_contents("shot M0\nshot M1\nshot M0\nshot\n");
-    ASSERT_NE(tmp, nullptr);
     auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, 2);
-    ASSERT_TRUE(reader->start_record());
-    ASSERT_FALSE(reader->is_end_of_record());
-    // first record
-    uint8_t bytes[]{0};
-    ASSERT_EQ(2, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(1, bytes[0]);
-    ASSERT_TRUE(reader->is_end_of_record());
-    // second_record
-    ASSERT_TRUE(reader->next_record());
-    ASSERT_FALSE(reader->read_bit());
-    ASSERT_TRUE(reader->read_bit());
-    ASSERT_TRUE(reader->is_end_of_record());
-    // third record
-    ASSERT_TRUE(reader->next_record());
-    bytes[0] = 0;
-    ASSERT_EQ(2, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(1, bytes[0]);
-    ASSERT_TRUE(reader->is_end_of_record());
-    // fourth record (0 bits)
-    ASSERT_TRUE(reader->next_record());
-    bytes[0] = 0xFF;
-    ASSERT_EQ(2, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(0, bytes[0]);
-    ASSERT_TRUE(reader->is_end_of_record());
-    // no more records
-    ASSERT_FALSE(reader->next_record());
+
+    simd_bits buf(2);
+    ASSERT_TRUE(reader->start_and_read_entire_record(buf));
+    ASSERT_EQ(buf[0], 1);
+    ASSERT_EQ(buf[1], 0);
+    ASSERT_TRUE(reader->start_and_read_entire_record(buf));
+    ASSERT_EQ(buf[0], 0);
+    ASSERT_EQ(buf[1], 1);
+    ASSERT_TRUE(reader->start_and_read_entire_record(buf));
+    ASSERT_EQ(buf[0], 1);
+    ASSERT_EQ(buf[1], 0);
+    ASSERT_TRUE(reader->start_and_read_entire_record(buf));
+    ASSERT_EQ(buf[0], 0);
+    ASSERT_EQ(buf[1], 0);
+    ASSERT_FALSE(reader->start_and_read_entire_record(buf));
 }
 
 TEST(MeasureRecordReader, FormatDets_MultipleResultTypes_D0L0) {
     FILE *tmp = tmpfile_with_contents("shot D0 D3 D5 L1 L2\n");
-    ASSERT_NE(tmp, nullptr);
     auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, 0, 7, 4);
-    ASSERT_TRUE(reader->start_record());
-    ASSERT_FALSE(reader->is_end_of_record());
-    // Detection events
-    uint8_t bytes[]{0};
-    ASSERT_EQ(8, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(0x29, bytes[0]);
-    // Logical observables
-    bytes[0] = 0;
-    ASSERT_EQ(3, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(3, bytes[0]);
+    simd_bits buf(11);
+    ASSERT_TRUE(reader->start_and_read_entire_record(buf));
+    ASSERT_EQ(buf[0], 1);
+    ASSERT_EQ(buf[1], 0);
+    ASSERT_EQ(buf[2], 0);
+    ASSERT_EQ(buf[3], 1);
+    ASSERT_EQ(buf[4], 0);
+    ASSERT_EQ(buf[5], 1);
+    ASSERT_EQ(buf[6], 0);
+    ASSERT_EQ(buf[7], 0);
+    ASSERT_EQ(buf[8], 1);
+    ASSERT_EQ(buf[9], 1);
+    ASSERT_EQ(buf[10], 0);
 
-    ASSERT_FALSE(reader->next_record());
-}
-
-TEST(MeasureRecordReader, FormatDets_MultipleResultTypes_D1L0) {
-    FILE *tmp = tmpfile_with_contents("shot D0 D3 D5 D6 L1 L2\n");
-    ASSERT_NE(tmp, nullptr);
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, 0, 7, 4);
-    ASSERT_TRUE(reader->start_record());
-    ASSERT_FALSE(reader->is_end_of_record());
-    // Detection events
-    uint8_t bytes[]{0};
-    ASSERT_EQ(8, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(0x69, bytes[0]);
-    // Logical observables
-    bytes[0] = 0;
-    ASSERT_EQ(3, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(3, bytes[0]);
-
-    ASSERT_FALSE(reader->next_record());
-}
-
-TEST(MeasureRecordReader, FormatDets_MultipleResultTypes_D0L1) {
-    FILE *tmp = tmpfile_with_contents("shot D0 D3 D5 L0 L1 L2\n");
-    ASSERT_NE(tmp, nullptr);
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, 0, 7, 4);
-    ASSERT_TRUE(reader->start_record());
-    ASSERT_FALSE(reader->is_end_of_record());
-    // Detection events
-    uint8_t bytes[]{0};
-    ASSERT_EQ(8, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(0xA9, bytes[0]);
-    // Logical observables
-    bytes[0] = 0;
-    ASSERT_EQ(3, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(3, bytes[0]);
-
-    ASSERT_FALSE(reader->next_record());
-}
-
-TEST(MeasureRecordReader, FormatDets_MultipleResultTypes_D1L1) {
-    FILE *tmp = tmpfile_with_contents("shot D0 D3 D5 D6 L0 L1 L2\n");
-    ASSERT_NE(tmp, nullptr);
-    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, 0, 7, 4);
-    ASSERT_TRUE(reader->start_record());
-    ASSERT_FALSE(reader->is_end_of_record());
-    // Detection events
-    uint8_t bytes[]{0};
-    ASSERT_EQ(8, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(0xE9, bytes[0]);
-    // Logical observables
-    bytes[0] = 0;
-    ASSERT_EQ(3, reader->read_bits_into_bytes(bytes));
-    ASSERT_EQ(3, bytes[0]);
-
-    ASSERT_FALSE(reader->next_record());
+    rewind(tmp);
+    reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, 0, 7, 4);
+    SparseShot sparse;
+    reader->start_and_read_entire_record(sparse);
+    ASSERT_EQ(sparse.hits, (std::vector<uint64_t>{0, 3, 5}));
+    ASSERT_EQ(sparse.obs_mask, 6);
 }
 
 TEST(MeasureRecordReader, Format01_InvalidInput) {
     FILE *tmp = tmpfile_with_contents("012\n");
     ASSERT_NE(tmp, nullptr);
     auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_01, 3);
-    ASSERT_TRUE(reader->start_record());
-    ASSERT_FALSE(reader->read_bit());
-    ASSERT_TRUE(reader->read_bit());
-    ASSERT_THROW({ reader->read_bit(); }, std::runtime_error);
+    simd_bits buf(3);
+    ASSERT_THROW({ reader->start_and_read_entire_record(buf); }, std::invalid_argument);
 }
 
 TEST(MeasureRecordReader, FormatHits_InvalidInput) {
     FILE *tmp = tmpfile_with_contents("100,1\n");
-    ASSERT_NE(tmp, nullptr);
     auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_HITS, 3);
-    ASSERT_THROW({ reader->start_record(); }, std::runtime_error);
+    simd_bits buf(3);
+    ASSERT_THROW({ reader->start_and_read_entire_record(buf); }, std::invalid_argument);
 }
 
-TEST(MeasureRecordReader, FormatHits_Repeated) {
+TEST(MeasureRecordReader, FormatHits_InvalidInput_sparse) {
+    FILE *tmp = tmpfile_with_contents("100,1\n");
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_HITS, 3);
+    SparseShot sparse;
+    ASSERT_THROW({ reader->start_and_read_entire_record(sparse); }, std::invalid_argument);
+}
+
+TEST(MeasureRecordReader, FormatHits_Repeated_Dense) {
     FILE *tmp = tmpfile_with_contents("1,1\n");
-    ASSERT_NE(tmp, nullptr);
     auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_HITS, 3);
-    ASSERT_TRUE(reader->start_record());
-    ASSERT_FALSE(reader->read_bit());
-    ASSERT_FALSE(reader->read_bit());
-    ASSERT_FALSE(reader->read_bit());
-    ASSERT_TRUE(reader->is_end_of_record());
-    ASSERT_FALSE(reader->start_record());
+    simd_bits buf(3);
+    ASSERT_TRUE(reader->start_and_read_entire_record(buf));
+    ASSERT_EQ(buf[0], 0);
+    ASSERT_EQ(buf[1], 0);
+    ASSERT_EQ(buf[2], 0);
 }
 
-TEST(MeasureRecordReader, FormatDets_InvalidInput) {
+TEST(MeasureRecordReader, FormatHits_Repeated_Sparse) {
+    FILE *tmp = tmpfile_with_contents("1,1\n");
+    auto reader = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_HITS, 3);
+    SparseShot sparse;
+    ASSERT_TRUE(reader->start_and_read_entire_record(sparse));
+    ASSERT_EQ(sparse.hits, (std::vector<uint64_t>{1,1}));
+}
+
+TEST(MeasureRecordReader, FormatDets_InvalidInput_Sparse) {
     FILE *tmp = tmpfile_with_contents("D2\n");
-    ASSERT_NE(tmp, nullptr);
     auto r = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, 3);
-    ASSERT_THROW({ r->start_record(); }, std::runtime_error);
+    SparseShot sparse;
+    ASSERT_THROW({ r->start_and_read_entire_record(sparse); }, std::invalid_argument);
+}
+
+TEST(MeasureRecordReader, FormatDets_InvalidInput_Dense) {
+    FILE *tmp = tmpfile_with_contents("D2\n");
+    auto r = MeasureRecordReader::make(tmp, SAMPLE_FORMAT_DETS, 3);
+    simd_bits buf(3);
+    ASSERT_THROW({ r->start_and_read_entire_record(buf); }, std::invalid_argument);
 }
 
 TEST(MeasureRecordReader, read_records_into_RoundTrip) {
@@ -886,7 +550,6 @@ TEST(MeasureRecordReader, start_and_read_entire_record) {
     for (const auto &kv : format_name_to_enum_map) {
         SampleFormat format = kv.second.id;
         if (format == SampleFormat::SAMPLE_FORMAT_PTB64) {
-            // TODO: support this format.
             continue;
         }
 
@@ -935,7 +598,6 @@ TEST(MeasureRecordReader, start_and_read_entire_record_all_zero) {
     for (const auto &kv : format_name_to_enum_map) {
         SampleFormat format = kv.second.id;
         if (format == SampleFormat::SAMPLE_FORMAT_PTB64) {
-            // TODO: support this format.
             continue;
         }
 
@@ -966,4 +628,73 @@ TEST(MeasureRecordReader, start_and_read_entire_record_all_zero) {
 
         fclose(f);
     }
+}
+
+TEST(MeasureRecordReader, start_and_read_entire_record_ptb64_dense) {
+    FILE *f = tmpfile();
+    simd_bits saved1 = simd_bits::random(64 * 71, SHARED_TEST_RNG());
+    simd_bits saved2 = simd_bits::random(64 * 71, SHARED_TEST_RNG());
+    for (size_t k = 0; k < 64*71 / 8; k++) {
+        putc(saved1.u8[k], f);
+    }
+    for (size_t k = 0; k < 64*71 / 8; k++) {
+        putc(saved2.u8[k], f);
+    }
+    rewind(f);
+
+    simd_bits loaded(71);
+    auto reader = MeasureRecordReader::make(f, SAMPLE_FORMAT_PTB64, 71, 0, 0);
+    for (size_t shot = 0; shot < 64; shot++) {
+        ASSERT_TRUE(reader->start_and_read_entire_record(loaded));
+        for (size_t m = 0; m < 71; m++) {
+            ASSERT_EQ(saved1[m*64 + shot], loaded[m]);
+        }
+    }
+    for (size_t shot = 0; shot < 64; shot++) {
+        ASSERT_TRUE(reader->start_and_read_entire_record(loaded));
+        for (size_t m = 0; m < 71; m++) {
+            ASSERT_EQ(saved2[m*64 + shot], loaded[m]);
+        }
+    }
+    ASSERT_FALSE(reader->start_and_read_entire_record(loaded));
+}
+
+TEST(MeasureRecordReader, start_and_read_entire_record_ptb64_sparse) {
+    FILE *f = tmpfile();
+    simd_bits saved1 = simd_bits::random(64 * 71, SHARED_TEST_RNG());
+    simd_bits saved2 = simd_bits::random(64 * 71, SHARED_TEST_RNG());
+    for (size_t k = 0; k < 64*71 / 8; k++) {
+        putc(saved1.u8[k], f);
+    }
+    for (size_t k = 0; k < 64*71 / 8; k++) {
+        putc(saved2.u8[k], f);
+    }
+    rewind(f);
+
+    auto reader = MeasureRecordReader::make(f, SAMPLE_FORMAT_PTB64, 71, 0, 0);
+    for (size_t shot = 0; shot < 64; shot++) {
+        SparseShot loaded;
+        ASSERT_TRUE(reader->start_and_read_entire_record(loaded));
+        std::vector<uint64_t> expected;
+        for (size_t m = 0; m < 71; m++) {
+            if (saved1[m*64 + shot]) {
+                expected.push_back(m);
+            }
+        }
+        ASSERT_EQ(loaded.hits, expected);
+    }
+    for (size_t shot = 0; shot < 64; shot++) {
+        SparseShot loaded;
+        ASSERT_TRUE(reader->start_and_read_entire_record(loaded));
+        std::vector<uint64_t> expected;
+        for (size_t m = 0; m < 71; m++) {
+            if (saved2[m*64 + shot]) {
+                expected.push_back(m);
+            }
+        }
+        ASSERT_EQ(loaded.hits, expected);
+    }
+
+    SparseShot discard;
+    ASSERT_FALSE(reader->start_and_read_entire_record(discard));
 }

--- a/src/stim/io/stim_data_formats.cc
+++ b/src/stim/io/stim_data_formats.cc
@@ -144,11 +144,10 @@ Each 64 bit word (8 bytes) of the data contains bits from the same measurement r
 containing the bits from the last measurement result, and then starts over again with data from the next 64 shots (if
 there are more).
 
-The shots are stored by byte order then significant order. The first shot's data goes into the least significant bit of
-the first byte of each 8 byte group. When the number of shots is not a multiple of 64, the bits corresponding to the
-missing shots are always zero.
+The shots are stored by byte order then significance order. The first shot's data goes into the least significant bit of
+the first byte of each 8 byte group.
 
-This format requires the reader to know the number of bits in each shot.
+This format requires the number of shots to be a multiple of 64.
 This format requires the reader to know the number of shots that were taken.
 
 This format is generally more tedious to work with, but useful for achieving good performance on data processing tasks
@@ -163,22 +162,26 @@ where it is possible to parallelize across shots using SIMD instructions.
     ...     path = str(pathlib.Path(d) / "tmp.dat")
     ...     stim.Circuit("""
     ...         X 1
-    ...         M 0 0 0 0 1 1 1 1 0 0 1 1 0 1
-    ...     """).compile_sampler().sample_write(shots=10, filepath=path, format="ptb64")
+    ...         M 0 1
+    ...     """).compile_sampler().sample_write(shots=64, filepath=path, format="ptb64")
+    ...     assert False
     ...     with open(path, 'rb') as f:
     ...         print(' '.join(hex(e)[2:] for e in f.read()))
-    0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 ff 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ff 3 0 0 0 0 0 0
+    0 0 0 0 0 0 0 0 F F F F F F F F
 )HELP",
             R"PYTHON(
 from typing import List
 
 def save_ptb64(shots: List[List[bool]]):
+    if len(shots) % 64 != 0:
+        raise ValueError("Number of shots must be a multiple of 64.")
+
     output = b""
     for shot_offset in range(0, len(shots), 64):
         bits_per_shot = len(shots[0])
         for measure_index in range(bits_per_shot):
             v = 0
-            for k in reversed(range(min(64, len(shots) - shot_offset))):
+            for k in range(64)[::-1]:
                 v <<= 1
                 v += shots[shot_offset + k][measure_index]
             output += v.to_bytes(8, 'little')
@@ -187,16 +190,22 @@ def save_ptb64(shots: List[List[bool]]):
             R"PYTHON(
 from typing import List
 
-def parse_ptb64(data: bytes, bits_per_shot: int, num_shots: int) -> List[List[bool]]:
+def parse_ptb64(data: bytes, bits_per_shot: int) -> List[List[bool]]:
+    num_shots = int(num_shots)
+    num_shot_groups = num_shots // 64
+    if len(data) * 8 != num_shot_groups * 64 * bits_per_shot:
+        raise ValueError("Number of shots must be a multiple of 64.")
+
     result = [[False] * bits_per_shot for _ in range(num_shots)]
-    group_byte_stride = bits_per_shot * 8
-    for shot_offset in range(num_shots):
-        shot_group = shot_offset // 64
-        shot_stripe = shot_offset % 64
-        for measure_index in range(bits_per_shot):
-            byte_offset = group_byte_stride*shot_group + measure_index * 8 + shot_stripe // 8
-            bit = (data[byte_offset] >> (shot_stripe % 8)) % 2 == 1
-            result[shot_offset][measure_index] = bit
+    for group_index in range(num_shot_groups):
+        group_bit_offset = 64 * bits_per_shot * group_index
+        for m in range(bits_per_shot):
+            m_bit_offset = m * 64
+            for shot in range(64):
+                bit_offset = group_bit_offset + m_bit_offset + shot
+                byte_offset = bit_offset // 8
+                bit = data[bit_offset // 8] & (1 << (bit_offset % 8)) != 0
+                result[shot_offset][measure_index] = bit
     return result
 )PYTHON",
         },

--- a/src/stim/mem/simd_util.cc
+++ b/src/stim/mem/simd_util.cc
@@ -13,3 +13,29 @@
 // limitations under the License.
 
 #include "stim/mem/simd_util.h"
+
+template<uint64_t mask, uint64_t shift>
+void inplace_transpose_64x64_pass(uint64_t *data) {
+    for (size_t k = 0; k < 64; k++) {
+        if (k & shift) {
+            continue;
+        }
+        uint64_t& x = data[k];
+        uint64_t& y = data[k + shift];
+        uint64_t a = x & mask;
+        uint64_t b = x & ~mask;
+        uint64_t c = y & mask;
+        uint64_t d = y & ~mask;
+        x = a | (c << shift);
+        y = (b >> shift) | d;
+    }
+}
+
+void stim::inplace_transpose_64x64(uint64_t *data) {
+    inplace_transpose_64x64_pass<0x5555555555555555UL, 1>(data);
+    inplace_transpose_64x64_pass<0x3333333333333333UL, 2>(data);
+    inplace_transpose_64x64_pass<0x0F0F0F0F0F0F0F0FUL, 4>(data);
+    inplace_transpose_64x64_pass<0x00FF00FF00FF00FFUL, 8>(data);
+    inplace_transpose_64x64_pass<0x0000FFFF0000FFFFUL, 16>(data);
+    inplace_transpose_64x64_pass<0x00000000FFFFFFFFUL, 32>(data);
+}

--- a/src/stim/mem/simd_util.h
+++ b/src/stim/mem/simd_util.h
@@ -35,6 +35,8 @@ inline uint64_t spread_bytes_32_to_64(uint32_t v) {
     return ((r << 8) | r) & 0xFF00FF00FF00FFULL;
 }
 
+void inplace_transpose_64x64(uint64_t *data);
+
 inline uint8_t popcnt64(uint64_t val) {
     val -= (val >> 1) & 0x5555555555555555ULL;
     val = (val & 0x3333333333333333ULL) + ((val >> 2) & 0x3333333333333333ULL);

--- a/src/stim/mem/simd_util.test.cc
+++ b/src/stim/mem/simd_util.test.cc
@@ -172,3 +172,14 @@ TEST(simd_util, popcnt64) {
         }
     }
 }
+
+TEST(simd_util, inplace_transpose_64x64) {
+    simd_bits data = simd_bits::random(64*64, SHARED_TEST_RNG());
+    simd_bits copy = data;
+    inplace_transpose_64x64(copy.u64);
+    for (size_t i = 0; i < 64; i++) {
+        for (size_t j = 0; j < 64; j++) {
+            ASSERT_EQ(data[i*64 + j], copy[j*64 + i]);
+        }
+    }
+}


### PR DESCRIPTION
- BREAKING CHANGE: ptb64 format now requires shot count to be a multiple of 64 when reading or writing
- Refactor record readers to only support whole-record reading (partial reading was just adding complexity and not being used)
- Add MeasureRecordReaderFormatPTB64 based on caching the shots as needed
-