### PR TITLE
Add `separate_observables=False` argument to measurement-to-detections conversion

### DIFF
--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -2556,7 +2556,7 @@
 > ```
 
 <a name="stim.CompiledMeasurementsToDetectionEventsConverter.convert"></a>
-### `stim.CompiledMeasurementsToDetectionEventsConverter.convert(self, *, measurements: object, sweep_bits: object = None, append_observables: bool, bit_pack_result: bool = False) -> object`
+### `stim.CompiledMeasurementsToDetectionEventsConverter.convert(self, *, measurements: object, sweep_bits: object = None, separate_observables: object = None, append_observables: object = None, bit_pack_result: bool = False) -> object`
 > ```
 > Converts measurement data into detection event data.
 > 
@@ -2575,30 +2575,53 @@
 >             shape=(num_shots, circuit.num_sweep_bits)
 >         dtype=np.uint8 (bit packed data):
 >             shape=(num_shots, math.ceil(circuit.num_sweep_bits / 8))
->     append_observables: When True, the observables in the circuit are included as part of the detection
->         event data. Specifically, they are treated as if they were additional detectors at the end of the
->         circuit. When False, observable data is not output.
+>     separate_observables: Defaults to False. When set to True, two numpy arrays are returned instead of one,
+>         with the second array containing the observable flip data.
+>     append_observables: Defaults to False. When set to True, the observables in the circuit are treated as
+>         if they were additional detectors. Their results are appended to the end of the detection event
+>         data.
 >     bit_pack_result: Defaults to False. When set to True, the returned numpy array contains bit packed
 >         data (dtype=np.uint8 with 8 bits per item) instead of unpacked data (dtype=np.bool8).
 > 
 > Returns:
->     The detection event data in a numpy array:
->         dtype=bool8
->         shape=(num_shots, circuit.num_detectors + circuit.num_observables * append_observables)
+>     The detection event data and (optionally) observable data.
+>     The result is a single numpy array if separate_observables is false, otherwise it's a tuple of two numpy arrays.
+>     When returning two numpy arrays, the first array is the detection event data and the second is the observable flip data.
+>     The dtype of the returned arrays is np.bool8 if bit_pack_result is false, otherwise they're np.uint8 arrays.
+>     shape[0] of the array(s) is the number of shots.
+>     shape[1] of the array(s) is the number of bits per shot (divided by 8 if bit packed) (e.g. for just detection event data it would be circuit.num_detectors).
 > 
 > Examples:
 >     >>> import stim
 >     >>> import numpy as np
 >     >>> converter = stim.Circuit('''
 >     ...    X 0
->     ...    M 0
+>     ...    M 0 1
 >     ...    DETECTOR rec[-1]
+>     ...    DETECTOR rec[-2]
+>     ...    OBSERVABLE_INCLUDE(0) rec[-2]
 >     ... ''').compile_m2d_converter()
->     >>> converter.convert(
->     ...     measurements=np.array([[0], [1]], dtype=np.bool8),
->     ...     append_observables=False,
+>     >>> dets, obs = converter.convert(
+>     ...     measurements=np.array([[1, 0],
+>     ...                            [1, 0],
+>     ...                            [1, 0],
+>     ...                            [0, 0],
+>     ...                            [1, 0]], dtype=np.bool8),
+>     ...     separate_observables=True,
 >     ... )
->     array([[ True],
+>     >>> dets
+>     array([[False, False],
+>            [False, False],
+>            [False, False],
+>            [ True, False],
+>            [False, False],
+>            [False, False]])
+>     >>> obs
+>     array([[False],
+>            [False],
+>            [False],
+>            [ True],
+>            [False],
 >            [False]])
 > ```
 

--- a/src/stim/main_namespaced.cc
+++ b/src/stim/main_namespaced.cc
@@ -198,7 +198,7 @@ int main_mode_measurements_to_detections(int argc, const char **argv) {
     FILE *in = find_open_file_argument("--in", stdin, "r", argc, argv);
     FILE *out = find_open_file_argument("--out", stdout, "w", argc, argv);
     FILE *sweep_in = find_open_file_argument("--sweep", stdin, "r", argc, argv);
-    FILE *obs_out = find_open_file_argument("--out", stdout, "w", argc, argv);
+    FILE *obs_out = find_open_file_argument("--obs_out", stdout, "w", argc, argv);
     if (sweep_in == stdin) {
         sweep_in = nullptr;
     }

--- a/src/stim/simulators/measurements_to_detection_events.pybind.cc
+++ b/src/stim/simulators/measurements_to_detection_events.pybind.cc
@@ -101,7 +101,7 @@ void CompiledMeasurementsToDetectionEventsConverter::convert_file(
         format_sweep_bits,
         detections_out.f,
         format_out,
-        circuit,
+        circuit.aliased_noiseless_circuit(),
         append_observables,
         ref_sample,
         obs_out.f,

--- a/src/stim/simulators/measurements_to_detection_events.pybind.h
+++ b/src/stim/simulators/measurements_to_detection_events.pybind.h
@@ -50,7 +50,8 @@ struct CompiledMeasurementsToDetectionEventsConverter {
     pybind11::object convert(
         const pybind11::object &measurements,
         const pybind11::object &sweep_bits,
-        bool append_observables,
+        const pybind11::object &separate_observables,
+        const pybind11::object &append_observables,
         bool bit_pack_result);
     void convert_file(
         const std::string &measurements_filepath,

--- a/src/stim/simulators/measurements_to_detection_events_test.py
+++ b/src/stim/simulators/measurements_to_detection_events_test.py
@@ -20,11 +20,12 @@ import stim
 
 def test_convert_file_without_sweep_bits():
     converter = stim.Circuit('''
-       X 0
-       CNOT sweep[0] 0
-       M 0
-       DETECTOR rec[-1]
-       OBSERVABLE_INCLUDE(0) rec[-1]
+        X_ERROR(0.1) 0
+        X 0
+        CNOT sweep[0] 0
+        M 0
+        DETECTOR rec[-1]
+        OBSERVABLE_INCLUDE(0) rec[-1]
     ''').compile_m2d_converter()
 
     with tempfile.TemporaryDirectory() as d:
@@ -85,6 +86,7 @@ def test_convert_file_without_sweep_bits():
 
 def test_convert():
     converter = stim.Circuit('''
+       X_ERROR(0.1) 0
        X 0
        CNOT sweep[0] 0
        M 0
@@ -121,6 +123,7 @@ def test_convert():
 def test_convert_bit_packed():
     converter = stim.Circuit('''
        REPEAT 100 {
+           X_ERROR(0.1) 0
            X 0
            MR 0
            DETECTOR rec[-1]
@@ -155,6 +158,7 @@ def test_convert_bit_packed_swept():
     converter = stim.Circuit('''
        REPEAT 100 {
            CNOT sweep[0] 0
+           X_ERROR(0.1) 0
            X 0
            MR 0
            DETECTOR rec[-1]
@@ -194,6 +198,7 @@ def test_convert_bit_packed_swept():
 def test_convert_bit_packed_separate_observables():
     converter = stim.Circuit('''
        REPEAT 100 {
+           X_ERROR(0.1) 0
            X 0
            MR 0
            DETECTOR rec[-1]
@@ -233,6 +238,31 @@ def test_convert_bit_packed_separate_observables():
         np.testing.assert_array_equal(actual_obs, expected_obs_packed)
 
 
+def test_noiseless_conversion():
+    converter = stim.Circuit('''
+       MR 0
+       DETECTOR rec[-1]
+       X 0
+       MR 0
+       DETECTOR rec[-1]
+       OBSERVABLE_INCLUDE(0) rec[-1]
+    ''').compile_m2d_converter()
+
+    measurements = np.array([[0, 0], [0, 1], [1, 0], [1, 1]], dtype=np.bool8)
+    expected_dets = np.array([[0, 1], [0, 0], [1, 1], [1, 0]], dtype=np.bool8)
+    expected_obs = np.array([[1], [0], [1], [0]], dtype=np.bool8)
+
+    actual_dets, actual_obs = converter.convert(
+        measurements=measurements,
+        separate_observables=True,
+    )
+    assert actual_dets.dtype == actual_obs.dtype == np.bool8
+    assert actual_dets.shape == (4, 2)
+    assert actual_obs.shape == (4, 1)
+    np.testing.assert_array_equal(actual_dets, expected_dets)
+    np.testing.assert_array_equal(actual_obs, expected_obs)
+
+
 def test_needs_append_or_separate():
     converter = stim.Circuit().compile_m2d_converter()
     ms = np.zeros(shape=(50, 0), dtype=np.bool8)
@@ -245,3 +275,15 @@ def test_needs_append_or_separate():
     np.testing.assert_array_equal(d1, d3)
     np.testing.assert_array_equal(d1, d4)
     np.testing.assert_array_equal(d1, d5)
+
+
+def test_anticommuting_pieces_combining_into_deterministic_observable():
+    c = stim.Circuit('''
+        MX 0
+        OBSERVABLE_INCLUDE(0) rec[-1]
+        MX 0
+        OBSERVABLE_INCLUDE(0) rec[-1]
+    ''').without_noise()
+    m = c.compile_sampler().sample_bit_packed(shots=1000)
+    det, obs = c.compile_m2d_converter().convert(measurements=m, separate_observables=True)
+    np.testing.assert_array_equal(obs, obs * 0)


### PR DESCRIPTION
- Fix an m2d segfault caused by `convert_file` not using the noiseless variant of a circuit (and triggering a safety check)
- Fix a nasty m2d conversion bug where observables were only keeping their last included component. **This circuit was failing:**

    ```
    MX 0
    OBSERVABLE_INCLUDE(0) rec[-1]
    MX 0
    OBSERVABLE_INCLUDE(0) rec[-1]
    ```