### PR TITLE
Fix compatibility issues with cirq dev

### DIFF
--- a/glue/cirq/stimcirq/_shift_coords_annotation_test.py
+++ b/glue/cirq/stimcirq/_shift_coords_annotation_test.py
@@ -1,22 +1,19 @@
 import cirq
 import numpy as np
-import pytest
 import stim
 import stimcirq
 
 
 def test_conversion():
-    stim_circuit = stim.Circuit(
-        """
+    stim_circuit = stim.Circuit("""
         M 0
         DETECTOR(4) rec[-1]
         SHIFT_COORDS(1, 2, 3)
         DETECTOR(5) rec[-1]
         TICK
-    """
-    )
+    """)
     cirq_circuit = cirq.Circuit(
-        cirq.measure(cirq.LineQubit(0)),
+        cirq.measure(cirq.LineQubit(0), key="0"),
         stimcirq.DetAnnotation(parity_keys=["0"], coordinate_metadata=[4]),
         stimcirq.ShiftCoordsAnnotation((1, 2, 3)),
         stimcirq.DetAnnotation(parity_keys=["0"], coordinate_metadata=[5]),
@@ -25,7 +22,7 @@ def test_conversion():
     assert stimcirq.stim_circuit_to_cirq_circuit(stim_circuit) == cirq_circuit
     assert stimcirq.stim_circuit_to_cirq_circuit(stim_circuit, flatten=False) == cirq_circuit
     assert stimcirq.stim_circuit_to_cirq_circuit(stim_circuit, flatten=True) == cirq.Circuit(
-        cirq.measure(cirq.LineQubit(0)),
+        cirq.measure(cirq.LineQubit(0), key="0"),
         stimcirq.DetAnnotation(parity_keys=["0"], coordinate_metadata=[4]),
         stimcirq.DetAnnotation(parity_keys=["0"], coordinate_metadata=[6]),
     )

--- a/glue/cirq/stimcirq/_stim_to_cirq.py
+++ b/glue/cirq/stimcirq/_stim_to_cirq.py
@@ -7,10 +7,7 @@ from typing import (
     DefaultDict,
     Dict,
     Iterable,
-    Iterator,
     List,
-    Sequence,
-    Set,
     Tuple,
     Union,
 )
@@ -52,6 +49,7 @@ def _proper_transform_circuit_qubits(circuit: cirq.AbstractCircuit, remap: Dict[
             cirq.CircuitOperation(
                 circuit=_proper_transform_circuit_qubits(op.circuit, remap).freeze(),
                 repetitions=op.repetitions,
+                use_repetition_ids=False,
             )
             if isinstance(op, cirq.CircuitOperation)
             else op.with_qubits(*[remap[q] for q in op.qubits])
@@ -122,6 +120,7 @@ class CircuitTranslationTracker:
             cirq.CircuitOperation(
                 cirq.FrozenCircuit(child.full_circuit + child.tick_circuit),
                 repetitions=block.repeat_count,
+                use_repetition_ids=False,
             )
         )
         self.qubit_coords = child.qubit_coords


### PR DESCRIPTION
- Also maintain compat with current version
- Avoid measure key == qubit name due to circuit diagram change
- Avoid implicit measure key from cirq.measure due to change in the default
- Start using `use_repetition_ids`

Fixes https://github.com/quantumlib/Stim/issues/224