### PR TITLE
Stop adding dummy edges to ensure one connected component for pymatching

### DIFF
--- a/glue/sample/requirements.txt
+++ b/glue/sample/requirements.txt
@@ -1,7 +1,7 @@
-matplotlib == 3.5.1
-networkx == 2.6.3
-numpy == 1.22.2
-pymatching == 0.6.0
-pytest == 7.0.1
-pandas == 1.4.1
-stim == 1.8.0
+matplotlib ~= 3.5
+networkx ~= 2.6
+numpy ~= 1.22
+pymatching ~= 0.7.0
+pytest ~= 7.0
+pandas ~= 1.4
+stim ~= 1.9

--- a/glue/sample/src/sinter/decoding_pymatching.py
+++ b/glue/sample/src/sinter/decoding_pymatching.py
@@ -103,7 +103,7 @@ def detector_error_model_to_nx_graph(model: stim.DetectorErrorModel) -> nx.Graph
         if g.has_edge(*dets):
             edge_data = g.get_edge_data(*dets)
             old_p = edge_data["error_probability"]
-            old_frame_changes = edge_data["qubit_id"]
+            old_frame_changes = edge_data["fault_ids"]
             # If frame changes differ, the code has distance 2; just keep whichever was first.
             if set(old_frame_changes) == set(frame_changes):
                 p = p * (1 - old_p) + old_p * (1 - p)
@@ -111,7 +111,7 @@ def detector_error_model_to_nx_graph(model: stim.DetectorErrorModel) -> nx.Graph
         if p > 0.5:
             p = 1 - p
         if p > 0:
-            g.add_edge(*dets, weight=math.log((1 - p) / p), qubit_id=frame_changes, error_probability=p)
+            g.add_edge(*dets, weight=math.log((1 - p) / p), fault_ids=frame_changes, error_probability=p)
 
     def handle_detector_coords(detector: int, coords: np.ndarray):
         g.add_node(detector, coords=coords)
@@ -132,6 +132,6 @@ def detector_error_model_to_pymatching_graph(model: stim.DetectorErrorModel) -> 
         g.add_node(k)
     # Ensure invincible observables are seen by adding a boundary edge with all observables.
     g.add_node(num_detectors + 1)
-    g.add_edge(num_detectors, num_detectors + 1, weight=1, qubit_id=list(range(num_observables)))
+    g.add_edge(num_detectors, num_detectors + 1, weight=1, fault_ids=list(range(num_observables)))
 
     return pymatching.Matching(g)

--- a/glue/sample/src/sinter/decoding_test.py
+++ b/glue/sample/src/sinter/decoding_test.py
@@ -105,6 +105,24 @@ def test_no_observables():
     assert result.errors == 0
 
 
+def test_invincible_observables():
+    c = stim.Circuit("""
+        X_ERROR(0.1) 0
+        M 0 1
+        DETECTOR rec[-2]
+        OBSERVABLE_INCLUDE(1) rec[-1]
+    """)
+    result = sample_decode(
+        circuit=c,
+        decoder_error_model=c.detector_error_model(decompose_errors=True),
+        num_shots=1000,
+        decoder='pymatching',
+    )
+    assert result.discards == 0
+    assert result.shots == 1000
+    assert result.errors == 0
+
+    
 @pytest.mark.parametrize("offset", range(8))
 def test_observable_offsets_mod8(offset: int):
     c = stim.Circuit("""


### PR DESCRIPTION
- pymatching no longer requires the input to have just one connected component
- Use new 'fault_ids' instead of old 'qubit_id' on edges
- Add a test that invincible observables work correctly
- Loosen sinter's declared requirements