### PR TITLE
Add optional bit packing when converting measurements to detection events

### DIFF
--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -2556,21 +2556,30 @@
 > ```
 
 <a name="stim.CompiledMeasurementsToDetectionEventsConverter.convert"></a>
-### `stim.CompiledMeasurementsToDetectionEventsConverter.convert(self, *, measurements: numpy.ndarray[bool], sweep_bits: numpy.ndarray[bool] = None, append_observables: bool) -> numpy.ndarray[bool]`
+### `stim.CompiledMeasurementsToDetectionEventsConverter.convert(self, *, measurements: object, sweep_bits: object = None, append_observables: bool, bit_pack_result: bool = False) -> object`
 > ```
 > Converts measurement data into detection event data.
 > 
 > Args:
->     measurements: A numpy array containing measurement data:
->         dtype=bool8
->         shape=(num_shots, circuit.num_measurements)
->     sweep_bits: A numpy array containing sweep data for `sweep[k]` controls in the circuit:
->         dtype=bool8
->         shape=(num_shots, circuit.num_sweep_bits)
->         Defaults to None (all sweep bits False).
+>     measurements: A numpy array containing measurement data. The dtype of the array is used
+>         to determine if it is bit packed or not.
+> 
+>         dtype=np.bool8 (unpacked data):
+>             shape=(num_shots, circuit.num_measurements)
+>         dtype=np.uint8 (bit packed data):
+>             shape=(num_shots, math.ceil(circuit.num_measurements / 8))
+>     sweep_bits: Optional. A numpy array containing sweep data for the `sweep[k]` controls in the circuit.
+>         The dtype of the array is used to determine if it is bit packed or not.
+> 
+>         dtype=np.bool8 (unpacked data):
+>             shape=(num_shots, circuit.num_sweep_bits)
+>         dtype=np.uint8 (bit packed data):
+>             shape=(num_shots, math.ceil(circuit.num_sweep_bits / 8))
 >     append_observables: When True, the observables in the circuit are included as part of the detection
 >         event data. Specifically, they are treated as if they were additional detectors at the end of the
 >         circuit. When False, observable data is not output.
+>     bit_pack_result: Defaults to False. When set to True, the returned numpy array contains bit packed
+>         data (dtype=np.uint8 with 8 bits per item) instead of unpacked data (dtype=np.bool8).
 > 
 > Returns:
 >     The detection event data in a numpy array:

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -1560,20 +1560,30 @@ class CompiledMeasurementsToDetectionEventsConverter:
     def __repr__(self) -> str:
         """Returns text that is a valid python expression evaluating to an equivalent `stim.CompiledMeasurementsToDetectionEventsConverter`.
         """
-    def convert(self, *, measurements: np.ndarray[bool], sweep_bits: np.ndarray[bool] = None, append_observables: bool) -> np.ndarray[bool]:
+    def convert(self, *, measurements: np.ndarray, sweep_bits: Optional[np.ndarray] = None, append_observables: bool, bit_pack_result: bool = False) -> np.ndarray:
+
         """Converts measurement data into detection event data.
         
         Args:
-            measurements: A numpy array containing measurement data:
-                dtype=bool8
-                shape=(num_shots, circuit.num_measurements)
-            sweep_bits: A numpy array containing sweep data for `sweep[k]` controls in the circuit:
-                dtype=bool8
-                shape=(num_shots, circuit.num_sweep_bits)
-                Defaults to None (all sweep bits False).
+            measurements: A numpy array containing measurement data. The dtype of the array is used
+                to determine if it is bit packed or not.
+        
+                dtype=np.bool8 (unpacked data):
+                    shape=(num_shots, circuit.num_measurements)
+                dtype=np.uint8 (bit packed data):
+                    shape=(num_shots, math.ceil(circuit.num_measurements / 8))
+            sweep_bits: Optional. A numpy array containing sweep data for the `sweep[k]` controls in the circuit.
+                The dtype of the array is used to determine if it is bit packed or not.
+        
+                dtype=np.bool8 (unpacked data):
+                    shape=(num_shots, circuit.num_sweep_bits)
+                dtype=np.uint8 (bit packed data):
+                    shape=(num_shots, math.ceil(circuit.num_sweep_bits / 8))
             append_observables: When True, the observables in the circuit are included as part of the detection
                 event data. Specifically, they are treated as if they were additional detectors at the end of the
                 circuit. When False, observable data is not output.
+            bit_pack_result: Defaults to False. When set to True, the returned numpy array contains bit packed
+                data (dtype=np.uint8 with 8 bits per item) instead of unpacked data (dtype=np.bool8).
         
         Returns:
             The detection event data in a numpy array:

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -1560,20 +1560,30 @@ class CompiledMeasurementsToDetectionEventsConverter:
     def __repr__(self) -> str:
         """Returns text that is a valid python expression evaluating to an equivalent `stim.CompiledMeasurementsToDetectionEventsConverter`.
         """
-    def convert(self, *, measurements: np.ndarray[bool], sweep_bits: np.ndarray[bool] = None, append_observables: bool) -> np.ndarray[bool]:
+    def convert(self, *, measurements: np.ndarray, sweep_bits: Optional[np.ndarray] = None, append_observables: bool, bit_pack_result: bool = False) -> np.ndarray:
+
         """Converts measurement data into detection event data.
         
         Args:
-            measurements: A numpy array containing measurement data:
-                dtype=bool8
-                shape=(num_shots, circuit.num_measurements)
-            sweep_bits: A numpy array containing sweep data for `sweep[k]` controls in the circuit:
-                dtype=bool8
-                shape=(num_shots, circuit.num_sweep_bits)
-                Defaults to None (all sweep bits False).
+            measurements: A numpy array containing measurement data. The dtype of the array is used
+                to determine if it is bit packed or not.
+        
+                dtype=np.bool8 (unpacked data):
+                    shape=(num_shots, circuit.num_measurements)
+                dtype=np.uint8 (bit packed data):
+                    shape=(num_shots, math.ceil(circuit.num_measurements / 8))
+            sweep_bits: Optional. A numpy array containing sweep data for the `sweep[k]` controls in the circuit.
+                The dtype of the array is used to determine if it is bit packed or not.
+        
+                dtype=np.bool8 (unpacked data):
+                    shape=(num_shots, circuit.num_sweep_bits)
+                dtype=np.uint8 (bit packed data):
+                    shape=(num_shots, math.ceil(circuit.num_sweep_bits / 8))
             append_observables: When True, the observables in the circuit are included as part of the detection
                 event data. Specifically, they are treated as if they were additional detectors at the end of the
                 circuit. When False, observable data is not output.
+            bit_pack_result: Defaults to False. When set to True, the returned numpy array contains bit packed
+                data (dtype=np.uint8 with 8 bits per item) instead of unpacked data (dtype=np.bool8).
         
         Returns:
             The detection event data in a numpy array:

--- a/glue/sample/README.md
+++ b/glue/sample/README.md
@@ -28,10 +28,11 @@ specified by the user (such as a target number of errors), saves the results to
 as simple CSV format, and has some basic  plotting functionality for viewing the
 results.
 
-Sinter doesn't support cloud compute, but it does scale extremely well within
+Sinter doesn't support cloud compute, but it does scale well on
 a single machine.
-I've tested it on 2 core machines and 96 core machines, and it consistently gets
-good resource utilization (>95%).
+I've tested it on 2 core machines, 4 core machines, and 96 core machines.
+Although there are potential pitfalls (e.g. setting batch sizes too large causes thrashing),
+sinter generally achieves good resource utilization of the processes you assign to it.
 
 <a name="how_to_install"></a>
 # How to install
@@ -54,7 +55,7 @@ to use sinter's python API.
 
 > **sinter is still in development. Its API is not stable.** 
 
-This example assumes you are in a python environment with stim and sinter
+This example assumes you are in a python environment with sinter
 installed.
 
 ```bash
@@ -101,7 +102,7 @@ def main():
     sinter.plot_error_rate(
         ax=ax,
         stats=samples,
-        curve_func=lambda stat: f"Rotated Surface Code d={stat.json_metadata['d']}",
+        group_func=lambda stat: f"Rotated Surface Code d={stat.json_metadata['d']}",
         x_func=lambda stat: stat.json_metadata['p'],
     )
     ax.loglog()
@@ -203,9 +204,9 @@ You can use sinter to collect statistics on each circuit by using the `sinter co
 This command takes options specifying how much data to collect, how to do decoding, etc.
 
 By default, sinter writes the collected statistics to stdout as CSV data.
-One particularly important option that changes this behavior is `-save_resume_filepath`,
+One particularly important option that changes this behavior is `--save_resume_filepath`,
 which allows the command to be interrupted and restarted without losing data.
-Any data already at the file specified by `-save_resume_filepath` will count towards the
+Any data already at the file specified by `--save_resume_filepath` will count towards the
 amount of statistics asked to be collected, and sinter will append new statistics to this file
 instead of overwriting it.
 

--- a/glue/sample/src/sinter/main_plot.py
+++ b/glue/sample/src/sinter/main_plot.py
@@ -163,7 +163,7 @@ def plot(
         plot_error_rate(
             ax=ax_err,
             stats=plotted_stats,
-            curve_func=group_func,
+            group_func=group_func,
             x_func=x_func,
             highlight_likelihood_ratio=highlight_likelihood_ratio,
             plot_args_func=lambda k, _: {'marker': MARKERS[k]},
@@ -180,7 +180,7 @@ def plot(
         plot_discard_rate(
             ax=ax_dis,
             stats=plotted_stats,
-            curve_func=group_func,
+            group_func=group_func,
             x_func=x_func,
             highlight_likelihood_ratio=highlight_likelihood_ratio,
             plot_args_func=lambda k, _: {'marker': MARKERS[k]},

--- a/glue/sample/src/sinter/plotting.py
+++ b/glue/sample/src/sinter/plotting.py
@@ -92,7 +92,7 @@ def plot_discard_rate(
         ax: 'plt.Axes',
         stats: 'Iterable[sinter.TaskStats]',
         x_func: Callable[['sinter.TaskStats'], float],
-        curve_func: Callable[['sinter.TaskStats'], TCurveId] = lambda _: None,
+        group_func: Callable[['sinter.TaskStats'], TCurveId] = lambda _: None,
         plot_args_func: Callable[[int, TCurveId], Dict[str, Any]] = lambda _: {},
         highlight_likelihood_ratio: Optional[float] = 1e-3,
 ) -> None:
@@ -103,13 +103,13 @@ def plot_discard_rate(
         stats: The collected statistics to plot.
         x_func: The X coordinate to use for each stat's data point. For example, this could be
             `x_func=lambda stat: stat.json_metadata['physical_error_rate']`.
-        curve_func: Optional. When specified, multiple curves will be plotted instead of one curve.
+        group_func: Optional. When specified, multiple curves will be plotted instead of one curve.
             The statistics are grouped into curves based on whether or not they get the same result
-            out of this function. For example, this could be `curve_func=lambda stat: stat.decoder`.
+            out of this function. For example, this could be `group_func=lambda stat: stat.decoder`.
         plot_args_func: Optional. Specifies additional arguments to give the the underlying calls to
             `plot` and `fill_between` used to do the actual plotting. For example, this can be used
             to specify markers and colors. Takes the index of the curve in sorted order and also a
-            curve_id (these will be 0 and None respectively if curve_func is not specified). For example,
+            curve_id (these will be 0 and None respectively if group_func is not specified). For example,
             this could be:
 
                 plot_args_func=lambda index, curve_id: {'color': 'red'
@@ -121,7 +121,7 @@ def plot_discard_rate(
             as likely as the max likelihood hypothesis will be highlighted.
     """
 
-    curve_groups = group_by(stats, key=curve_func)
+    curve_groups = group_by(stats, key=group_func)
     for k, curve_id in enumerate(sorted(curve_groups.keys(), key=better_sorted_str_terms)):
         stats = sorted(curve_groups[curve_id], key=x_func)
 
@@ -166,7 +166,7 @@ def plot_error_rate(
         ax: 'plt.Axes',
         stats: 'Iterable[sinter.TaskStats]',
         x_func: Callable[['sinter.TaskStats'], float],
-        curve_func: Callable[['sinter.TaskStats'], TCurveId] = lambda _: None,
+        group_func: Callable[['sinter.TaskStats'], TCurveId] = lambda _: None,
         plot_args_func: Callable[[int, TCurveId], Dict[str, Any]] = lambda _k, _c: {'marker': MARKERS[_k]},
         highlight_likelihood_ratio: Optional[float] = 1e-3,
 ) -> None:
@@ -177,13 +177,13 @@ def plot_error_rate(
         stats: The collected statistics to plot.
         x_func: The X coordinate to use for each stat's data point. For example, this could be
             `x_func=lambda stat: stat.json_metadata['physical_error_rate']`.
-        curve_func: Optional. When specified, multiple curves will be plotted instead of one curve.
+        group_func: Optional. When specified, multiple curves will be plotted instead of one curve.
             The statistics are grouped into curves based on whether or not they get the same result
-            out of this function. For example, this could be `curve_func=lambda stat: stat.decoder`.
+            out of this function. For example, this could be `group_func=lambda stat: stat.decoder`.
         plot_args_func: Optional. Specifies additional arguments to give the the underlying calls to
             `plot` and `fill_between` used to do the actual plotting. For example, this can be used
             to specify markers and colors. Takes the index of the curve in sorted order and also a
-            curve_id (these will be 0 and None respectively if curve_func is not specified). For example,
+            curve_id (these will be 0 and None respectively if group_func is not specified). For example,
             this could be:
 
                 plot_args_func=lambda index, curve_id: {'color': 'red'
@@ -194,7 +194,7 @@ def plot_error_rate(
             Set to this a value between 0 and 1, and the hypothesis probabilities at least that many times
             as likely as the max likelihood hypothesis will be highlighted.
     """
-    curve_groups = group_by(stats, key=curve_func)
+    curve_groups = group_by(stats, key=group_func)
     for k, curve_id in enumerate(sorted(curve_groups.keys(), key=better_sorted_str_terms)):
         stats = sorted(curve_groups[curve_id], key=x_func)
 

--- a/glue/sample/src/sinter/plotting_test.py
+++ b/glue/sample/src/sinter/plotting_test.py
@@ -23,14 +23,14 @@ def test_plotting_does_not_crash():
     sinter.plot_error_rate(
         ax=ax,
         stats=stats,
-        curve_func=lambda e: f"Rotated Surface Code d={e.json_metadata['d']}",
+        group_func=lambda e: f"Rotated Surface Code d={e.json_metadata['d']}",
         x_func=lambda e: e.json_metadata['p'],
         plot_args_func=lambda k, e: {'marker': "ov*sp^<>8PhH+xXDd|"[k]},
     )
     sinter.plot_discard_rate(
         ax=ax,
         stats=stats,
-        curve_func=lambda e: f"Rotated Surface Code d={e.json_metadata['d']}",
+        group_func=lambda e: f"Rotated Surface Code d={e.json_metadata['d']}",
         x_func=lambda e: e.json_metadata['p'],
         plot_args_func=lambda k, e: {'marker': "ov*sp^<>8PhH+xXDd|"[k]},
     )

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -488,7 +488,7 @@ pybind11::class_<Circuit> pybind_circuit(pybind11::module &m) {
                 for (auto t : op.target_data.args) {
                     args.append(t);
                 }
-                if (op.target_data.args.size() == 0) {
+                if (op.target_data.args.empty()) {
                     // Backwards compatibility.
                     result.append(pybind11::make_tuple(op.gate->name, targets, 0));
                 } else if (op.target_data.args.size() == 1) {
@@ -674,7 +674,8 @@ pybind11::class_<Circuit> pybind_circuit(pybind11::module &m) {
             pybind11::arg("name"),
             pybind11::arg("targets") = pybind11::make_tuple(),
             pybind11::arg("arg") = pybind11::none(),
-            k == 0 ? "[DEPRECATED] use stim.Circuit.append instead" : clean_doc_string(u8R"DOC(
+            k == 0 ? "[DEPRECATED] use stim.Circuit.append instead"
+                   : clean_doc_string(u8R"DOC(
                 Appends an operation into the circuit.
                 @overload def append(self, name: str, targets: Union[int, stim.GateTarget, Iterable[Union[int, stim.GateTarget]]], arg: Union[float, Iterable[float]]) -> None:
                 @overload def append(self, name: Union[stim.CircuitOperation, stim.CircuitRepeatBlock]) -> None:
@@ -721,7 +722,7 @@ pybind11::class_<Circuit> pybind_circuit(pybind11::module &m) {
                         `cirq.append_operation` (but not `cirq.append`) will default to a single 0.0 argument for gates
                         that take exactly one argument.
             )DOC")
-                .data());
+                         .data());
     }
 
     c.def(

--- a/src/stim/dem/detector_error_model_target.pybind.cc
+++ b/src/stim/dem/detector_error_model_target.pybind.cc
@@ -20,7 +20,7 @@
 using namespace stim;
 using namespace stim_pybind;
 
-void pybind_detector_error_model_target(pybind11::module &m) {
+void stim_pybind::pybind_detector_error_model_target(pybind11::module &m) {
     auto c = pybind11::class_<ExposedDemTarget>(
         m, "DemTarget", "An instruction target from a detector error model (.dem) file.");
 

--- a/src/stim/dem/detector_error_model_target.pybind.h
+++ b/src/stim/dem/detector_error_model_target.pybind.h
@@ -19,6 +19,8 @@
 
 #include "stim/dem/detector_error_model.h"
 
+namespace stim_pybind {
+
 struct ExposedDemTarget : stim::DemTarget {
     std::string repr() const;
     ExposedDemTarget(stim::DemTarget target);
@@ -29,5 +31,7 @@ struct ExposedDemTarget : stim::DemTarget {
 };
 
 void pybind_detector_error_model_target(pybind11::module &m);
+
+}  // namespace stim_pybind
 
 #endif

--- a/src/stim/io/read_write.pybind.h
+++ b/src/stim/io/read_write.pybind.h
@@ -15,8 +15,20 @@
 #ifndef _STIM_IO_READ_WRITE_PYBIND_H
 #define _STIM_IO_READ_WRITE_PYBIND_H
 
+#include <cstddef>
 #include <pybind11/pybind11.h>
 
+#include "stim/mem/simd_bit_table.h"
+
+namespace stim_pybind {
+
+stim::simd_bit_table numpy_array_to_transposed_simd_table(
+    const pybind11::object &data, size_t expected_bits_per_shot, size_t *num_shots_out);
+pybind11::object transposed_simd_bit_table_to_numpy(
+    const stim::simd_bit_table &table, size_t bits_per_shot, size_t num_shots, bool bit_pack_result);
+
 void pybind_read_write(pybind11::module &m);
+
+}  // namespace stim_pybind
 
 #endif

--- a/src/stim/io/read_write_pytest.py
+++ b/src/stim/io/read_write_pytest.py
@@ -115,7 +115,7 @@ def test_write_shot_data_file_01():
     with tempfile.TemporaryDirectory() as d:
         path = str(pathlib.Path(d) / 'file.01')
 
-        with pytest.raises(ValueError, match='bool8 but data.shape'):
+        with pytest.raises(ValueError, match='4 bits per shot.+bool8'):
             stim.write_shot_data_file(
                 data=np.array([
                     [0, 1, 0],
@@ -126,7 +126,7 @@ def test_write_shot_data_file_01():
                 num_measurements=4,
             )
 
-        with pytest.raises(ValueError, match='uint8 but data.shape'):
+        with pytest.raises(ValueError, match='4 bits per shot.+uint8'):
             stim.write_shot_data_file(
                 data=np.array([
                     [0, 1, 0],

--- a/src/stim/py/compiled_detector_sampler.pybind.cc
+++ b/src/stim/py/compiled_detector_sampler.pybind.cc
@@ -18,8 +18,8 @@
 #include "stim/py/base.pybind.h"
 #include "stim/simulators/detection_simulator.h"
 #include "stim/simulators/frame_simulator.h"
-#include "stim/simulators/tableau_simulator.h"
 #include "stim/simulators/measurements_to_detection_events.pybind.h"
+#include "stim/simulators/tableau_simulator.h"
 
 using namespace stim;
 using namespace stim_pybind;
@@ -82,7 +82,16 @@ void CompiledDetectorSampler::sample_write(
     RaiiFile out(filepath.data(), "w");
     RaiiFile obs_out(obs_out_filepath, "w");
     auto parsed_obs_out_format = format_to_enum(obs_out_format);
-    detector_samples_out(circuit, num_samples, prepend_observables, append_observables, out.f, f, *prng, obs_out.f, parsed_obs_out_format);
+    detector_samples_out(
+        circuit,
+        num_samples,
+        prepend_observables,
+        append_observables,
+        out.f,
+        f,
+        *prng,
+        obs_out.f,
+        parsed_obs_out_format);
 }
 
 std::string CompiledDetectorSampler::repr() const {

--- a/src/stim/py/stim.pybind.cc
+++ b/src/stim/py/stim.pybind.cc
@@ -19,6 +19,7 @@
 #include "stim/circuit/circuit.pybind.h"
 #include "stim/dem/detector_error_model.pybind.h"
 #include "stim/io/read_write.pybind.h"
+#include "stim/main_namespaced.h"
 #include "stim/py/base.pybind.h"
 #include "stim/py/compiled_detector_sampler.pybind.h"
 #include "stim/py/compiled_measurement_sampler.pybind.h"
@@ -29,7 +30,6 @@
 #include "stim/stabilizers/pauli_string.pybind.h"
 #include "stim/stabilizers/tableau.h"
 #include "stim/stabilizers/tableau.pybind.h"
-#include "stim/main_namespaced.h"
 
 #define xstr(s) str(s)
 #define str(s) #s

--- a/src/stim/simulators/measurements_to_detection_events.pybind.cc
+++ b/src/stim/simulators/measurements_to_detection_events.pybind.cc
@@ -285,6 +285,7 @@ void pybind_compiled_measurements_to_detection_events_converter_methods(
         pybind11::arg("bit_pack_result") = false,
         clean_doc_string(u8R"DOC(
             Converts measurement data into detection event data.
+            @signature def convert(self, *, measurements: np.ndarray, sweep_bits: Optional[np.ndarray] = None, append_observables: bool, bit_pack_result: bool = False) -> np.ndarray:
 
             Args:
                 measurements: A numpy array containing measurement data. The dtype of the array is used

--- a/src/stim/simulators/measurements_to_detection_events.pybind.cc
+++ b/src/stim/simulators/measurements_to_detection_events.pybind.cc
@@ -15,6 +15,7 @@
 #include "stim/simulators/measurements_to_detection_events.pybind.h"
 
 #include "stim/circuit/circuit.pybind.h"
+#include "stim/io/read_write.pybind.h"
 #include "stim/py/base.pybind.h"
 #include "stim/simulators/detection_simulator.h"
 #include "stim/simulators/frame_simulator.h"
@@ -28,12 +29,12 @@ CompiledMeasurementsToDetectionEventsConverter::CompiledMeasurementsToDetectionE
     simd_bits ref_sample, Circuit circuit, bool skip_reference_sample)
     : skip_reference_sample(skip_reference_sample),
       ref_sample(ref_sample),
-      circuit(circuit),
       circuit_num_measurements(circuit.count_measurements()),
       circuit_num_sweep_bits(circuit.count_sweep_bits()),
       circuit_num_detectors(circuit.count_detectors()),
       circuit_num_observables(circuit.count_observables()),
-      circuit_num_qubits(circuit.count_qubits()) {
+      circuit_num_qubits(circuit.count_qubits()),
+      circuit(std::move(circuit)) {
 }
 std::string CompiledMeasurementsToDetectionEventsConverter::repr() const {
     std::stringstream result;
@@ -112,51 +113,31 @@ void CompiledMeasurementsToDetectionEventsConverter::convert_file(
         circuit_num_sweep_bits);
 }
 
-pybind11::array_t<bool> CompiledMeasurementsToDetectionEventsConverter::convert(
-    const pybind11::array_t<bool> &measurements, const pybind11::array_t<bool> &sweep_bits, bool append_observables) {
-    size_t num_shots = measurements.shape(0);
-    if (measurements.ndim() != 2) {
-        throw std::invalid_argument("Need len(measurements.shape) == 2");
-    }
-    if ((size_t)measurements.shape(1) != circuit_num_measurements) {
-        throw std::invalid_argument("Need measurements.shape[1] == circuit.num_measurements");
-    }
-    if (sweep_bits.ndim() != 0) {
-        if (sweep_bits.ndim() != 2) {
-            throw std::invalid_argument("Need len(sweep_bits.shape) == 2");
-        }
-        if ((size_t)sweep_bits.shape(1) != circuit_num_sweep_bits) {
-            throw std::invalid_argument("Need sweep_bits.shape[1] == circuit.num_sweep_bits");
-        }
-        if ((size_t)sweep_bits.shape(0) != num_shots) {
+pybind11::object CompiledMeasurementsToDetectionEventsConverter::convert(
+    const pybind11::object &measurements,
+    const pybind11::object &sweep_bits,
+    bool append_observables,
+    bool bit_pack_result) {
+    size_t num_shots;
+    simd_bit_table measurements_minor_shot_index =
+        numpy_array_to_transposed_simd_table(measurements, circuit_num_measurements, &num_shots);
+
+    simd_bit_table sweep_bits_minor_shot_index{0, num_shots};
+    if (!sweep_bits.is_none()) {
+        size_t num_sweep_shots;
+        sweep_bits_minor_shot_index =
+            numpy_array_to_transposed_simd_table(sweep_bits, circuit_num_sweep_bits, &num_sweep_shots);
+        if (num_shots != num_sweep_shots) {
             throw std::invalid_argument("Need sweep_bits.shape[0] == measurements.shape[0]");
         }
     }
 
-    simd_bit_table measurements__minor_shot_index(circuit_num_measurements, num_shots);
-    auto m = measurements.unchecked();
-    for (size_t shot_index = 0; shot_index < num_shots; shot_index++) {
-        for (size_t m_index = 0; m_index < circuit_num_measurements; m_index++) {
-            measurements__minor_shot_index[m_index][shot_index] ^= (bool)m(shot_index, m_index);
-        }
-    }
-
-    simd_bit_table sweep_bits__minor_shot_index(circuit_num_sweep_bits, num_shots);
-    if (sweep_bits.ndim() != 0) {
-        auto s = sweep_bits.unchecked();
-        for (size_t shot_index = 0; shot_index < num_shots; shot_index++) {
-            for (size_t b_index = 0; b_index < circuit_num_sweep_bits; b_index++) {
-                sweep_bits__minor_shot_index[b_index][shot_index] ^= (bool)s(shot_index, b_index);
-            }
-        }
-    }
-
     size_t num_output_bits = circuit_num_detectors + circuit_num_observables * append_observables;
-    simd_bit_table out_detection_results__minor_shot_index(num_output_bits, num_shots);
+    simd_bit_table out_detection_results_minor_shot_index(num_output_bits, num_shots);
     stim::measurements_to_detection_events_helper(
-        measurements__minor_shot_index,
-        sweep_bits__minor_shot_index,
-        out_detection_results__minor_shot_index,
+        measurements_minor_shot_index,
+        sweep_bits_minor_shot_index,
+        out_detection_results_minor_shot_index,
         circuit.aliased_noiseless_circuit(),
         ref_sample,
         append_observables,
@@ -165,22 +146,8 @@ pybind11::array_t<bool> CompiledMeasurementsToDetectionEventsConverter::convert(
         circuit_num_observables,
         circuit_num_qubits);
 
-    std::vector<uint8_t> bytes;
-    bytes.resize(num_output_bits * num_shots);
-    size_t k = 0;
-    for (size_t shot_index = 0; shot_index < num_shots; shot_index++) {
-        for (size_t o_index = 0; o_index < num_output_bits; o_index++) {
-            bytes[k++] = out_detection_results__minor_shot_index[o_index][shot_index];
-        }
-    }
-
-    void *ptr = bytes.data();
-    pybind11::ssize_t itemsize = sizeof(uint8_t);
-    std::vector<pybind11::ssize_t> shape{(pybind11::ssize_t)num_shots, (pybind11::ssize_t)num_output_bits};
-    std::vector<pybind11::ssize_t> stride{(pybind11::ssize_t)num_output_bits, 1};
-    const std::string &format = pybind11::format_descriptor<bool>::value;
-    bool readonly = true;
-    return pybind11::array_t<bool>(pybind11::buffer_info(ptr, itemsize, format, 2, shape, stride, readonly));
+    return transposed_simd_bit_table_to_numpy(
+        out_detection_results_minor_shot_index, num_output_bits, num_shots, bit_pack_result);
 }
 
 pybind11::class_<CompiledMeasurementsToDetectionEventsConverter>
@@ -315,20 +282,30 @@ void pybind_compiled_measurements_to_detection_events_converter_methods(
         pybind11::arg("measurements"),
         pybind11::arg("sweep_bits") = pybind11::none(),
         pybind11::arg("append_observables"),
+        pybind11::arg("bit_pack_result") = false,
         clean_doc_string(u8R"DOC(
             Converts measurement data into detection event data.
 
             Args:
-                measurements: A numpy array containing measurement data:
-                    dtype=bool8
-                    shape=(num_shots, circuit.num_measurements)
-                sweep_bits: A numpy array containing sweep data for `sweep[k]` controls in the circuit:
-                    dtype=bool8
-                    shape=(num_shots, circuit.num_sweep_bits)
-                    Defaults to None (all sweep bits False).
+                measurements: A numpy array containing measurement data. The dtype of the array is used
+                    to determine if it is bit packed or not.
+
+                    dtype=np.bool8 (unpacked data):
+                        shape=(num_shots, circuit.num_measurements)
+                    dtype=np.uint8 (bit packed data):
+                        shape=(num_shots, math.ceil(circuit.num_measurements / 8))
+                sweep_bits: Optional. A numpy array containing sweep data for the `sweep[k]` controls in the circuit.
+                    The dtype of the array is used to determine if it is bit packed or not.
+
+                    dtype=np.bool8 (unpacked data):
+                        shape=(num_shots, circuit.num_sweep_bits)
+                    dtype=np.uint8 (bit packed data):
+                        shape=(num_shots, math.ceil(circuit.num_sweep_bits / 8))
                 append_observables: When True, the observables in the circuit are included as part of the detection
                     event data. Specifically, they are treated as if they were additional detectors at the end of the
                     circuit. When False, observable data is not output.
+                bit_pack_result: Defaults to False. When set to True, the returned numpy array contains bit packed
+                    data (dtype=np.uint8 with 8 bits per item) instead of unpacked data (dtype=np.bool8).
 
             Returns:
                 The detection event data in a numpy array:

--- a/src/stim/simulators/measurements_to_detection_events.pybind.h
+++ b/src/stim/simulators/measurements_to_detection_events.pybind.h
@@ -33,12 +33,13 @@ struct RaiiFile {
 struct CompiledMeasurementsToDetectionEventsConverter {
     const bool skip_reference_sample;
     const stim::simd_bits ref_sample;
-    const stim::Circuit circuit;
     const uint64_t circuit_num_measurements;
     const uint64_t circuit_num_sweep_bits;
     const uint64_t circuit_num_detectors;
     const uint64_t circuit_num_observables;
     const size_t circuit_num_qubits;
+    const stim::Circuit circuit;
+
     CompiledMeasurementsToDetectionEventsConverter() = delete;
     CompiledMeasurementsToDetectionEventsConverter(const CompiledMeasurementsToDetectionEventsConverter &) = delete;
     CompiledMeasurementsToDetectionEventsConverter(CompiledMeasurementsToDetectionEventsConverter &&) = default;
@@ -46,10 +47,11 @@ struct CompiledMeasurementsToDetectionEventsConverter {
     CompiledMeasurementsToDetectionEventsConverter(
         stim::simd_bits ref_sample, stim::Circuit circuit, bool skip_reference_sample);
 
-    pybind11::array_t<bool> convert(
-        const pybind11::array_t<bool> &measurements,
-        const pybind11::array_t<bool> &sweep_bits,
-        bool append_observables);
+    pybind11::object convert(
+        const pybind11::object &measurements,
+        const pybind11::object &sweep_bits,
+        bool append_observables,
+        bool bit_pack_result);
     void convert_file(
         const std::string &measurements_filepath,
         const std::string &measurements_format,


### PR DESCRIPTION
- Add `bit_pack_result=false` argument to m2d convert method
- Extract `stim_pybind::transposed_simd_bit_table_to_numpy` method
- Extract `stim_pybind::numpy_array_to_transposed_simd_table` method
- Fix a few compiler warnings
- Rename curve_func parameter to group_func in sinter to be consistent with command line tool