### PR TITLE
Install `stim` command line tool when pip installing stim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
     env:
       CIBW_BUILD: "${{ matrix.os_dist.dist }}"
       CIBW_TEST_REQUIRES: cirq-core pytest
-      CIBW_TEST_COMMAND: pytest {project}/src {project}/glue/cirq
+      CIBW_TEST_COMMAND: pytest {project}/src {project}/glue/cirq && stim help
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/doc/developer_documentation.md
+++ b/doc/developer_documentation.md
@@ -437,12 +437,12 @@ python -c "import stimzx; import doctest; assert doctest.testmod(stimzx).failed 
 Because stim is a C++ extension, it is non-trivial to create working
 python packages for it.
 To make cross-platform release wheels, we rely heavily on cibuildwheels.
-To make development wheels, we various other options are possible.
+To make development wheels, various other options are possible.
 
 ## <a name="pypackage.stim.cibuildwheels"></a>python packaging `stim` with cibuildwheels
 
-When a commit is merged into the `main` branch of stim's github repository,
-there are github actions that use [cibuildwheels](https://github.com/pypa/cibuildwheel)
+When a commit is merged into the `main` branch of stim's GitHub repository,
+there are GitHub actions that use [cibuildwheels](https://github.com/pypa/cibuildwheel)
 to build wheels for all supported platforms.
 
 When these wheels are finished building, they are automatically uploaded to
@@ -491,7 +491,7 @@ You can directly install stim as a development python wheel by using pip (very s
 ```bash
 # from the repository root
 pip install -e .
-# output is at dist/*
+# stim is now installed in current virtualenv as dev reference
 ```
 
 

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -264,6 +264,7 @@
     - [`stim.TableauSimulator.ycy`](#stim.TableauSimulator.ycy)
     - [`stim.TableauSimulator.ycz`](#stim.TableauSimulator.ycz)
     - [`stim.TableauSimulator.z`](#stim.TableauSimulator.z)
+- [`stim.main`](#stim.main)
 - [`stim.read_shot_data_file`](#stim.read_shot_data_file)
 - [`stim.target_combiner`](#stim.target_combiner)
 - [`stim.target_inv`](#stim.target_inv)
@@ -611,6 +612,70 @@
 >     )
 > ```
 
+<a name="stim.main"></a>
+## `stim.main(*, command_line_args: List[str]) -> int`
+> ```
+> Runs the command line tool version of stim on the given arguments.
+> 
+> Note that by default any input will be read from stdin, any output
+> will print to stdout (as opposed to being intercepted). For most
+> commands, you can use arguments like `--out` to write to a file
+> instead of stdout and `--in` to read from a file instead of stdin.
+> 
+> Returns:
+>     An exit code (0 means success, not zero means failure).
+> 
+> Raises:
+>     A large variety of errors, depending on what you are doing and
+>     how it failed! Beware that many errors are caught by the main
+>     method itself and printed to stderr, with the only indication
+>     that something went wrong being the return code.
+> 
+> Example:
+>     >>> stim.main(command_line_args=[
+>     ...     "gen",
+>     ...     "--code=repetition_code",
+>     ...     "--task=memory",
+>     ...     "--rounds=1000",
+>     ...     "--distance=2",
+>     ... ])
+>     # Generated repetition_code circuit.
+>     # task: memory
+>     # rounds: 1000
+>     # distance: 2
+>     # before_round_data_depolarization: 0
+>     # before_measure_flip_probability: 0
+>     # after_reset_flip_probability: 0
+>     # after_clifford_depolarization: 0
+>     # layout:
+>     # L0 Z1 d2
+>     # Legend:
+>     #     d# = data qubit
+>     #     L# = data qubit with logical observable crossing
+>     #     Z# = measurement qubit
+>     R 0 1 2
+>     TICK
+>     CX 0 1
+>     TICK
+>     CX 2 1
+>     TICK
+>     MR 1
+>     DETECTOR(1, 0) rec[-1]
+>     REPEAT 999 {
+>         TICK
+>         CX 0 1
+>         TICK
+>         CX 2 1
+>         TICK
+>         MR 1
+>         SHIFT_COORDS(0, 1)
+>         DETECTOR(1, 0) rec[-1] rec[-2]
+>     }
+>     M 0 2
+>     DETECTOR(1, 1) rec[-1] rec[-2] rec[-3]
+>     OBSERVABLE_INCLUDE(0) rec[-1]
+> ```
+
 <a name="stim.read_shot_data_file"></a>
 ## `stim.read_shot_data_file(*, path: str, format: str, num_measurements: handle = None, num_detectors: handle = None, num_observables: handle = None, bit_pack: bool = False) -> object`
 > ```
@@ -665,7 +730,7 @@
 > ```
 
 <a name="stim.target_inv"></a>
-## `stim.target_inv(qubit_index: int) -> int`
+## `stim.target_inv(qubit_index: int) -> stim.GateTarget`
 > ```
 > Returns a target flagged as inverted that can be passed into Circuit.append_operation
 > For example, the '!1' in 'M 0 !1 2' is qubit 1 flagged as inverted,
@@ -696,7 +761,7 @@
 > ```
 
 <a name="stim.target_rec"></a>
-## `stim.target_rec(lookback_index: int) -> int`
+## `stim.target_rec(lookback_index: int) -> stim.GateTarget`
 > ```
 > Returns a record target that can be passed into Circuit.append_operation.
 > For example, the 'rec[-2]' in 'DETECTOR rec[-2]' is a record target.
@@ -745,28 +810,28 @@
 > ```
 
 <a name="stim.target_sweep_bit"></a>
-## `stim.target_sweep_bit(sweep_bit_index: int) -> int`
+## `stim.target_sweep_bit(sweep_bit_index: int) -> stim.GateTarget`
 > ```
 > Returns a sweep bit target that can be passed into Circuit.append_operation
 > For example, the 'sweep[5]' in 'CNOT sweep[5] 7' is from `stim.target_sweep_bit(5)`.
 > ```
 
 <a name="stim.target_x"></a>
-## `stim.target_x(qubit_index: int, invert: bool = False) -> int`
+## `stim.target_x(qubit_index: int, invert: bool = False) -> stim.GateTarget`
 > ```
 > Returns a target flagged as Pauli X that can be passed into Circuit.append_operation
 > For example, the 'X1' in 'CORRELATED_ERROR(0.1) X1 Y2 Z3' is qubit 1 flagged as Pauli X.
 > ```
 
 <a name="stim.target_y"></a>
-## `stim.target_y(qubit_index: int, invert: bool = False) -> int`
+## `stim.target_y(qubit_index: int, invert: bool = False) -> stim.GateTarget`
 > ```
 > Returns a target flagged as Pauli Y that can be passed into Circuit.append_operation
 > For example, the 'Y2' in 'CORRELATED_ERROR(0.1) X1 Y2 Z3' is qubit 2 flagged as Pauli Y.
 > ```
 
 <a name="stim.target_z"></a>
-## `stim.target_z(qubit_index: int, invert: bool = False) -> int`
+## `stim.target_z(qubit_index: int, invert: bool = False) -> stim.GateTarget`
 > ```
 > Returns a target flagged as Pauli Z that can be passed into Circuit.append_operation
 > For example, the 'Z3' in 'CORRELATED_ERROR(0.1) X1 Y2 Z3' is qubit 3 flagged as Pauli Z.
@@ -3687,9 +3752,6 @@
 > 
 > Returns:
 >     The mutated Pauli string.
-> 
-> Raises:
->     ValueError: The Pauli strings have different lengths.
 > ```
 
 <a name="stim.PauliString.__init__"></a>

--- a/glue/python/src/stim/_main_argv.py
+++ b/glue/python/src/stim/_main_argv.py
@@ -1,0 +1,11 @@
+import sys
+
+import stim
+
+
+def main_argv():
+    stim.main(command_line_args=sys.argv[1:])
+
+
+if __name__ == '__main__':
+    main_argv()

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,9 @@ setup(
     packages=['stim'],
     package_dir={'stim': 'glue/python/src/stim'},
     install_requires=['numpy'],
+    entry_points={
+        'console_scripts': ['stim=stim._main_argv:main_argv'],
+    },
     # Needed on Windows to avoid the default `build` colliding with Bazel's `BUILD`.
     options={'build': {'build_base': 'python_build_stim'}},
 )

--- a/src/stim/circuit/gate_target.cc
+++ b/src/stim/circuit/gate_target.cc
@@ -41,8 +41,8 @@ GateTarget GateTarget::qubit(uint32_t qubit, bool inverted) {
     return {qubit | (TARGET_INVERTED_BIT * inverted)};
 }
 GateTarget GateTarget::rec(int32_t lookback) {
-    if (lookback >= 0 || lookback < -(int32_t)TARGET_VALUE_MASK) {
-        throw std::invalid_argument("lookback further than " + std::to_string(-(int32_t)TARGET_VALUE_MASK));
+    if (lookback >= 0 || lookback <= -(1 << 24)) {
+        throw std::out_of_range("Need -16777215 <= lookback <= -1");
     }
     return {((uint32_t)-lookback) | TARGET_RECORD_BIT};
 }

--- a/src/stim/circuit/gate_target.test.cc
+++ b/src/stim/circuit/gate_target.test.cc
@@ -121,9 +121,9 @@ TEST(gate_target, qubit) {
 }
 
 TEST(gate_target, record) {
-    ASSERT_THROW({ GateTarget::rec(1); }, std::invalid_argument);
-    ASSERT_THROW({ GateTarget::rec(0); }, std::invalid_argument);
-    ASSERT_THROW({ GateTarget::rec(-(int32_t{1} << 30)); }, std::invalid_argument);
+    ASSERT_THROW({ GateTarget::rec(1); }, std::out_of_range);
+    ASSERT_THROW({ GateTarget::rec(0); }, std::out_of_range);
+    ASSERT_THROW({ GateTarget::rec(-(int32_t{1} << 30)); }, std::out_of_range);
 
     auto t = GateTarget::rec(-5);
     ASSERT_EQ(t.is_combiner(), false);

--- a/src/stim/simulators/tableau_simulator.pybind.cc
+++ b/src/stim/simulators/tableau_simulator.pybind.cc
@@ -44,9 +44,13 @@ TempViewableData args_to_targets(PyTableauSimulator &self, const pybind11::args 
     uint32_t max_q = 0;
     try {
         for (const auto &e : args) {
-            uint32_t q = e.cast<uint32_t>();
-            max_q = std::max(max_q, q & TARGET_VALUE_MASK);
-            arguments.push_back(GateTarget{q});
+            if (pybind11::isinstance<GateTarget>(e)) {
+                arguments.push_back(pybind11::cast<GateTarget>(e));
+            } else {
+                uint32_t q = e.cast<uint32_t>();
+                max_q = std::max(max_q, q & TARGET_VALUE_MASK);
+                arguments.push_back(GateTarget{q});
+            }
         }
     } catch (const pybind11::cast_error &) {
         throw std::out_of_range("Target qubits must be non-negative integers.");

--- a/src/stim/stabilizers/pauli_string.pybind.cc
+++ b/src/stim/stabilizers/pauli_string.pybind.cc
@@ -674,9 +674,6 @@ void pybind_pauli_string(pybind11::module &m) {
 
             Returns:
                 The mutated Pauli string.
-
-            Raises:
-                ValueError: The Pauli strings have different lengths.
         )DOC")
             .data());
 


### PR DESCRIPTION
- Add `stim.main` for acting like command line from python
- Add `stim` entrypoint to stim's setup.py
- Fix some documentation typos
- Refactor target methods like `target_x` to return a `stim.GateTarget` instead of a raw integer