### PR TITLE
Show 'initializing...' when waiting for strong id in sinter

### DIFF
--- a/glue/sample/src/sinter/collection_tracker_for_single_task.py
+++ b/glue/sample/src/sinter/collection_tracker_for_single_task.py
@@ -80,8 +80,8 @@ class CollectionTrackerForSingleTask:
             self.finished_stats += self.existing_data.stats_for(self.task)
         else:
             self.deployed_shots -= result.stats.shots
-            self.deployed_processes -= 1
             self.finished_stats += result.stats
+        self.deployed_processes -= 1
 
     def is_done(self) -> bool:
         if self.task.detector_error_model is None or self.waiting_for_dem:
@@ -144,6 +144,7 @@ class CollectionTrackerForSingleTask:
             if self.waiting_for_dem:
                 return None
             self.waiting_for_dem = True
+            self.deployed_processes += 1
             return WorkIn(
                 work_key=None,
                 task=self.task,
@@ -174,10 +175,13 @@ class CollectionTrackerForSingleTask:
             f'processes={self.deployed_processes}'.ljust(13),
             f'~core_mins_left={t}'.ljust(24),
         ]
-        if self.copts.max_shots is not None:
-            terms.append(f'shots_left={max(0, self.copts.max_shots - self.finished_stats.shots)}'.ljust(20))
-        if self.copts.max_errors is not None:
-            terms.append(f'errors_left={max(0, self.copts.max_errors - self.finished_stats.errors)}'.ljust(20))
+        if self.task.detector_error_model is None:
+            terms.append(f'(initializing...) ')
+        else:
+            if self.copts.max_shots is not None:
+                terms.append(f'shots_left={max(0, self.copts.max_shots - self.finished_stats.shots)}'.ljust(20))
+            if self.copts.max_errors is not None:
+                terms.append(f'errors_left={max(0, self.copts.max_errors - self.finished_stats.errors)}'.ljust(20))
         terms.append(f'{self.task.json_metadata}')
         return ''.join(terms)
 

--- a/glue/sample/src/sinter/main_collect.py
+++ b/glue/sample/src/sinter/main_collect.py
@@ -183,5 +183,5 @@ def main_collect(*, command_line_args: List[str]):
             start_batch_size=args.start_batch_size,
         )
     except KeyboardInterrupt:
+        printer.show_latest_progress('')
         print("\033[33m\nInterrupted\033[0m")
-        return

--- a/glue/sample/src/sinter/printer.py
+++ b/glue/sample/src/sinter/printer.py
@@ -44,7 +44,8 @@ class ThrottledProgressPrinter:
         if dt <= 0:
             self.next_can_print_time = t + self.min_progress_delay
             self.is_worker_running = False
-            print('\033[31m' + self.latest_msg + '\033[0m', file=sys.stderr, flush=True)
+            if self.latest_msg != "":
+                print('\033[31m' + self.latest_msg + '\033[0m', file=sys.stderr, flush=True)
         return max(dt, 0)
 
     def _print_worker(self):


### PR DESCRIPTION
- Fix showing shots left before knowing how many were collected
- Fix redundant status message after keyboardinterrupt
- Switch from any amount of waiting to just immediate SIGKILL-ing of children when shutting down workers