### PR TITLE
Various tableau utility methods and compatibility fixes

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@rules_python//python:packaging.bzl", "py_wheel")
+load("@pybind11_bazel//:build_defs.bzl", "pybind_extension")
 
 SOURCE_FILES_NO_MAIN = glob(
     [

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,15 +18,20 @@ http_archive(
 
 http_archive(
     name = "rules_python",
-    sha256 = "954aa89b491be4a083304a2cb838019c8b8c3720a7abb9c4cb81ac7a24230cea",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.4.0/rules_python-0.4.0.tar.gz",
+    sha256 = "5fa3c738d33acca3b97622a13a741129f67ef43f5fdfcec63b29374cc0574c29",
+    strip_prefix = "rules_python-0.9.0",
+    url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.9.0.tar.gz",
 )
 
 http_archive(
     name = "pybind11_bazel",
-    sha256 = "e4a9536f49d4a88e3c5a09954de49c4a18d6b1632c457a62d6ec4878c27f1b5b",
-    strip_prefix = "pybind11_bazel-7f397b5d2cc2434bbd651e096548f7b40c128044",
-    urls = ["https://github.com/pybind/pybind11_bazel/archive/7f397b5d2cc2434bbd651e096548f7b40c128044.zip"],
+    # Patch is a workaround for 3.10 deprecation of distutils causing python_configure to fail.
+    # The patch contents are from https://github.com/jeongukjae/nori-clone/commit/3e4fc321d570ce5dcabccdf1bab1144d839405a7
+    patch_args = ["-p1"],
+    patches = ["//:pybind11_bazel.patch"],
+    sha256 = "fec6281e4109115c5157ca720b8fe20c8f655f773172290b03f57353c11869c2",
+    strip_prefix = "pybind11_bazel-72cbbf1fbc830e487e3012862b7b720001b70672",
+    urls = ["https://github.com/pybind/pybind11_bazel/archive/72cbbf1fbc830e487e3012862b7b720001b70672.zip"],
 )
 
 load("@pybind11_bazel//:python_configure.bzl", "python_configure")

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -219,6 +219,7 @@
     - [`stim.Tableau.prepend`](#stim.Tableau.prepend)
     - [`stim.Tableau.random`](#stim.Tableau.random)
     - [`stim.Tableau.then`](#stim.Tableau.then)
+    - [`stim.Tableau.to_unitary_matrix`](#stim.Tableau.to_unitary_matrix)
     - [`stim.Tableau.x_output`](#stim.Tableau.x_output)
     - [`stim.Tableau.x_output_pauli`](#stim.Tableau.x_output_pauli)
     - [`stim.Tableau.y_output`](#stim.Tableau.y_output)
@@ -244,7 +245,16 @@
     - [`stim.TableauSimulator.measure_many`](#stim.TableauSimulator.measure_many)
     - [`stim.TableauSimulator.peek_bloch`](#stim.TableauSimulator.peek_bloch)
     - [`stim.TableauSimulator.peek_observable_expectation`](#stim.TableauSimulator.peek_observable_expectation)
+    - [`stim.TableauSimulator.peek_x`](#stim.TableauSimulator.peek_x)
+    - [`stim.TableauSimulator.peek_y`](#stim.TableauSimulator.peek_y)
+    - [`stim.TableauSimulator.peek_z`](#stim.TableauSimulator.peek_z)
+    - [`stim.TableauSimulator.postselect_x`](#stim.TableauSimulator.postselect_x)
+    - [`stim.TableauSimulator.postselect_y`](#stim.TableauSimulator.postselect_y)
+    - [`stim.TableauSimulator.postselect_z`](#stim.TableauSimulator.postselect_z)
     - [`stim.TableauSimulator.reset`](#stim.TableauSimulator.reset)
+    - [`stim.TableauSimulator.reset_x`](#stim.TableauSimulator.reset_x)
+    - [`stim.TableauSimulator.reset_y`](#stim.TableauSimulator.reset_y)
+    - [`stim.TableauSimulator.reset_z`](#stim.TableauSimulator.reset_z)
     - [`stim.TableauSimulator.s`](#stim.TableauSimulator.s)
     - [`stim.TableauSimulator.s_dag`](#stim.TableauSimulator.s_dag)
     - [`stim.TableauSimulator.set_inverse_tableau`](#stim.TableauSimulator.set_inverse_tableau)
@@ -4738,6 +4748,40 @@
 >     True
 > ```
 
+<a name="stim.Tableau.to_unitary_matrix"></a>
+### `stim.Tableau.to_unitary_matrix(self, *, endian: str) -> numpy.ndarray[numpy.float32]`
+> ```
+> Converts the tableau into a unitary matrix.
+> 
+> Args:
+>     endian:
+>         "little": The first qubit is the least significant (corresponds
+>             to an offset of 1 in the state vector).
+>         "big": The first qubit is the most significant (corresponds
+>             to an offset of 2**(n - 1) in the state vector).
+> 
+> Returns:
+>     A numpy array with dtype=np.complex64 and shape=(1 << len(tableau), 1 << len(tableau)).
+> 
+> Example:
+>     >>> import stim
+>     >>> cnot = stim.Tableau.from_conjugated_generators(
+>     ...     xs=[
+>     ...         stim.PauliString("XX"),
+>     ...         stim.PauliString("_X"),
+>     ...     ],
+>     ...     zs=[
+>     ...         stim.PauliString("Z_"),
+>     ...         stim.PauliString("ZZ"),
+>     ...     ],
+>     ... )
+>     >>> cnot.to_unitary_matrix(endian='big')
+>     array([[1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+>            [0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j],
+>            [0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j],
+>            [0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j]], dtype=complex64)
+> ```
+
 <a name="stim.Tableau.x_output"></a>
 ### `stim.Tableau.x_output(self, target: int) -> stim.PauliString`
 > ```
@@ -5309,13 +5353,226 @@
 >     IIZ 1
 > ```
 
+<a name="stim.TableauSimulator.peek_x"></a>
+### `stim.TableauSimulator.peek_x(self, target: int) -> int`
+> ```
+> Returns the expected value of a qubit's X observable (which will always be -1, 0, or +1).
+> 
+> This is a non-physical operation.
+> It reports information about the quantum state without disturbing it.
+> 
+> Args:
+>     target: The qubit to analyze.
+> 
+> Returns:
+>     +1: Qubit is in the |+> state.
+>     -1: Qubit is in the |-> state.
+>     0: Qubit is in some other state.
+> 
+> Example:
+>     >>> import stim
+>     >>> s = stim.TableauSimulator()
+>     >>> s.reset_z(0)
+>     >>> s.peek_x(0)
+>     0
+>     >>> s.reset_x(0)
+>     >>> s.peek_x(0)
+>     1
+>     >>> s.Z(0)
+>     >>> s.peek_x(0)
+>     -1
+> ```
+
+<a name="stim.TableauSimulator.peek_y"></a>
+### `stim.TableauSimulator.peek_y(self, target: int) -> int`
+> ```
+> Returns the expected value of a qubit's Y observable (which will always be -1, 0, or +1).
+> 
+> This is a non-physical operation.
+> It reports information about the quantum state without disturbing it.
+> 
+> Args:
+>     target: The qubit to analyze.
+> 
+> Returns:
+>     +1: Qubit is in the |i> state.
+>     -1: Qubit is in the |-i> state.
+>     0: Qubit is in some other state.
+> 
+> Example:
+>     >>> import stim
+>     >>> s = stim.TableauSimulator()
+>     >>> s.reset_z(0)
+>     >>> s.peek_y(0)
+>     0
+>     >>> s.reset_y(0)
+>     >>> s.peek_y(0)
+>     1
+>     >>> s.Z(0)
+>     >>> s.peek_y(0)
+>     -1
+> ```
+
+<a name="stim.TableauSimulator.peek_z"></a>
+### `stim.TableauSimulator.peek_z(self, target: int) -> int`
+> ```
+> Returns the expected value of a qubit's Z observable (which will always be -1, 0, or +1).
+> 
+> This is a non-physical operation.
+> It reports information about the quantum state without disturbing it.
+> 
+> Args:
+>     target: The qubit to analyze.
+> 
+> Returns:
+>     +1: Qubit is in the |0> state.
+>     -1: Qubit is in the |1> state.
+>     0: Qubit is in some other state.
+> 
+> Example:
+>     >>> import stim
+>     >>> s = stim.TableauSimulator()
+>     >>> s.reset_x(0)
+>     >>> s.peek_z(0)
+>     0
+>     >>> s.reset_z(0)
+>     >>> s.peek_z(0)
+>     1
+>     >>> s.X(0)
+>     >>> s.peek_z(0)
+>     -1
+> ```
+
+<a name="stim.TableauSimulator.postselect_x"></a>
+### `stim.TableauSimulator.postselect_x(self, targets: object, *, desired_value: bool) -> None`
+> ```
+> Postselects qubits in the X basis, or raises an exception.
+> 
+> Postselecting a qubit forces it to collapse to a specific state, as
+> if it was measured and that state was the result of the measurement.
+> 
+> Args:
+>     targets: The qubit index or indices to postselect.
+>     desired_value:
+>         False: postselect targets into the |+> state.
+>         True: postselect targets into the |-> state.
+> 
+> Raises:
+>     ValueError:
+>         The postselection failed. One of the qubits was in a state
+>         orthogonal to the desired state, so it was literally
+>         impossible for a measurement of the qubit to return the
+>         desired result.
+> ```
+
+<a name="stim.TableauSimulator.postselect_y"></a>
+### `stim.TableauSimulator.postselect_y(self, targets: object, *, desired_value: bool) -> None`
+> ```
+> Postselects qubits in the Y basis, or raises an exception.
+> 
+> Postselecting a qubit forces it to collapse to a specific state, as
+> if it was measured and that state was the result of the measurement.
+> 
+> Args:
+>     targets: The qubit index or indices to postselect.
+>     desired_value:
+>         False: postselect targets into the |i> state.
+>         True: postselect targets into the |-i> state.
+> 
+> Raises:
+>     ValueError:
+>         The postselection failed. One of the qubits was in a state
+>         orthogonal to the desired state, so it was literally
+>         impossible for a measurement of the qubit to return the
+>         desired result.
+> ```
+
+<a name="stim.TableauSimulator.postselect_z"></a>
+### `stim.TableauSimulator.postselect_z(self, targets: object, *, desired_value: bool) -> None`
+> ```
+> Postselects qubits in the Z basis, or raises an exception.
+> 
+> Postselecting a qubit forces it to collapse to a specific state, as
+> if it was measured and that state was the result of the measurement.
+> 
+> Args:
+>     targets: The qubit index or indices to postselect.
+>     desired_value:
+>         False: postselect targets into the |0> state.
+>         True: postselect targets into the |1> state.
+> 
+> Raises:
+>     ValueError:
+>         The postselection failed. One of the qubits was in a state
+>         orthogonal to the desired state, so it was literally
+>         impossible for a measurement of the qubit to return the
+>         desired result.
+> ```
+
 <a name="stim.TableauSimulator.reset"></a>
 ### `stim.TableauSimulator.reset(self, *args) -> None`
 > ```
-> Resets qubits to zero (e.g. by swapping them for zero'd qubit from the environment).
+> Resets qubits to the |0> state.
 > 
 > Args:
 >     *targets: The indices of the qubits to reset.
+> 
+> Example:
+>     >>> import stim
+>     >>> s = stim.TableauSimulator()
+>     >>> s.X(0)
+>     >>> s.reset(0)
+>     >>> s.peek_bloch(0)
+>     +Z
+> ```
+
+<a name="stim.TableauSimulator.reset_x"></a>
+### `stim.TableauSimulator.reset_x(self, *args) -> None`
+> ```
+> Resets qubits to the |+> state.
+> 
+> Args:
+>     *targets: The indices of the qubits to reset.
+> 
+> Example:
+>     >>> import stim
+>     >>> s = stim.TableauSimulator()
+>     >>> s.reset_x(0)
+>     >>> s.peek_bloch(0)
+>     +X
+> ```
+
+<a name="stim.TableauSimulator.reset_y"></a>
+### `stim.TableauSimulator.reset_y(self, *args) -> None`
+> ```
+> Resets qubits to the |i> state.
+> 
+> Args:
+>     *targets: The indices of the qubits to reset.
+> 
+> Example:
+>     >>> import stim
+>     >>> s = stim.TableauSimulator()
+>     >>> s.reset_y(0)
+>     >>> s.peek_bloch(0)
+>     +Y
+> ```
+
+<a name="stim.TableauSimulator.reset_z"></a>
+### `stim.TableauSimulator.reset_z(self, *args) -> None`
+> ```
+> Resets qubits to the |0> state.
+> 
+> Args:
+>     *targets: The indices of the qubits to reset.
+> 
+> Example:
+>     >>> import stim
+>     >>> s = stim.TableauSimulator()
+>     >>> s.H(0)
+>     >>> s.reset_z(0)
+>     >>> s.peek_bloch(0)
+>     +Z
 > ```
 
 <a name="stim.TableauSimulator.s"></a>
@@ -5430,35 +5687,47 @@
 > ```
 
 <a name="stim.TableauSimulator.state_vector"></a>
-### `stim.TableauSimulator.state_vector(self) -> numpy.ndarray[numpy.float32]`
+### `stim.TableauSimulator.state_vector(self, *, endian: str = 'little') -> numpy.ndarray[numpy.float32]`
 > ```
 > Returns a wavefunction that satisfies the stabilizers of the simulator's current state.
 > 
 > This function takes O(n * 2**n) time and O(2**n) space, where n is the number of qubits. The computation is
 > done by initialization a random state vector and iteratively projecting it into the +1 eigenspace of each
-> stabilizer of the state. The global phase of the result is arbitrary (and will vary from call to call).
+> stabilizer of the state. The state is then canonicalized so that zero values are actually exactly 0, and so
+> that the first non-zero entry is positive.
 > 
-> The result is in little endian order. The amplitude at offset b_0 + b_1*2 + b_2*4 + ... + b_{n-1}*2^{n-1} is
-> the amplitude for the computational basis state where the qubit with index 0 is storing the bit b_0, the
-> qubit with index 1 is storing the bit b_1, etc.
+> Args:
+>     endian:
+>         "little" (default): state vector is in little endian order, where higher index qubits
+>             correspond to larger changes in the state index.
+>         "big": state vector is in little endian order, where higher index qubits correspond to
+>             smaller changes in the state index.
 > 
 > Returns:
->     A `numpy.ndarray[numpy.complex64]` of computational basis amplitudes in little endian order.
+>     A `numpy.ndarray[numpy.complex64]` of computational basis amplitudes.
+> 
+>     If the result is in little endian order then the amplitude at offset b_0 + b_1*2 + b_2*4 + ... + b_{n-1}*2^{n-1} is
+>     the amplitude for the computational basis state where the qubit with index 0 is storing the bit b_0, the
+>     qubit with index 1 is storing the bit b_1, etc.
+> 
+>     If the result is in little endian order then the amplitude at offset b_0 + b_1*2 + b_2*4 + ... + b_{n-1}*2^{n-1} is
+>     the amplitude for the computational basis state where the qubit with index 0 is storing the bit b_{n-1}, the
+>     qubit with index 1 is storing the bit b_{n-2}, etc.
 > 
 > Examples:
 >     >>> import stim
 >     >>> import numpy as np
-> 
->     >>> # Check that the qubit-to-amplitude-index ordering is little-endian.
 >     >>> s = stim.TableauSimulator()
->     >>> s.x(1)
->     >>> s.x(4)
->     >>> vector = s.state_vector()
->     >>> np.abs(vector[0b_10010]).round(2)
->     1.0
->     >>> tensor = vector.reshape((2, 2, 2, 2, 2))
->     >>> np.abs(tensor[1, 0, 0, 1, 0]).round(2)
->     1.0
+>     >>> s.x(2)
+>     >>> list(s.state_vector(endian='little'))
+>     [0j, 0j, 0j, 0j, (1+0j), 0j, 0j, 0j]
+> 
+>     >>> list(s.state_vector(endian='big'))
+>     [0j, (1+0j), 0j, 0j, 0j, 0j, 0j, 0j]
+> 
+>     >>> s.sqrt_x(1, 2)
+>     >>> list(s.state_vector())
+>     [(0.5+0j), 0j, -0.5j, 0j, 0.5j, 0j, (0.5+0j), 0j]
 > ```
 
 <a name="stim.TableauSimulator.swap"></a>

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -4384,7 +4384,7 @@ def main(*, command_line_args: List[str]) -> int:
         DETECTOR(1, 1) rec[-1] rec[-2] rec[-3]
         OBSERVABLE_INCLUDE(0) rec[-1]
     """
-def read_shot_data_file(path: str, format: str, num_measurements: int = 0, num_detectors: int = 0, num_observables: int = 0, bit_pack: bool = False) -> np.ndarray:
+def read_shot_data_file(*, path: str, format: str, num_measurements: int = 0, num_detectors: int = 0, num_observables: int = 0, bit_pack: bool = False) -> np.ndarray:
 
     """Reads shot data, such as measurement samples, from a file.
     

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -6,7 +6,7 @@ if TYPE_CHECKING:
     import numpy as np
 class Circuit:
     """A mutable stabilizer circuit.
-    
+
     Examples:
         >>> import stim
         >>> c = stim.Circuit()
@@ -14,7 +14,7 @@ class Circuit:
         >>> c.append("M", 0)
         >>> c.compile_sampler().sample(shots=1)
         array([[1]], dtype=uint8)
-    
+
         >>> stim.Circuit('''
         ...    H 0
         ...    CNOT 0 1
@@ -22,11 +22,11 @@ class Circuit:
         ...    DETECTOR rec[-1] rec[-2]
         ... ''').compile_detector_sampler().sample(shots=1)
         array([[0]], dtype=uint8)
-    
+
     """
     def __add__(self, second: stim.Circuit) -> stim.Circuit:
         """Creates a circuit by appending two circuits.
-        
+
         Examples:
             >>> import stim
             >>> c1 = stim.Circuit('''
@@ -54,15 +54,15 @@ class Circuit:
         pass
     def __getitem__(self, index_or_slice: object) -> object:
         """Returns copies of instructions from the circuit.
-        
+
         Args:
             index_or_slice: An integer index picking out an instruction to return, or a slice picking out a range
                 of instructions to return as a circuit.
-        
+
         Returns:
             If the index was an integer, then an instruction from the circuit.
             If the index was a slice, then a circuit made up of the instructions in that slice.
-        
+
         Examples:
             >>> import stim
             >>> circuit = stim.Circuit('''
@@ -92,7 +92,7 @@ class Circuit:
         """
     def __iadd__(self, second: stim.Circuit) -> stim.Circuit:
         """Appends a circuit into the receiving circuit (mutating it).
-        
+
         Examples:
             >>> import stim
             >>> c1 = stim.Circuit('''
@@ -112,13 +112,13 @@ class Circuit:
         """
     def __imul__(self, repetitions: int) -> stim.Circuit:
         """Mutates the circuit by putting its contents into a REPEAT block.
-        
+
         Special case: if the repetition count is 0, the circuit is cleared.
         Special case: if the repetition count is 1, nothing happens.
-        
+
         Args:
             repetitions: The number of times the REPEAT block should repeat.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit('''
@@ -136,10 +136,10 @@ class Circuit:
         """
     def __init__(self, stim_program_text: str = '') -> None:
         """Creates a stim.Circuit.
-        
+
         Args:
             stim_program_text: Defaults to empty. Describes operations to append into the circuit.
-        
+
         Examples:
             >>> import stim
             >>> empty = stim.Circuit()
@@ -151,9 +151,9 @@ class Circuit:
         """
     def __len__(self) -> int:
         """Returns the number of top-level instructions and blocks in the circuit.
-        
+
         Instructions inside of blocks are not included in this count.
-        
+
         Examples:
             >>> import stim
             >>> len(stim.Circuit())
@@ -176,13 +176,13 @@ class Circuit:
         """
     def __mul__(self, repetitions: int) -> stim.Circuit:
         """Returns a circuit with a REPEAT block containing the current circuit's instructions.
-        
+
         Special case: if the repetition count is 0, an empty circuit is returned.
         Special case: if the repetition count is 1, an equal circuit with no REPEAT block is returned.
-        
+
         Args:
             repetitions: The number of times the REPEAT block should repeat.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit('''
@@ -205,13 +205,13 @@ class Circuit:
         """
     def __rmul__(self, repetitions: int) -> stim.Circuit:
         """Returns a circuit with a REPEAT block containing the current circuit's instructions.
-        
+
         Special case: if the repetition count is 0, an empty circuit is returned.
         Special case: if the repetition count is 1, an equal circuit with no REPEAT block is returned.
-        
+
         Args:
             repetitions: The number of times the REPEAT block should repeat.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit('''
@@ -237,9 +237,9 @@ class Circuit:
         pass
     def append(self, name: object, targets: object = (), arg: object = None) -> None:
         """Appends an operation into the circuit.
-        
+
         Note: `stim.Circuit.append_operation` is an alias of `stim.Circuit.append`.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit()
@@ -258,14 +258,14 @@ class Circuit:
                 X_ERROR(0.125) 0
                 E(0.25) X0 Y2
             ''')
-        
+
         Args:
             name: The name of the operation's gate (e.g. "H" or "M" or "CNOT").
-        
+
                 This argument can also be set to a `stim.CircuitInstruction` or `stim.CircuitInstructionBlock`, which
                 results in the instruction or block being appended to the circuit. The other arguments (targets and
                 arg) can't be specified when doing so.
-        
+
                 (The argument name `name` is no longer quite right, but being kept for backwards compatibility.)
             targets: The objects operated on by the gate. This can be either a single target or an iterable of
                 multiple targets to broadcast the gate over. Each target can be an integer (a qubit), a
@@ -275,14 +275,14 @@ class Circuit:
                 list of doubles parameterizing the gate. Different gates take different parens arguments. For
                 example, X_ERROR takes a probability, OBSERVABLE_INCLUDE takes an observable index, and
                 PAULI_CHANNEL_1 takes three disjoint probabilities.
-        
+
                 Note: Defaults to no parens arguments. Except, for backwards compatibility reasons,
                 `cirq.append_operation` (but not `cirq.append`) will default to a single 0.0 argument for gates
                 that take exactly one argument.
         """
     def append_from_stim_program_text(self, stim_program_text: str) -> None:
         """Appends operations described by a STIM format program into the circuit.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit()
@@ -298,7 +298,7 @@ class Circuit:
             CX 0 2
             M 2
             CX rec[-1] 1
-        
+
         Args:
             stim_program_text: The STIM program text containing the circuit operations to append.
         """
@@ -307,48 +307,48 @@ class Circuit:
         """
     def approx_equals(self, other: object, *, atol: float) -> bool:
         """Checks if a circuit is approximately equal to another circuit.
-        
+
         Two circuits are approximately equal if they are equal up to slight perturbations of instruction arguments
         such as probabilities. For example `X_ERROR(0.100) 0` is approximately equal to `X_ERROR(0.099)` within an
         absolute tolerance of 0.002. All other details of the circuits (such as the ordering of instructions and
         targets) must be exactly the same.
-        
+
         Args:
             other: The circuit, or other object, to compare to this one.
             atol: The absolute error tolerance. The maximum amount each probability may have been perturbed by.
-        
+
         Returns:
             True if the given object is a circuit approximately equal up to the receiving circuit up to the given
             tolerance, otherwise False.
-        
+
         Examples:
             >>> import stim
             >>> base = stim.Circuit('''
             ...    X_ERROR(0.099) 0 1 2
             ...    M 0 1 2
             ... ''')
-        
+
             >>> base.approx_equals(base, atol=0)
             True
-        
+
             >>> base.approx_equals(stim.Circuit('''
             ...    X_ERROR(0.101) 0 1 2
             ...    M 0 1 2
             ... '''), atol=0)
             False
-        
+
             >>> base.approx_equals(stim.Circuit('''
             ...    X_ERROR(0.101) 0 1 2
             ...    M 0 1 2
             ... '''), atol=0.0001)
             False
-        
+
             >>> base.approx_equals(stim.Circuit('''
             ...    X_ERROR(0.101) 0 1 2
             ...    M 0 1 2
             ... '''), atol=0.01)
             True
-        
+
             >>> base.approx_equals(stim.Circuit('''
             ...    DEPOLARIZE1(0.099) 0 1 2
             ...    MRX 0 1 2
@@ -357,7 +357,7 @@ class Circuit:
         """
     def clear(self) -> None:
         """Clears the contents of the circuit.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit('''
@@ -370,28 +370,28 @@ class Circuit:
         """
     def compile_detector_sampler(self, *, seed: object = None) -> stim.CompiledDetectorSampler:
         """Returns a CompiledDetectorSampler, which can quickly batch sample detection events, for the circuit.
-        
+
         Args:
             seed: PARTIALLY determines simulation results by deterministically seeding the random number generator.
                 Must be None or an integer in range(2**64).
-        
+
                 Defaults to None. When set to None, a prng seeded by system entropy is used.
-        
+
                 When set to an integer, making the exact same series calls on the exact same machine with the exact
                 same version of Stim will produce the exact same simulation results.
-        
+
                 CAUTION: simulation results *WILL NOT* be consistent between versions of Stim. This restriction is
                 present to make it possible to have future optimizations to the random sampling, and is enforced by
                 introducing intentional differences in the seeding strategy from version to version.
-        
+
                 CAUTION: simulation results *MAY NOT* be consistent across machines that differ in the width of
                 supported SIMD instructions. For example, using the same seed on a machine that supports AVX
                 instructions and one that only supports SSE instructions may produce different simulation results.
-        
+
                 CAUTION: simulation results *MAY NOT* be consistent if you vary how many shots are taken. For
                 example, taking 10 shots and then 90 shots will give different results from taking 100 shots in one
                 call.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit('''
@@ -406,24 +406,24 @@ class Circuit:
         """
     def compile_m2d_converter(self, *, skip_reference_sample: bool = False) -> stim.CompiledMeasurementsToDetectionEventsConverter:
         """Returns an object that can efficiently convert measurements into detection events for the given circuit.
-        
+
         The converter uses a noiseless reference sample, collected from the circuit using stim's Tableau simulator
         during initialization of the converter, as a baseline for determining what the expected value of a detector
         is.
-        
+
         Note that the expected behavior of gauge detectors (detectors that are not actually deterministic under
         noiseless execution) can vary depending on the reference sample. Stim mitigates this by always generating
         the same reference sample for a given circuit.
-        
+
         Args:
             skip_reference_sample: Defaults to False. When set to True, the reference sample used by the converter
                 is initialized to all-zeroes instead of being collected from the circuit. This should only be used
                 if it's known that the all-zeroes sample is actually a possible result from the circuit (under
                 noiseless execution).
-        
+
         Returns:
             An initialized stim.CompiledMeasurementsToDetectionEventsConverter.
-        
+
         Examples:
             >>> import stim
             >>> import numpy as np
@@ -441,13 +441,13 @@ class Circuit:
         """
     def compile_sampler(self, *, skip_reference_sample: bool = False, seed: object = None) -> stim.CompiledMeasurementSampler:
         """Returns a CompiledMeasurementSampler, which can quickly batch sample measurements, for the circuit.
-        
+
         Args:
             skip_reference_sample: Defaults to False. When set to True, the reference sample used by the sampler is
                 initialized to all-zeroes instead of being collected from the circuit. This means that the results
                 returned by the sampler are actually whether or not each measurement was *flipped*, instead of true
                 measurement results.
-        
+
                 Forcing an all-zero reference sample is useful when you are only interested in error propagation and
                 don't want to have to deal with the fact that some measurements want to be On when no errors occur.
                 It is also useful when you know for sure that the all-zero result is actually a possible result from
@@ -457,24 +457,24 @@ class Circuit:
                 optimization.
             seed: PARTIALLY determines simulation results by deterministically seeding the random number generator.
                 Must be None or an integer in range(2**64).
-        
+
                 Defaults to None. When set to None, a prng seeded by system entropy is used.
-        
+
                 When set to an integer, making the exact same series calls on the exact same machine with the exact
                 same version of Stim will produce the exact same simulation results.
-        
+
                 CAUTION: simulation results *WILL NOT* be consistent between versions of Stim. This restriction is
                 present to make it possible to have future optimizations to the random sampling, and is enforced by
                 introducing intentional differences in the seeding strategy from version to version.
-        
+
                 CAUTION: simulation results *MAY NOT* be consistent across machines that differ in the width of
                 supported SIMD instructions. For example, using the same seed on a machine that supports AVX
                 instructions and one that only supports SSE instructions may produce different simulation results.
-        
+
                 CAUTION: simulation results *MAY NOT* be consistent if you vary how many shots are taken. For
                 example, taking 10 shots and then 90 shots will give different results from taking 100 shots in one
                 call.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit('''
@@ -487,10 +487,10 @@ class Circuit:
         """
     def copy(self) -> stim.Circuit:
         """Returns a copy of the circuit. An independent circuit with the same contents.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> c1 = stim.Circuit("H 0")
             >>> c2 = c1.copy()
             >>> c2 is c1
@@ -500,7 +500,7 @@ class Circuit:
         """
     def detector_error_model(self, *, decompose_errors: bool = False, flatten_loops: bool = False, allow_gauge_detectors: bool = False, approximate_disjoint_errors: float = False, ignore_decomposition_failures: bool = False, block_decomposition_from_introducing_remnant_edges: bool = False) -> stim.DetectorErrorModel:
         """Returns a stim.DetectorErrorModel describing the error processes in the circuit.
-        
+
         Args:
             decompose_errors: Defaults to false. When set to true, the error analysis attempts to decompose the
                 components of composite error mechanisms (such as depolarization errors) into simpler errors, and
@@ -520,7 +520,7 @@ class Circuit:
                 the error model. For example, if detectors D1 and D3 both anti-commute with a reset, then the error
                 model has a gauge `error(0.5) D1 D3`. When gauges are identified, one of the involved detectors is
                 removed from the system using Gaussian elimination.
-        
+
                 Note that logical observables are still verified to be deterministic, even if this option is set.
             approximate_disjoint_errors: Defaults to false. When set to false, composite error mechanisms with
                 disjoint components (such as `PAULI_CHANNEL_1(0.1, 0.2, 0.0)`) can cause the error analysis to throw
@@ -529,7 +529,7 @@ class Circuit:
                 probabilities. For example, a ``PAULI_CHANNEL_1(0.1, 0.2, 0.0)` becomes equivalent to an
                 `X_ERROR(0.1)` followed by a `Z_ERROR(0.2)`. This assumption is an approximation, but it is a good
                 approximation for small probabilities.
-        
+
                 This argument can also be set to a probability between 0 and 1, setting a threshold below which the
                 approximation is acceptable. Any error mechanisms that have a component probability above the
                 threshold will cause an exception to be thrown.
@@ -539,23 +539,23 @@ class Circuit:
                 Instead, the undecomposed error is inserted into the output. Whatever tool
                 the detector error model is then given to is responsible for dealing with the
                 undecomposed errors (e.g. a tool may choose to simply ignore them).
-        
+
                 Irrelevant unless decompose_errors=True.
             block_decomposition_from_introducing_remnant_edges: Defaults to False.
                 Requires that both A B and C D be present elsewhere in the detector error model
                 in order to decompose A B C D into A B ^ C D. Normally, only one of A B or C D
                 needs to appear to allow this decomposition.
-        
+
                 Remnant edges can be a useful feature for ensuring decomposition succeeds, but
                 they can also reduce the effective code distance by giving the decoder single
                 edges that actually represent multiple errors in the circuit (resulting in the
                 decoder making misinformed choices when decoding).
-        
+
                 Irrelevant unless decompose_errors=True.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> stim.Circuit('''
             ...     X_ERROR(0.125) 0
             ...     X_ERROR(0.25) 1
@@ -572,7 +572,7 @@ class Circuit:
         """
     def explain_detector_error_model_errors(self, *, dem_filter: object = None, reduce_to_one_representative_error: bool = False) -> List[stim.ExplainedError]:
         """Explains how detector error model errors are produced by circuit errors.
-        
+
         Args:
             dem_filter: Defaults to None (unused). When used, the output will only contain detector error
                 model errors that appear in the given `stim.DetectorErrorModel`. Any error mechanisms from the
@@ -580,11 +580,11 @@ class Circuit:
                 in the result, but with an empty list of associated circuit error mechanisms.
             reduce_to_one_representative_error: Defaults to False. When True, the items in the result will contain
                 at most one circuit error mechanism.
-        
+
         Returns:
             A `List[stim.ExplainedError]` (see `stim.ExplainedError` for more information). Each item in the list
             describes how a detector error model error can be produced by individual circuit errors.
-        
+
         Examples:
             >>> import stim
             >>> circuit = stim.Circuit('''
@@ -620,12 +620,12 @@ class Circuit:
         """
     def flattened(self) -> stim.Circuit:
         """Creates an equivalent circuit without REPEAT or SHIFT_COORDS.
-        
+
         Returns:
             A `stim.Circuit` with the same instructions in the same order,
             but with loops flattened into repeated instructions and with
             all coordinate shifts inlined.
-        
+
         Examples:
             >>> import stim
             >>> circuit = stim.Circuit('''
@@ -656,11 +656,11 @@ class Circuit:
         """
     def flattened_operations(self) -> list:
         """[DEPRECATED]
-        
+
         Returns a list of tuples encoding the contents of the circuit.
         Instead of this method, use `for instruction in circuit` or, to
         avoid REPEAT blocks, `for instruction in circuit.flattened()`.
-        
+
         Examples:
             >>> import stim
             >>> stim.Circuit('''
@@ -669,7 +669,7 @@ class Circuit:
             ...    M 0 !1
             ... ''').flattened_operations()
             [('H', [0], 0), ('X_ERROR', [1], 0.125), ('M', [0, ('inv', 1)], 0)]
-        
+
             >>> stim.Circuit('''
             ...    REPEAT 2 {
             ...        H 6
@@ -680,16 +680,16 @@ class Circuit:
     @staticmethod
     def generated(code_task: str, *, distance: int, rounds: int, after_clifford_depolarization: float = 0.0, before_round_data_depolarization: float = 0.0, before_measure_flip_probability: float = 0.0, after_reset_flip_probability: float = 0.0) -> stim.Circuit:
         """Generates common circuits.
-        
+
         The generated circuits can include configurable noise.
-        
+
         The generated circuits include DETECTOR and OBSERVABLE_INCLUDE annotations so that their detection events
         and logical observables can be sampled.
-        
+
         The generated circuits include TICK annotations to mark the progression of time. (E.g. so that converting
         them using `stimcirq.stim_circuit_to_cirq_circuit` will produce a `cirq.Circuit` with the intended moment
         structure.)
-        
+
         Args:
             code_task: A string identifying the type of circuit to generate. Available types are:
                 - `repetition_code:memory`
@@ -716,10 +716,10 @@ class Circuit:
             after_reset_flip_probability: Defaults to 0. The probability (p) of `X_ERROR(p)` operations applied
                 to qubits after each reset (X basis resets use `Z_ERROR(p)` instead). The after-reset flips are only
                 included if this probability is not 0.
-        
+
         Returns:
             The generated circuit.
-        
+
         Examples:
             >>> import stim
             >>> circuit = stim.Circuit.generated(
@@ -762,17 +762,17 @@ class Circuit:
         """
     def get_detector_coordinates(self, only: object = None) -> Dict[int, List[float]]:
         """Returns the coordinate metadata of detectors in the circuit.
-        
+
         Args:
             only: Defaults to None (meaning include all detectors). A list of detector indices to include in the
                 result. Detector indices beyond the end of the detector error model of the circuit cause an error.
-        
+
         Returns:
             A dictionary mapping integers (detector indices) to lists of floats (coordinates).
             A dictionary mapping detector indices to lists of floats.
             Detectors with no specified coordinate data are mapped to an empty tuple.
             If `only` is specified, then `set(result.keys()) == set(only)`.
-        
+
         Examples:
             >>> import stim
             >>> circuit = stim.Circuit('''
@@ -791,13 +791,13 @@ class Circuit:
         """
     def get_final_qubit_coordinates(self) -> Dict[int, List[float]]:
         """Returns the coordinate metadata of qubits in the circuit.
-        
+
         If a qubit's coordinates are specified multiple times, only the last specified coordinates are returned.
-        
+
         Returns:
             A dictionary mapping qubit indices (integers) to coordinates (lists of floats).
             Qubits that never had their coordinates specified are not included in the result.
-        
+
         Examples:
             >>> import stim
             >>> circuit = stim.Circuit('''
@@ -809,7 +809,7 @@ class Circuit:
     @property
     def num_detectors(self) -> int:
         """Counts the number of bits produced when sampling the circuit's detectors.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit('''
@@ -827,7 +827,7 @@ class Circuit:
     @property
     def num_measurements(self) -> int:
         """Counts the number of bits produced when sampling the circuit's measurements.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit('''
@@ -842,9 +842,9 @@ class Circuit:
     @property
     def num_observables(self) -> int:
         """Counts the number of bits produced when sampling the circuit's logical observables.
-        
+
         This is one more than the largest observable index given to OBSERVABLE_INCLUDE.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit('''
@@ -858,9 +858,9 @@ class Circuit:
     @property
     def num_qubits(self) -> int:
         """Counts the number of qubits used when simulating the circuit.
-        
+
         This is always one more than the largest qubit index used by the circuit.
-        
+
         Examples:
             >>> import stim
             >>> stim.Circuit('''
@@ -878,9 +878,9 @@ class Circuit:
     @property
     def num_sweep_bits(self) -> int:
         """Returns the number of sweep bits needed to completely configure the circuit.
-        
+
         This is always one more than the largest sweep bit index used by the circuit.
-        
+
         Examples:
             >>> import stim
             >>> stim.Circuit('''
@@ -895,27 +895,27 @@ class Circuit:
         """
     def search_for_undetectable_logical_errors(self, *, dont_explore_detection_event_sets_with_size_above: int, dont_explore_edges_with_degree_above: int, dont_explore_edges_increasing_symptom_degree: bool, canonicalize_circuit_errors: bool = False) -> List[stim.ExplainedError]:
         """Searches for lists of errors from the model that form an undetectable logical error.
-        
+
         THIS IS A HEURISTIC METHOD. It does not guarantee that it will find errors of particular
         sizes, or with particular properties. The errors it finds are a tangled combination of the
         truncation parameters you specify, internal optimizations which are correct when not
         truncating, and minutia of the circuit being considered.
-        
+
         If you want a well behaved method that does provide guarantees of finding errors of a
         particular type, use `stim.Circuit.shortest_graphlike_error`. This method is more
         thorough than that (assuming you don't truncate so hard you omit graphlike edges),
         but exactly how thorough is difficult to describe. It's also not guaranteed that the
         behavior of this method will not be changed in the future in a way that permutes which
         logical errors are found and which are missed.
-        
+
         This search method considers hyper errors, so it has worst case exponential runtime. It is
         important to carefully consider the arguments you are providing, which truncate the search
         space and trade cost for quality.
-        
+
         The search progresses by starting from each error that crosses a logical observable, noting
         which detection events each error produces, and then iteratively adding in errors touching
         those detection events attempting to cancel out the detection event with the lowest index.
-        
+
         Beware that the choice of logical observable can interact with the truncation options. Using
         different observables can change whether or not the search succeeds, even if those observables
         are equal modulo the stabilizers of the code. This is because the edges crossing logical
@@ -924,7 +924,7 @@ class Circuit:
         progresses. For example, if the logical observable is next to a boundary, then the starting
         edges are likely boundary edges (degree 1) with 'room to grow', whereas if the observable was
         running through the bulk then the starting edges will have degree at least 2.
-        
+
         Args:
             dont_explore_detection_event_sets_with_size_above: Truncates the search space by refusing to
                 cross an edge (i.e. add an error) when doing so would produce an intermediate state that
@@ -945,12 +945,12 @@ class Circuit:
                     symptoms, with a preference towards errors that are simpler (e.g. apply Paulis to fewer qubits).
                     This discards mostly-redundant information about different ways to produce the same symptoms in
                     order to give a succinct result.
-        
+
         Returns:
             A detector error model containing only the error mechanisms that cause the undetectable
             logical error. The error mechanisms will have their probabilities set to 1 (indicating that
             they are necessary) and will not suggest a decomposition.
-        
+
         Examples:
             >>> import stim
             >>> circuit = stim.Circuit.generated(
@@ -967,18 +967,18 @@ class Circuit:
         """
     def shortest_graphlike_error(self, *, ignore_ungraphlike_errors: bool = True, canonicalize_circuit_errors: bool = False) -> List[stim.ExplainedError]:
         """Finds a minimum sized set of graphlike errors that produce an undetected logical error.
-        
+
         A "graphlike error" is an error that creates at most two detection events (causes a change in the parity of
         the measurement sets of at most two DETECTOR annotations).
-        
+
         Note that this method does not pay attention to error probabilities (other than ignoring errors with
         probability 0). It searches for a logical error with the minimum *number* of physical errors, not the
         maximum probability of those physical errors all occurring.
-        
+
         This method works by converting the circuit into a `stim.DetectorErrorModel` using
         `circuit.detector_error_model(...)`, computing the shortest graphlike error of the error model, and then
         converting the physical errors making up that logical error back into representative circuit errors.
-        
+
         Args:
             ignore_ungraphlike_errors:
                 False: Attempt to decompose any ungraphlike errors in the circuit into graphlike parts.
@@ -999,15 +999,15 @@ class Circuit:
                     symptoms, with a preference towards errors that are simpler (e.g. apply Paulis to fewer qubits).
                     This discards mostly-redundant information about different ways to produce the same symptoms in
                     order to give a succinct result.
-        
+
         Returns:
             A detector error model containing only the error mechanisms that cause the undetectable
             logical error. The error mechanisms will have their probabilities set to 1 (indicating that
             they are necessary) and will not suggest a decomposition.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> circuit = stim.Circuit.generated(
             ...     "repetition_code:memory",
             ...     rounds=10,
@@ -1018,17 +1018,17 @@ class Circuit:
         """
     def without_noise(self) -> stim.Circuit:
         """Returns a copy of the circuit with all noise processes removed.
-        
+
         Pure noise instructions, such as X_ERROR and DEPOLARIZE2, are not
         included in the result.
-        
+
         Noisy measurement instructions, like `M(0.001)`, have their noise
         parameter removed.
-        
+
         Returns:
             A `stim.Circuit` with the same instructions except all noise
             processes have been removed.
-        
+
         Examples:
             >>> import stim
             >>> circuit = stim.Circuit('''
@@ -1077,7 +1077,7 @@ class CircuitErrorLocation:
 class CircuitErrorLocationStackFrame:
     """Describes the location of an instruction being executed within a
     circuit or loop, distinguishing between separate loop iterations.
-    
+
     The full location of an instruction is a list of these frames,
     drilling down from the top level circuit to the inner-most loop
     that the instruction is within.
@@ -1107,7 +1107,7 @@ class CircuitErrorLocationStackFrame:
         """
 class CircuitInstruction:
     """An instruction, like `H 0 1` or `CNOT rec[-1] 5`, from a circuit.
-    
+
     Examples:
         >>> import stim
         >>> circuit = stim.Circuit('''
@@ -1127,7 +1127,7 @@ class CircuitInstruction:
         """
     def __init__(self, name: str, targets: List[object], gate_args: List[float] = ()) -> None:
         """Initializes a `stim.CircuitInstruction`.
-        
+
         Args:
             name: The name of the instruction being applied.
             targets: The targets the instruction is being applied to. These can be raw values like `0` and
@@ -1146,7 +1146,7 @@ class CircuitInstruction:
         """
     def gate_args_copy(self) -> List[float]:
         """Returns the gate's arguments (numbers parameterizing the instruction).
-        
+
         For noisy gates this typically a list of probabilities.
         For OBSERVABLE_INCLUDE it's a singleton list containing the logical observable index.
         """
@@ -1159,7 +1159,7 @@ class CircuitInstruction:
         """
 class CircuitRepeatBlock:
     """A REPEAT block from a circuit.
-    
+
     Examples:
         >>> import stim
         >>> circuit = stim.Circuit('''
@@ -1183,7 +1183,7 @@ class CircuitRepeatBlock:
         """
     def __init__(self, repeat_count: int, body: stim.Circuit) -> None:
         """Initializes a `stim.CircuitRepeatBlock`.
-        
+
         Args:
             repeat_count: The number of times to repeat the block.
             body: The body of the block, as a circuit.
@@ -1196,10 +1196,10 @@ class CircuitRepeatBlock:
         """
     def body_copy(self) -> stim.Circuit:
         """Returns a copy of the body of the repeat block.
-        
+
         The copy is forced to ensure it's clear that editing the result will not change the circuit that the repeat
         block came from.
-        
+
         Examples:
             >>> import stim
             >>> circuit = stim.Circuit('''
@@ -1219,7 +1219,7 @@ class CircuitRepeatBlock:
     @property
     def repeat_count(self) -> int:
         """The repetition count of the repeat block.
-        
+
         Examples:
             >>> import stim
             >>> circuit = stim.Circuit('''
@@ -1261,7 +1261,7 @@ class CircuitTargetsInsideInstruction:
     @property
     def targets_in_range(self) -> List[stim.GateTargetWithCoords]:
         """Returns the subset of targets of the gate / instruction that were being executed.
-        
+
         Includes coordinate data with the targets.
         """
 class CompiledDetectorSampler:
@@ -1269,32 +1269,32 @@ class CompiledDetectorSampler:
     """
     def __init__(self, circuit: stim.Circuit, *, seed: object = None) -> None:
         """Creates a detector sampler, which can sample the detectors (and optionally observables) in a circuit.
-        
+
         Args:
             circuit: The circuit to sample from.
             seed: PARTIALLY determines simulation results by deterministically seeding the random number generator.
                 Must be None or an integer in range(2**64).
-        
+
                 Defaults to None. When set to None, a prng seeded by system entropy is used.
-        
+
                 When set to an integer, making the exact same series calls on the exact same machine with the exact
                 same version of Stim will produce the exact same simulation results.
-        
+
                 CAUTION: simulation results *WILL NOT* be consistent between versions of Stim. This restriction is
                 present to make it possible to have future optimizations to the random sampling, and is enforced by
                 introducing intentional differences in the seeding strategy from version to version.
-        
+
                 CAUTION: simulation results *MAY NOT* be consistent across machines that differ in the width of
                 supported SIMD instructions. For example, using the same seed on a machine that supports AVX
                 instructions and one that only supports SSE instructions may produce different simulation results.
-        
+
                 CAUTION: simulation results *MAY NOT* be consistent if you vary how many shots are taken. For
                 example, taking 10 shots and then 90 shots will give different results from taking 100 shots in one
                 call.
-        
+
         Returns:
             An initialized stim.CompiledDetectorSampler.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit('''
@@ -1313,17 +1313,17 @@ class CompiledDetectorSampler:
         """
     def sample(self, shots: int, *, prepend_observables: bool = False, append_observables: bool = False) -> np.ndarray[bool]:
         """Returns a numpy array containing a batch of detector samples from the circuit.
-        
+
         The circuit must define the detectors using DETECTOR instructions. Observables defined by OBSERVABLE_INCLUDE
         instructions can also be included in the results as honorary detectors.
-        
+
         Args:
             shots: The number of times to sample every detector in the circuit.
             prepend_observables: Defaults to false. When set, observables are included with the detectors and are
                 placed at the start of the results.
             append_observables: Defaults to false. When set, observables are included with the detectors and are
                 placed at the end of the results.
-        
+
         Returns:
             A numpy array with `dtype=uint8` and `shape=(shots, n)` where
             `n = num_detectors + num_observables*(append_observables + prepend_observables)`.
@@ -1331,17 +1331,17 @@ class CompiledDetectorSampler:
         """
     def sample_bit_packed(self, shots: int, *, prepend_observables: bool = False, append_observables: bool = False) -> np.ndarray[np.uint8]:
         """Returns a numpy array containing bit packed batch of detector samples from the circuit.
-        
+
         The circuit must define the detectors using DETECTOR instructions. Observables defined by OBSERVABLE_INCLUDE
         instructions can also be included in the results as honorary detectors.
-        
+
         Args:
             shots: The number of times to sample every detector in the circuit.
             prepend_observables: Defaults to false. When set, observables are included with the detectors and are
                 placed at the start of the results.
             append_observables: Defaults to false. When set, observables are included with the detectors and are
                 placed at the end of the results.
-        
+
         Returns:
             A numpy array with `dtype=uint8` and `shape=(shots, n)` where
             `n = num_detectors + num_observables*(append_observables + prepend_observables)`.
@@ -1349,7 +1349,7 @@ class CompiledDetectorSampler:
         """
     def sample_write(self, shots: int, *, filepath: str, format: str = '01', prepend_observables: bool = False, append_observables: bool = False, obs_out_filepath: str = None, obs_out_format: str = '01') -> None:
         """Samples detection events from the circuit and writes them to a file.
-        
+
         Examples:
             >>> import stim
             >>> import tempfile
@@ -1367,7 +1367,7 @@ class CompiledDetectorSampler:
             shot D0
             shot D0
             shot D0
-        
+
         Args:
             shots: The number of times to sample every measurement in the circuit.
             filepath: The file to write the results to.
@@ -1383,7 +1383,7 @@ class CompiledDetectorSampler:
                 data.
             append_observables: Sample observables as part of each shot, and put them at the end of the detector
                 data.
-        
+
         Returns:
             None.
         """
@@ -1392,18 +1392,18 @@ class CompiledMeasurementSampler:
     """
     def __init__(self, circuit: stim.Circuit, *, skip_reference_sample: bool = False, seed: object = None) -> None:
         """Creates a measurement sampler for the given circuit.
-        
+
         The sampler uses a noiseless reference sample, collected from the circuit using stim's Tableau simulator
         during initialization of the sampler, as a baseline for deriving more samples using an error propagation
         simulator.
-        
+
         Args:
             circuit: The stim circuit to sample from.
             skip_reference_sample: Defaults to False. When set to True, the reference sample used by the sampler is
                 initialized to all-zeroes instead of being collected from the circuit. This means that the results
                 returned by the sampler are actually whether or not each measurement was *flipped*, instead of true
                 measurement results.
-        
+
                 Forcing an all-zero reference sample is useful when you are only interested in error propagation and
                 don't want to have to deal with the fact that some measurements want to be On when no errors occur.
                 It is also useful when you know for sure that the all-zero result is actually a possible result from
@@ -1413,27 +1413,27 @@ class CompiledMeasurementSampler:
                 optimization.
             seed: PARTIALLY determines simulation results by deterministically seeding the random number generator.
                 Must be None or an integer in range(2**64).
-        
+
                 Defaults to None. When set to None, a prng seeded by system entropy is used.
-        
+
                 When set to an integer, making the exact same series calls on the exact same machine with the exact
                 same version of Stim will produce the exact same simulation results.
-        
+
                 CAUTION: simulation results *WILL NOT* be consistent between versions of Stim. This restriction is
                 present to make it possible to have future optimizations to the random sampling, and is enforced by
                 introducing intentional differences in the seeding strategy from version to version.
-        
+
                 CAUTION: simulation results *MAY NOT* be consistent across machines that differ in the width of
                 supported SIMD instructions. For example, using the same seed on a machine that supports AVX
                 instructions and one that only supports SSE instructions may produce different simulation results.
-        
+
                 CAUTION: simulation results *MAY NOT* be consistent if you vary how many shots are taken. For
                 example, taking 10 shots and then 90 shots will give different results from taking 100 shots in one
                 call.
-        
+
         Returns:
             An initialized stim.CompiledMeasurementSampler.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit('''
@@ -1449,7 +1449,7 @@ class CompiledMeasurementSampler:
         """
     def sample(self, shots: int) -> np.ndarray[bool]:
         """Returns a numpy array containing a batch of measurement samples from the circuit.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit('''
@@ -1459,17 +1459,17 @@ class CompiledMeasurementSampler:
             >>> s = c.compile_sampler()
             >>> s.sample(shots=1)
             array([[1, 0, 1, 1]], dtype=uint8)
-        
+
         Args:
             shots: The number of times to sample every measurement in the circuit.
-        
+
         Returns:
             A numpy array with `dtype=uint8` and `shape=(shots, num_measurements)`.
             The bit for measurement `m` in shot `s` is at `result[s, m]`.
         """
     def sample_bit_packed(self, shots: int) -> np.ndarray[np.uint8]:
         """Returns a numpy array containing a bit packed batch of measurement samples from the circuit.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit('''
@@ -1479,17 +1479,17 @@ class CompiledMeasurementSampler:
             >>> s = c.compile_sampler()
             >>> s.sample_bit_packed(shots=1)
             array([[255,   4]], dtype=uint8)
-        
+
         Args:
             shots: The number of times to sample every measurement in the circuit.
-        
+
         Returns:
             A numpy array with `dtype=uint8` and `shape=(shots, (num_measurements + 7) // 8)`.
             The bit for measurement `m` in shot `s` is at `result[s, (m // 8)] & 2**(m % 8)`.
         """
     def sample_write(self, shots: int, *, filepath: str, format: str = '01') -> None:
         """Samples measurements from the circuit and writes them to a file.
-        
+
         Examples:
             >>> import stim
             >>> import tempfile
@@ -1507,14 +1507,14 @@ class CompiledMeasurementSampler:
             1011
             1011
             1011
-        
+
         Args:
             shots: The number of times to sample every measurement in the circuit.
             filepath: The file to write the results to.
             format: The output format to write the results with.
                 Valid values are "01", "b8", "r8", "hits", "dets", and "ptb64".
                 Defaults to "01".
-        
+
         Returns:
             None.
         """
@@ -1523,25 +1523,25 @@ class CompiledMeasurementsToDetectionEventsConverter:
     """
     def __init__(self, circuit: stim.Circuit, *, skip_reference_sample: bool = False) -> None:
         """Creates a measurement-to-detection-events converter for the given circuit.
-        
+
         The converter uses a noiseless reference sample, collected from the circuit using stim's Tableau simulator
         during initialization of the converter, as a baseline for determining what the expected value of a detector
         is.
-        
+
         Note that the expected behavior of gauge detectors (detectors that are not actually deterministic under
         noiseless execution) can vary depending on the reference sample. Stim mitigates this by always generating
         the same reference sample for a given circuit.
-        
+
         Args:
             circuit: The stim circuit to use for conversions.
             skip_reference_sample: Defaults to False. When set to True, the reference sample used by the converter
                 is initialized to all-zeroes instead of being collected from the circuit. This should only be used
                 if it's known that the all-zeroes sample is actually a possible result from the circuit (under
                 noiseless execution).
-        
+
         Returns:
             An initialized stim.CompiledMeasurementsToDetectionEventsConverter.
-        
+
         Examples:
             >>> import stim
             >>> import numpy as np
@@ -1563,18 +1563,18 @@ class CompiledMeasurementsToDetectionEventsConverter:
     def convert(self, *, measurements: np.ndarray, sweep_bits: Optional[np.ndarray] = None, separate_observables: bool = False, append_observables: bool = False, bit_pack_result: bool = False) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
 
         """Converts measurement data into detection event data.
-        
+
         Args:
             measurements: A numpy array containing measurement data. The dtype of the array is used
                 to determine if it is bit packed or not.
-        
+
                 dtype=np.bool8 (unpacked data):
                     shape=(num_shots, circuit.num_measurements)
                 dtype=np.uint8 (bit packed data):
                     shape=(num_shots, math.ceil(circuit.num_measurements / 8))
             sweep_bits: Optional. A numpy array containing sweep data for the `sweep[k]` controls in the circuit.
                 The dtype of the array is used to determine if it is bit packed or not.
-        
+
                 dtype=np.bool8 (unpacked data):
                     shape=(num_shots, circuit.num_sweep_bits)
                 dtype=np.uint8 (bit packed data):
@@ -1586,7 +1586,7 @@ class CompiledMeasurementsToDetectionEventsConverter:
                 data.
             bit_pack_result: Defaults to False. When set to True, the returned numpy array contains bit packed
                 data (dtype=np.uint8 with 8 bits per item) instead of unpacked data (dtype=np.bool8).
-        
+
         Returns:
             The detection event data and (optionally) observable data.
             The result is a single numpy array if separate_observables is false, otherwise it's a tuple of two numpy arrays.
@@ -1594,7 +1594,7 @@ class CompiledMeasurementsToDetectionEventsConverter:
             The dtype of the returned arrays is np.bool8 if bit_pack_result is false, otherwise they're np.uint8 arrays.
             shape[0] of the array(s) is the number of shots.
             shape[1] of the array(s) is the number of bits per shot (divided by 8 if bit packed) (e.g. for just detection event data it would be circuit.num_detectors).
-        
+
         Examples:
             >>> import stim
             >>> import numpy as np
@@ -1630,7 +1630,7 @@ class CompiledMeasurementsToDetectionEventsConverter:
         """
     def convert_file(self, *, measurements_filepath: str, measurements_format: str = '01', sweep_bits_filepath: str = None, sweep_bits_format: str = '01', detection_events_filepath: str, detection_events_format: str = '01', append_observables: bool = False, obs_out_filepath: str = None, obs_out_format: str = '01') -> None:
         """Reads measurement data from a file, converts it, and writes the detection events to another file.
-        
+
         Args:
             measurements_filepath: A file containing measurement data to be converted.
             measurements_format: The format the measurement data is stored in.
@@ -1655,7 +1655,7 @@ class CompiledMeasurementsToDetectionEventsConverter:
             append_observables: When True, the observables in the circuit are included as part of the detection
                 event data. Specifically, they are treated as if they were additional detectors at the end of the
                 circuit. When False, observable data is not output.
-        
+
         Examples:
             >>> import stim
             >>> import tempfile
@@ -1680,7 +1680,7 @@ class CompiledMeasurementsToDetectionEventsConverter:
         """
 class DemInstruction:
     """An instruction from a detector error model.
-    
+
     Examples:
         >>> import stim
         >>> model = stim.DetectorErrorModel('''
@@ -1699,12 +1699,12 @@ class DemInstruction:
         """
     def __init__(self, type: str, args: List[float], targets: List[object]) -> None:
         """Creates a stim.DemInstruction.
-        
+
         Args:
             type: The name of the instruction type (e.g. "error" or "shift_detectors").
             args: Numeric values parameterizing the instruction (e.g. the 0.1 in "error(0.1)").
             targets: The objects the instruction involves (e.g. the "D0" and "L1" in "error(0.1) D0 L1").
-        
+
         Examples:
             >>> import stim
             >>> instruction = stim.DemInstruction('error', [0.125], [stim.target_relative_detector_id(5)])
@@ -1733,7 +1733,7 @@ class DemInstruction:
         """
 class DemRepeatBlock:
     """A repeat block from a detector error model.
-    
+
     Examples:
         >>> import stim
         >>> model = stim.DetectorErrorModel('''
@@ -1753,11 +1753,11 @@ class DemRepeatBlock:
         """
     def __init__(self, repeat_count: int, block: stim.DetectorErrorModel) -> None:
         """Creates a stim.DemRepeatBlock.
-        
+
         Args:
             repeat_count: The number of times the repeat block's body is supposed to execute.
             block: The body of the repeat block as a DetectorErrorModel containing the instructions to repeat.
-        
+
         Examples:
             >>> import stim
             >>> repeat_block = stim.DemRepeatBlock(100, stim.DetectorErrorModel('''
@@ -1805,13 +1805,13 @@ class DemTarget:
     @staticmethod
     def logical_observable_id(index: int) -> stim.DemTarget:
         """Returns a logical observable id identifying a frame change (e.g. "L5" in a .dem file).
-        
+
         Args:
             index: The index of the observable.
-        
+
         Returns:
             The logical observable target.
-        
+
         Examples:
             >>> import stim
             >>> m = stim.DetectorErrorModel()
@@ -1826,13 +1826,13 @@ class DemTarget:
     @staticmethod
     def relative_detector_id(index: int) -> stim.DemTarget:
         """Returns a relative detector id (e.g. "D5" in a .dem file).
-        
+
         Args:
             index: The index of the detector, relative to the current detector offset.
-        
+
         Returns:
             The relative detector target.
-        
+
         Examples:
             >>> import stim
             >>> m = stim.DetectorErrorModel()
@@ -1847,7 +1847,7 @@ class DemTarget:
     @staticmethod
     def separator() -> stim.DemTarget:
         """Returns a target separator (e.g. "^" in a .dem file).
-        
+
         Examples:
             >>> import stim
             >>> m = stim.DetectorErrorModel()
@@ -1864,9 +1864,9 @@ class DemTarget:
     @property
     def val(self) -> int:
         """Returns the target's integer value.
-        
+
         Example:
-        
+
             >>> import stim
             >>> stim.target_relative_detector_id(5).val
             5
@@ -1875,15 +1875,15 @@ class DemTarget:
         """
 class DemTargetWithCoords:
     """A detector error model instruction target with associated coords.
-    
+
     It is also guaranteed that, if the type of the DEM target is a
     relative detector id, it is actually absolute (i.e. relative to
     0).
-    
+
     For example, if the DEM target is a detector from a circuit with
     coordinate arguments given to detectors, the coords field will
     contain the coordinate data for the detector.
-    
+
     This is helpful information to have available when debugging a
     problem in a circuit, instead of having to constantly manually
     look up the coordinates of a detector index in order to understand
@@ -1895,7 +1895,7 @@ class DemTargetWithCoords:
     @property
     def coords(self) -> List[float]:
         """Returns the associated coordinate information as a list of flaots.
-        
+
         If there is no coordinate information, returns an empty list.
         """
     @property
@@ -1904,7 +1904,7 @@ class DemTargetWithCoords:
         """
 class DetectorErrorModel:
     """A list of instructions describing error mechanisms in terms of the detection events they produce.
-    
+
     Examples:
         >>> import stim
         >>> model = stim.DetectorErrorModel('''
@@ -1916,7 +1916,7 @@ class DetectorErrorModel:
         ... ''')
         >>> len(model)
         5
-    
+
         >>> stim.Circuit('''
         ...     X_ERROR(0.125) 0
         ...     X_ERROR(0.25) 1
@@ -1933,7 +1933,7 @@ class DetectorErrorModel:
     """
     def __add__(self, second: stim.DetectorErrorModel) -> stim.DetectorErrorModel:
         """Creates a detector error model by appending two models.
-        
+
         Examples:
             >>> import stim
             >>> m1 = stim.DetectorErrorModel('''
@@ -1959,11 +1959,11 @@ class DetectorErrorModel:
         pass
     def __getitem__(self, index_or_slice: object) -> object:
         """Returns copies of instructions from the detector error model.
-        
+
         Args:
             index_or_slice: An integer index picking out an instruction to return, or a slice picking out a range
                 of instructions to return as a detector error model.
-        
+
         Examples:
         Examples:
             >>> import stim
@@ -1994,7 +1994,7 @@ class DetectorErrorModel:
         """
     def __iadd__(self, second: stim.DetectorErrorModel) -> stim.DetectorErrorModel:
         """Appends a detector error model into the receiving model (mutating it).
-        
+
         Examples:
             >>> import stim
             >>> m1 = stim.DetectorErrorModel('''
@@ -2012,13 +2012,13 @@ class DetectorErrorModel:
         """
     def __imul__(self, repetitions: int) -> stim.DetectorErrorModel:
         """Mutates the detector error model by putting its contents into a repeat block.
-        
+
         Special case: if the repetition count is 0, the model is cleared.
         Special case: if the repetition count is 1, nothing happens.
-        
+
         Args:
             repetitions: The number of times the repeat block should repeat.
-        
+
         Examples:
             >>> import stim
             >>> m = stim.DetectorErrorModel('''
@@ -2034,11 +2034,11 @@ class DetectorErrorModel:
         """
     def __init__(self, detector_error_model_text: str = '') -> None:
         """Creates a stim.DetectorErrorModel.
-        
+
         Args:
             detector_error_model_text: Defaults to empty. Describes instructions to append into the circuit in the
                 detector error model (.dem) format.
-        
+
         Examples:
             >>> import stim
             >>> empty = stim.DetectorErrorModel()
@@ -2048,9 +2048,9 @@ class DetectorErrorModel:
         """
     def __len__(self) -> int:
         """Returns the number of top-level instructions and blocks in the detector error model.
-        
+
         Instructions inside of blocks are not included in this count.
-        
+
         Examples:
             >>> import stim
             >>> len(stim.DetectorErrorModel())
@@ -2071,13 +2071,13 @@ class DetectorErrorModel:
         """
     def __mul__(self, repetitions: int) -> stim.DetectorErrorModel:
         """Returns a detector error model with a repeat block containing the current model's instructions.
-        
+
         Special case: if the repetition count is 0, an empty model is returned.
         Special case: if the repetition count is 1, an equal model with no repeat block is returned.
-        
+
         Args:
             repetitions: The number of times the repeat block should repeat.
-        
+
         Examples:
             >>> import stim
             >>> m = stim.DetectorErrorModel('''
@@ -2100,13 +2100,13 @@ class DetectorErrorModel:
         """
     def __rmul__(self, repetitions: int) -> stim.DetectorErrorModel:
         """Returns a detector error model with a repeat block containing the current model's instructions.
-        
+
         Special case: if the repetition count is 0, an empty model is returned.
         Special case: if the repetition count is 1, an equal model with no repeat block is returned.
-        
+
         Args:
             repetitions: The number of times the repeat block should repeat.
-        
+
         Examples:
             >>> import stim
             >>> m = stim.DetectorErrorModel('''
@@ -2126,7 +2126,7 @@ class DetectorErrorModel:
         """
     def append(self, instruction: object, parens_arguments: object = None, targets: List[object] = ()) -> None:
         """Appends an instruction to the detector error model.
-        
+
         Args:
             instruction: Either the name of an instruction, a stim.DemInstruction, or a stim.DemRepeatBlock.
                 The `parens_arguments` and `targets` arguments are given if and only if the instruction is a name.
@@ -2134,7 +2134,7 @@ class DetectorErrorModel:
                 detector error model file (eg. the `0.25` in `error(0.25) D0`). This argument can be given either
                 a list of doubles, or a single double (which will be implicitly wrapped into a list).
             targets: The instruction targets, such as the `D0` in `error(0.25) D0`.
-        
+
         Examples:
             >>> import stim
             >>> m = stim.DetectorErrorModel()
@@ -2152,7 +2152,7 @@ class DetectorErrorModel:
                 error(0.125) D1
                 error(0.25) D1 ^ D2 L3
             ''')
-        
+
             >>> m.append("shift_detectors", (1, 2, 3), [5])
             >>> print(repr(m))
             stim.DetectorErrorModel('''
@@ -2160,7 +2160,7 @@ class DetectorErrorModel:
                 error(0.25) D1 ^ D2 L3
                 shift_detectors(1, 2, 3) 5
             ''')
-        
+
             >>> m += m * 3
             >>> m.append(m[0])
             >>> m.append(m[-2])
@@ -2184,44 +2184,44 @@ class DetectorErrorModel:
         """
     def approx_equals(self, other: object, *, atol: float) -> bool:
         """Checks if a detector error model is approximately equal to another detector error model.
-        
+
         Two detector error model are approximately equal if they are equal up to slight perturbations of instruction
         arguments such as probabilities. For example `error(0.100) D0` is approximately equal to `error(0.099) D0`
         within an absolute tolerance of 0.002. All other details of the models (such as the ordering of errors and
         their targets) must be exactly the same.
-        
+
         Args:
             other: The detector error model, or other object, to compare to this one.
             atol: The absolute error tolerance. The maximum amount each probability may have been perturbed by.
-        
+
         Returns:
             True if the given object is a detector error model approximately equal up to the receiving circuit up to
             the given tolerance, otherwise False.
-        
+
         Examples:
             >>> import stim
             >>> base = stim.DetectorErrorModel('''
             ...    error(0.099) D0 D1
             ... ''')
-        
+
             >>> base.approx_equals(base, atol=0)
             True
-        
+
             >>> base.approx_equals(stim.DetectorErrorModel('''
             ...    error(0.101) D0 D1
             ... '''), atol=0)
             False
-        
+
             >>> base.approx_equals(stim.DetectorErrorModel('''
             ...    error(0.101) D0 D1
             ... '''), atol=0.0001)
             False
-        
+
             >>> base.approx_equals(stim.DetectorErrorModel('''
             ...    error(0.101) D0 D1
             ... '''), atol=0.01)
             True
-        
+
             >>> base.approx_equals(stim.DetectorErrorModel('''
             ...    error(0.099) D0 D1 L0 L1 L2 L3 L4
             ... '''), atol=9999)
@@ -2229,7 +2229,7 @@ class DetectorErrorModel:
         """
     def clear(self) -> None:
         """Clears the contents of the detector error model.
-        
+
         Examples:
             >>> import stim
             >>> model = stim.DetectorErrorModel('''
@@ -2241,10 +2241,10 @@ class DetectorErrorModel:
         """
     def copy(self) -> stim.DetectorErrorModel:
         """Returns a copy of the detector error model. An independent model with the same contents.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> c1 = stim.DetectorErrorModel("error(0.1) D0 D1")
             >>> c2 = c1.copy()
             >>> c2 is c1
@@ -2254,16 +2254,16 @@ class DetectorErrorModel:
         """
     def get_detector_coordinates(self, only: object = None) -> Dict[int, List[float]]:
         """Returns the coordinate metadata of detectors in the detector error model.
-        
+
         Args:
             only: Defaults to None (meaning include all detectors). A list of detector indices to include in the
                 result. Detector indices beyond the end of the detector error model cause an error.
-        
+
         Returns:
             A dictionary mapping integers (detector indices) to lists of floats (coordinates).
             Detectors with no specified coordinate data are mapped to an empty tuple.
             If `only` is specified, then `set(result.keys()) == set(only)`.
-        
+
         Examples:
             >>> import stim
             >>> dem = stim.DetectorErrorModel('''
@@ -2280,13 +2280,13 @@ class DetectorErrorModel:
     @property
     def num_detectors(self) -> int:
         """Counts the number of detectors (e.g. `D2`) in the error model.
-        
+
         Detector indices are assumed to be contiguous from 0 up to whatever the maximum detector id is.
         If the largest detector's absolute id is n-1, then the number of detectors is n.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> stim.Circuit('''
             ...     X_ERROR(0.125) 0
             ...     X_ERROR(0.25) 1
@@ -2296,12 +2296,12 @@ class DetectorErrorModel:
             ...     DETECTOR rec[-1]
             ... ''').detector_error_model().num_detectors
             2
-        
+
             >>> stim.DetectorErrorModel('''
             ...    error(0.1) D0 D199
             ... ''').num_detectors
             200
-        
+
             >>> stim.DetectorErrorModel('''
             ...    shift_detectors 1000
             ...    error(0.1) D0 D199
@@ -2311,13 +2311,13 @@ class DetectorErrorModel:
     @property
     def num_errors(self) -> int:
         """Counts the number of errors (e.g. `error(0.1) D0`) in the error model.
-        
+
         Error instructions inside repeat blocks count once per repetition.
         Redundant errors with the same targets count as separate errors.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> stim.DetectorErrorModel('''
             ...     error(0.125) D0
             ...     repeat 100 {
@@ -2331,20 +2331,20 @@ class DetectorErrorModel:
     @property
     def num_observables(self) -> int:
         """Counts the number of frame changes (e.g. `L2`) in the error model.
-        
+
         Observable indices are assumed to be contiguous from 0 up to whatever the maximum observable id is.
         If the largest observable's id is n-1, then the number of observables is n.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> stim.Circuit('''
             ...     X_ERROR(0.125) 0
             ...     M 0
             ...     OBSERVABLE_INCLUDE(99) rec[-1]
             ... ''').detector_error_model().num_observables
             100
-        
+
             >>> stim.DetectorErrorModel('''
             ...    error(0.1) L399
             ... ''').num_observables
@@ -2352,11 +2352,11 @@ class DetectorErrorModel:
         """
     def shortest_graphlike_error(self, ignore_ungraphlike_errors: bool = False) -> stim.DetectorErrorModel:
         """Finds a minimum sized set of graphlike errors that produce an undetected logical error.
-        
+
         Note that this method does not pay attention to error probabilities (other than ignoring errors with
         probability 0). It searches for a logical error with the minimum *number* of physical errors, not the
         maximum probability of those physical errors all occurring.
-        
+
         This method works by looking for errors that have frame changes (eg. "error(0.1) D0 D1 L5" flips the frame
         of observable 5). These errors are converted into one or two symptoms and a net frame change. The symptoms
         can then be moved around by following errors touching that symptom. Each symptom is moved until it
@@ -2367,12 +2367,12 @@ class DetectorErrorModel:
         stabilizer of the system; a dead end). The search process advances like a breadth first search, seeded from
         all the frame-change errors and branching them outward in tandem, until one of them wins the race to find a
         solution.
-        
+
         Args:
             ignore_ungraphlike_errors: Defaults to False. When False, an exception is raised if there are any
                 errors in the model that are not graphlike. When True, those errors are skipped as if they weren't
                 present.
-        
+
                 A graphlike error is an error with at most two symptoms per decomposed component.
                     graphlike:
                         error(0.1) D0
@@ -2382,21 +2382,21 @@ class DetectorErrorModel:
                     not graphlike:
                         error(0.1) D0 D1 D2
                         error(0.1) D0 D1 D2 ^ D3
-        
+
         Returns:
             A detector error model containing just the error instructions corresponding to an undetectable logical
             error. There will be no other kinds of instructions (no `repeat`s, no `shift_detectors`, etc).
             The error probabilities will all be set to 1.
-        
+
             The `len` of the returned model is the graphlike code distance of the circuit. But beware that in
             general the true code distance may be smaller. For example, in the XZ surface code with twists, the true
             minimum sized logical error is likely to use Y errors. But each Y error decomposes into two graphlike
             components (the X part and the Z part). As a result, the graphlike code distance in that context is
             likely to be nearly twice as large as the true code distance.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> stim.DetectorErrorModel('''
             ...     error(0.125) D0
             ...     error(0.125) D0 D1
@@ -2407,7 +2407,7 @@ class DetectorErrorModel:
                 error(1) D1
                 error(1) D1 L55
             ''')
-        
+
             >>> stim.DetectorErrorModel('''
             ...     error(0.125) D0 D1 D2
             ...     error(0.125) L0
@@ -2415,7 +2415,7 @@ class DetectorErrorModel:
             stim.DetectorErrorModel('''
                 error(1) L0
             ''')
-        
+
             >>> circuit = stim.Circuit.generated(
             ...     "repetition_code:memory",
             ...     rounds=10,
@@ -2434,11 +2434,11 @@ class ExplainedError:
     @property
     def circuit_error_locations(self) -> List[stim.CircuitErrorLocation]:
         """The locations of circuit errors that produce the symptoms in dem_error_terms.
-        
+
         Note: if this list contains a single entry, it may be because a result
         with a single representative error was requested (as opposed to all possible
         errors).
-        
+
         Note: if this list is empty, it may be because there was a DEM error decomposed
         into parts where one of the parts is impossible to make on its own from a single
         circuit error.
@@ -2449,7 +2449,7 @@ class ExplainedError:
         """
 class FlippedMeasurement:
     """Describes a measurement that was flipped.
-    
+
     Gives the measurement's index in the measurement record, and also
     the observable of the measurement.
     """
@@ -2459,7 +2459,7 @@ class FlippedMeasurement:
     @property
     def observable(self) -> List[stim.GateTargetWithCoords]:
         """Returns the observable of the flipped measurement.
-        
+
         For example, an `MX 5` measurement will have the observable X5.
         """
     @property
@@ -2470,7 +2470,7 @@ class FlippedMeasurement:
         """
 class GateTarget:
     """Represents a gate target, like `0` or `rec[-1]`, from a circuit.
-    
+
     Examples:
         >>> import stim
         >>> circuit = stim.Circuit('''
@@ -2486,7 +2486,7 @@ class GateTarget:
         """
     def __init__(self, value: object) -> None:
         """Initializes a `stim.GateTarget`.
-        
+
         Args:
             value: A target like `5` or `stim.target_rec(-1)`.
         """
@@ -2503,7 +2503,7 @@ class GateTarget:
     @property
     def is_inverted_result_target(self) -> bool:
         """Returns whether or not this is an inverted target.
-        
+
         Inverted targets include inverted qubit targets `stim.target_inv(5)` (`!5` in a circuit file) and
         inverted Pauli targets like `stim.target_x(4, invert=True)` (`!X4` in a circuit file).
         """
@@ -2537,11 +2537,11 @@ class GateTarget:
         """
 class GateTargetWithCoords:
     """A gate target with associated coordinate information.
-    
+
     For example, if the gate target is a qubit from a circuit with
     QUBIT_COORDS instructions, the coords field will contain the
     coordinate data from the QUBIT_COORDS instruction for the qubit.
-    
+
     This is helpful information to have available when debugging a
     problem in a circuit, instead of having to constantly manually
     look up the coordinates of a qubit index in order to understand
@@ -2553,7 +2553,7 @@ class GateTargetWithCoords:
     @property
     def coords(self) -> List[float]:
         """Returns the associated coordinate information as a list of flaots.
-        
+
         If there is no coordinate information, returns an empty list.
         """
     @property
@@ -2562,9 +2562,9 @@ class GateTargetWithCoords:
         """
 class PauliString:
     """A signed Pauli tensor product (e.g. "+X \u2297 X \u2297 X" or "-Y \u2297 Z".
-    
+
     Represents a collection of Pauli operations (I, X, Y, Z) applied pairwise to a collection of qubits.
-    
+
     Examples:
         >>> import stim
         >>> stim.PauliString("XX") * stim.PauliString("YY")
@@ -2574,21 +2574,21 @@ class PauliString:
     """
     def __add__(self, rhs: stim.PauliString) -> stim.PauliString:
         """Returns the tensor product of two Pauli strings.
-        
+
         Concatenates the Pauli strings and multiplies their signs.
-        
+
         Args:
             rhs: A second stim.PauliString.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> stim.PauliString("X") + stim.PauliString("YZ")
             stim.PauliString("+XYZ")
-        
+
             >>> stim.PauliString("iX") + stim.PauliString("-X")
             stim.PauliString("-iXX")
-        
+
         Returns:
             The tensor product.
         """
@@ -2603,10 +2603,10 @@ class PauliString:
         pass
     def __getitem__(self, index_or_slice: object) -> object:
         """Returns an individual Pauli or Pauli string slice from the pauli string.
-        
+
         Individual Paulis are returned as an int using the encoding 0=I, 1=X, 2=Y, 3=Z.
         Slices are returned as a stim.PauliString (always with positive sign).
-        
+
         Examples:
             >>> import stim
             >>> p = stim.PauliString("_XYZ")
@@ -2618,10 +2618,10 @@ class PauliString:
             stim.PauliString("+_X")
             >>> p[::-1]
             stim.PauliString("+ZYX_")
-        
+
         Args:
             index_or_slice: The index of the pauli to return, or the slice of paulis to return.
-        
+
         Returns:
             0: Identity.
             1: Pauli X.
@@ -2630,15 +2630,15 @@ class PauliString:
         """
     def __iadd__(self, rhs: stim.PauliString) -> stim.PauliString:
         """Performs an inplace tensor product.
-        
+
         Concatenates the given Pauli string onto the receiving string and multiplies their signs.
-        
+
         Args:
             rhs: A second stim.PauliString.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> p = stim.PauliString("iX")
             >>> alias = p
             >>> p += stim.PauliString("-YY")
@@ -2646,72 +2646,72 @@ class PauliString:
             stim.PauliString("-iXYY")
             >>> alias is p
             True
-        
+
         Returns:
             The mutated pauli string.
         """
     def __imul__(self, rhs: object) -> stim.PauliString:
         """Inplace right-multiplies the Pauli string by another Pauli string, a complex unit, or a tensor power.
-        
+
         Args:
             rhs: The right hand side of the multiplication. This can be:
                 - A stim.PauliString to right-multiply term-by-term into the paulis of the pauli string.
                 - A complex unit (1, -1, 1j, -1j) to multiply into the sign of the pauli string.
                 - A non-negative integer indicating the tensor power to raise the pauli string to (how many times to repeat it).
-        
+
         Examples:
             >>> import stim
-        
+
             >>> p = stim.PauliString("X")
             >>> p *= 1j
             >>> p
             stim.PauliString("+iX")
-        
+
             >>> p = stim.PauliString("iXY_")
             >>> p *= 3
             >>> p
             stim.PauliString("-iXY_XY_XY_")
-        
+
             >>> p = stim.PauliString("X")
             >>> alias = p
             >>> p *= stim.PauliString("Y")
             >>> alias
             stim.PauliString("+iZ")
-        
+
             >>> p = stim.PauliString("X")
             >>> p *= stim.PauliString("_YY")
             >>> p
             stim.PauliString("+XYY")
-        
+
         Returns:
             The mutated Pauli string.
         """
     @staticmethod
     def __init__(*args, **kwargs):
         """Overloaded function.
-        
+
         1. __init__(self: stim.PauliString, num_qubits: int) -> None
-        
+
         Creates an identity Pauli string over the given number of qubits.
-        
+
         Examples:
             >>> import stim
             >>> p = stim.PauliString(5)
             >>> print(p)
             +_____
-        
+
         Args:
             num_qubits: The number of qubits the Pauli string acts on.
-        
-        
+
+
         2. __init__(self: stim.PauliString, text: str) -> None
-        
+
         Creates a stim.PauliString from a text string.
-        
+
         The string can optionally start with a sign ('+', '-', 'i', '+i', or '-i').
         The rest of the string should be characters from '_IXYZ' where
         '_' and 'I' mean identity, 'X' means Pauli X, 'Y' means Pauli Y, and 'Z' means Pauli Z.
-        
+
         Examples:
             >>> import stim
             >>> print(stim.PauliString("YZ"))
@@ -2722,15 +2722,15 @@ class PauliString:
             -___X_
             >>> print(stim.PauliString("iX"))
             +iX
-        
+
         Args:
             text: A text description of the Pauli string's contents, such as "+XXX" or "-_YX".
-        
-        
+
+
         3. __init__(self: stim.PauliString, copy: stim.PauliString) -> None
-        
+
         Creates a copy of a stim.PauliString.
-        
+
         Examples:
             >>> import stim
             >>> a = stim.PauliString("YZ")
@@ -2739,46 +2739,46 @@ class PauliString:
             False
             >>> b == a
             True
-        
+
         Args:
             copy: The pauli string to make a copy of.
-        
-        
+
+
         4. __init__(self: stim.PauliString, pauli_indices: List[int]) -> None
-        
+
         Creates a stim.PauliString from a list of integer pauli indices.
-        
+
         The indexing scheme that is used is:
             0 -> I
             1 -> X
             2 -> Y
             3 -> Z
-        
+
         Examples:
             >>> import stim
             >>> stim.PauliString([0, 1, 2, 3, 0, 3])
             stim.PauliString("+_XYZ_Z")
-        
+
         Args:
             pauli_indices: A sequence of integers from 0 to 3 (inclusive) indicating paulis.
         """
     def __itruediv__(self, rhs: complex) -> stim.PauliString:
         """Inplace divides the Pauli string by a complex unit.
-        
+
         Args:
             rhs: The divisor. Can be 1, -1, 1j, or -1j.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> p = stim.PauliString("X")
             >>> p /= 1j
             >>> p
             stim.PauliString("-iX")
-        
+
         Returns:
             The mutated Pauli string.
-        
+
         Raises:
             ValueError: The divisor isn't 1, -1, 1j, or -1j.
         """
@@ -2787,23 +2787,23 @@ class PauliString:
         """
     def __mul__(self, rhs: object) -> stim.PauliString:
         """Right-multiplies the Pauli string by another Pauli string, a complex unit, or a tensor power.
-        
+
         Args:
             rhs: The right hand side of the multiplication. This can be:
                 - A stim.PauliString to right-multiply term-by-term with the paulis of the pauli string.
                 - A complex unit (1, -1, 1j, -1j) to multiply with the sign of the pauli string.
                 - A non-negative integer indicating the tensor power to raise the pauli string to (how many times to repeat it).
-        
+
         Examples:
             >>> import stim
-        
+
             >>> stim.PauliString("X") * 1
             stim.PauliString("+X")
             >>> stim.PauliString("X") * -1
             stim.PauliString("-X")
             >>> stim.PauliString("X") * 1j
             stim.PauliString("+iX")
-        
+
             >>> stim.PauliString("X") * 2
             stim.PauliString("+XX")
             >>> stim.PauliString("-X") * 2
@@ -2814,17 +2814,17 @@ class PauliString:
             stim.PauliString("+XXX")
             >>> stim.PauliString("iX") * 3
             stim.PauliString("-iXXX")
-        
+
             >>> stim.PauliString("X") * stim.PauliString("Y")
             stim.PauliString("+iZ")
             >>> stim.PauliString("X") * stim.PauliString("XX_")
             stim.PauliString("+_X_")
             >>> stim.PauliString("XXXX") * stim.PauliString("_XYZ")
             stim.PauliString("+X_ZY")
-        
+
         Returns:
             The product or tensor power.
-        
+
         Raises:
             TypeError: The right hand side isn't a stim.PauliString, a non-negative integer, or a complex unit (1, -1, 1j, or -1j).
         """
@@ -2833,7 +2833,7 @@ class PauliString:
         """
     def __neg__(self) -> stim.PauliString:
         """Returns the negation of the pauli string.
-        
+
         Examples:
             >>> import stim
             >>> -stim.PauliString("X")
@@ -2845,7 +2845,7 @@ class PauliString:
         """
     def __pos__(self) -> stim.PauliString:
         """Returns a pauli string with the same contents.
-        
+
         Examples:
             >>> import stim
             >>> +stim.PauliString("+X")
@@ -2860,23 +2860,23 @@ class PauliString:
         """
     def __rmul__(self, lhs: object) -> stim.PauliString:
         """Left-multiplies the Pauli string by another Pauli string, a complex unit, or a tensor power.
-        
+
         Args:
             lhs: The left hand side of the multiplication. This can be:
                 - A stim.PauliString to left-multiply term-by-term into the paulis of the pauli string.
                 - A complex unit (1, -1, 1j, -1j) to multiply into the sign of the pauli string.
                 - A non-negative integer indicating the tensor power to raise the pauli string to (how many times to repeat it).
-        
+
         Examples:
             >>> import stim
-        
+
             >>> 1 * stim.PauliString("X")
             stim.PauliString("+X")
             >>> -1 * stim.PauliString("X")
             stim.PauliString("-X")
             >>> 1j * stim.PauliString("X")
             stim.PauliString("+iX")
-        
+
             >>> 2 * stim.PauliString("X")
             stim.PauliString("+XX")
             >>> 2 * stim.PauliString("-X")
@@ -2887,27 +2887,27 @@ class PauliString:
             stim.PauliString("+XXX")
             >>> 3 * stim.PauliString("iX")
             stim.PauliString("-iXXX")
-        
+
             >>> stim.PauliString("X") * stim.PauliString("Y")
             stim.PauliString("+iZ")
             >>> stim.PauliString("X") * stim.PauliString("XX_")
             stim.PauliString("+_X_")
             >>> stim.PauliString("XXXX") * stim.PauliString("_XYZ")
             stim.PauliString("+X_ZY")
-        
+
         Returns:
             The product.
-        
+
         Raises:
             ValueError: The scalar phase factor isn't 1, -1, 1j, or -1j.
         """
     def __setitem__(self, index: int, new_pauli: object) -> None:
         """Mutates an entry in the pauli string using the encoding 0=I, 1=X, 2=Y, 3=Z.
-        
+
         Args:
             index: The index of the pauli to overwrite.
             new_pauli: Either a character from '_IXYZ' or an integer from range(4).
-        
+
         Examples:
             >>> import stim
             >>> p = stim.PauliString(4)
@@ -2934,31 +2934,31 @@ class PauliString:
         """
     def __truediv__(self, rhs: complex) -> stim.PauliString:
         """Divides the Pauli string by a complex unit.
-        
+
         Args:
             rhs: The divisor. Can be 1, -1, 1j, or -1j.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> stim.PauliString("X") / 1j
             stim.PauliString("-iX")
-        
+
         Returns:
             The quotient.
-        
+
         Raises:
             ValueError: The divisor isn't 1, -1, 1j, or -1j.
         """
     def commutes(self, other: stim.PauliString) -> bool:
         """Determines if two Pauli strings commute or not.
-        
+
         Two Pauli strings commute if they have an even number of matched
         non-equal non-identity Pauli terms. Otherwise they anticommute.
-        
+
         Args:
             other: The other Pauli string.
-        
+
         Examples:
             >>> import stim
             >>> xx = stim.PauliString("XX")
@@ -2976,13 +2976,13 @@ class PauliString:
             True
             >>> xx.commutes(stim.PauliString(""))
             True
-        
+
         Returns:
             True if the Pauli strings commute, False if they anti-commute.
         """
     def copy(self) -> stim.PauliString:
         """Returns a copy of the pauli string. An independent pauli string with the same contents.
-        
+
         Examples:
             >>> import stim
             >>> p1 = stim.PauliString.random(2)
@@ -2998,13 +2998,13 @@ class PauliString:
     @staticmethod
     def random(num_qubits: int, *, allow_imaginary: bool = False) -> stim.PauliString:
         """Samples a uniformly random Hermitian Pauli string over the given number of qubits.
-        
+
         Args:
             num_qubits: The number of qubits the Pauli string should act on.
             allow_imaginary: Defaults to False. If True, the sign of the result may be 1j or -1j
                 in addition to +1 or -1. In other words, setting this to True allows the result
                 to be non-Hermitian.
-        
+
         Examples:
             >>> import stim
             >>> p = stim.PauliString.random(5)
@@ -3012,20 +3012,20 @@ class PauliString:
             5
             >>> p.sign in [-1, +1]
             True
-        
+
             >>> p2 = stim.PauliString.random(3, allow_imaginary=True)
             >>> len(p2)
             3
             >>> p2.sign in [-1, +1, 1j, -1j]
             True
-        
+
         Returns:
             The sampled Pauli string.
         """
     @property
     def sign(self) -> complex:
         """The sign of the Pauli string. Can be +1, -1, 1j, or -1j.
-        
+
         Examples:
             >>> import stim
             >>> stim.PauliString("X").sign
@@ -3042,10 +3042,10 @@ class PauliString:
         pass
 class Tableau:
     """A stabilizer tableau.
-    
+
     Represents a Clifford operation by explicitly storing how that operation conjugates a list of Pauli
     group generators into composite Pauli products.
-    
+
     Examples:
         >>> import stim
         >>> stim.Tableau.from_named_gate("H")
@@ -3057,7 +3057,7 @@ class Tableau:
                 stim.PauliString("+X"),
             ],
         )
-    
+
         >>> t = stim.Tableau.random(5)
         >>> t_inv = t**-1
         >>> print(t * t_inv)
@@ -3068,20 +3068,20 @@ class Tableau:
         | __ __ XZ __ __
         | __ __ __ XZ __
         | __ __ __ __ XZ
-    
+
         >>> x2z3 = t.x_output(2) * t.z_output(3)
         >>> t_inv(x2z3)
         stim.PauliString("+__XZ_")
     """
     def __add__(self, rhs: stim.Tableau) -> stim.Tableau:
         """Returns the direct sum (diagonal concatenation) of two Tableaus.
-        
+
         Args:
             rhs: A second stim.Tableau.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> s = stim.Tableau.from_named_gate("S")
             >>> cz = stim.Tableau.from_named_gate("CZ")
             >>> print(s + cz)
@@ -3090,19 +3090,19 @@ class Tableau:
             | YZ __ __
             | __ XZ Z_
             | __ Z_ XZ
-        
+
         Returns:
             The direct sum.
         """
     def __call__(self, pauli_string: stim.PauliString) -> stim.PauliString:
         """Returns the result of conjugating the given PauliString by the Tableau's Clifford operation.
-        
+
         Args:
             pauli_string: The pauli string to conjugate.
-        
+
         Returns:
             The new conjugated pauli string.
-        
+
         Examples:
             >>> import stim
             >>> t = stim.Tableau.from_named_gate("CNOT")
@@ -3116,13 +3116,13 @@ class Tableau:
         """
     def __iadd__(self, rhs: stim.Tableau) -> stim.Tableau:
         """Performs an inplace direct sum (diagonal concatenation).
-        
+
         Args:
             rhs: A second stim.Tableau.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> s = stim.Tableau.from_named_gate("S")
             >>> cz = stim.Tableau.from_named_gate("CZ")
             >>> alias = s
@@ -3135,13 +3135,13 @@ class Tableau:
             | YZ __ __
             | __ XZ Z_
             | __ Z_ XZ
-        
+
         Returns:
             The mutated tableau.
         """
     def __init__(self, num_qubits: int) -> None:
         """Creates an identity tableau over the given number of qubits.
-        
+
         Examples:
             >>> import stim
             >>> t = stim.Tableau(3)
@@ -3151,7 +3151,7 @@ class Tableau:
             | XZ __ __
             | __ XZ __
             | __ __ XZ
-        
+
         Args:
             num_qubits: The number of qubits the tableau's operation acts on.
         """
@@ -3160,14 +3160,14 @@ class Tableau:
         """
     def __mul__(self, rhs: stim.Tableau) -> stim.Tableau:
         """Returns the product of two tableaus.
-        
+
         If the tableau T1 represents the Clifford operation with unitary C1,
         and the tableau T2 represents the Clifford operation with unitary C2,
         then the tableau T1*T2 represents the Clifford operation with unitary C1*C2.
-        
+
         Args:
             rhs: The tableau  on the right hand side of the multiplication.
-        
+
         Examples:
             >>> import stim
             >>> t1 = stim.Tableau.random(4)
@@ -3182,13 +3182,13 @@ class Tableau:
         """
     def __pow__(self, exponent: int) -> stim.Tableau:
         """Raises the tableau to an integer power.
-        
+
         Large powers are reached efficiently using repeated squaring.
         Negative powers are reached by inverting the tableau.
-        
+
         Args:
             exponent: The power to raise to. Can be negative, zero, or positive.
-        
+
         Examples:
             >>> import stim
             >>> s = stim.Tableau.from_named_gate("S")
@@ -3215,13 +3215,13 @@ class Tableau:
         """
     def append(self, gate: stim.Tableau, targets: List[int]) -> None:
         """Appends an operation's effect into this tableau, mutating this tableau.
-        
+
         Time cost is O(n*m*m) where n=len(self) and m=len(gate).
-        
+
         Args:
             gate: The tableau of the operation being appended into this tableau.
             targets: The qubits being targeted by the gate.
-        
+
         Examples:
             >>> import stim
             >>> cnot = stim.Tableau.from_named_gate("CNOT")
@@ -3234,7 +3234,7 @@ class Tableau:
         """
     def copy(self) -> stim.Tableau:
         """Returns a copy of the tableau. An independent tableau with the same contents.
-        
+
         Examples:
             >>> import stim
             >>> t1 = stim.Tableau.random(2)
@@ -3247,20 +3247,20 @@ class Tableau:
     @staticmethod
     def from_conjugated_generators(*, xs: List[stim.PauliString], zs: List[stim.PauliString]) -> stim.Tableau:
         """Creates a tableau from the given outputs for each generator.
-        
+
         Verifies that the tableau is well formed.
-        
+
         Args:
             xs: A List[stim.PauliString] with the results of conjugating X0, X1, etc.
             zs: A List[stim.PauliString] with the results of conjugating Z0, Z1, etc.
-        
+
         Returns:
             The created tableau.
-        
+
         Raises:
             ValueError: The given outputs are malformed. Their lengths are inconsistent,
                 or they don't satisfy the required commutation relationships.
-        
+
         Examples:
             >>> import stim
             >>> identity3 = stim.Tableau.from_conjugated_generators(
@@ -3281,13 +3281,13 @@ class Tableau:
     @staticmethod
     def from_named_gate(name: str) -> stim.Tableau:
         """Returns the tableau of a named Clifford gate.
-        
+
         Args:
             name: The name of the Clifford gate.
-        
+
         Returns:
             The gate's tableau.
-        
+
         Examples:
             >>> import stim
             >>> print(stim.Tableau.from_named_gate("H"))
@@ -3306,22 +3306,22 @@ class Tableau:
         """
     def inverse(self, *, unsigned: bool = False) -> stim.Tableau:
         """Computes the inverse of the tableau.
-        
+
         The inverse T^-1 of a tableau T is the unique tableau with the property that T * T^-1 = T^-1 * T = I where
         I is the identity tableau.
-        
+
         Args:
             unsigned: Defaults to false. When set to true, skips computing the signs of the output observables and
                 instead just set them all to be positive. This is beneficial because computing the signs takes
                 O(n^3) time and the rest of the inverse computation is O(n^2) where n is the number of qubits in the
                 tableau. So, if you only need the Pauli terms (not the signs), it is significantly cheaper.
-        
+
         Returns:
             The inverse tableau.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> # Check that the inverse agrees with hard-coded tableaus in the gate data.
             >>> s = stim.Tableau.from_named_gate("S")
             >>> s_dag = stim.Tableau.from_named_gate("S_DAG")
@@ -3330,14 +3330,14 @@ class Tableau:
             >>> z = stim.Tableau.from_named_gate("Z")
             >>> z.inverse() == z
             True
-        
+
             >>> # Check that multiplying by the inverse produces the identity.
             >>> t = stim.Tableau.random(10)
             >>> t_inv = t.inverse()
             >>> identity = stim.Tableau(10)
             >>> t * t_inv == t_inv * t == identity
             True
-        
+
             >>> # Check a manual case.
             >>> t = stim.Tableau.from_conjugated_generators(
             ...     xs=[stim.PauliString("-__Z"), stim.PauliString("+XZ_"), stim.PauliString("+_ZZ")],
@@ -3358,21 +3358,21 @@ class Tableau:
         """
     def inverse_x_output(self, input_index: int, *, unsigned: bool = False) -> stim.PauliString:
         """Returns the result of conjugating an X Pauli generator by the inverse of the tableau.
-        
+
         A faster version of `tableau.inverse(unsigned).x_output(input_index)`.
-        
+
         Args:
             input_index: Identifies the column (the qubit of the X generator) to return from the inverse tableau.
             unsigned: Defaults to false. When set to true, skips computing the result's sign and instead just sets
                 it to positive. This is beneficial because computing the sign takes O(n^2) time whereas all other
                 parts of the computation take O(n) time where n is the number of qubits in the tableau.
-        
+
         Returns:
             The result of conjugating an X generator by the inverse of the tableau.
-        
+
         Examples:
             >>> import stim
-        
+
             # Check equivalence with the inverse's x_output.
             >>> t = stim.Tableau.random(4)
             >>> expected = t.inverse().x_output(0)
@@ -3384,24 +3384,24 @@ class Tableau:
         """
     def inverse_x_output_pauli(self, input_index: int, output_index: int) -> int:
         """Returns a Pauli term from the tableau's inverse's output pauli string for an input X generator.
-        
+
         A constant-time equivalent for `tableau.inverse().x_output(input_index)[output_index]`.
-        
+
         Args:
             input_index: Identifies the column (the qubit of the input X generator) in the inverse tableau.
             output_index: Identifies the row (the output qubit) in the inverse tableau.
-        
+
         Returns:
             An integer identifying Pauli at the given location in the inverse tableau:
-        
+
                 0: I
                 1: X
                 2: Y
                 3: Z
-        
+
         Examples:
             >>> import stim
-        
+
             >>> t_inv = stim.Tableau.from_conjugated_generators(
             ...     xs=[stim.PauliString("-Y_"), stim.PauliString("+YZ")],
             ...     zs=[stim.PauliString("-ZY"), stim.PauliString("+YX")],
@@ -3417,21 +3417,21 @@ class Tableau:
         """
     def inverse_y_output(self, input_index: int, *, unsigned: bool = False) -> stim.PauliString:
         """Returns the result of conjugating a Y Pauli generator by the inverse of the tableau.
-        
+
         A faster version of `tableau.inverse(unsigned).y_output(input_index)`.
-        
+
         Args:
             input_index: Identifies the column (the qubit of the Y generator) to return from the inverse tableau.
             unsigned: Defaults to false. When set to true, skips computing the result's sign and instead just sets
                 it to positive. This is beneficial because computing the sign takes O(n^2) time whereas all other
                 parts of the computation take O(n) time where n is the number of qubits in the tableau.
-        
+
         Returns:
             The result of conjugating a Y generator by the inverse of the tableau.
-        
+
         Examples:
             >>> import stim
-        
+
             # Check equivalence with the inverse's y_output.
             >>> t = stim.Tableau.random(4)
             >>> expected = t.inverse().y_output(0)
@@ -3443,24 +3443,24 @@ class Tableau:
         """
     def inverse_y_output_pauli(self, input_index: int, output_index: int) -> int:
         """Returns a Pauli term from the tableau's inverse's output pauli string for an input Y generator.
-        
+
         A constant-time equivalent for `tableau.inverse().y_output(input_index)[output_index]`.
-        
+
         Args:
             input_index: Identifies the column (the qubit of the input Y generator) in the inverse tableau.
             output_index: Identifies the row (the output qubit) in the inverse tableau.
-        
+
         Returns:
             An integer identifying Pauli at the given location in the inverse tableau:
-        
+
                 0: I
                 1: X
                 2: Y
                 3: Z
-        
+
         Examples:
             >>> import stim
-        
+
             >>> t_inv = stim.Tableau.from_conjugated_generators(
             ...     xs=[stim.PauliString("-Y_"), stim.PauliString("+YZ")],
             ...     zs=[stim.PauliString("-ZY"), stim.PauliString("+YX")],
@@ -3476,23 +3476,23 @@ class Tableau:
         """
     def inverse_z_output(self, input_index: int, *, unsigned: bool = False) -> stim.PauliString:
         """Returns the result of conjugating a Z Pauli generator by the inverse of the tableau.
-        
+
         A faster version of `tableau.inverse(unsigned).z_output(input_index)`.
-        
+
         Args:
             input_index: Identifies the column (the qubit of the Z generator) to return from the inverse tableau.
             unsigned: Defaults to false. When set to true, skips computing the result's sign and instead just sets
                 it to positive. This is beneficial because computing the sign takes O(n^2) time whereas all other
                 parts of the computation take O(n) time where n is the number of qubits in the tableau.
-        
+
         Returns:
             The result of conjugating a Z generator by the inverse of the tableau.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> import stim
-        
+
             # Check equivalence with the inverse's z_output.
             >>> t = stim.Tableau.random(4)
             >>> expected = t.inverse().z_output(0)
@@ -3504,24 +3504,24 @@ class Tableau:
         """
     def inverse_z_output_pauli(self, input_index: int, output_index: int) -> int:
         """Returns a Pauli term from the tableau's inverse's output pauli string for an input Z generator.
-        
+
         A constant-time equivalent for `tableau.inverse().z_output(input_index)[output_index]`.
-        
+
         Args:
             input_index: Identifies the column (the qubit of the input Z generator) in the inverse tableau.
             output_index: Identifies the row (the output qubit) in the inverse tableau.
-        
+
         Returns:
             An integer identifying Pauli at the given location in the inverse tableau:
-        
+
                 0: I
                 1: X
                 2: Y
                 3: Z
-        
+
         Examples:
             >>> import stim
-        
+
             >>> t_inv = stim.Tableau.from_conjugated_generators(
             ...     xs=[stim.PauliString("-Y_"), stim.PauliString("+YZ")],
             ...     zs=[stim.PauliString("-ZY"), stim.PauliString("+YX")],
@@ -3537,13 +3537,13 @@ class Tableau:
         """
     def prepend(self, gate: stim.Tableau, targets: List[int]) -> None:
         """Prepends an operation's effect into this tableau, mutating this tableau.
-        
+
         Time cost is O(n*m*m) where n=len(self) and m=len(gate).
-        
+
         Args:
             gate: The tableau of the operation being prepended into this tableau.
             targets: The qubits being targeted by the gate.
-        
+
         Examples:
             >>> import stim
             >>> h = stim.Tableau.from_named_gate("H")
@@ -3556,17 +3556,17 @@ class Tableau:
     @staticmethod
     def random(num_qubits: int) -> stim.Tableau:
         """Samples a uniformly random Clifford operation over the given number of qubits and returns its tableau.
-        
+
         Args:
             num_qubits: The number of qubits the tableau should act on.
-        
+
         Returns:
             The sampled tableau.
-        
+
         Examples:
             >>> import stim
             >>> t = stim.Tableau.random(42)
-        
+
         References:
             "Hadamard-free circuits expose the structure of the Clifford group"
             Sergey Bravyi, Dmitri Maslov
@@ -3574,15 +3574,15 @@ class Tableau:
         """
     def then(self, second: stim.Tableau) -> stim.Tableau:
         """Returns the result of composing two tableaus.
-        
+
         If the tableau T1 represents the Clifford operation with unitary C1,
         and the tableau T2 represents the Clifford operation with unitary C2,
         then the tableau T1.then(T2) represents the Clifford operation with unitary C2*C1.
-        
+
         Args:
             second: The result is equivalent to applying the second tableau after
                 the receiving tableau.
-        
+
         Examples:
             >>> import stim
             >>> t1 = stim.Tableau.random(4)
@@ -3594,16 +3594,16 @@ class Tableau:
         """
     def x_output(self, target: int) -> stim.PauliString:
         """Returns the result of conjugating a Pauli X by the tableau's Clifford operation.
-        
+
         Args:
             target: The qubit targeted by the Pauli X operation.
-        
+
         Examples:
             >>> import stim
             >>> h = stim.Tableau.from_named_gate("H")
             >>> h.x_output(0)
             stim.PauliString("+Z")
-        
+
             >>> cnot = stim.Tableau.from_named_gate("CNOT")
             >>> cnot.x_output(0)
             stim.PauliString("+XX")
@@ -3612,24 +3612,24 @@ class Tableau:
         """
     def x_output_pauli(self, input_index: int, output_index: int) -> int:
         """Returns a Pauli term from the tableau's output pauli string for an input X generator.
-        
+
         A constant-time equivalent for `tableau.x_output(input_index)[output_index]`.
-        
+
         Args:
             input_index: Identifies the tableau column (the qubit of the input X generator).
             output_index: Identifies the tableau row (the output qubit).
-        
+
         Returns:
             An integer identifying Pauli at the given location in the tableau:
-        
+
                 0: I
                 1: X
                 2: Y
                 3: Z
-        
+
         Examples:
             >>> import stim
-        
+
             >>> t = stim.Tableau.from_conjugated_generators(
             ...     xs=[stim.PauliString("-Y_"), stim.PauliString("+YZ")],
             ...     zs=[stim.PauliString("-ZY"), stim.PauliString("+YX")],
@@ -3645,16 +3645,16 @@ class Tableau:
         """
     def y_output(self, target: int) -> stim.PauliString:
         """Returns the result of conjugating a Pauli Y by the tableau's Clifford operation.
-        
+
         Args:
             target: The qubit targeted by the Pauli Y operation.
-        
+
         Examples:
             >>> import stim
             >>> h = stim.Tableau.from_named_gate("H")
             >>> h.y_output(0)
             stim.PauliString("-Y")
-        
+
             >>> cnot = stim.Tableau.from_named_gate("CNOT")
             >>> cnot.y_output(0)
             stim.PauliString("+YX")
@@ -3663,24 +3663,24 @@ class Tableau:
         """
     def y_output_pauli(self, input_index: int, output_index: int) -> int:
         """Returns a Pauli term from the tableau's output pauli string for an input Y generator.
-        
+
         A constant-time equivalent for `tableau.y_output(input_index)[output_index]`.
-        
+
         Args:
             input_index: Identifies the tableau column (the qubit of the input Y generator).
             output_index: Identifies the tableau row (the output qubit).
-        
+
         Returns:
             An integer identifying Pauli at the given location in the tableau:
-        
+
                 0: I
                 1: X
                 2: Y
                 3: Z
-        
+
         Examples:
             >>> import stim
-        
+
             >>> t = stim.Tableau.from_conjugated_generators(
             ...     xs=[stim.PauliString("-Y_"), stim.PauliString("+YZ")],
             ...     zs=[stim.PauliString("-ZY"), stim.PauliString("+YX")],
@@ -3696,16 +3696,16 @@ class Tableau:
         """
     def z_output(self, target: int) -> stim.PauliString:
         """Returns the result of conjugating a Pauli Z by the tableau's Clifford operation.
-        
+
         Args:
             target: The qubit targeted by the Pauli Z operation.
-        
+
         Examples:
             >>> import stim
             >>> h = stim.Tableau.from_named_gate("H")
             >>> h.z_output(0)
             stim.PauliString("+X")
-        
+
             >>> cnot = stim.Tableau.from_named_gate("CNOT")
             >>> cnot.z_output(0)
             stim.PauliString("+Z_")
@@ -3714,24 +3714,24 @@ class Tableau:
         """
     def z_output_pauli(self, input_index: int, output_index: int) -> int:
         """Returns a Pauli term from the tableau's output pauli string for an input Z generator.
-        
+
         A constant-time equivalent for `tableau.z_output(input_index)[output_index]`.
-        
+
         Args:
             input_index: Identifies the tableau column (the qubit of the input Z generator).
             output_index: Identifies the tableau row (the output qubit).
-        
+
         Returns:
             An integer identifying Pauli at the given location in the tableau:
-        
+
                 0: I
                 1: X
                 2: Y
                 3: Z
-        
+
         Examples:
             >>> import stim
-        
+
             >>> t = stim.Tableau.from_conjugated_generators(
             ...     xs=[stim.PauliString("-Y_"), stim.PauliString("+YZ")],
             ...     zs=[stim.PauliString("-ZY"), stim.PauliString("+YX")],
@@ -3747,9 +3747,9 @@ class Tableau:
         """
 class TableauSimulator:
     """A quantum stabilizer circuit simulator whose internal state is an inverse stabilizer tableau.
-    
+
     Supports interactive usage, where gates and measurements are applied on demand.
-    
+
     Examples:
         >>> import stim
         >>> s = stim.TableauSimulator()
@@ -3759,7 +3759,7 @@ class TableauSimulator:
         ...     s.cnot(1, 2)
         >>> s.measure(1) == s.measure(2)
         True
-    
+
         >>> s = stim.TableauSimulator()
         >>> s.h(0)
         >>> s.cnot(0, 1)
@@ -3777,21 +3777,21 @@ class TableauSimulator:
     """
     def canonical_stabilizers(self) -> List[stim.PauliString]:
         """Returns a list of the stabilizers of the simulator's current state in a standard form.
-        
+
         Two simulators have the same canonical stabilizers if and only if their current quantum state is equal
         (and tracking the same number of qubits).
-        
+
         The canonical form is computed as follows:
-        
+
             1. Get a list of stabilizers using the `z_output`s of `simulator.current_inverse_tableau()**-1`.
             2. Perform Gaussian elimination on each generator g (ordered X0, Z0, X1, Z1, X2, Z2, etc).
                 2a) Pick any stabilizer that uses the generator g. If there are none, go to the next g.
                 2b) Multiply that stabilizer into all other stabilizers that use the generator g.
                 2c) Swap that stabilizer with the stabilizer at position `next_output` then increment `next_output`.
-        
+
         Returns:
             A List[stim.PauliString] of the simulator's state's stabilizers.
-        
+
         Examples:
             >>> import stim
             >>> s = stim.TableauSimulator()
@@ -3800,7 +3800,7 @@ class TableauSimulator:
             >>> s.x(2)
             >>> s.canonical_stabilizers()
             [stim.PauliString("+XX_"), stim.PauliString("+ZZ_"), stim.PauliString("-__Z")]
-        
+
             >>> # Scramble the stabilizers then check that the canonical form is unchanged.
             >>> s.set_inverse_tableau(s.current_inverse_tableau()**-1)
             >>> s.cnot(0, 1)
@@ -3813,7 +3813,7 @@ class TableauSimulator:
         """
     def cnot(self, *targets) -> None:
         """Applies a controlled X gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets, and so forth.
@@ -3821,10 +3821,10 @@ class TableauSimulator:
         """
     def copy(self) -> stim.TableauSimulator:
         """Returns a copy of the simulator. A simulator with the same internal state.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> s1 = stim.TableauSimulator()
             >>> s1.set_inverse_tableau(stim.Tableau.random(1))
             >>> s2 = s1.copy()
@@ -3832,7 +3832,7 @@ class TableauSimulator:
             False
             >>> s2.current_inverse_tableau() == s1.current_inverse_tableau()
             True
-        
+
             >>> s = stim.TableauSimulator()
             >>> def brute_force_post_select(qubit, desired_result):
             ...     global s
@@ -3848,10 +3848,10 @@ class TableauSimulator:
         """
     def current_inverse_tableau(self) -> stim.Tableau:
         """Returns a copy of the internal state of the simulator as a stim.Tableau.
-        
+
         Returns:
             A stim.Tableau copy of the simulator's state.
-        
+
         Examples:
             >>> import stim
             >>> s = stim.TableauSimulator()
@@ -3880,7 +3880,7 @@ class TableauSimulator:
         """
     def current_measurement_record(self) -> List[bool]:
         """Returns a copy of the record of all measurements performed by the simulator.
-        
+
         Examples:
             >>> import stim
             >>> s = stim.TableauSimulator()
@@ -3896,13 +3896,13 @@ class TableauSimulator:
             >>> s.do(stim.Circuit("M 0"))
             >>> s.current_measurement_record()
             [False, True, True]
-        
+
         Returns:
             A list of booleans containing the result of every measurement performed by the simulator so far.
         """
     def cy(self, *targets) -> None:
         """Applies a controlled Y gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets, and so forth.
@@ -3910,7 +3910,7 @@ class TableauSimulator:
         """
     def cz(self, *targets) -> None:
         """Applies a controlled Z gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets, and so forth.
@@ -3924,10 +3924,10 @@ class TableauSimulator:
         pass
     def do(self, circuit_or_pauli_string: object) -> None:
         """Applies a circuit or pauli string to the simulator's state.
-        
+
         Args:
             circuit_or_pauli_string: A stim.Circuit or a stim.PauliString containing operations to apply.
-        
+
         Examples:
             >>> import stim
             >>> s = stim.TableauSimulator()
@@ -3937,7 +3937,7 @@ class TableauSimulator:
             ... '''))
             >>> s.current_measurement_record()
             [True]
-        
+
             >>> s = stim.TableauSimulator()
             >>> s.do(stim.PauliString("IXYZ"))
             >>> s.measure_many(0, 1, 2, 3)
@@ -3945,25 +3945,25 @@ class TableauSimulator:
         """
     def h(self, *targets) -> None:
         """Applies a Hadamard gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
     def h_xy(self, *targets) -> None:
         """Applies a variant of the Hadamard gate that swaps the X and Y axes to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
     def h_yz(self, *targets) -> None:
         """Applies a variant of the Hadamard gate that swaps the Y and Z axes to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
     def iswap(self, *targets) -> None:
         """Applies an ISWAP gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets, and so forth.
@@ -3971,7 +3971,7 @@ class TableauSimulator:
         """
     def iswap_dag(self, *targets) -> None:
         """Applies an ISWAP_DAG gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets, and so forth.
@@ -3979,22 +3979,22 @@ class TableauSimulator:
         """
     def measure(self, target: int) -> bool:
         """Measures a single qubit.
-        
+
         Unlike the other methods on TableauSimulator, this one does not broadcast
         over multiple targets. This is to avoid returning a list, which would
         create a pitfall where typing `if sim.measure(qubit)` would be a bug.
-        
+
         To measure multiple qubits, use `TableauSimulator.measure_many`.
-        
+
         Args:
             target: The index of the qubit to measure.
-        
+
         Returns:
             The measurement result as a bool.
         """
     def measure_kickback(self, target: int) -> tuple:
         """Measures a qubit and returns the result as well as its Pauli kickback (if any).
-        
+
         The "Pauli kickback" of a stabilizer circuit measurement is a set of Pauli operations that
         flip the post-measurement system state between the two possible post-measurement states.
         For example, consider measuring one of the qubits in the state |00>+|11> in the Z basis.
@@ -4005,30 +4005,30 @@ class TableauSimulator:
         Note that there are often many possible equivalent Pauli kickbacks. For example,
         if in the previous example there was a third qubit in the |0> state, then both
         `stim.PauliString("XX_")` and `stim.PauliString("XXZ")` are valid kickbacks.
-        
+
         Measurements with determinist results don't have a Pauli kickback.
-        
+
         Args:
             target: The index of the qubit to measure.
-        
+
         Returns:
             A (result, kickback) tuple.
             The result is a bool containing the measurement's output.
             The kickback is either None (meaning the measurement was deterministic) or a stim.PauliString
             (meaning the measurement was random, and the operations in the Pauli string flip between the
             two possible post-measurement states).
-        
+
         Examples:
             >>> import stim
             >>> s = stim.TableauSimulator()
-        
+
             >>> s.measure_kickback(0)
             (False, None)
-        
+
             >>> s.h(0)
             >>> s.measure_kickback(0)[1]
             stim.PauliString("+X")
-        
+
             >>> def pseudo_post_select(qubit, desired_result):
             ...     m, kick = s.measure_kickback(qubit)
             ...     if m != desired_result:
@@ -4045,21 +4045,21 @@ class TableauSimulator:
         """
     def measure_many(self, *targets) -> List[bool]:
         """Measures multiple qubits.
-        
+
         Args:
             *targets: The indices of the qubits to measure.
-        
+
         Returns:
             The measurement results as a list of bools.
         """
     def peek_bloch(self, target: int) -> stim.PauliString:
         """Returns the current bloch vector of the qubit, represented as a stim.PauliString.
-        
+
         This is a non-physical operation. It reports information about the qubit without disturbing it.
-        
+
         Args:
             target: The qubit to peek at.
-        
+
         Returns:
             stim.PauliString("I"): The qubit is entangled. Its bloch vector is x=y=z=0.
             stim.PauliString("+Z"): The qubit is in the |0> state. Its bloch vector is z=+1, x=y=0.
@@ -4068,7 +4068,7 @@ class TableauSimulator:
             stim.PauliString("-Y"): The qubit is in the |-i> state. Its bloch vector is y=-1, x=z=0.
             stim.PauliString("+X"): The qubit is in the |+> state. Its bloch vector is x=+1, y=z=0.
             stim.PauliString("-X"): The qubit is in the |-> state. Its bloch vector is x=-1, y=z=0.
-        
+
         Examples:
             >>> import stim
             >>> s = stim.TableauSimulator()
@@ -4089,19 +4089,19 @@ class TableauSimulator:
         """
     def peek_observable_expectation(self, observable: stim.PauliString) -> int:
         """Determines the expected value of an observable (which will always be -1, 0, or +1).
-        
+
         This is a non-physical operation.
         It reports information about the quantum state without disturbing it.
-        
+
         Args:
             observable: The observable to determine the expected value of.
                 This observable must have a real sign, not an imaginary sign.
-        
+
         Returns:
             +1: Observable will be deterministically false when measured.
             -1: Observable will be deterministically true when measured.
             0: Observable will be random when measured.
-        
+
         Examples:
             >>> import stim
             >>> s = stim.TableauSimulator()
@@ -4111,7 +4111,7 @@ class TableauSimulator:
             0
             >>> s.peek_observable_expectation(stim.PauliString("-Z"))
             -1
-        
+
             >>> s.do(stim.Circuit('''
             ...     H 0
             ...     CNOT 0 1
@@ -4127,39 +4127,228 @@ class TableauSimulator:
             II 1
             IIZ 1
         """
+    def peek_x(self, target: int) -> int:
+        """Returns the expected value of a qubit's X observable (which will always be -1, 0, or +1).
+
+        This is a non-physical operation.
+        It reports information about the quantum state without disturbing it.
+
+        Args:
+            target: The qubit to analyze.
+
+        Returns:
+            +1: Qubit is in the |+> state.
+            -1: Qubit is in the |-> state.
+            0: Qubit is in some other state.
+
+        Example:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_z(0)
+            >>> s.peek_x(0)
+            0
+            >>> s.reset_x(0)
+            >>> s.peek_x(0)
+            1
+            >>> s.Z(0)
+            >>> s.peek_x(0)
+            -1
+        """
+    def peek_y(self, target: int) -> int:
+        """Returns the expected value of a qubit's Y observable (which will always be -1, 0, or +1).
+
+        This is a non-physical operation.
+        It reports information about the quantum state without disturbing it.
+
+        Args:
+            target: The qubit to analyze.
+
+        Returns:
+            +1: Qubit is in the |i> state.
+            -1: Qubit is in the |-i> state.
+            0: Qubit is in some other state.
+
+        Example:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_z(0)
+            >>> s.peek_y(0)
+            0
+            >>> s.reset_y(0)
+            >>> s.peek_y(0)
+            1
+            >>> s.Z(0)
+            >>> s.peek_y(0)
+            -1
+        """
+    def peek_z(self, target: int) -> int:
+        """Returns the expected value of a qubit's Z observable (which will always be -1, 0, or +1).
+
+        This is a non-physical operation.
+        It reports information about the quantum state without disturbing it.
+
+        Args:
+            target: The qubit to analyze.
+
+        Returns:
+            +1: Qubit is in the |0> state.
+            -1: Qubit is in the |1> state.
+            0: Qubit is in some other state.
+
+        Example:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.peek_z(0)
+            0
+            >>> s.reset_z(0)
+            >>> s.peek_z(0)
+            1
+            >>> s.X(0)
+            >>> s.peek_z(0)
+            -1
+        """
+    def postselect_x(self, targets: Union[int, Iterable[int]], *, desired_value: bool) -> None:
+
+        """Postselects qubits in the X basis, or raises an exception.
+
+        Postselecting a qubit forces it to collapse to a specific state, as
+        if it was measured and that state was the result of the measurement.
+
+        Args:
+            targets: The qubit index or indices to postselect.
+            desired_value:
+                False: postselect targets into the |+> state.
+                True: postselect targets into the |-> state.
+
+        Raises:
+            ValueError:
+                The postselection failed. One of the qubits was in a state
+                orthogonal to the desired state, so it was literally
+                impossible for a measurement of the qubit to return the
+                desired result.
+        """
+    def postselect_y(self, targets: Union[int, Iterable[int]], *, desired_value: bool) -> None:
+
+        """Postselects qubits in the Y basis, or raises an exception.
+
+        Postselecting a qubit forces it to collapse to a specific state, as
+        if it was measured and that state was the result of the measurement.
+
+        Args:
+            targets: The qubit index or indices to postselect.
+            desired_value:
+                False: postselect targets into the |i> state.
+                True: postselect targets into the |-i> state.
+
+        Raises:
+            ValueError:
+                The postselection failed. One of the qubits was in a state
+                orthogonal to the desired state, so it was literally
+                impossible for a measurement of the qubit to return the
+                desired result.
+        """
+    def postselect_z(self, targets: Union[int, Iterable[int]], *, desired_value: bool) -> None:
+
+        """Postselects qubits in the Z basis, or raises an exception.
+
+        Postselecting a qubit forces it to collapse to a specific state, as
+        if it was measured and that state was the result of the measurement.
+
+        Args:
+            targets: The qubit index or indices to postselect.
+            desired_value:
+                False: postselect targets into the |0> state.
+                True: postselect targets into the |1> state.
+
+        Raises:
+            ValueError:
+                The postselection failed. One of the qubits was in a state
+                orthogonal to the desired state, so it was literally
+                impossible for a measurement of the qubit to return the
+                desired result.
+        """
     def reset(self, *targets) -> None:
-        """Resets qubits to zero (e.g. by swapping them for zero'd qubit from the environment).
-        
+        """Resets qubits to the |0> state.
+
         Args:
             *targets: The indices of the qubits to reset.
+
+        Example:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.X(0)
+            >>> s.reset(0)
+            >>> s.peek_bloch(0)
+            +Z
+        """
+    def reset_x(self, *targets) -> None:
+        """Resets qubits to the |+> state.
+
+        Args:
+            *targets: The indices of the qubits to reset.
+
+        Example:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.peek_bloch(0)
+            +X
+        """
+    def reset_y(self, *targets) -> None:
+        """Resets qubits to the |i> state.
+
+        Args:
+            *targets: The indices of the qubits to reset.
+
+        Example:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_y(0)
+            >>> s.peek_bloch(0)
+            +Y
+        """
+    def reset_z(self, *targets) -> None:
+        """Resets qubits to the |0> state.
+
+        Args:
+            *targets: The indices of the qubits to reset.
+
+        Example:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.H(0)
+            >>> s.reset_z(0)
+            >>> s.peek_bloch(0)
+            +Z
         """
     def s(self, *targets) -> None:
         """Applies a SQRT_Z gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
     def s_dag(self, *targets) -> None:
         """Applies a SQRT_Z_DAG gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
     def set_inverse_tableau(self, new_inverse_tableau: stim.Tableau) -> None:
         """Overwrites the simulator's internal state with a copy of the given inverse tableau.
-        
+
         The inverse tableau specifies how Pauli product observables of qubits at the current time transform
         into equivalent Pauli product observables at the beginning of time, when all qubits were in the
         |0> state. For example, if the Z observable on qubit 5 maps to a product of Z observables at the
         start of time then a Z basis measurement on qubit 5 will be deterministic and equal to the sign
         of the product. Whereas if it mapped to a product of observables including an X or a Y then the Z
         basis measurement would be random.
-        
+
         Any qubits not within the length of the tableau are implicitly in the |0> state.
-        
+
         Args:
             new_inverse_tableau: The tableau to overwrite the internal state with.
-        
+
         Examples:
             >>> import stim
             >>> s = stim.TableauSimulator()
@@ -4170,27 +4359,27 @@ class TableauSimulator:
         """
     def set_num_qubits(self, new_num_qubits: int) -> None:
         """Forces the simulator's internal state to track exactly the qubits whose indices are in range(new_num_qubits).
-        
+
         Note that untracked qubits are always assumed to be in the |0> state. Therefore, calling this method
         will effectively force any qubit whose index is outside range(new_num_qubits) to be reset to |0>.
-        
+
         Note that this method does not prevent future operations from implicitly expanding the size of the
         tracked state (e.g. setting the number of qubits to 5 will not prevent a Hadamard from then being
         applied to qubit 100, increasing the number of qubits to 101).
-        
+
         Args:
             new_num_qubits: The length of the range of qubits the internal simulator should be tracking.
-        
+
         Examples:
             >>> import stim
             >>> s = stim.TableauSimulator()
             >>> len(s.current_inverse_tableau())
             0
-        
+
             >>> s.set_num_qubits(5)
             >>> len(s.current_inverse_tableau())
             5
-        
+
             >>> s.x(0, 1, 2, 3)
             >>> s.set_num_qubits(2)
             >>> s.measure_many(0, 1, 2, 3)
@@ -4198,46 +4387,46 @@ class TableauSimulator:
         """
     def sqrt_x(self, *targets) -> None:
         """Applies a SQRT_X gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
     def sqrt_x_dag(self, *targets) -> None:
         """Applies a SQRT_X_DAG gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
     def sqrt_y(self, *targets) -> None:
         """Applies a SQRT_Y gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
     def sqrt_y_dag(self, *targets) -> None:
         """Applies a SQRT_Y_DAG gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
     def state_vector(self) -> np.ndarray[np.float32]:
         """Returns a wavefunction that satisfies the stabilizers of the simulator's current state.
-        
+
         This function takes O(n * 2**n) time and O(2**n) space, where n is the number of qubits. The computation is
         done by initialization a random state vector and iteratively projecting it into the +1 eigenspace of each
         stabilizer of the state. The global phase of the result is arbitrary (and will vary from call to call).
-        
+
         The result is in little endian order. The amplitude at offset b_0 + b_1*2 + b_2*4 + ... + b_{n-1}*2^{n-1} is
         the amplitude for the computational basis state where the qubit with index 0 is storing the bit b_0, the
         qubit with index 1 is storing the bit b_1, etc.
-        
+
         Returns:
             A `numpy.ndarray[numpy.complex64]` of computational basis amplitudes in little endian order.
-        
+
         Examples:
             >>> import stim
             >>> import numpy as np
-        
+
             >>> # Check that the qubit-to-amplitude-index ordering is little-endian.
             >>> s = stim.TableauSimulator()
             >>> s.x(1)
@@ -4251,7 +4440,7 @@ class TableauSimulator:
         """
     def swap(self, *targets) -> None:
         """Applies a swap gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets, and so forth.
@@ -4259,13 +4448,13 @@ class TableauSimulator:
         """
     def x(self, *targets) -> None:
         """Applies a Pauli X gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
     def xcx(self, *targets) -> None:
         """Applies an X-controlled X gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets, and so forth.
@@ -4273,7 +4462,7 @@ class TableauSimulator:
         """
     def xcy(self, *targets) -> None:
         """Applies an X-controlled Y gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets, and so forth.
@@ -4281,7 +4470,7 @@ class TableauSimulator:
         """
     def xcz(self, *targets) -> None:
         """Applies an X-controlled Z gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets, and so forth.
@@ -4289,13 +4478,13 @@ class TableauSimulator:
         """
     def y(self, *targets) -> None:
         """Applies a Pauli Y gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
     def ycx(self, *targets) -> None:
         """Applies a Y-controlled X gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets, and so forth.
@@ -4303,7 +4492,7 @@ class TableauSimulator:
         """
     def ycy(self, *targets) -> None:
         """Applies a Y-controlled Y gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets, and so forth.
@@ -4311,7 +4500,7 @@ class TableauSimulator:
         """
     def ycz(self, *targets) -> None:
         """Applies a Y-controlled Z gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets, and so forth.
@@ -4319,27 +4508,27 @@ class TableauSimulator:
         """
     def z(self, *targets) -> None:
         """Applies a Pauli Z gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
 def main(*, command_line_args: List[str]) -> int:
     """Runs the command line tool version of stim on the given arguments.
-    
+
     Note that by default any input will be read from stdin, any output
     will print to stdout (as opposed to being intercepted). For most
     commands, you can use arguments like `--out` to write to a file
     instead of stdout and `--in` to read from a file instead of stdin.
-    
+
     Returns:
         An exit code (0 means success, not zero means failure).
-    
+
     Raises:
         A large variety of errors, depending on what you are doing and
         how it failed! Beware that many errors are caught by the main
         method itself and printed to stderr, with the only indication
         that something went wrong being the return code.
-    
+
     Example:
         >>> stim.main(command_line_args=[
         ...     "gen",
@@ -4387,7 +4576,7 @@ def main(*, command_line_args: List[str]) -> int:
 def read_shot_data_file(*, path: str, format: str, num_measurements: int = 0, num_detectors: int = 0, num_observables: int = 0, bit_pack: bool = False) -> np.ndarray:
 
     """Reads shot data, such as measurement samples, from a file.
-    
+
     Args:
         path: The path to the file to read the data from.
         format: The format that the data is stored in, such as 'b8'.
@@ -4399,10 +4588,10 @@ def read_shot_data_file(*, path: str, format: str, num_measurements: int = 0, nu
         num_observables: How many observables there are per shot.
             Note that this only refers to observables *stored in the file*, not to
             observables from the original circuit that was sampled.
-    
+
     Returns:
         A numpy array containing the loaded data.
-    
+
         If bit_pack=False:
             dtype = np.bool8
             shape = (num_shots, num_measurements + num_detectors + num_observables)
@@ -4411,7 +4600,7 @@ def read_shot_data_file(*, path: str, format: str, num_measurements: int = 0, nu
             dtype = np.uint8
             shape = (num_shots, math.ceil((num_measurements + num_detectors + num_observables) / 8))
             bit b from shot s is at result[s, b // 8] & (1 << (b % 8))
-    
+
     Examples:
         >>> import stim
         >>> import pathlib
@@ -4440,13 +4629,13 @@ def target_inv(qubit_index: int) -> stim.GateTarget:
     """
 def target_logical_observable_id(index: int) -> stim.DemTarget:
     """Returns a logical observable id identifying a frame change (e.g. "L5" in a .dem file).
-    
+
     Args:
         index: The index of the observable.
-    
+
     Returns:
         The logical observable target.
-    
+
     Examples:
         >>> import stim
         >>> m = stim.DetectorErrorModel()
@@ -4464,13 +4653,13 @@ def target_rec(lookback_index: int) -> stim.GateTarget:
     """
 def target_relative_detector_id(index: int) -> stim.DemTarget:
     """Returns a relative detector id (e.g. "D5" in a .dem file).
-    
+
     Args:
         index: The index of the detector, relative to the current detector offset.
-    
+
     Returns:
         The relative detector target.
-    
+
     Examples:
         >>> import stim
         >>> m = stim.DetectorErrorModel()
@@ -4484,7 +4673,7 @@ def target_relative_detector_id(index: int) -> stim.DemTarget:
     """
 def target_separator() -> stim.DemTarget:
     """Returns a target separator (e.g. "^" in a .dem file).
-    
+
     Examples:
         >>> import stim
         >>> m = stim.DetectorErrorModel()
@@ -4516,12 +4705,12 @@ def target_z(qubit_index: int, invert: bool = False) -> stim.GateTarget:
     """
 def write_shot_data_file(*, data: object, path: str, format: str, num_measurements: Any = None, num_detectors: Any = None, num_observables: Any = None) -> None:
     """Writes shot data, such as measurement samples, to a file.
-    
+
     Args:
         data: The data to write to the file. This must be a numpy array. The dtype
             of the array determines whether or not the data is bit packed, and the
             shape must match the bits per shot.
-    
+
             dtype=np.bool8: Not bit packed. Shape must be (num_shots, num_measurements + num_detectors + num_observables).
             dtype=np.uint8: Yes bit packed. Shape must be (num_shots, math.ceil((num_measurements + num_detectors + num_observables) / 8)).
         path: The path to the file to write the data to.
@@ -4532,7 +4721,7 @@ def write_shot_data_file(*, data: object, path: str, format: str, num_measuremen
         num_observables: How many observables there are per shot.
             Note that this only refers to observables *in the given shot data*, not to
             observables from the original circuit that was sampled.
-    
+
     Examples:
         >>> import stim
         >>> import pathlib

--- a/glue/cirq/stimcirq/_det_annotation.py
+++ b/glue/cirq/stimcirq/_det_annotation.py
@@ -40,7 +40,7 @@ class DetAnnotation(cirq.Operation):
         return self
 
     def _value_equality_values_(self) -> Any:
-        return self.parity_keys, self.coordinate_metadata
+        return self.parity_keys, self.relative_keys, self.coordinate_metadata
 
     def _circuit_diagram_info_(self, args: Any) -> str:
         items: List[str] = [repr(e) for e in sorted(self.parity_keys)]
@@ -48,9 +48,12 @@ class DetAnnotation(cirq.Operation):
         k = ",".join(str(e) for e in items)
         return f"Det({k})"
 
+    @staticmethod
+    def _json_namespace_() -> str:
+        return ''
+
     def _json_dict_(self) -> Dict[str, Any]:
         result = {
-            'cirq_type': self.__class__.__name__,
             'parity_keys': sorted(self.parity_keys),
             'coordinate_metadata': self.coordinate_metadata,
         }

--- a/glue/cirq/stimcirq/_det_annotation_test.py
+++ b/glue/cirq/stimcirq/_det_annotation_test.py
@@ -162,3 +162,10 @@ def test_json_serialization():
     json = cirq.to_json(c)
     c2 = cirq.read_json(json_text=json, resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER])
     assert c == c2
+
+
+def test_json_backwards_compat_exact():
+    raw = stimcirq.DetAnnotation(parity_keys=['a'], relative_keys=[-2], coordinate_metadata=(3, 5))
+    packed = '{\n  "cirq_type": "DetAnnotation",\n  "parity_keys": [\n    "a"\n  ],\n  "coordinate_metadata": [\n    3,\n    5\n  ],\n  "relative_keys": [\n    -2\n  ]\n}'
+    assert cirq.read_json(json_text=packed, resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER]) == raw
+    assert cirq.to_json(raw) == packed

--- a/glue/cirq/stimcirq/_measure_and_or_reset_gate.py
+++ b/glue/cirq/stimcirq/_measure_and_or_reset_gate.py
@@ -122,9 +122,12 @@ class MeasureAndOrResetGate(cirq.Gate):
             f'measure_flip_probability={self.measure_flip_probability!r})'
         )
 
+    @staticmethod
+    def _json_namespace_() -> str:
+        return ''
+
     def _json_dict_(self) -> Dict[str, Any]:
         return {
-            'cirq_type': self.__class__.__name__,
             'measure': self.measure,
             'reset': self.reset,
             'basis': self.basis,

--- a/glue/cirq/stimcirq/_measure_and_or_reset_gate_test.py
+++ b/glue/cirq/stimcirq/_measure_and_or_reset_gate_test.py
@@ -27,3 +27,17 @@ def test_json_serialization():
     json = cirq.to_json(c)
     c2 = cirq.read_json(json_text=json, resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER])
     assert c == c2
+
+
+def test_json_backwards_compat_exact():
+    raw = stimcirq.MeasureAndOrResetGate(
+        measure=True,
+        reset=True,
+        basis='X',
+        key='res',
+        invert_measure=True,
+        measure_flip_probability=0.25,
+    )
+    packed = '{\n  "cirq_type": "MeasureAndOrResetGate",\n  "measure": true,\n  "reset": true,\n  "basis": "X",\n  "invert_measure": true,\n  "key": "res",\n  "measure_flip_probability": 0.25\n}'
+    assert cirq.read_json(json_text=packed, resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER]) == raw
+    assert cirq.to_json(raw) == packed

--- a/glue/cirq/stimcirq/_obs_annotation.py
+++ b/glue/cirq/stimcirq/_obs_annotation.py
@@ -38,7 +38,7 @@ class CumulativeObservableAnnotation(cirq.Operation):
         return self
 
     def _value_equality_values_(self) -> Any:
-        return self.parity_keys, self.observable_index
+        return self.parity_keys, self.relative_keys, self.observable_index
 
     def _circuit_diagram_info_(self, args: Any) -> str:
         items: List[str] = [repr(e) for e in sorted(self.parity_keys)]
@@ -54,9 +54,12 @@ class CumulativeObservableAnnotation(cirq.Operation):
             f'observable_index={self.observable_index!r})'
         )
 
+    @staticmethod
+    def _json_namespace_() -> str:
+        return ''
+
     def _json_dict_(self) -> Dict[str, Any]:
         result = {
-            'cirq_type': self.__class__.__name__,
             'parity_keys': sorted(self.parity_keys),
             'observable_index': self.observable_index,
         }

--- a/glue/cirq/stimcirq/_obs_annotation_test.py
+++ b/glue/cirq/stimcirq/_obs_annotation_test.py
@@ -190,3 +190,10 @@ def test_json_serialization():
     json = cirq.to_json(c)
     c2 = cirq.read_json(json_text=json, resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER])
     assert c == c2
+
+
+def test_json_backwards_compat_exact():
+    raw = stimcirq.CumulativeObservableAnnotation(parity_keys=['z'], relative_keys=[-2], observable_index=5)
+    packed = '{\n  "cirq_type": "CumulativeObservableAnnotation",\n  "parity_keys": [\n    "z"\n  ],\n  "observable_index": 5,\n  "relative_keys": [\n    -2\n  ]\n}'
+    assert cirq.read_json(json_text=packed, resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER]) == raw
+    assert cirq.to_json(raw) == packed

--- a/glue/cirq/stimcirq/_shift_coords_annotation.py
+++ b/glue/cirq/stimcirq/_shift_coords_annotation.py
@@ -33,8 +33,12 @@ class ShiftCoordsAnnotation(cirq.Operation):
         k = ",".join(repr(e) for e in self.shift)
         return f"ShiftCoords({k})"
 
+    @staticmethod
+    def _json_namespace_() -> str:
+        return ''
+
     def _json_dict_(self) -> Dict[str, Any]:
-        return {'cirq_type': self.__class__.__name__, 'shift': self.shift}
+        return {'shift': self.shift}
 
     def __repr__(self) -> str:
         return f'stimcirq.ShiftCoordsAnnotation({self.shift!r})'

--- a/glue/cirq/stimcirq/_shift_coords_annotation_test.py
+++ b/glue/cirq/stimcirq/_shift_coords_annotation_test.py
@@ -75,3 +75,10 @@ def test_json_serialization():
     json = cirq.to_json(c)
     c2 = cirq.read_json(json_text=json, resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER])
     assert c == c2
+
+
+def test_json_backwards_compat_exact():
+    raw = stimcirq.ShiftCoordsAnnotation([2, 3, 5])
+    packed = '{\n  "cirq_type": "ShiftCoordsAnnotation",\n  "shift": [\n    2,\n    3,\n    5\n  ]\n}'
+    assert cirq.read_json(json_text=packed, resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER]) == raw
+    assert cirq.to_json(raw) == packed

--- a/glue/cirq/stimcirq/_sweep_pauli.py
+++ b/glue/cirq/stimcirq/_sweep_pauli.py
@@ -57,9 +57,12 @@ class SweepPauli(cirq.Gate):
     def _circuit_diagram_info_(self, args: Any) -> str:
         return f"{self.pauli}^sweep[{self.stim_sweep_bit_index}]='{self.cirq_sweep_symbol}'"
 
+    @staticmethod
+    def _json_namespace_() -> str:
+        return ''
+
     def _json_dict_(self) -> Dict[str, Any]:
         return {
-            'cirq_type': self.__class__.__name__,
             'pauli': self.pauli,
             'stim_sweep_bit_index': self.stim_sweep_bit_index,
             'cirq_sweep_symbol': self.cirq_sweep_symbol,

--- a/glue/cirq/stimcirq/_sweep_pauli_test.py
+++ b/glue/cirq/stimcirq/_sweep_pauli_test.py
@@ -97,3 +97,10 @@ def test_json_serialization():
     json = cirq.to_json(c)
     c2 = cirq.read_json(json_text=json, resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER])
     assert c == c2
+
+
+def test_json_backwards_compat_exact():
+    raw = stimcirq.SweepPauli(stim_sweep_bit_index=2, pauli=cirq.Z, cirq_sweep_symbol="abc")
+    packed = '{\n  "cirq_type": "SweepPauli",\n  "pauli": {\n    "cirq_type": "_PauliZ",\n    "exponent": 1.0,\n    "global_shift": 0.0\n  },\n  "stim_sweep_bit_index": 2,\n  "cirq_sweep_symbol": "abc"\n}'
+    assert cirq.read_json(json_text=packed, resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER]) == raw
+    assert cirq.to_json(raw) == packed

--- a/glue/cirq/stimcirq/_two_qubit_asymmetric_depolarize.py
+++ b/glue/cirq/stimcirq/_two_qubit_asymmetric_depolarize.py
@@ -53,5 +53,9 @@ class TwoQubitAsymmetricDepolarizingChannel(cirq.Gate):
     def __repr__(self):
         return f"stimcirq.TwoQubitAsymmetricDepolarizingChannel({self.probabilities!r})"
 
+    @staticmethod
+    def _json_namespace_() -> str:
+        return ''
+
     def _json_dict_(self) -> Dict[str, Any]:
-        return {'cirq_type': self.__class__.__name__, 'probabilities': list(self.probabilities)}
+        return {'probabilities': list(self.probabilities)}

--- a/glue/cirq/stimcirq/_two_qubit_asymmetric_depolarize_test.py
+++ b/glue/cirq/stimcirq/_two_qubit_asymmetric_depolarize_test.py
@@ -44,3 +44,10 @@ def test_json_serialization():
     json = cirq.to_json(c)
     c2 = cirq.read_json(json_text=json, resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER])
     assert c == c2
+
+
+def test_json_backwards_compat_exact():
+    raw = stimcirq.TwoQubitAsymmetricDepolarizingChannel([0.0125, 0.1, 0, 0.23, 0, 0, 0.0375, 0, 0.01, 0, 0, 0, 0, 0.25, 0])
+    packed = '{\n  "cirq_type": "TwoQubitAsymmetricDepolarizingChannel",\n  "probabilities": [\n    0.0125,\n    0.1,\n    0,\n    0.23,\n    0,\n    0,\n    0.0375,\n    0,\n    0.01,\n    0,\n    0,\n    0,\n    0,\n    0.25,\n    0\n  ]\n}'
+    assert cirq.read_json(json_text=packed, resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER]) == raw
+    assert cirq.to_json(raw) == packed

--- a/glue/python/generate_stub_file.py
+++ b/glue/python/generate_stub_file.py
@@ -72,7 +72,10 @@ def normalize_doc_string(d: str) -> str:
 
 
 def indented(*, paragraph: str, indentation: str) -> str:
-    return "".join(indentation + line for line in paragraph.splitlines(keepends=True))
+    return "".join(
+        indentation * (line != '\n') + line
+        for line in paragraph.splitlines(keepends=True)
+    )
 
 
 def print_doc(*, full_name: str, parent: object, obj: object, level: int):

--- a/glue/python/generate_stub_file.py
+++ b/glue/python/generate_stub_file.py
@@ -84,8 +84,6 @@ def print_doc(*, full_name: str, parent: object, obj: object, level: int):
     term_name = full_name.split(".")[-1]
     is_property = isinstance(obj, property)
     is_method = doc.startswith(term_name)
-    if term_name == "circuit_error_locations":
-        xxx = 0
     has_setter = False
     sig_name = ''
     if is_method or is_property:

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -6,7 +6,7 @@ if TYPE_CHECKING:
     import numpy as np
 class Circuit:
     """A mutable stabilizer circuit.
-    
+
     Examples:
         >>> import stim
         >>> c = stim.Circuit()
@@ -14,7 +14,7 @@ class Circuit:
         >>> c.append("M", 0)
         >>> c.compile_sampler().sample(shots=1)
         array([[1]], dtype=uint8)
-    
+
         >>> stim.Circuit('''
         ...    H 0
         ...    CNOT 0 1
@@ -22,11 +22,11 @@ class Circuit:
         ...    DETECTOR rec[-1] rec[-2]
         ... ''').compile_detector_sampler().sample(shots=1)
         array([[0]], dtype=uint8)
-    
+
     """
     def __add__(self, second: stim.Circuit) -> stim.Circuit:
         """Creates a circuit by appending two circuits.
-        
+
         Examples:
             >>> import stim
             >>> c1 = stim.Circuit('''
@@ -54,15 +54,15 @@ class Circuit:
         pass
     def __getitem__(self, index_or_slice: object) -> object:
         """Returns copies of instructions from the circuit.
-        
+
         Args:
             index_or_slice: An integer index picking out an instruction to return, or a slice picking out a range
                 of instructions to return as a circuit.
-        
+
         Returns:
             If the index was an integer, then an instruction from the circuit.
             If the index was a slice, then a circuit made up of the instructions in that slice.
-        
+
         Examples:
             >>> import stim
             >>> circuit = stim.Circuit('''
@@ -92,7 +92,7 @@ class Circuit:
         """
     def __iadd__(self, second: stim.Circuit) -> stim.Circuit:
         """Appends a circuit into the receiving circuit (mutating it).
-        
+
         Examples:
             >>> import stim
             >>> c1 = stim.Circuit('''
@@ -112,13 +112,13 @@ class Circuit:
         """
     def __imul__(self, repetitions: int) -> stim.Circuit:
         """Mutates the circuit by putting its contents into a REPEAT block.
-        
+
         Special case: if the repetition count is 0, the circuit is cleared.
         Special case: if the repetition count is 1, nothing happens.
-        
+
         Args:
             repetitions: The number of times the REPEAT block should repeat.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit('''
@@ -136,10 +136,10 @@ class Circuit:
         """
     def __init__(self, stim_program_text: str = '') -> None:
         """Creates a stim.Circuit.
-        
+
         Args:
             stim_program_text: Defaults to empty. Describes operations to append into the circuit.
-        
+
         Examples:
             >>> import stim
             >>> empty = stim.Circuit()
@@ -151,9 +151,9 @@ class Circuit:
         """
     def __len__(self) -> int:
         """Returns the number of top-level instructions and blocks in the circuit.
-        
+
         Instructions inside of blocks are not included in this count.
-        
+
         Examples:
             >>> import stim
             >>> len(stim.Circuit())
@@ -176,13 +176,13 @@ class Circuit:
         """
     def __mul__(self, repetitions: int) -> stim.Circuit:
         """Returns a circuit with a REPEAT block containing the current circuit's instructions.
-        
+
         Special case: if the repetition count is 0, an empty circuit is returned.
         Special case: if the repetition count is 1, an equal circuit with no REPEAT block is returned.
-        
+
         Args:
             repetitions: The number of times the REPEAT block should repeat.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit('''
@@ -205,13 +205,13 @@ class Circuit:
         """
     def __rmul__(self, repetitions: int) -> stim.Circuit:
         """Returns a circuit with a REPEAT block containing the current circuit's instructions.
-        
+
         Special case: if the repetition count is 0, an empty circuit is returned.
         Special case: if the repetition count is 1, an equal circuit with no REPEAT block is returned.
-        
+
         Args:
             repetitions: The number of times the REPEAT block should repeat.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit('''
@@ -237,9 +237,9 @@ class Circuit:
         pass
     def append(self, name: object, targets: object = (), arg: object = None) -> None:
         """Appends an operation into the circuit.
-        
+
         Note: `stim.Circuit.append_operation` is an alias of `stim.Circuit.append`.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit()
@@ -258,14 +258,14 @@ class Circuit:
                 X_ERROR(0.125) 0
                 E(0.25) X0 Y2
             ''')
-        
+
         Args:
             name: The name of the operation's gate (e.g. "H" or "M" or "CNOT").
-        
+
                 This argument can also be set to a `stim.CircuitInstruction` or `stim.CircuitInstructionBlock`, which
                 results in the instruction or block being appended to the circuit. The other arguments (targets and
                 arg) can't be specified when doing so.
-        
+
                 (The argument name `name` is no longer quite right, but being kept for backwards compatibility.)
             targets: The objects operated on by the gate. This can be either a single target or an iterable of
                 multiple targets to broadcast the gate over. Each target can be an integer (a qubit), a
@@ -275,14 +275,14 @@ class Circuit:
                 list of doubles parameterizing the gate. Different gates take different parens arguments. For
                 example, X_ERROR takes a probability, OBSERVABLE_INCLUDE takes an observable index, and
                 PAULI_CHANNEL_1 takes three disjoint probabilities.
-        
+
                 Note: Defaults to no parens arguments. Except, for backwards compatibility reasons,
                 `cirq.append_operation` (but not `cirq.append`) will default to a single 0.0 argument for gates
                 that take exactly one argument.
         """
     def append_from_stim_program_text(self, stim_program_text: str) -> None:
         """Appends operations described by a STIM format program into the circuit.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit()
@@ -298,7 +298,7 @@ class Circuit:
             CX 0 2
             M 2
             CX rec[-1] 1
-        
+
         Args:
             stim_program_text: The STIM program text containing the circuit operations to append.
         """
@@ -307,48 +307,48 @@ class Circuit:
         """
     def approx_equals(self, other: object, *, atol: float) -> bool:
         """Checks if a circuit is approximately equal to another circuit.
-        
+
         Two circuits are approximately equal if they are equal up to slight perturbations of instruction arguments
         such as probabilities. For example `X_ERROR(0.100) 0` is approximately equal to `X_ERROR(0.099)` within an
         absolute tolerance of 0.002. All other details of the circuits (such as the ordering of instructions and
         targets) must be exactly the same.
-        
+
         Args:
             other: The circuit, or other object, to compare to this one.
             atol: The absolute error tolerance. The maximum amount each probability may have been perturbed by.
-        
+
         Returns:
             True if the given object is a circuit approximately equal up to the receiving circuit up to the given
             tolerance, otherwise False.
-        
+
         Examples:
             >>> import stim
             >>> base = stim.Circuit('''
             ...    X_ERROR(0.099) 0 1 2
             ...    M 0 1 2
             ... ''')
-        
+
             >>> base.approx_equals(base, atol=0)
             True
-        
+
             >>> base.approx_equals(stim.Circuit('''
             ...    X_ERROR(0.101) 0 1 2
             ...    M 0 1 2
             ... '''), atol=0)
             False
-        
+
             >>> base.approx_equals(stim.Circuit('''
             ...    X_ERROR(0.101) 0 1 2
             ...    M 0 1 2
             ... '''), atol=0.0001)
             False
-        
+
             >>> base.approx_equals(stim.Circuit('''
             ...    X_ERROR(0.101) 0 1 2
             ...    M 0 1 2
             ... '''), atol=0.01)
             True
-        
+
             >>> base.approx_equals(stim.Circuit('''
             ...    DEPOLARIZE1(0.099) 0 1 2
             ...    MRX 0 1 2
@@ -357,7 +357,7 @@ class Circuit:
         """
     def clear(self) -> None:
         """Clears the contents of the circuit.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit('''
@@ -370,28 +370,28 @@ class Circuit:
         """
     def compile_detector_sampler(self, *, seed: object = None) -> stim.CompiledDetectorSampler:
         """Returns a CompiledDetectorSampler, which can quickly batch sample detection events, for the circuit.
-        
+
         Args:
             seed: PARTIALLY determines simulation results by deterministically seeding the random number generator.
                 Must be None or an integer in range(2**64).
-        
+
                 Defaults to None. When set to None, a prng seeded by system entropy is used.
-        
+
                 When set to an integer, making the exact same series calls on the exact same machine with the exact
                 same version of Stim will produce the exact same simulation results.
-        
+
                 CAUTION: simulation results *WILL NOT* be consistent between versions of Stim. This restriction is
                 present to make it possible to have future optimizations to the random sampling, and is enforced by
                 introducing intentional differences in the seeding strategy from version to version.
-        
+
                 CAUTION: simulation results *MAY NOT* be consistent across machines that differ in the width of
                 supported SIMD instructions. For example, using the same seed on a machine that supports AVX
                 instructions and one that only supports SSE instructions may produce different simulation results.
-        
+
                 CAUTION: simulation results *MAY NOT* be consistent if you vary how many shots are taken. For
                 example, taking 10 shots and then 90 shots will give different results from taking 100 shots in one
                 call.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit('''
@@ -406,24 +406,24 @@ class Circuit:
         """
     def compile_m2d_converter(self, *, skip_reference_sample: bool = False) -> stim.CompiledMeasurementsToDetectionEventsConverter:
         """Returns an object that can efficiently convert measurements into detection events for the given circuit.
-        
+
         The converter uses a noiseless reference sample, collected from the circuit using stim's Tableau simulator
         during initialization of the converter, as a baseline for determining what the expected value of a detector
         is.
-        
+
         Note that the expected behavior of gauge detectors (detectors that are not actually deterministic under
         noiseless execution) can vary depending on the reference sample. Stim mitigates this by always generating
         the same reference sample for a given circuit.
-        
+
         Args:
             skip_reference_sample: Defaults to False. When set to True, the reference sample used by the converter
                 is initialized to all-zeroes instead of being collected from the circuit. This should only be used
                 if it's known that the all-zeroes sample is actually a possible result from the circuit (under
                 noiseless execution).
-        
+
         Returns:
             An initialized stim.CompiledMeasurementsToDetectionEventsConverter.
-        
+
         Examples:
             >>> import stim
             >>> import numpy as np
@@ -441,13 +441,13 @@ class Circuit:
         """
     def compile_sampler(self, *, skip_reference_sample: bool = False, seed: object = None) -> stim.CompiledMeasurementSampler:
         """Returns a CompiledMeasurementSampler, which can quickly batch sample measurements, for the circuit.
-        
+
         Args:
             skip_reference_sample: Defaults to False. When set to True, the reference sample used by the sampler is
                 initialized to all-zeroes instead of being collected from the circuit. This means that the results
                 returned by the sampler are actually whether or not each measurement was *flipped*, instead of true
                 measurement results.
-        
+
                 Forcing an all-zero reference sample is useful when you are only interested in error propagation and
                 don't want to have to deal with the fact that some measurements want to be On when no errors occur.
                 It is also useful when you know for sure that the all-zero result is actually a possible result from
@@ -457,24 +457,24 @@ class Circuit:
                 optimization.
             seed: PARTIALLY determines simulation results by deterministically seeding the random number generator.
                 Must be None or an integer in range(2**64).
-        
+
                 Defaults to None. When set to None, a prng seeded by system entropy is used.
-        
+
                 When set to an integer, making the exact same series calls on the exact same machine with the exact
                 same version of Stim will produce the exact same simulation results.
-        
+
                 CAUTION: simulation results *WILL NOT* be consistent between versions of Stim. This restriction is
                 present to make it possible to have future optimizations to the random sampling, and is enforced by
                 introducing intentional differences in the seeding strategy from version to version.
-        
+
                 CAUTION: simulation results *MAY NOT* be consistent across machines that differ in the width of
                 supported SIMD instructions. For example, using the same seed on a machine that supports AVX
                 instructions and one that only supports SSE instructions may produce different simulation results.
-        
+
                 CAUTION: simulation results *MAY NOT* be consistent if you vary how many shots are taken. For
                 example, taking 10 shots and then 90 shots will give different results from taking 100 shots in one
                 call.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit('''
@@ -487,10 +487,10 @@ class Circuit:
         """
     def copy(self) -> stim.Circuit:
         """Returns a copy of the circuit. An independent circuit with the same contents.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> c1 = stim.Circuit("H 0")
             >>> c2 = c1.copy()
             >>> c2 is c1
@@ -500,7 +500,7 @@ class Circuit:
         """
     def detector_error_model(self, *, decompose_errors: bool = False, flatten_loops: bool = False, allow_gauge_detectors: bool = False, approximate_disjoint_errors: float = False, ignore_decomposition_failures: bool = False, block_decomposition_from_introducing_remnant_edges: bool = False) -> stim.DetectorErrorModel:
         """Returns a stim.DetectorErrorModel describing the error processes in the circuit.
-        
+
         Args:
             decompose_errors: Defaults to false. When set to true, the error analysis attempts to decompose the
                 components of composite error mechanisms (such as depolarization errors) into simpler errors, and
@@ -520,7 +520,7 @@ class Circuit:
                 the error model. For example, if detectors D1 and D3 both anti-commute with a reset, then the error
                 model has a gauge `error(0.5) D1 D3`. When gauges are identified, one of the involved detectors is
                 removed from the system using Gaussian elimination.
-        
+
                 Note that logical observables are still verified to be deterministic, even if this option is set.
             approximate_disjoint_errors: Defaults to false. When set to false, composite error mechanisms with
                 disjoint components (such as `PAULI_CHANNEL_1(0.1, 0.2, 0.0)`) can cause the error analysis to throw
@@ -529,7 +529,7 @@ class Circuit:
                 probabilities. For example, a ``PAULI_CHANNEL_1(0.1, 0.2, 0.0)` becomes equivalent to an
                 `X_ERROR(0.1)` followed by a `Z_ERROR(0.2)`. This assumption is an approximation, but it is a good
                 approximation for small probabilities.
-        
+
                 This argument can also be set to a probability between 0 and 1, setting a threshold below which the
                 approximation is acceptable. Any error mechanisms that have a component probability above the
                 threshold will cause an exception to be thrown.
@@ -539,23 +539,23 @@ class Circuit:
                 Instead, the undecomposed error is inserted into the output. Whatever tool
                 the detector error model is then given to is responsible for dealing with the
                 undecomposed errors (e.g. a tool may choose to simply ignore them).
-        
+
                 Irrelevant unless decompose_errors=True.
             block_decomposition_from_introducing_remnant_edges: Defaults to False.
                 Requires that both A B and C D be present elsewhere in the detector error model
                 in order to decompose A B C D into A B ^ C D. Normally, only one of A B or C D
                 needs to appear to allow this decomposition.
-        
+
                 Remnant edges can be a useful feature for ensuring decomposition succeeds, but
                 they can also reduce the effective code distance by giving the decoder single
                 edges that actually represent multiple errors in the circuit (resulting in the
                 decoder making misinformed choices when decoding).
-        
+
                 Irrelevant unless decompose_errors=True.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> stim.Circuit('''
             ...     X_ERROR(0.125) 0
             ...     X_ERROR(0.25) 1
@@ -572,7 +572,7 @@ class Circuit:
         """
     def explain_detector_error_model_errors(self, *, dem_filter: object = None, reduce_to_one_representative_error: bool = False) -> List[stim.ExplainedError]:
         """Explains how detector error model errors are produced by circuit errors.
-        
+
         Args:
             dem_filter: Defaults to None (unused). When used, the output will only contain detector error
                 model errors that appear in the given `stim.DetectorErrorModel`. Any error mechanisms from the
@@ -580,11 +580,11 @@ class Circuit:
                 in the result, but with an empty list of associated circuit error mechanisms.
             reduce_to_one_representative_error: Defaults to False. When True, the items in the result will contain
                 at most one circuit error mechanism.
-        
+
         Returns:
             A `List[stim.ExplainedError]` (see `stim.ExplainedError` for more information). Each item in the list
             describes how a detector error model error can be produced by individual circuit errors.
-        
+
         Examples:
             >>> import stim
             >>> circuit = stim.Circuit('''
@@ -620,12 +620,12 @@ class Circuit:
         """
     def flattened(self) -> stim.Circuit:
         """Creates an equivalent circuit without REPEAT or SHIFT_COORDS.
-        
+
         Returns:
             A `stim.Circuit` with the same instructions in the same order,
             but with loops flattened into repeated instructions and with
             all coordinate shifts inlined.
-        
+
         Examples:
             >>> import stim
             >>> circuit = stim.Circuit('''
@@ -656,11 +656,11 @@ class Circuit:
         """
     def flattened_operations(self) -> list:
         """[DEPRECATED]
-        
+
         Returns a list of tuples encoding the contents of the circuit.
         Instead of this method, use `for instruction in circuit` or, to
         avoid REPEAT blocks, `for instruction in circuit.flattened()`.
-        
+
         Examples:
             >>> import stim
             >>> stim.Circuit('''
@@ -669,7 +669,7 @@ class Circuit:
             ...    M 0 !1
             ... ''').flattened_operations()
             [('H', [0], 0), ('X_ERROR', [1], 0.125), ('M', [0, ('inv', 1)], 0)]
-        
+
             >>> stim.Circuit('''
             ...    REPEAT 2 {
             ...        H 6
@@ -680,16 +680,16 @@ class Circuit:
     @staticmethod
     def generated(code_task: str, *, distance: int, rounds: int, after_clifford_depolarization: float = 0.0, before_round_data_depolarization: float = 0.0, before_measure_flip_probability: float = 0.0, after_reset_flip_probability: float = 0.0) -> stim.Circuit:
         """Generates common circuits.
-        
+
         The generated circuits can include configurable noise.
-        
+
         The generated circuits include DETECTOR and OBSERVABLE_INCLUDE annotations so that their detection events
         and logical observables can be sampled.
-        
+
         The generated circuits include TICK annotations to mark the progression of time. (E.g. so that converting
         them using `stimcirq.stim_circuit_to_cirq_circuit` will produce a `cirq.Circuit` with the intended moment
         structure.)
-        
+
         Args:
             code_task: A string identifying the type of circuit to generate. Available types are:
                 - `repetition_code:memory`
@@ -716,10 +716,10 @@ class Circuit:
             after_reset_flip_probability: Defaults to 0. The probability (p) of `X_ERROR(p)` operations applied
                 to qubits after each reset (X basis resets use `Z_ERROR(p)` instead). The after-reset flips are only
                 included if this probability is not 0.
-        
+
         Returns:
             The generated circuit.
-        
+
         Examples:
             >>> import stim
             >>> circuit = stim.Circuit.generated(
@@ -762,17 +762,17 @@ class Circuit:
         """
     def get_detector_coordinates(self, only: object = None) -> Dict[int, List[float]]:
         """Returns the coordinate metadata of detectors in the circuit.
-        
+
         Args:
             only: Defaults to None (meaning include all detectors). A list of detector indices to include in the
                 result. Detector indices beyond the end of the detector error model of the circuit cause an error.
-        
+
         Returns:
             A dictionary mapping integers (detector indices) to lists of floats (coordinates).
             A dictionary mapping detector indices to lists of floats.
             Detectors with no specified coordinate data are mapped to an empty tuple.
             If `only` is specified, then `set(result.keys()) == set(only)`.
-        
+
         Examples:
             >>> import stim
             >>> circuit = stim.Circuit('''
@@ -791,13 +791,13 @@ class Circuit:
         """
     def get_final_qubit_coordinates(self) -> Dict[int, List[float]]:
         """Returns the coordinate metadata of qubits in the circuit.
-        
+
         If a qubit's coordinates are specified multiple times, only the last specified coordinates are returned.
-        
+
         Returns:
             A dictionary mapping qubit indices (integers) to coordinates (lists of floats).
             Qubits that never had their coordinates specified are not included in the result.
-        
+
         Examples:
             >>> import stim
             >>> circuit = stim.Circuit('''
@@ -809,7 +809,7 @@ class Circuit:
     @property
     def num_detectors(self) -> int:
         """Counts the number of bits produced when sampling the circuit's detectors.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit('''
@@ -827,7 +827,7 @@ class Circuit:
     @property
     def num_measurements(self) -> int:
         """Counts the number of bits produced when sampling the circuit's measurements.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit('''
@@ -842,9 +842,9 @@ class Circuit:
     @property
     def num_observables(self) -> int:
         """Counts the number of bits produced when sampling the circuit's logical observables.
-        
+
         This is one more than the largest observable index given to OBSERVABLE_INCLUDE.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit('''
@@ -858,9 +858,9 @@ class Circuit:
     @property
     def num_qubits(self) -> int:
         """Counts the number of qubits used when simulating the circuit.
-        
+
         This is always one more than the largest qubit index used by the circuit.
-        
+
         Examples:
             >>> import stim
             >>> stim.Circuit('''
@@ -878,9 +878,9 @@ class Circuit:
     @property
     def num_sweep_bits(self) -> int:
         """Returns the number of sweep bits needed to completely configure the circuit.
-        
+
         This is always one more than the largest sweep bit index used by the circuit.
-        
+
         Examples:
             >>> import stim
             >>> stim.Circuit('''
@@ -895,27 +895,27 @@ class Circuit:
         """
     def search_for_undetectable_logical_errors(self, *, dont_explore_detection_event_sets_with_size_above: int, dont_explore_edges_with_degree_above: int, dont_explore_edges_increasing_symptom_degree: bool, canonicalize_circuit_errors: bool = False) -> List[stim.ExplainedError]:
         """Searches for lists of errors from the model that form an undetectable logical error.
-        
+
         THIS IS A HEURISTIC METHOD. It does not guarantee that it will find errors of particular
         sizes, or with particular properties. The errors it finds are a tangled combination of the
         truncation parameters you specify, internal optimizations which are correct when not
         truncating, and minutia of the circuit being considered.
-        
+
         If you want a well behaved method that does provide guarantees of finding errors of a
         particular type, use `stim.Circuit.shortest_graphlike_error`. This method is more
         thorough than that (assuming you don't truncate so hard you omit graphlike edges),
         but exactly how thorough is difficult to describe. It's also not guaranteed that the
         behavior of this method will not be changed in the future in a way that permutes which
         logical errors are found and which are missed.
-        
+
         This search method considers hyper errors, so it has worst case exponential runtime. It is
         important to carefully consider the arguments you are providing, which truncate the search
         space and trade cost for quality.
-        
+
         The search progresses by starting from each error that crosses a logical observable, noting
         which detection events each error produces, and then iteratively adding in errors touching
         those detection events attempting to cancel out the detection event with the lowest index.
-        
+
         Beware that the choice of logical observable can interact with the truncation options. Using
         different observables can change whether or not the search succeeds, even if those observables
         are equal modulo the stabilizers of the code. This is because the edges crossing logical
@@ -924,7 +924,7 @@ class Circuit:
         progresses. For example, if the logical observable is next to a boundary, then the starting
         edges are likely boundary edges (degree 1) with 'room to grow', whereas if the observable was
         running through the bulk then the starting edges will have degree at least 2.
-        
+
         Args:
             dont_explore_detection_event_sets_with_size_above: Truncates the search space by refusing to
                 cross an edge (i.e. add an error) when doing so would produce an intermediate state that
@@ -945,12 +945,12 @@ class Circuit:
                     symptoms, with a preference towards errors that are simpler (e.g. apply Paulis to fewer qubits).
                     This discards mostly-redundant information about different ways to produce the same symptoms in
                     order to give a succinct result.
-        
+
         Returns:
             A detector error model containing only the error mechanisms that cause the undetectable
             logical error. The error mechanisms will have their probabilities set to 1 (indicating that
             they are necessary) and will not suggest a decomposition.
-        
+
         Examples:
             >>> import stim
             >>> circuit = stim.Circuit.generated(
@@ -967,18 +967,18 @@ class Circuit:
         """
     def shortest_graphlike_error(self, *, ignore_ungraphlike_errors: bool = True, canonicalize_circuit_errors: bool = False) -> List[stim.ExplainedError]:
         """Finds a minimum sized set of graphlike errors that produce an undetected logical error.
-        
+
         A "graphlike error" is an error that creates at most two detection events (causes a change in the parity of
         the measurement sets of at most two DETECTOR annotations).
-        
+
         Note that this method does not pay attention to error probabilities (other than ignoring errors with
         probability 0). It searches for a logical error with the minimum *number* of physical errors, not the
         maximum probability of those physical errors all occurring.
-        
+
         This method works by converting the circuit into a `stim.DetectorErrorModel` using
         `circuit.detector_error_model(...)`, computing the shortest graphlike error of the error model, and then
         converting the physical errors making up that logical error back into representative circuit errors.
-        
+
         Args:
             ignore_ungraphlike_errors:
                 False: Attempt to decompose any ungraphlike errors in the circuit into graphlike parts.
@@ -999,15 +999,15 @@ class Circuit:
                     symptoms, with a preference towards errors that are simpler (e.g. apply Paulis to fewer qubits).
                     This discards mostly-redundant information about different ways to produce the same symptoms in
                     order to give a succinct result.
-        
+
         Returns:
             A detector error model containing only the error mechanisms that cause the undetectable
             logical error. The error mechanisms will have their probabilities set to 1 (indicating that
             they are necessary) and will not suggest a decomposition.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> circuit = stim.Circuit.generated(
             ...     "repetition_code:memory",
             ...     rounds=10,
@@ -1018,17 +1018,17 @@ class Circuit:
         """
     def without_noise(self) -> stim.Circuit:
         """Returns a copy of the circuit with all noise processes removed.
-        
+
         Pure noise instructions, such as X_ERROR and DEPOLARIZE2, are not
         included in the result.
-        
+
         Noisy measurement instructions, like `M(0.001)`, have their noise
         parameter removed.
-        
+
         Returns:
             A `stim.Circuit` with the same instructions except all noise
             processes have been removed.
-        
+
         Examples:
             >>> import stim
             >>> circuit = stim.Circuit('''
@@ -1077,7 +1077,7 @@ class CircuitErrorLocation:
 class CircuitErrorLocationStackFrame:
     """Describes the location of an instruction being executed within a
     circuit or loop, distinguishing between separate loop iterations.
-    
+
     The full location of an instruction is a list of these frames,
     drilling down from the top level circuit to the inner-most loop
     that the instruction is within.
@@ -1107,7 +1107,7 @@ class CircuitErrorLocationStackFrame:
         """
 class CircuitInstruction:
     """An instruction, like `H 0 1` or `CNOT rec[-1] 5`, from a circuit.
-    
+
     Examples:
         >>> import stim
         >>> circuit = stim.Circuit('''
@@ -1127,7 +1127,7 @@ class CircuitInstruction:
         """
     def __init__(self, name: str, targets: List[object], gate_args: List[float] = ()) -> None:
         """Initializes a `stim.CircuitInstruction`.
-        
+
         Args:
             name: The name of the instruction being applied.
             targets: The targets the instruction is being applied to. These can be raw values like `0` and
@@ -1146,7 +1146,7 @@ class CircuitInstruction:
         """
     def gate_args_copy(self) -> List[float]:
         """Returns the gate's arguments (numbers parameterizing the instruction).
-        
+
         For noisy gates this typically a list of probabilities.
         For OBSERVABLE_INCLUDE it's a singleton list containing the logical observable index.
         """
@@ -1159,7 +1159,7 @@ class CircuitInstruction:
         """
 class CircuitRepeatBlock:
     """A REPEAT block from a circuit.
-    
+
     Examples:
         >>> import stim
         >>> circuit = stim.Circuit('''
@@ -1183,7 +1183,7 @@ class CircuitRepeatBlock:
         """
     def __init__(self, repeat_count: int, body: stim.Circuit) -> None:
         """Initializes a `stim.CircuitRepeatBlock`.
-        
+
         Args:
             repeat_count: The number of times to repeat the block.
             body: The body of the block, as a circuit.
@@ -1196,10 +1196,10 @@ class CircuitRepeatBlock:
         """
     def body_copy(self) -> stim.Circuit:
         """Returns a copy of the body of the repeat block.
-        
+
         The copy is forced to ensure it's clear that editing the result will not change the circuit that the repeat
         block came from.
-        
+
         Examples:
             >>> import stim
             >>> circuit = stim.Circuit('''
@@ -1219,7 +1219,7 @@ class CircuitRepeatBlock:
     @property
     def repeat_count(self) -> int:
         """The repetition count of the repeat block.
-        
+
         Examples:
             >>> import stim
             >>> circuit = stim.Circuit('''
@@ -1261,7 +1261,7 @@ class CircuitTargetsInsideInstruction:
     @property
     def targets_in_range(self) -> List[stim.GateTargetWithCoords]:
         """Returns the subset of targets of the gate / instruction that were being executed.
-        
+
         Includes coordinate data with the targets.
         """
 class CompiledDetectorSampler:
@@ -1269,32 +1269,32 @@ class CompiledDetectorSampler:
     """
     def __init__(self, circuit: stim.Circuit, *, seed: object = None) -> None:
         """Creates a detector sampler, which can sample the detectors (and optionally observables) in a circuit.
-        
+
         Args:
             circuit: The circuit to sample from.
             seed: PARTIALLY determines simulation results by deterministically seeding the random number generator.
                 Must be None or an integer in range(2**64).
-        
+
                 Defaults to None. When set to None, a prng seeded by system entropy is used.
-        
+
                 When set to an integer, making the exact same series calls on the exact same machine with the exact
                 same version of Stim will produce the exact same simulation results.
-        
+
                 CAUTION: simulation results *WILL NOT* be consistent between versions of Stim. This restriction is
                 present to make it possible to have future optimizations to the random sampling, and is enforced by
                 introducing intentional differences in the seeding strategy from version to version.
-        
+
                 CAUTION: simulation results *MAY NOT* be consistent across machines that differ in the width of
                 supported SIMD instructions. For example, using the same seed on a machine that supports AVX
                 instructions and one that only supports SSE instructions may produce different simulation results.
-        
+
                 CAUTION: simulation results *MAY NOT* be consistent if you vary how many shots are taken. For
                 example, taking 10 shots and then 90 shots will give different results from taking 100 shots in one
                 call.
-        
+
         Returns:
             An initialized stim.CompiledDetectorSampler.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit('''
@@ -1313,17 +1313,17 @@ class CompiledDetectorSampler:
         """
     def sample(self, shots: int, *, prepend_observables: bool = False, append_observables: bool = False) -> np.ndarray[bool]:
         """Returns a numpy array containing a batch of detector samples from the circuit.
-        
+
         The circuit must define the detectors using DETECTOR instructions. Observables defined by OBSERVABLE_INCLUDE
         instructions can also be included in the results as honorary detectors.
-        
+
         Args:
             shots: The number of times to sample every detector in the circuit.
             prepend_observables: Defaults to false. When set, observables are included with the detectors and are
                 placed at the start of the results.
             append_observables: Defaults to false. When set, observables are included with the detectors and are
                 placed at the end of the results.
-        
+
         Returns:
             A numpy array with `dtype=uint8` and `shape=(shots, n)` where
             `n = num_detectors + num_observables*(append_observables + prepend_observables)`.
@@ -1331,17 +1331,17 @@ class CompiledDetectorSampler:
         """
     def sample_bit_packed(self, shots: int, *, prepend_observables: bool = False, append_observables: bool = False) -> np.ndarray[np.uint8]:
         """Returns a numpy array containing bit packed batch of detector samples from the circuit.
-        
+
         The circuit must define the detectors using DETECTOR instructions. Observables defined by OBSERVABLE_INCLUDE
         instructions can also be included in the results as honorary detectors.
-        
+
         Args:
             shots: The number of times to sample every detector in the circuit.
             prepend_observables: Defaults to false. When set, observables are included with the detectors and are
                 placed at the start of the results.
             append_observables: Defaults to false. When set, observables are included with the detectors and are
                 placed at the end of the results.
-        
+
         Returns:
             A numpy array with `dtype=uint8` and `shape=(shots, n)` where
             `n = num_detectors + num_observables*(append_observables + prepend_observables)`.
@@ -1349,7 +1349,7 @@ class CompiledDetectorSampler:
         """
     def sample_write(self, shots: int, *, filepath: str, format: str = '01', prepend_observables: bool = False, append_observables: bool = False, obs_out_filepath: str = None, obs_out_format: str = '01') -> None:
         """Samples detection events from the circuit and writes them to a file.
-        
+
         Examples:
             >>> import stim
             >>> import tempfile
@@ -1367,7 +1367,7 @@ class CompiledDetectorSampler:
             shot D0
             shot D0
             shot D0
-        
+
         Args:
             shots: The number of times to sample every measurement in the circuit.
             filepath: The file to write the results to.
@@ -1383,7 +1383,7 @@ class CompiledDetectorSampler:
                 data.
             append_observables: Sample observables as part of each shot, and put them at the end of the detector
                 data.
-        
+
         Returns:
             None.
         """
@@ -1392,18 +1392,18 @@ class CompiledMeasurementSampler:
     """
     def __init__(self, circuit: stim.Circuit, *, skip_reference_sample: bool = False, seed: object = None) -> None:
         """Creates a measurement sampler for the given circuit.
-        
+
         The sampler uses a noiseless reference sample, collected from the circuit using stim's Tableau simulator
         during initialization of the sampler, as a baseline for deriving more samples using an error propagation
         simulator.
-        
+
         Args:
             circuit: The stim circuit to sample from.
             skip_reference_sample: Defaults to False. When set to True, the reference sample used by the sampler is
                 initialized to all-zeroes instead of being collected from the circuit. This means that the results
                 returned by the sampler are actually whether or not each measurement was *flipped*, instead of true
                 measurement results.
-        
+
                 Forcing an all-zero reference sample is useful when you are only interested in error propagation and
                 don't want to have to deal with the fact that some measurements want to be On when no errors occur.
                 It is also useful when you know for sure that the all-zero result is actually a possible result from
@@ -1413,27 +1413,27 @@ class CompiledMeasurementSampler:
                 optimization.
             seed: PARTIALLY determines simulation results by deterministically seeding the random number generator.
                 Must be None or an integer in range(2**64).
-        
+
                 Defaults to None. When set to None, a prng seeded by system entropy is used.
-        
+
                 When set to an integer, making the exact same series calls on the exact same machine with the exact
                 same version of Stim will produce the exact same simulation results.
-        
+
                 CAUTION: simulation results *WILL NOT* be consistent between versions of Stim. This restriction is
                 present to make it possible to have future optimizations to the random sampling, and is enforced by
                 introducing intentional differences in the seeding strategy from version to version.
-        
+
                 CAUTION: simulation results *MAY NOT* be consistent across machines that differ in the width of
                 supported SIMD instructions. For example, using the same seed on a machine that supports AVX
                 instructions and one that only supports SSE instructions may produce different simulation results.
-        
+
                 CAUTION: simulation results *MAY NOT* be consistent if you vary how many shots are taken. For
                 example, taking 10 shots and then 90 shots will give different results from taking 100 shots in one
                 call.
-        
+
         Returns:
             An initialized stim.CompiledMeasurementSampler.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit('''
@@ -1449,7 +1449,7 @@ class CompiledMeasurementSampler:
         """
     def sample(self, shots: int) -> np.ndarray[bool]:
         """Returns a numpy array containing a batch of measurement samples from the circuit.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit('''
@@ -1459,17 +1459,17 @@ class CompiledMeasurementSampler:
             >>> s = c.compile_sampler()
             >>> s.sample(shots=1)
             array([[1, 0, 1, 1]], dtype=uint8)
-        
+
         Args:
             shots: The number of times to sample every measurement in the circuit.
-        
+
         Returns:
             A numpy array with `dtype=uint8` and `shape=(shots, num_measurements)`.
             The bit for measurement `m` in shot `s` is at `result[s, m]`.
         """
     def sample_bit_packed(self, shots: int) -> np.ndarray[np.uint8]:
         """Returns a numpy array containing a bit packed batch of measurement samples from the circuit.
-        
+
         Examples:
             >>> import stim
             >>> c = stim.Circuit('''
@@ -1479,17 +1479,17 @@ class CompiledMeasurementSampler:
             >>> s = c.compile_sampler()
             >>> s.sample_bit_packed(shots=1)
             array([[255,   4]], dtype=uint8)
-        
+
         Args:
             shots: The number of times to sample every measurement in the circuit.
-        
+
         Returns:
             A numpy array with `dtype=uint8` and `shape=(shots, (num_measurements + 7) // 8)`.
             The bit for measurement `m` in shot `s` is at `result[s, (m // 8)] & 2**(m % 8)`.
         """
     def sample_write(self, shots: int, *, filepath: str, format: str = '01') -> None:
         """Samples measurements from the circuit and writes them to a file.
-        
+
         Examples:
             >>> import stim
             >>> import tempfile
@@ -1507,14 +1507,14 @@ class CompiledMeasurementSampler:
             1011
             1011
             1011
-        
+
         Args:
             shots: The number of times to sample every measurement in the circuit.
             filepath: The file to write the results to.
             format: The output format to write the results with.
                 Valid values are "01", "b8", "r8", "hits", "dets", and "ptb64".
                 Defaults to "01".
-        
+
         Returns:
             None.
         """
@@ -1523,25 +1523,25 @@ class CompiledMeasurementsToDetectionEventsConverter:
     """
     def __init__(self, circuit: stim.Circuit, *, skip_reference_sample: bool = False) -> None:
         """Creates a measurement-to-detection-events converter for the given circuit.
-        
+
         The converter uses a noiseless reference sample, collected from the circuit using stim's Tableau simulator
         during initialization of the converter, as a baseline for determining what the expected value of a detector
         is.
-        
+
         Note that the expected behavior of gauge detectors (detectors that are not actually deterministic under
         noiseless execution) can vary depending on the reference sample. Stim mitigates this by always generating
         the same reference sample for a given circuit.
-        
+
         Args:
             circuit: The stim circuit to use for conversions.
             skip_reference_sample: Defaults to False. When set to True, the reference sample used by the converter
                 is initialized to all-zeroes instead of being collected from the circuit. This should only be used
                 if it's known that the all-zeroes sample is actually a possible result from the circuit (under
                 noiseless execution).
-        
+
         Returns:
             An initialized stim.CompiledMeasurementsToDetectionEventsConverter.
-        
+
         Examples:
             >>> import stim
             >>> import numpy as np
@@ -1563,18 +1563,18 @@ class CompiledMeasurementsToDetectionEventsConverter:
     def convert(self, *, measurements: np.ndarray, sweep_bits: Optional[np.ndarray] = None, separate_observables: bool = False, append_observables: bool = False, bit_pack_result: bool = False) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
 
         """Converts measurement data into detection event data.
-        
+
         Args:
             measurements: A numpy array containing measurement data. The dtype of the array is used
                 to determine if it is bit packed or not.
-        
+
                 dtype=np.bool8 (unpacked data):
                     shape=(num_shots, circuit.num_measurements)
                 dtype=np.uint8 (bit packed data):
                     shape=(num_shots, math.ceil(circuit.num_measurements / 8))
             sweep_bits: Optional. A numpy array containing sweep data for the `sweep[k]` controls in the circuit.
                 The dtype of the array is used to determine if it is bit packed or not.
-        
+
                 dtype=np.bool8 (unpacked data):
                     shape=(num_shots, circuit.num_sweep_bits)
                 dtype=np.uint8 (bit packed data):
@@ -1586,7 +1586,7 @@ class CompiledMeasurementsToDetectionEventsConverter:
                 data.
             bit_pack_result: Defaults to False. When set to True, the returned numpy array contains bit packed
                 data (dtype=np.uint8 with 8 bits per item) instead of unpacked data (dtype=np.bool8).
-        
+
         Returns:
             The detection event data and (optionally) observable data.
             The result is a single numpy array if separate_observables is false, otherwise it's a tuple of two numpy arrays.
@@ -1594,7 +1594,7 @@ class CompiledMeasurementsToDetectionEventsConverter:
             The dtype of the returned arrays is np.bool8 if bit_pack_result is false, otherwise they're np.uint8 arrays.
             shape[0] of the array(s) is the number of shots.
             shape[1] of the array(s) is the number of bits per shot (divided by 8 if bit packed) (e.g. for just detection event data it would be circuit.num_detectors).
-        
+
         Examples:
             >>> import stim
             >>> import numpy as np
@@ -1630,7 +1630,7 @@ class CompiledMeasurementsToDetectionEventsConverter:
         """
     def convert_file(self, *, measurements_filepath: str, measurements_format: str = '01', sweep_bits_filepath: str = None, sweep_bits_format: str = '01', detection_events_filepath: str, detection_events_format: str = '01', append_observables: bool = False, obs_out_filepath: str = None, obs_out_format: str = '01') -> None:
         """Reads measurement data from a file, converts it, and writes the detection events to another file.
-        
+
         Args:
             measurements_filepath: A file containing measurement data to be converted.
             measurements_format: The format the measurement data is stored in.
@@ -1655,7 +1655,7 @@ class CompiledMeasurementsToDetectionEventsConverter:
             append_observables: When True, the observables in the circuit are included as part of the detection
                 event data. Specifically, they are treated as if they were additional detectors at the end of the
                 circuit. When False, observable data is not output.
-        
+
         Examples:
             >>> import stim
             >>> import tempfile
@@ -1680,7 +1680,7 @@ class CompiledMeasurementsToDetectionEventsConverter:
         """
 class DemInstruction:
     """An instruction from a detector error model.
-    
+
     Examples:
         >>> import stim
         >>> model = stim.DetectorErrorModel('''
@@ -1699,12 +1699,12 @@ class DemInstruction:
         """
     def __init__(self, type: str, args: List[float], targets: List[object]) -> None:
         """Creates a stim.DemInstruction.
-        
+
         Args:
             type: The name of the instruction type (e.g. "error" or "shift_detectors").
             args: Numeric values parameterizing the instruction (e.g. the 0.1 in "error(0.1)").
             targets: The objects the instruction involves (e.g. the "D0" and "L1" in "error(0.1) D0 L1").
-        
+
         Examples:
             >>> import stim
             >>> instruction = stim.DemInstruction('error', [0.125], [stim.target_relative_detector_id(5)])
@@ -1733,7 +1733,7 @@ class DemInstruction:
         """
 class DemRepeatBlock:
     """A repeat block from a detector error model.
-    
+
     Examples:
         >>> import stim
         >>> model = stim.DetectorErrorModel('''
@@ -1753,11 +1753,11 @@ class DemRepeatBlock:
         """
     def __init__(self, repeat_count: int, block: stim.DetectorErrorModel) -> None:
         """Creates a stim.DemRepeatBlock.
-        
+
         Args:
             repeat_count: The number of times the repeat block's body is supposed to execute.
             block: The body of the repeat block as a DetectorErrorModel containing the instructions to repeat.
-        
+
         Examples:
             >>> import stim
             >>> repeat_block = stim.DemRepeatBlock(100, stim.DetectorErrorModel('''
@@ -1805,13 +1805,13 @@ class DemTarget:
     @staticmethod
     def logical_observable_id(index: int) -> stim.DemTarget:
         """Returns a logical observable id identifying a frame change (e.g. "L5" in a .dem file).
-        
+
         Args:
             index: The index of the observable.
-        
+
         Returns:
             The logical observable target.
-        
+
         Examples:
             >>> import stim
             >>> m = stim.DetectorErrorModel()
@@ -1826,13 +1826,13 @@ class DemTarget:
     @staticmethod
     def relative_detector_id(index: int) -> stim.DemTarget:
         """Returns a relative detector id (e.g. "D5" in a .dem file).
-        
+
         Args:
             index: The index of the detector, relative to the current detector offset.
-        
+
         Returns:
             The relative detector target.
-        
+
         Examples:
             >>> import stim
             >>> m = stim.DetectorErrorModel()
@@ -1847,7 +1847,7 @@ class DemTarget:
     @staticmethod
     def separator() -> stim.DemTarget:
         """Returns a target separator (e.g. "^" in a .dem file).
-        
+
         Examples:
             >>> import stim
             >>> m = stim.DetectorErrorModel()
@@ -1864,9 +1864,9 @@ class DemTarget:
     @property
     def val(self) -> int:
         """Returns the target's integer value.
-        
+
         Example:
-        
+
             >>> import stim
             >>> stim.target_relative_detector_id(5).val
             5
@@ -1875,15 +1875,15 @@ class DemTarget:
         """
 class DemTargetWithCoords:
     """A detector error model instruction target with associated coords.
-    
+
     It is also guaranteed that, if the type of the DEM target is a
     relative detector id, it is actually absolute (i.e. relative to
     0).
-    
+
     For example, if the DEM target is a detector from a circuit with
     coordinate arguments given to detectors, the coords field will
     contain the coordinate data for the detector.
-    
+
     This is helpful information to have available when debugging a
     problem in a circuit, instead of having to constantly manually
     look up the coordinates of a detector index in order to understand
@@ -1895,7 +1895,7 @@ class DemTargetWithCoords:
     @property
     def coords(self) -> List[float]:
         """Returns the associated coordinate information as a list of flaots.
-        
+
         If there is no coordinate information, returns an empty list.
         """
     @property
@@ -1904,7 +1904,7 @@ class DemTargetWithCoords:
         """
 class DetectorErrorModel:
     """A list of instructions describing error mechanisms in terms of the detection events they produce.
-    
+
     Examples:
         >>> import stim
         >>> model = stim.DetectorErrorModel('''
@@ -1916,7 +1916,7 @@ class DetectorErrorModel:
         ... ''')
         >>> len(model)
         5
-    
+
         >>> stim.Circuit('''
         ...     X_ERROR(0.125) 0
         ...     X_ERROR(0.25) 1
@@ -1933,7 +1933,7 @@ class DetectorErrorModel:
     """
     def __add__(self, second: stim.DetectorErrorModel) -> stim.DetectorErrorModel:
         """Creates a detector error model by appending two models.
-        
+
         Examples:
             >>> import stim
             >>> m1 = stim.DetectorErrorModel('''
@@ -1959,11 +1959,11 @@ class DetectorErrorModel:
         pass
     def __getitem__(self, index_or_slice: object) -> object:
         """Returns copies of instructions from the detector error model.
-        
+
         Args:
             index_or_slice: An integer index picking out an instruction to return, or a slice picking out a range
                 of instructions to return as a detector error model.
-        
+
         Examples:
         Examples:
             >>> import stim
@@ -1994,7 +1994,7 @@ class DetectorErrorModel:
         """
     def __iadd__(self, second: stim.DetectorErrorModel) -> stim.DetectorErrorModel:
         """Appends a detector error model into the receiving model (mutating it).
-        
+
         Examples:
             >>> import stim
             >>> m1 = stim.DetectorErrorModel('''
@@ -2012,13 +2012,13 @@ class DetectorErrorModel:
         """
     def __imul__(self, repetitions: int) -> stim.DetectorErrorModel:
         """Mutates the detector error model by putting its contents into a repeat block.
-        
+
         Special case: if the repetition count is 0, the model is cleared.
         Special case: if the repetition count is 1, nothing happens.
-        
+
         Args:
             repetitions: The number of times the repeat block should repeat.
-        
+
         Examples:
             >>> import stim
             >>> m = stim.DetectorErrorModel('''
@@ -2034,11 +2034,11 @@ class DetectorErrorModel:
         """
     def __init__(self, detector_error_model_text: str = '') -> None:
         """Creates a stim.DetectorErrorModel.
-        
+
         Args:
             detector_error_model_text: Defaults to empty. Describes instructions to append into the circuit in the
                 detector error model (.dem) format.
-        
+
         Examples:
             >>> import stim
             >>> empty = stim.DetectorErrorModel()
@@ -2048,9 +2048,9 @@ class DetectorErrorModel:
         """
     def __len__(self) -> int:
         """Returns the number of top-level instructions and blocks in the detector error model.
-        
+
         Instructions inside of blocks are not included in this count.
-        
+
         Examples:
             >>> import stim
             >>> len(stim.DetectorErrorModel())
@@ -2071,13 +2071,13 @@ class DetectorErrorModel:
         """
     def __mul__(self, repetitions: int) -> stim.DetectorErrorModel:
         """Returns a detector error model with a repeat block containing the current model's instructions.
-        
+
         Special case: if the repetition count is 0, an empty model is returned.
         Special case: if the repetition count is 1, an equal model with no repeat block is returned.
-        
+
         Args:
             repetitions: The number of times the repeat block should repeat.
-        
+
         Examples:
             >>> import stim
             >>> m = stim.DetectorErrorModel('''
@@ -2100,13 +2100,13 @@ class DetectorErrorModel:
         """
     def __rmul__(self, repetitions: int) -> stim.DetectorErrorModel:
         """Returns a detector error model with a repeat block containing the current model's instructions.
-        
+
         Special case: if the repetition count is 0, an empty model is returned.
         Special case: if the repetition count is 1, an equal model with no repeat block is returned.
-        
+
         Args:
             repetitions: The number of times the repeat block should repeat.
-        
+
         Examples:
             >>> import stim
             >>> m = stim.DetectorErrorModel('''
@@ -2126,7 +2126,7 @@ class DetectorErrorModel:
         """
     def append(self, instruction: object, parens_arguments: object = None, targets: List[object] = ()) -> None:
         """Appends an instruction to the detector error model.
-        
+
         Args:
             instruction: Either the name of an instruction, a stim.DemInstruction, or a stim.DemRepeatBlock.
                 The `parens_arguments` and `targets` arguments are given if and only if the instruction is a name.
@@ -2134,7 +2134,7 @@ class DetectorErrorModel:
                 detector error model file (eg. the `0.25` in `error(0.25) D0`). This argument can be given either
                 a list of doubles, or a single double (which will be implicitly wrapped into a list).
             targets: The instruction targets, such as the `D0` in `error(0.25) D0`.
-        
+
         Examples:
             >>> import stim
             >>> m = stim.DetectorErrorModel()
@@ -2152,7 +2152,7 @@ class DetectorErrorModel:
                 error(0.125) D1
                 error(0.25) D1 ^ D2 L3
             ''')
-        
+
             >>> m.append("shift_detectors", (1, 2, 3), [5])
             >>> print(repr(m))
             stim.DetectorErrorModel('''
@@ -2160,7 +2160,7 @@ class DetectorErrorModel:
                 error(0.25) D1 ^ D2 L3
                 shift_detectors(1, 2, 3) 5
             ''')
-        
+
             >>> m += m * 3
             >>> m.append(m[0])
             >>> m.append(m[-2])
@@ -2184,44 +2184,44 @@ class DetectorErrorModel:
         """
     def approx_equals(self, other: object, *, atol: float) -> bool:
         """Checks if a detector error model is approximately equal to another detector error model.
-        
+
         Two detector error model are approximately equal if they are equal up to slight perturbations of instruction
         arguments such as probabilities. For example `error(0.100) D0` is approximately equal to `error(0.099) D0`
         within an absolute tolerance of 0.002. All other details of the models (such as the ordering of errors and
         their targets) must be exactly the same.
-        
+
         Args:
             other: The detector error model, or other object, to compare to this one.
             atol: The absolute error tolerance. The maximum amount each probability may have been perturbed by.
-        
+
         Returns:
             True if the given object is a detector error model approximately equal up to the receiving circuit up to
             the given tolerance, otherwise False.
-        
+
         Examples:
             >>> import stim
             >>> base = stim.DetectorErrorModel('''
             ...    error(0.099) D0 D1
             ... ''')
-        
+
             >>> base.approx_equals(base, atol=0)
             True
-        
+
             >>> base.approx_equals(stim.DetectorErrorModel('''
             ...    error(0.101) D0 D1
             ... '''), atol=0)
             False
-        
+
             >>> base.approx_equals(stim.DetectorErrorModel('''
             ...    error(0.101) D0 D1
             ... '''), atol=0.0001)
             False
-        
+
             >>> base.approx_equals(stim.DetectorErrorModel('''
             ...    error(0.101) D0 D1
             ... '''), atol=0.01)
             True
-        
+
             >>> base.approx_equals(stim.DetectorErrorModel('''
             ...    error(0.099) D0 D1 L0 L1 L2 L3 L4
             ... '''), atol=9999)
@@ -2229,7 +2229,7 @@ class DetectorErrorModel:
         """
     def clear(self) -> None:
         """Clears the contents of the detector error model.
-        
+
         Examples:
             >>> import stim
             >>> model = stim.DetectorErrorModel('''
@@ -2241,10 +2241,10 @@ class DetectorErrorModel:
         """
     def copy(self) -> stim.DetectorErrorModel:
         """Returns a copy of the detector error model. An independent model with the same contents.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> c1 = stim.DetectorErrorModel("error(0.1) D0 D1")
             >>> c2 = c1.copy()
             >>> c2 is c1
@@ -2254,16 +2254,16 @@ class DetectorErrorModel:
         """
     def get_detector_coordinates(self, only: object = None) -> Dict[int, List[float]]:
         """Returns the coordinate metadata of detectors in the detector error model.
-        
+
         Args:
             only: Defaults to None (meaning include all detectors). A list of detector indices to include in the
                 result. Detector indices beyond the end of the detector error model cause an error.
-        
+
         Returns:
             A dictionary mapping integers (detector indices) to lists of floats (coordinates).
             Detectors with no specified coordinate data are mapped to an empty tuple.
             If `only` is specified, then `set(result.keys()) == set(only)`.
-        
+
         Examples:
             >>> import stim
             >>> dem = stim.DetectorErrorModel('''
@@ -2280,13 +2280,13 @@ class DetectorErrorModel:
     @property
     def num_detectors(self) -> int:
         """Counts the number of detectors (e.g. `D2`) in the error model.
-        
+
         Detector indices are assumed to be contiguous from 0 up to whatever the maximum detector id is.
         If the largest detector's absolute id is n-1, then the number of detectors is n.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> stim.Circuit('''
             ...     X_ERROR(0.125) 0
             ...     X_ERROR(0.25) 1
@@ -2296,12 +2296,12 @@ class DetectorErrorModel:
             ...     DETECTOR rec[-1]
             ... ''').detector_error_model().num_detectors
             2
-        
+
             >>> stim.DetectorErrorModel('''
             ...    error(0.1) D0 D199
             ... ''').num_detectors
             200
-        
+
             >>> stim.DetectorErrorModel('''
             ...    shift_detectors 1000
             ...    error(0.1) D0 D199
@@ -2311,13 +2311,13 @@ class DetectorErrorModel:
     @property
     def num_errors(self) -> int:
         """Counts the number of errors (e.g. `error(0.1) D0`) in the error model.
-        
+
         Error instructions inside repeat blocks count once per repetition.
         Redundant errors with the same targets count as separate errors.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> stim.DetectorErrorModel('''
             ...     error(0.125) D0
             ...     repeat 100 {
@@ -2331,20 +2331,20 @@ class DetectorErrorModel:
     @property
     def num_observables(self) -> int:
         """Counts the number of frame changes (e.g. `L2`) in the error model.
-        
+
         Observable indices are assumed to be contiguous from 0 up to whatever the maximum observable id is.
         If the largest observable's id is n-1, then the number of observables is n.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> stim.Circuit('''
             ...     X_ERROR(0.125) 0
             ...     M 0
             ...     OBSERVABLE_INCLUDE(99) rec[-1]
             ... ''').detector_error_model().num_observables
             100
-        
+
             >>> stim.DetectorErrorModel('''
             ...    error(0.1) L399
             ... ''').num_observables
@@ -2352,11 +2352,11 @@ class DetectorErrorModel:
         """
     def shortest_graphlike_error(self, ignore_ungraphlike_errors: bool = False) -> stim.DetectorErrorModel:
         """Finds a minimum sized set of graphlike errors that produce an undetected logical error.
-        
+
         Note that this method does not pay attention to error probabilities (other than ignoring errors with
         probability 0). It searches for a logical error with the minimum *number* of physical errors, not the
         maximum probability of those physical errors all occurring.
-        
+
         This method works by looking for errors that have frame changes (eg. "error(0.1) D0 D1 L5" flips the frame
         of observable 5). These errors are converted into one or two symptoms and a net frame change. The symptoms
         can then be moved around by following errors touching that symptom. Each symptom is moved until it
@@ -2367,12 +2367,12 @@ class DetectorErrorModel:
         stabilizer of the system; a dead end). The search process advances like a breadth first search, seeded from
         all the frame-change errors and branching them outward in tandem, until one of them wins the race to find a
         solution.
-        
+
         Args:
             ignore_ungraphlike_errors: Defaults to False. When False, an exception is raised if there are any
                 errors in the model that are not graphlike. When True, those errors are skipped as if they weren't
                 present.
-        
+
                 A graphlike error is an error with at most two symptoms per decomposed component.
                     graphlike:
                         error(0.1) D0
@@ -2382,21 +2382,21 @@ class DetectorErrorModel:
                     not graphlike:
                         error(0.1) D0 D1 D2
                         error(0.1) D0 D1 D2 ^ D3
-        
+
         Returns:
             A detector error model containing just the error instructions corresponding to an undetectable logical
             error. There will be no other kinds of instructions (no `repeat`s, no `shift_detectors`, etc).
             The error probabilities will all be set to 1.
-        
+
             The `len` of the returned model is the graphlike code distance of the circuit. But beware that in
             general the true code distance may be smaller. For example, in the XZ surface code with twists, the true
             minimum sized logical error is likely to use Y errors. But each Y error decomposes into two graphlike
             components (the X part and the Z part). As a result, the graphlike code distance in that context is
             likely to be nearly twice as large as the true code distance.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> stim.DetectorErrorModel('''
             ...     error(0.125) D0
             ...     error(0.125) D0 D1
@@ -2407,7 +2407,7 @@ class DetectorErrorModel:
                 error(1) D1
                 error(1) D1 L55
             ''')
-        
+
             >>> stim.DetectorErrorModel('''
             ...     error(0.125) D0 D1 D2
             ...     error(0.125) L0
@@ -2415,7 +2415,7 @@ class DetectorErrorModel:
             stim.DetectorErrorModel('''
                 error(1) L0
             ''')
-        
+
             >>> circuit = stim.Circuit.generated(
             ...     "repetition_code:memory",
             ...     rounds=10,
@@ -2434,11 +2434,11 @@ class ExplainedError:
     @property
     def circuit_error_locations(self) -> List[stim.CircuitErrorLocation]:
         """The locations of circuit errors that produce the symptoms in dem_error_terms.
-        
+
         Note: if this list contains a single entry, it may be because a result
         with a single representative error was requested (as opposed to all possible
         errors).
-        
+
         Note: if this list is empty, it may be because there was a DEM error decomposed
         into parts where one of the parts is impossible to make on its own from a single
         circuit error.
@@ -2449,7 +2449,7 @@ class ExplainedError:
         """
 class FlippedMeasurement:
     """Describes a measurement that was flipped.
-    
+
     Gives the measurement's index in the measurement record, and also
     the observable of the measurement.
     """
@@ -2459,7 +2459,7 @@ class FlippedMeasurement:
     @property
     def observable(self) -> List[stim.GateTargetWithCoords]:
         """Returns the observable of the flipped measurement.
-        
+
         For example, an `MX 5` measurement will have the observable X5.
         """
     @property
@@ -2470,7 +2470,7 @@ class FlippedMeasurement:
         """
 class GateTarget:
     """Represents a gate target, like `0` or `rec[-1]`, from a circuit.
-    
+
     Examples:
         >>> import stim
         >>> circuit = stim.Circuit('''
@@ -2486,7 +2486,7 @@ class GateTarget:
         """
     def __init__(self, value: object) -> None:
         """Initializes a `stim.GateTarget`.
-        
+
         Args:
             value: A target like `5` or `stim.target_rec(-1)`.
         """
@@ -2503,7 +2503,7 @@ class GateTarget:
     @property
     def is_inverted_result_target(self) -> bool:
         """Returns whether or not this is an inverted target.
-        
+
         Inverted targets include inverted qubit targets `stim.target_inv(5)` (`!5` in a circuit file) and
         inverted Pauli targets like `stim.target_x(4, invert=True)` (`!X4` in a circuit file).
         """
@@ -2537,11 +2537,11 @@ class GateTarget:
         """
 class GateTargetWithCoords:
     """A gate target with associated coordinate information.
-    
+
     For example, if the gate target is a qubit from a circuit with
     QUBIT_COORDS instructions, the coords field will contain the
     coordinate data from the QUBIT_COORDS instruction for the qubit.
-    
+
     This is helpful information to have available when debugging a
     problem in a circuit, instead of having to constantly manually
     look up the coordinates of a qubit index in order to understand
@@ -2553,7 +2553,7 @@ class GateTargetWithCoords:
     @property
     def coords(self) -> List[float]:
         """Returns the associated coordinate information as a list of flaots.
-        
+
         If there is no coordinate information, returns an empty list.
         """
     @property
@@ -2562,9 +2562,9 @@ class GateTargetWithCoords:
         """
 class PauliString:
     """A signed Pauli tensor product (e.g. "+X \u2297 X \u2297 X" or "-Y \u2297 Z".
-    
+
     Represents a collection of Pauli operations (I, X, Y, Z) applied pairwise to a collection of qubits.
-    
+
     Examples:
         >>> import stim
         >>> stim.PauliString("XX") * stim.PauliString("YY")
@@ -2574,21 +2574,21 @@ class PauliString:
     """
     def __add__(self, rhs: stim.PauliString) -> stim.PauliString:
         """Returns the tensor product of two Pauli strings.
-        
+
         Concatenates the Pauli strings and multiplies their signs.
-        
+
         Args:
             rhs: A second stim.PauliString.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> stim.PauliString("X") + stim.PauliString("YZ")
             stim.PauliString("+XYZ")
-        
+
             >>> stim.PauliString("iX") + stim.PauliString("-X")
             stim.PauliString("-iXX")
-        
+
         Returns:
             The tensor product.
         """
@@ -2603,10 +2603,10 @@ class PauliString:
         pass
     def __getitem__(self, index_or_slice: object) -> object:
         """Returns an individual Pauli or Pauli string slice from the pauli string.
-        
+
         Individual Paulis are returned as an int using the encoding 0=I, 1=X, 2=Y, 3=Z.
         Slices are returned as a stim.PauliString (always with positive sign).
-        
+
         Examples:
             >>> import stim
             >>> p = stim.PauliString("_XYZ")
@@ -2618,10 +2618,10 @@ class PauliString:
             stim.PauliString("+_X")
             >>> p[::-1]
             stim.PauliString("+ZYX_")
-        
+
         Args:
             index_or_slice: The index of the pauli to return, or the slice of paulis to return.
-        
+
         Returns:
             0: Identity.
             1: Pauli X.
@@ -2630,15 +2630,15 @@ class PauliString:
         """
     def __iadd__(self, rhs: stim.PauliString) -> stim.PauliString:
         """Performs an inplace tensor product.
-        
+
         Concatenates the given Pauli string onto the receiving string and multiplies their signs.
-        
+
         Args:
             rhs: A second stim.PauliString.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> p = stim.PauliString("iX")
             >>> alias = p
             >>> p += stim.PauliString("-YY")
@@ -2646,72 +2646,72 @@ class PauliString:
             stim.PauliString("-iXYY")
             >>> alias is p
             True
-        
+
         Returns:
             The mutated pauli string.
         """
     def __imul__(self, rhs: object) -> stim.PauliString:
         """Inplace right-multiplies the Pauli string by another Pauli string, a complex unit, or a tensor power.
-        
+
         Args:
             rhs: The right hand side of the multiplication. This can be:
                 - A stim.PauliString to right-multiply term-by-term into the paulis of the pauli string.
                 - A complex unit (1, -1, 1j, -1j) to multiply into the sign of the pauli string.
                 - A non-negative integer indicating the tensor power to raise the pauli string to (how many times to repeat it).
-        
+
         Examples:
             >>> import stim
-        
+
             >>> p = stim.PauliString("X")
             >>> p *= 1j
             >>> p
             stim.PauliString("+iX")
-        
+
             >>> p = stim.PauliString("iXY_")
             >>> p *= 3
             >>> p
             stim.PauliString("-iXY_XY_XY_")
-        
+
             >>> p = stim.PauliString("X")
             >>> alias = p
             >>> p *= stim.PauliString("Y")
             >>> alias
             stim.PauliString("+iZ")
-        
+
             >>> p = stim.PauliString("X")
             >>> p *= stim.PauliString("_YY")
             >>> p
             stim.PauliString("+XYY")
-        
+
         Returns:
             The mutated Pauli string.
         """
     @staticmethod
     def __init__(*args, **kwargs):
         """Overloaded function.
-        
+
         1. __init__(self: stim.PauliString, num_qubits: int) -> None
-        
+
         Creates an identity Pauli string over the given number of qubits.
-        
+
         Examples:
             >>> import stim
             >>> p = stim.PauliString(5)
             >>> print(p)
             +_____
-        
+
         Args:
             num_qubits: The number of qubits the Pauli string acts on.
-        
-        
+
+
         2. __init__(self: stim.PauliString, text: str) -> None
-        
+
         Creates a stim.PauliString from a text string.
-        
+
         The string can optionally start with a sign ('+', '-', 'i', '+i', or '-i').
         The rest of the string should be characters from '_IXYZ' where
         '_' and 'I' mean identity, 'X' means Pauli X, 'Y' means Pauli Y, and 'Z' means Pauli Z.
-        
+
         Examples:
             >>> import stim
             >>> print(stim.PauliString("YZ"))
@@ -2722,15 +2722,15 @@ class PauliString:
             -___X_
             >>> print(stim.PauliString("iX"))
             +iX
-        
+
         Args:
             text: A text description of the Pauli string's contents, such as "+XXX" or "-_YX".
-        
-        
+
+
         3. __init__(self: stim.PauliString, copy: stim.PauliString) -> None
-        
+
         Creates a copy of a stim.PauliString.
-        
+
         Examples:
             >>> import stim
             >>> a = stim.PauliString("YZ")
@@ -2739,46 +2739,46 @@ class PauliString:
             False
             >>> b == a
             True
-        
+
         Args:
             copy: The pauli string to make a copy of.
-        
-        
+
+
         4. __init__(self: stim.PauliString, pauli_indices: List[int]) -> None
-        
+
         Creates a stim.PauliString from a list of integer pauli indices.
-        
+
         The indexing scheme that is used is:
             0 -> I
             1 -> X
             2 -> Y
             3 -> Z
-        
+
         Examples:
             >>> import stim
             >>> stim.PauliString([0, 1, 2, 3, 0, 3])
             stim.PauliString("+_XYZ_Z")
-        
+
         Args:
             pauli_indices: A sequence of integers from 0 to 3 (inclusive) indicating paulis.
         """
     def __itruediv__(self, rhs: complex) -> stim.PauliString:
         """Inplace divides the Pauli string by a complex unit.
-        
+
         Args:
             rhs: The divisor. Can be 1, -1, 1j, or -1j.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> p = stim.PauliString("X")
             >>> p /= 1j
             >>> p
             stim.PauliString("-iX")
-        
+
         Returns:
             The mutated Pauli string.
-        
+
         Raises:
             ValueError: The divisor isn't 1, -1, 1j, or -1j.
         """
@@ -2787,23 +2787,23 @@ class PauliString:
         """
     def __mul__(self, rhs: object) -> stim.PauliString:
         """Right-multiplies the Pauli string by another Pauli string, a complex unit, or a tensor power.
-        
+
         Args:
             rhs: The right hand side of the multiplication. This can be:
                 - A stim.PauliString to right-multiply term-by-term with the paulis of the pauli string.
                 - A complex unit (1, -1, 1j, -1j) to multiply with the sign of the pauli string.
                 - A non-negative integer indicating the tensor power to raise the pauli string to (how many times to repeat it).
-        
+
         Examples:
             >>> import stim
-        
+
             >>> stim.PauliString("X") * 1
             stim.PauliString("+X")
             >>> stim.PauliString("X") * -1
             stim.PauliString("-X")
             >>> stim.PauliString("X") * 1j
             stim.PauliString("+iX")
-        
+
             >>> stim.PauliString("X") * 2
             stim.PauliString("+XX")
             >>> stim.PauliString("-X") * 2
@@ -2814,17 +2814,17 @@ class PauliString:
             stim.PauliString("+XXX")
             >>> stim.PauliString("iX") * 3
             stim.PauliString("-iXXX")
-        
+
             >>> stim.PauliString("X") * stim.PauliString("Y")
             stim.PauliString("+iZ")
             >>> stim.PauliString("X") * stim.PauliString("XX_")
             stim.PauliString("+_X_")
             >>> stim.PauliString("XXXX") * stim.PauliString("_XYZ")
             stim.PauliString("+X_ZY")
-        
+
         Returns:
             The product or tensor power.
-        
+
         Raises:
             TypeError: The right hand side isn't a stim.PauliString, a non-negative integer, or a complex unit (1, -1, 1j, or -1j).
         """
@@ -2833,7 +2833,7 @@ class PauliString:
         """
     def __neg__(self) -> stim.PauliString:
         """Returns the negation of the pauli string.
-        
+
         Examples:
             >>> import stim
             >>> -stim.PauliString("X")
@@ -2845,7 +2845,7 @@ class PauliString:
         """
     def __pos__(self) -> stim.PauliString:
         """Returns a pauli string with the same contents.
-        
+
         Examples:
             >>> import stim
             >>> +stim.PauliString("+X")
@@ -2860,23 +2860,23 @@ class PauliString:
         """
     def __rmul__(self, lhs: object) -> stim.PauliString:
         """Left-multiplies the Pauli string by another Pauli string, a complex unit, or a tensor power.
-        
+
         Args:
             lhs: The left hand side of the multiplication. This can be:
                 - A stim.PauliString to left-multiply term-by-term into the paulis of the pauli string.
                 - A complex unit (1, -1, 1j, -1j) to multiply into the sign of the pauli string.
                 - A non-negative integer indicating the tensor power to raise the pauli string to (how many times to repeat it).
-        
+
         Examples:
             >>> import stim
-        
+
             >>> 1 * stim.PauliString("X")
             stim.PauliString("+X")
             >>> -1 * stim.PauliString("X")
             stim.PauliString("-X")
             >>> 1j * stim.PauliString("X")
             stim.PauliString("+iX")
-        
+
             >>> 2 * stim.PauliString("X")
             stim.PauliString("+XX")
             >>> 2 * stim.PauliString("-X")
@@ -2887,27 +2887,27 @@ class PauliString:
             stim.PauliString("+XXX")
             >>> 3 * stim.PauliString("iX")
             stim.PauliString("-iXXX")
-        
+
             >>> stim.PauliString("X") * stim.PauliString("Y")
             stim.PauliString("+iZ")
             >>> stim.PauliString("X") * stim.PauliString("XX_")
             stim.PauliString("+_X_")
             >>> stim.PauliString("XXXX") * stim.PauliString("_XYZ")
             stim.PauliString("+X_ZY")
-        
+
         Returns:
             The product.
-        
+
         Raises:
             ValueError: The scalar phase factor isn't 1, -1, 1j, or -1j.
         """
     def __setitem__(self, index: int, new_pauli: object) -> None:
         """Mutates an entry in the pauli string using the encoding 0=I, 1=X, 2=Y, 3=Z.
-        
+
         Args:
             index: The index of the pauli to overwrite.
             new_pauli: Either a character from '_IXYZ' or an integer from range(4).
-        
+
         Examples:
             >>> import stim
             >>> p = stim.PauliString(4)
@@ -2934,31 +2934,31 @@ class PauliString:
         """
     def __truediv__(self, rhs: complex) -> stim.PauliString:
         """Divides the Pauli string by a complex unit.
-        
+
         Args:
             rhs: The divisor. Can be 1, -1, 1j, or -1j.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> stim.PauliString("X") / 1j
             stim.PauliString("-iX")
-        
+
         Returns:
             The quotient.
-        
+
         Raises:
             ValueError: The divisor isn't 1, -1, 1j, or -1j.
         """
     def commutes(self, other: stim.PauliString) -> bool:
         """Determines if two Pauli strings commute or not.
-        
+
         Two Pauli strings commute if they have an even number of matched
         non-equal non-identity Pauli terms. Otherwise they anticommute.
-        
+
         Args:
             other: The other Pauli string.
-        
+
         Examples:
             >>> import stim
             >>> xx = stim.PauliString("XX")
@@ -2976,13 +2976,13 @@ class PauliString:
             True
             >>> xx.commutes(stim.PauliString(""))
             True
-        
+
         Returns:
             True if the Pauli strings commute, False if they anti-commute.
         """
     def copy(self) -> stim.PauliString:
         """Returns a copy of the pauli string. An independent pauli string with the same contents.
-        
+
         Examples:
             >>> import stim
             >>> p1 = stim.PauliString.random(2)
@@ -2998,13 +2998,13 @@ class PauliString:
     @staticmethod
     def random(num_qubits: int, *, allow_imaginary: bool = False) -> stim.PauliString:
         """Samples a uniformly random Hermitian Pauli string over the given number of qubits.
-        
+
         Args:
             num_qubits: The number of qubits the Pauli string should act on.
             allow_imaginary: Defaults to False. If True, the sign of the result may be 1j or -1j
                 in addition to +1 or -1. In other words, setting this to True allows the result
                 to be non-Hermitian.
-        
+
         Examples:
             >>> import stim
             >>> p = stim.PauliString.random(5)
@@ -3012,20 +3012,20 @@ class PauliString:
             5
             >>> p.sign in [-1, +1]
             True
-        
+
             >>> p2 = stim.PauliString.random(3, allow_imaginary=True)
             >>> len(p2)
             3
             >>> p2.sign in [-1, +1, 1j, -1j]
             True
-        
+
         Returns:
             The sampled Pauli string.
         """
     @property
     def sign(self) -> complex:
         """The sign of the Pauli string. Can be +1, -1, 1j, or -1j.
-        
+
         Examples:
             >>> import stim
             >>> stim.PauliString("X").sign
@@ -3042,10 +3042,10 @@ class PauliString:
         pass
 class Tableau:
     """A stabilizer tableau.
-    
+
     Represents a Clifford operation by explicitly storing how that operation conjugates a list of Pauli
     group generators into composite Pauli products.
-    
+
     Examples:
         >>> import stim
         >>> stim.Tableau.from_named_gate("H")
@@ -3057,7 +3057,7 @@ class Tableau:
                 stim.PauliString("+X"),
             ],
         )
-    
+
         >>> t = stim.Tableau.random(5)
         >>> t_inv = t**-1
         >>> print(t * t_inv)
@@ -3068,20 +3068,20 @@ class Tableau:
         | __ __ XZ __ __
         | __ __ __ XZ __
         | __ __ __ __ XZ
-    
+
         >>> x2z3 = t.x_output(2) * t.z_output(3)
         >>> t_inv(x2z3)
         stim.PauliString("+__XZ_")
     """
     def __add__(self, rhs: stim.Tableau) -> stim.Tableau:
         """Returns the direct sum (diagonal concatenation) of two Tableaus.
-        
+
         Args:
             rhs: A second stim.Tableau.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> s = stim.Tableau.from_named_gate("S")
             >>> cz = stim.Tableau.from_named_gate("CZ")
             >>> print(s + cz)
@@ -3090,19 +3090,19 @@ class Tableau:
             | YZ __ __
             | __ XZ Z_
             | __ Z_ XZ
-        
+
         Returns:
             The direct sum.
         """
     def __call__(self, pauli_string: stim.PauliString) -> stim.PauliString:
         """Returns the result of conjugating the given PauliString by the Tableau's Clifford operation.
-        
+
         Args:
             pauli_string: The pauli string to conjugate.
-        
+
         Returns:
             The new conjugated pauli string.
-        
+
         Examples:
             >>> import stim
             >>> t = stim.Tableau.from_named_gate("CNOT")
@@ -3116,13 +3116,13 @@ class Tableau:
         """
     def __iadd__(self, rhs: stim.Tableau) -> stim.Tableau:
         """Performs an inplace direct sum (diagonal concatenation).
-        
+
         Args:
             rhs: A second stim.Tableau.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> s = stim.Tableau.from_named_gate("S")
             >>> cz = stim.Tableau.from_named_gate("CZ")
             >>> alias = s
@@ -3135,13 +3135,13 @@ class Tableau:
             | YZ __ __
             | __ XZ Z_
             | __ Z_ XZ
-        
+
         Returns:
             The mutated tableau.
         """
     def __init__(self, num_qubits: int) -> None:
         """Creates an identity tableau over the given number of qubits.
-        
+
         Examples:
             >>> import stim
             >>> t = stim.Tableau(3)
@@ -3151,7 +3151,7 @@ class Tableau:
             | XZ __ __
             | __ XZ __
             | __ __ XZ
-        
+
         Args:
             num_qubits: The number of qubits the tableau's operation acts on.
         """
@@ -3160,14 +3160,14 @@ class Tableau:
         """
     def __mul__(self, rhs: stim.Tableau) -> stim.Tableau:
         """Returns the product of two tableaus.
-        
+
         If the tableau T1 represents the Clifford operation with unitary C1,
         and the tableau T2 represents the Clifford operation with unitary C2,
         then the tableau T1*T2 represents the Clifford operation with unitary C1*C2.
-        
+
         Args:
             rhs: The tableau  on the right hand side of the multiplication.
-        
+
         Examples:
             >>> import stim
             >>> t1 = stim.Tableau.random(4)
@@ -3182,13 +3182,13 @@ class Tableau:
         """
     def __pow__(self, exponent: int) -> stim.Tableau:
         """Raises the tableau to an integer power.
-        
+
         Large powers are reached efficiently using repeated squaring.
         Negative powers are reached by inverting the tableau.
-        
+
         Args:
             exponent: The power to raise to. Can be negative, zero, or positive.
-        
+
         Examples:
             >>> import stim
             >>> s = stim.Tableau.from_named_gate("S")
@@ -3215,13 +3215,13 @@ class Tableau:
         """
     def append(self, gate: stim.Tableau, targets: List[int]) -> None:
         """Appends an operation's effect into this tableau, mutating this tableau.
-        
+
         Time cost is O(n*m*m) where n=len(self) and m=len(gate).
-        
+
         Args:
             gate: The tableau of the operation being appended into this tableau.
             targets: The qubits being targeted by the gate.
-        
+
         Examples:
             >>> import stim
             >>> cnot = stim.Tableau.from_named_gate("CNOT")
@@ -3234,7 +3234,7 @@ class Tableau:
         """
     def copy(self) -> stim.Tableau:
         """Returns a copy of the tableau. An independent tableau with the same contents.
-        
+
         Examples:
             >>> import stim
             >>> t1 = stim.Tableau.random(2)
@@ -3247,20 +3247,20 @@ class Tableau:
     @staticmethod
     def from_conjugated_generators(*, xs: List[stim.PauliString], zs: List[stim.PauliString]) -> stim.Tableau:
         """Creates a tableau from the given outputs for each generator.
-        
+
         Verifies that the tableau is well formed.
-        
+
         Args:
             xs: A List[stim.PauliString] with the results of conjugating X0, X1, etc.
             zs: A List[stim.PauliString] with the results of conjugating Z0, Z1, etc.
-        
+
         Returns:
             The created tableau.
-        
+
         Raises:
             ValueError: The given outputs are malformed. Their lengths are inconsistent,
                 or they don't satisfy the required commutation relationships.
-        
+
         Examples:
             >>> import stim
             >>> identity3 = stim.Tableau.from_conjugated_generators(
@@ -3281,13 +3281,13 @@ class Tableau:
     @staticmethod
     def from_named_gate(name: str) -> stim.Tableau:
         """Returns the tableau of a named Clifford gate.
-        
+
         Args:
             name: The name of the Clifford gate.
-        
+
         Returns:
             The gate's tableau.
-        
+
         Examples:
             >>> import stim
             >>> print(stim.Tableau.from_named_gate("H"))
@@ -3306,22 +3306,22 @@ class Tableau:
         """
     def inverse(self, *, unsigned: bool = False) -> stim.Tableau:
         """Computes the inverse of the tableau.
-        
+
         The inverse T^-1 of a tableau T is the unique tableau with the property that T * T^-1 = T^-1 * T = I where
         I is the identity tableau.
-        
+
         Args:
             unsigned: Defaults to false. When set to true, skips computing the signs of the output observables and
                 instead just set them all to be positive. This is beneficial because computing the signs takes
                 O(n^3) time and the rest of the inverse computation is O(n^2) where n is the number of qubits in the
                 tableau. So, if you only need the Pauli terms (not the signs), it is significantly cheaper.
-        
+
         Returns:
             The inverse tableau.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> # Check that the inverse agrees with hard-coded tableaus in the gate data.
             >>> s = stim.Tableau.from_named_gate("S")
             >>> s_dag = stim.Tableau.from_named_gate("S_DAG")
@@ -3330,14 +3330,14 @@ class Tableau:
             >>> z = stim.Tableau.from_named_gate("Z")
             >>> z.inverse() == z
             True
-        
+
             >>> # Check that multiplying by the inverse produces the identity.
             >>> t = stim.Tableau.random(10)
             >>> t_inv = t.inverse()
             >>> identity = stim.Tableau(10)
             >>> t * t_inv == t_inv * t == identity
             True
-        
+
             >>> # Check a manual case.
             >>> t = stim.Tableau.from_conjugated_generators(
             ...     xs=[stim.PauliString("-__Z"), stim.PauliString("+XZ_"), stim.PauliString("+_ZZ")],
@@ -3358,21 +3358,21 @@ class Tableau:
         """
     def inverse_x_output(self, input_index: int, *, unsigned: bool = False) -> stim.PauliString:
         """Returns the result of conjugating an X Pauli generator by the inverse of the tableau.
-        
+
         A faster version of `tableau.inverse(unsigned).x_output(input_index)`.
-        
+
         Args:
             input_index: Identifies the column (the qubit of the X generator) to return from the inverse tableau.
             unsigned: Defaults to false. When set to true, skips computing the result's sign and instead just sets
                 it to positive. This is beneficial because computing the sign takes O(n^2) time whereas all other
                 parts of the computation take O(n) time where n is the number of qubits in the tableau.
-        
+
         Returns:
             The result of conjugating an X generator by the inverse of the tableau.
-        
+
         Examples:
             >>> import stim
-        
+
             # Check equivalence with the inverse's x_output.
             >>> t = stim.Tableau.random(4)
             >>> expected = t.inverse().x_output(0)
@@ -3384,24 +3384,24 @@ class Tableau:
         """
     def inverse_x_output_pauli(self, input_index: int, output_index: int) -> int:
         """Returns a Pauli term from the tableau's inverse's output pauli string for an input X generator.
-        
+
         A constant-time equivalent for `tableau.inverse().x_output(input_index)[output_index]`.
-        
+
         Args:
             input_index: Identifies the column (the qubit of the input X generator) in the inverse tableau.
             output_index: Identifies the row (the output qubit) in the inverse tableau.
-        
+
         Returns:
             An integer identifying Pauli at the given location in the inverse tableau:
-        
+
                 0: I
                 1: X
                 2: Y
                 3: Z
-        
+
         Examples:
             >>> import stim
-        
+
             >>> t_inv = stim.Tableau.from_conjugated_generators(
             ...     xs=[stim.PauliString("-Y_"), stim.PauliString("+YZ")],
             ...     zs=[stim.PauliString("-ZY"), stim.PauliString("+YX")],
@@ -3417,21 +3417,21 @@ class Tableau:
         """
     def inverse_y_output(self, input_index: int, *, unsigned: bool = False) -> stim.PauliString:
         """Returns the result of conjugating a Y Pauli generator by the inverse of the tableau.
-        
+
         A faster version of `tableau.inverse(unsigned).y_output(input_index)`.
-        
+
         Args:
             input_index: Identifies the column (the qubit of the Y generator) to return from the inverse tableau.
             unsigned: Defaults to false. When set to true, skips computing the result's sign and instead just sets
                 it to positive. This is beneficial because computing the sign takes O(n^2) time whereas all other
                 parts of the computation take O(n) time where n is the number of qubits in the tableau.
-        
+
         Returns:
             The result of conjugating a Y generator by the inverse of the tableau.
-        
+
         Examples:
             >>> import stim
-        
+
             # Check equivalence with the inverse's y_output.
             >>> t = stim.Tableau.random(4)
             >>> expected = t.inverse().y_output(0)
@@ -3443,24 +3443,24 @@ class Tableau:
         """
     def inverse_y_output_pauli(self, input_index: int, output_index: int) -> int:
         """Returns a Pauli term from the tableau's inverse's output pauli string for an input Y generator.
-        
+
         A constant-time equivalent for `tableau.inverse().y_output(input_index)[output_index]`.
-        
+
         Args:
             input_index: Identifies the column (the qubit of the input Y generator) in the inverse tableau.
             output_index: Identifies the row (the output qubit) in the inverse tableau.
-        
+
         Returns:
             An integer identifying Pauli at the given location in the inverse tableau:
-        
+
                 0: I
                 1: X
                 2: Y
                 3: Z
-        
+
         Examples:
             >>> import stim
-        
+
             >>> t_inv = stim.Tableau.from_conjugated_generators(
             ...     xs=[stim.PauliString("-Y_"), stim.PauliString("+YZ")],
             ...     zs=[stim.PauliString("-ZY"), stim.PauliString("+YX")],
@@ -3476,23 +3476,23 @@ class Tableau:
         """
     def inverse_z_output(self, input_index: int, *, unsigned: bool = False) -> stim.PauliString:
         """Returns the result of conjugating a Z Pauli generator by the inverse of the tableau.
-        
+
         A faster version of `tableau.inverse(unsigned).z_output(input_index)`.
-        
+
         Args:
             input_index: Identifies the column (the qubit of the Z generator) to return from the inverse tableau.
             unsigned: Defaults to false. When set to true, skips computing the result's sign and instead just sets
                 it to positive. This is beneficial because computing the sign takes O(n^2) time whereas all other
                 parts of the computation take O(n) time where n is the number of qubits in the tableau.
-        
+
         Returns:
             The result of conjugating a Z generator by the inverse of the tableau.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> import stim
-        
+
             # Check equivalence with the inverse's z_output.
             >>> t = stim.Tableau.random(4)
             >>> expected = t.inverse().z_output(0)
@@ -3504,24 +3504,24 @@ class Tableau:
         """
     def inverse_z_output_pauli(self, input_index: int, output_index: int) -> int:
         """Returns a Pauli term from the tableau's inverse's output pauli string for an input Z generator.
-        
+
         A constant-time equivalent for `tableau.inverse().z_output(input_index)[output_index]`.
-        
+
         Args:
             input_index: Identifies the column (the qubit of the input Z generator) in the inverse tableau.
             output_index: Identifies the row (the output qubit) in the inverse tableau.
-        
+
         Returns:
             An integer identifying Pauli at the given location in the inverse tableau:
-        
+
                 0: I
                 1: X
                 2: Y
                 3: Z
-        
+
         Examples:
             >>> import stim
-        
+
             >>> t_inv = stim.Tableau.from_conjugated_generators(
             ...     xs=[stim.PauliString("-Y_"), stim.PauliString("+YZ")],
             ...     zs=[stim.PauliString("-ZY"), stim.PauliString("+YX")],
@@ -3537,13 +3537,13 @@ class Tableau:
         """
     def prepend(self, gate: stim.Tableau, targets: List[int]) -> None:
         """Prepends an operation's effect into this tableau, mutating this tableau.
-        
+
         Time cost is O(n*m*m) where n=len(self) and m=len(gate).
-        
+
         Args:
             gate: The tableau of the operation being prepended into this tableau.
             targets: The qubits being targeted by the gate.
-        
+
         Examples:
             >>> import stim
             >>> h = stim.Tableau.from_named_gate("H")
@@ -3556,17 +3556,17 @@ class Tableau:
     @staticmethod
     def random(num_qubits: int) -> stim.Tableau:
         """Samples a uniformly random Clifford operation over the given number of qubits and returns its tableau.
-        
+
         Args:
             num_qubits: The number of qubits the tableau should act on.
-        
+
         Returns:
             The sampled tableau.
-        
+
         Examples:
             >>> import stim
             >>> t = stim.Tableau.random(42)
-        
+
         References:
             "Hadamard-free circuits expose the structure of the Clifford group"
             Sergey Bravyi, Dmitri Maslov
@@ -3574,15 +3574,15 @@ class Tableau:
         """
     def then(self, second: stim.Tableau) -> stim.Tableau:
         """Returns the result of composing two tableaus.
-        
+
         If the tableau T1 represents the Clifford operation with unitary C1,
         and the tableau T2 represents the Clifford operation with unitary C2,
         then the tableau T1.then(T2) represents the Clifford operation with unitary C2*C1.
-        
+
         Args:
             second: The result is equivalent to applying the second tableau after
                 the receiving tableau.
-        
+
         Examples:
             >>> import stim
             >>> t1 = stim.Tableau.random(4)
@@ -3592,18 +3592,49 @@ class Tableau:
             >>> t3(p) == t2(t1(p))
             True
         """
+    def to_unitary_matrix(self, *, endian: str) -> np.ndarray[np.float32]:
+        """Converts the tableau into a unitary matrix.
+
+        Args:
+            endian:
+                "little": The first qubit is the least significant (corresponds
+                    to an offset of 1 in the state vector).
+                "big": The first qubit is the most significant (corresponds
+                    to an offset of 2**(n - 1) in the state vector).
+
+        Returns:
+            A numpy array with dtype=np.complex64 and shape=(1 << len(tableau), 1 << len(tableau)).
+
+        Example:
+            >>> import stim
+            >>> cnot = stim.Tableau.from_conjugated_generators(
+            ...     xs=[
+            ...         stim.PauliString("XX"),
+            ...         stim.PauliString("_X"),
+            ...     ],
+            ...     zs=[
+            ...         stim.PauliString("Z_"),
+            ...         stim.PauliString("ZZ"),
+            ...     ],
+            ... )
+            >>> cnot.to_unitary_matrix(endian='big')
+            array([[1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+                   [0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j],
+                   [0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j],
+                   [0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j]], dtype=complex64)
+        """
     def x_output(self, target: int) -> stim.PauliString:
         """Returns the result of conjugating a Pauli X by the tableau's Clifford operation.
-        
+
         Args:
             target: The qubit targeted by the Pauli X operation.
-        
+
         Examples:
             >>> import stim
             >>> h = stim.Tableau.from_named_gate("H")
             >>> h.x_output(0)
             stim.PauliString("+Z")
-        
+
             >>> cnot = stim.Tableau.from_named_gate("CNOT")
             >>> cnot.x_output(0)
             stim.PauliString("+XX")
@@ -3612,24 +3643,24 @@ class Tableau:
         """
     def x_output_pauli(self, input_index: int, output_index: int) -> int:
         """Returns a Pauli term from the tableau's output pauli string for an input X generator.
-        
+
         A constant-time equivalent for `tableau.x_output(input_index)[output_index]`.
-        
+
         Args:
             input_index: Identifies the tableau column (the qubit of the input X generator).
             output_index: Identifies the tableau row (the output qubit).
-        
+
         Returns:
             An integer identifying Pauli at the given location in the tableau:
-        
+
                 0: I
                 1: X
                 2: Y
                 3: Z
-        
+
         Examples:
             >>> import stim
-        
+
             >>> t = stim.Tableau.from_conjugated_generators(
             ...     xs=[stim.PauliString("-Y_"), stim.PauliString("+YZ")],
             ...     zs=[stim.PauliString("-ZY"), stim.PauliString("+YX")],
@@ -3645,16 +3676,16 @@ class Tableau:
         """
     def y_output(self, target: int) -> stim.PauliString:
         """Returns the result of conjugating a Pauli Y by the tableau's Clifford operation.
-        
+
         Args:
             target: The qubit targeted by the Pauli Y operation.
-        
+
         Examples:
             >>> import stim
             >>> h = stim.Tableau.from_named_gate("H")
             >>> h.y_output(0)
             stim.PauliString("-Y")
-        
+
             >>> cnot = stim.Tableau.from_named_gate("CNOT")
             >>> cnot.y_output(0)
             stim.PauliString("+YX")
@@ -3663,24 +3694,24 @@ class Tableau:
         """
     def y_output_pauli(self, input_index: int, output_index: int) -> int:
         """Returns a Pauli term from the tableau's output pauli string for an input Y generator.
-        
+
         A constant-time equivalent for `tableau.y_output(input_index)[output_index]`.
-        
+
         Args:
             input_index: Identifies the tableau column (the qubit of the input Y generator).
             output_index: Identifies the tableau row (the output qubit).
-        
+
         Returns:
             An integer identifying Pauli at the given location in the tableau:
-        
+
                 0: I
                 1: X
                 2: Y
                 3: Z
-        
+
         Examples:
             >>> import stim
-        
+
             >>> t = stim.Tableau.from_conjugated_generators(
             ...     xs=[stim.PauliString("-Y_"), stim.PauliString("+YZ")],
             ...     zs=[stim.PauliString("-ZY"), stim.PauliString("+YX")],
@@ -3696,16 +3727,16 @@ class Tableau:
         """
     def z_output(self, target: int) -> stim.PauliString:
         """Returns the result of conjugating a Pauli Z by the tableau's Clifford operation.
-        
+
         Args:
             target: The qubit targeted by the Pauli Z operation.
-        
+
         Examples:
             >>> import stim
             >>> h = stim.Tableau.from_named_gate("H")
             >>> h.z_output(0)
             stim.PauliString("+X")
-        
+
             >>> cnot = stim.Tableau.from_named_gate("CNOT")
             >>> cnot.z_output(0)
             stim.PauliString("+Z_")
@@ -3714,24 +3745,24 @@ class Tableau:
         """
     def z_output_pauli(self, input_index: int, output_index: int) -> int:
         """Returns a Pauli term from the tableau's output pauli string for an input Z generator.
-        
+
         A constant-time equivalent for `tableau.z_output(input_index)[output_index]`.
-        
+
         Args:
             input_index: Identifies the tableau column (the qubit of the input Z generator).
             output_index: Identifies the tableau row (the output qubit).
-        
+
         Returns:
             An integer identifying Pauli at the given location in the tableau:
-        
+
                 0: I
                 1: X
                 2: Y
                 3: Z
-        
+
         Examples:
             >>> import stim
-        
+
             >>> t = stim.Tableau.from_conjugated_generators(
             ...     xs=[stim.PauliString("-Y_"), stim.PauliString("+YZ")],
             ...     zs=[stim.PauliString("-ZY"), stim.PauliString("+YX")],
@@ -3747,9 +3778,9 @@ class Tableau:
         """
 class TableauSimulator:
     """A quantum stabilizer circuit simulator whose internal state is an inverse stabilizer tableau.
-    
+
     Supports interactive usage, where gates and measurements are applied on demand.
-    
+
     Examples:
         >>> import stim
         >>> s = stim.TableauSimulator()
@@ -3759,7 +3790,7 @@ class TableauSimulator:
         ...     s.cnot(1, 2)
         >>> s.measure(1) == s.measure(2)
         True
-    
+
         >>> s = stim.TableauSimulator()
         >>> s.h(0)
         >>> s.cnot(0, 1)
@@ -3777,21 +3808,21 @@ class TableauSimulator:
     """
     def canonical_stabilizers(self) -> List[stim.PauliString]:
         """Returns a list of the stabilizers of the simulator's current state in a standard form.
-        
+
         Two simulators have the same canonical stabilizers if and only if their current quantum state is equal
         (and tracking the same number of qubits).
-        
+
         The canonical form is computed as follows:
-        
+
             1. Get a list of stabilizers using the `z_output`s of `simulator.current_inverse_tableau()**-1`.
             2. Perform Gaussian elimination on each generator g (ordered X0, Z0, X1, Z1, X2, Z2, etc).
                 2a) Pick any stabilizer that uses the generator g. If there are none, go to the next g.
                 2b) Multiply that stabilizer into all other stabilizers that use the generator g.
                 2c) Swap that stabilizer with the stabilizer at position `next_output` then increment `next_output`.
-        
+
         Returns:
             A List[stim.PauliString] of the simulator's state's stabilizers.
-        
+
         Examples:
             >>> import stim
             >>> s = stim.TableauSimulator()
@@ -3800,7 +3831,7 @@ class TableauSimulator:
             >>> s.x(2)
             >>> s.canonical_stabilizers()
             [stim.PauliString("+XX_"), stim.PauliString("+ZZ_"), stim.PauliString("-__Z")]
-        
+
             >>> # Scramble the stabilizers then check that the canonical form is unchanged.
             >>> s.set_inverse_tableau(s.current_inverse_tableau()**-1)
             >>> s.cnot(0, 1)
@@ -3813,7 +3844,7 @@ class TableauSimulator:
         """
     def cnot(self, *targets) -> None:
         """Applies a controlled X gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets, and so forth.
@@ -3821,10 +3852,10 @@ class TableauSimulator:
         """
     def copy(self) -> stim.TableauSimulator:
         """Returns a copy of the simulator. A simulator with the same internal state.
-        
+
         Examples:
             >>> import stim
-        
+
             >>> s1 = stim.TableauSimulator()
             >>> s1.set_inverse_tableau(stim.Tableau.random(1))
             >>> s2 = s1.copy()
@@ -3832,7 +3863,7 @@ class TableauSimulator:
             False
             >>> s2.current_inverse_tableau() == s1.current_inverse_tableau()
             True
-        
+
             >>> s = stim.TableauSimulator()
             >>> def brute_force_post_select(qubit, desired_result):
             ...     global s
@@ -3848,10 +3879,10 @@ class TableauSimulator:
         """
     def current_inverse_tableau(self) -> stim.Tableau:
         """Returns a copy of the internal state of the simulator as a stim.Tableau.
-        
+
         Returns:
             A stim.Tableau copy of the simulator's state.
-        
+
         Examples:
             >>> import stim
             >>> s = stim.TableauSimulator()
@@ -3880,7 +3911,7 @@ class TableauSimulator:
         """
     def current_measurement_record(self) -> List[bool]:
         """Returns a copy of the record of all measurements performed by the simulator.
-        
+
         Examples:
             >>> import stim
             >>> s = stim.TableauSimulator()
@@ -3896,13 +3927,13 @@ class TableauSimulator:
             >>> s.do(stim.Circuit("M 0"))
             >>> s.current_measurement_record()
             [False, True, True]
-        
+
         Returns:
             A list of booleans containing the result of every measurement performed by the simulator so far.
         """
     def cy(self, *targets) -> None:
         """Applies a controlled Y gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets, and so forth.
@@ -3910,7 +3941,7 @@ class TableauSimulator:
         """
     def cz(self, *targets) -> None:
         """Applies a controlled Z gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets, and so forth.
@@ -3924,10 +3955,10 @@ class TableauSimulator:
         pass
     def do(self, circuit_or_pauli_string: object) -> None:
         """Applies a circuit or pauli string to the simulator's state.
-        
+
         Args:
             circuit_or_pauli_string: A stim.Circuit or a stim.PauliString containing operations to apply.
-        
+
         Examples:
             >>> import stim
             >>> s = stim.TableauSimulator()
@@ -3937,7 +3968,7 @@ class TableauSimulator:
             ... '''))
             >>> s.current_measurement_record()
             [True]
-        
+
             >>> s = stim.TableauSimulator()
             >>> s.do(stim.PauliString("IXYZ"))
             >>> s.measure_many(0, 1, 2, 3)
@@ -3945,25 +3976,25 @@ class TableauSimulator:
         """
     def h(self, *targets) -> None:
         """Applies a Hadamard gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
     def h_xy(self, *targets) -> None:
         """Applies a variant of the Hadamard gate that swaps the X and Y axes to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
     def h_yz(self, *targets) -> None:
         """Applies a variant of the Hadamard gate that swaps the Y and Z axes to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
     def iswap(self, *targets) -> None:
         """Applies an ISWAP gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets, and so forth.
@@ -3971,7 +4002,7 @@ class TableauSimulator:
         """
     def iswap_dag(self, *targets) -> None:
         """Applies an ISWAP_DAG gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets, and so forth.
@@ -3979,22 +4010,22 @@ class TableauSimulator:
         """
     def measure(self, target: int) -> bool:
         """Measures a single qubit.
-        
+
         Unlike the other methods on TableauSimulator, this one does not broadcast
         over multiple targets. This is to avoid returning a list, which would
         create a pitfall where typing `if sim.measure(qubit)` would be a bug.
-        
+
         To measure multiple qubits, use `TableauSimulator.measure_many`.
-        
+
         Args:
             target: The index of the qubit to measure.
-        
+
         Returns:
             The measurement result as a bool.
         """
     def measure_kickback(self, target: int) -> tuple:
         """Measures a qubit and returns the result as well as its Pauli kickback (if any).
-        
+
         The "Pauli kickback" of a stabilizer circuit measurement is a set of Pauli operations that
         flip the post-measurement system state between the two possible post-measurement states.
         For example, consider measuring one of the qubits in the state |00>+|11> in the Z basis.
@@ -4005,30 +4036,30 @@ class TableauSimulator:
         Note that there are often many possible equivalent Pauli kickbacks. For example,
         if in the previous example there was a third qubit in the |0> state, then both
         `stim.PauliString("XX_")` and `stim.PauliString("XXZ")` are valid kickbacks.
-        
+
         Measurements with determinist results don't have a Pauli kickback.
-        
+
         Args:
             target: The index of the qubit to measure.
-        
+
         Returns:
             A (result, kickback) tuple.
             The result is a bool containing the measurement's output.
             The kickback is either None (meaning the measurement was deterministic) or a stim.PauliString
             (meaning the measurement was random, and the operations in the Pauli string flip between the
             two possible post-measurement states).
-        
+
         Examples:
             >>> import stim
             >>> s = stim.TableauSimulator()
-        
+
             >>> s.measure_kickback(0)
             (False, None)
-        
+
             >>> s.h(0)
             >>> s.measure_kickback(0)[1]
             stim.PauliString("+X")
-        
+
             >>> def pseudo_post_select(qubit, desired_result):
             ...     m, kick = s.measure_kickback(qubit)
             ...     if m != desired_result:
@@ -4045,21 +4076,21 @@ class TableauSimulator:
         """
     def measure_many(self, *targets) -> List[bool]:
         """Measures multiple qubits.
-        
+
         Args:
             *targets: The indices of the qubits to measure.
-        
+
         Returns:
             The measurement results as a list of bools.
         """
     def peek_bloch(self, target: int) -> stim.PauliString:
         """Returns the current bloch vector of the qubit, represented as a stim.PauliString.
-        
+
         This is a non-physical operation. It reports information about the qubit without disturbing it.
-        
+
         Args:
             target: The qubit to peek at.
-        
+
         Returns:
             stim.PauliString("I"): The qubit is entangled. Its bloch vector is x=y=z=0.
             stim.PauliString("+Z"): The qubit is in the |0> state. Its bloch vector is z=+1, x=y=0.
@@ -4068,7 +4099,7 @@ class TableauSimulator:
             stim.PauliString("-Y"): The qubit is in the |-i> state. Its bloch vector is y=-1, x=z=0.
             stim.PauliString("+X"): The qubit is in the |+> state. Its bloch vector is x=+1, y=z=0.
             stim.PauliString("-X"): The qubit is in the |-> state. Its bloch vector is x=-1, y=z=0.
-        
+
         Examples:
             >>> import stim
             >>> s = stim.TableauSimulator()
@@ -4089,19 +4120,19 @@ class TableauSimulator:
         """
     def peek_observable_expectation(self, observable: stim.PauliString) -> int:
         """Determines the expected value of an observable (which will always be -1, 0, or +1).
-        
+
         This is a non-physical operation.
         It reports information about the quantum state without disturbing it.
-        
+
         Args:
             observable: The observable to determine the expected value of.
                 This observable must have a real sign, not an imaginary sign.
-        
+
         Returns:
             +1: Observable will be deterministically false when measured.
             -1: Observable will be deterministically true when measured.
             0: Observable will be random when measured.
-        
+
         Examples:
             >>> import stim
             >>> s = stim.TableauSimulator()
@@ -4111,7 +4142,7 @@ class TableauSimulator:
             0
             >>> s.peek_observable_expectation(stim.PauliString("-Z"))
             -1
-        
+
             >>> s.do(stim.Circuit('''
             ...     H 0
             ...     CNOT 0 1
@@ -4127,39 +4158,228 @@ class TableauSimulator:
             II 1
             IIZ 1
         """
+    def peek_x(self, target: int) -> int:
+        """Returns the expected value of a qubit's X observable (which will always be -1, 0, or +1).
+
+        This is a non-physical operation.
+        It reports information about the quantum state without disturbing it.
+
+        Args:
+            target: The qubit to analyze.
+
+        Returns:
+            +1: Qubit is in the |+> state.
+            -1: Qubit is in the |-> state.
+            0: Qubit is in some other state.
+
+        Example:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_z(0)
+            >>> s.peek_x(0)
+            0
+            >>> s.reset_x(0)
+            >>> s.peek_x(0)
+            1
+            >>> s.Z(0)
+            >>> s.peek_x(0)
+            -1
+        """
+    def peek_y(self, target: int) -> int:
+        """Returns the expected value of a qubit's Y observable (which will always be -1, 0, or +1).
+
+        This is a non-physical operation.
+        It reports information about the quantum state without disturbing it.
+
+        Args:
+            target: The qubit to analyze.
+
+        Returns:
+            +1: Qubit is in the |i> state.
+            -1: Qubit is in the |-i> state.
+            0: Qubit is in some other state.
+
+        Example:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_z(0)
+            >>> s.peek_y(0)
+            0
+            >>> s.reset_y(0)
+            >>> s.peek_y(0)
+            1
+            >>> s.Z(0)
+            >>> s.peek_y(0)
+            -1
+        """
+    def peek_z(self, target: int) -> int:
+        """Returns the expected value of a qubit's Z observable (which will always be -1, 0, or +1).
+
+        This is a non-physical operation.
+        It reports information about the quantum state without disturbing it.
+
+        Args:
+            target: The qubit to analyze.
+
+        Returns:
+            +1: Qubit is in the |0> state.
+            -1: Qubit is in the |1> state.
+            0: Qubit is in some other state.
+
+        Example:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.peek_z(0)
+            0
+            >>> s.reset_z(0)
+            >>> s.peek_z(0)
+            1
+            >>> s.X(0)
+            >>> s.peek_z(0)
+            -1
+        """
+    def postselect_x(self, targets: Union[int, Iterable[int]], *, desired_value: bool) -> None:
+
+        """Postselects qubits in the X basis, or raises an exception.
+
+        Postselecting a qubit forces it to collapse to a specific state, as
+        if it was measured and that state was the result of the measurement.
+
+        Args:
+            targets: The qubit index or indices to postselect.
+            desired_value:
+                False: postselect targets into the |+> state.
+                True: postselect targets into the |-> state.
+
+        Raises:
+            ValueError:
+                The postselection failed. One of the qubits was in a state
+                orthogonal to the desired state, so it was literally
+                impossible for a measurement of the qubit to return the
+                desired result.
+        """
+    def postselect_y(self, targets: Union[int, Iterable[int]], *, desired_value: bool) -> None:
+
+        """Postselects qubits in the Y basis, or raises an exception.
+
+        Postselecting a qubit forces it to collapse to a specific state, as
+        if it was measured and that state was the result of the measurement.
+
+        Args:
+            targets: The qubit index or indices to postselect.
+            desired_value:
+                False: postselect targets into the |i> state.
+                True: postselect targets into the |-i> state.
+
+        Raises:
+            ValueError:
+                The postselection failed. One of the qubits was in a state
+                orthogonal to the desired state, so it was literally
+                impossible for a measurement of the qubit to return the
+                desired result.
+        """
+    def postselect_z(self, targets: Union[int, Iterable[int]], *, desired_value: bool) -> None:
+
+        """Postselects qubits in the Z basis, or raises an exception.
+
+        Postselecting a qubit forces it to collapse to a specific state, as
+        if it was measured and that state was the result of the measurement.
+
+        Args:
+            targets: The qubit index or indices to postselect.
+            desired_value:
+                False: postselect targets into the |0> state.
+                True: postselect targets into the |1> state.
+
+        Raises:
+            ValueError:
+                The postselection failed. One of the qubits was in a state
+                orthogonal to the desired state, so it was literally
+                impossible for a measurement of the qubit to return the
+                desired result.
+        """
     def reset(self, *targets) -> None:
-        """Resets qubits to zero (e.g. by swapping them for zero'd qubit from the environment).
-        
+        """Resets qubits to the |0> state.
+
         Args:
             *targets: The indices of the qubits to reset.
+
+        Example:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.X(0)
+            >>> s.reset(0)
+            >>> s.peek_bloch(0)
+            +Z
+        """
+    def reset_x(self, *targets) -> None:
+        """Resets qubits to the |+> state.
+
+        Args:
+            *targets: The indices of the qubits to reset.
+
+        Example:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.peek_bloch(0)
+            +X
+        """
+    def reset_y(self, *targets) -> None:
+        """Resets qubits to the |i> state.
+
+        Args:
+            *targets: The indices of the qubits to reset.
+
+        Example:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_y(0)
+            >>> s.peek_bloch(0)
+            +Y
+        """
+    def reset_z(self, *targets) -> None:
+        """Resets qubits to the |0> state.
+
+        Args:
+            *targets: The indices of the qubits to reset.
+
+        Example:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.H(0)
+            >>> s.reset_z(0)
+            >>> s.peek_bloch(0)
+            +Z
         """
     def s(self, *targets) -> None:
         """Applies a SQRT_Z gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
     def s_dag(self, *targets) -> None:
         """Applies a SQRT_Z_DAG gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
     def set_inverse_tableau(self, new_inverse_tableau: stim.Tableau) -> None:
         """Overwrites the simulator's internal state with a copy of the given inverse tableau.
-        
+
         The inverse tableau specifies how Pauli product observables of qubits at the current time transform
         into equivalent Pauli product observables at the beginning of time, when all qubits were in the
         |0> state. For example, if the Z observable on qubit 5 maps to a product of Z observables at the
         start of time then a Z basis measurement on qubit 5 will be deterministic and equal to the sign
         of the product. Whereas if it mapped to a product of observables including an X or a Y then the Z
         basis measurement would be random.
-        
+
         Any qubits not within the length of the tableau are implicitly in the |0> state.
-        
+
         Args:
             new_inverse_tableau: The tableau to overwrite the internal state with.
-        
+
         Examples:
             >>> import stim
             >>> s = stim.TableauSimulator()
@@ -4170,27 +4390,27 @@ class TableauSimulator:
         """
     def set_num_qubits(self, new_num_qubits: int) -> None:
         """Forces the simulator's internal state to track exactly the qubits whose indices are in range(new_num_qubits).
-        
+
         Note that untracked qubits are always assumed to be in the |0> state. Therefore, calling this method
         will effectively force any qubit whose index is outside range(new_num_qubits) to be reset to |0>.
-        
+
         Note that this method does not prevent future operations from implicitly expanding the size of the
         tracked state (e.g. setting the number of qubits to 5 will not prevent a Hadamard from then being
         applied to qubit 100, increasing the number of qubits to 101).
-        
+
         Args:
             new_num_qubits: The length of the range of qubits the internal simulator should be tracking.
-        
+
         Examples:
             >>> import stim
             >>> s = stim.TableauSimulator()
             >>> len(s.current_inverse_tableau())
             0
-        
+
             >>> s.set_num_qubits(5)
             >>> len(s.current_inverse_tableau())
             5
-        
+
             >>> s.x(0, 1, 2, 3)
             >>> s.set_num_qubits(2)
             >>> s.measure_many(0, 1, 2, 3)
@@ -4198,60 +4418,72 @@ class TableauSimulator:
         """
     def sqrt_x(self, *targets) -> None:
         """Applies a SQRT_X gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
     def sqrt_x_dag(self, *targets) -> None:
         """Applies a SQRT_X_DAG gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
     def sqrt_y(self, *targets) -> None:
         """Applies a SQRT_Y gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
     def sqrt_y_dag(self, *targets) -> None:
         """Applies a SQRT_Y_DAG gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def state_vector(self) -> np.ndarray[np.float32]:
+    def state_vector(self, *, endian: str = 'little') -> np.ndarray[np.float32]:
         """Returns a wavefunction that satisfies the stabilizers of the simulator's current state.
-        
+
         This function takes O(n * 2**n) time and O(2**n) space, where n is the number of qubits. The computation is
         done by initialization a random state vector and iteratively projecting it into the +1 eigenspace of each
-        stabilizer of the state. The global phase of the result is arbitrary (and will vary from call to call).
-        
-        The result is in little endian order. The amplitude at offset b_0 + b_1*2 + b_2*4 + ... + b_{n-1}*2^{n-1} is
-        the amplitude for the computational basis state where the qubit with index 0 is storing the bit b_0, the
-        qubit with index 1 is storing the bit b_1, etc.
-        
+        stabilizer of the state. The state is then canonicalized so that zero values are actually exactly 0, and so
+        that the first non-zero entry is positive.
+
+        Args:
+            endian:
+                "little" (default): state vector is in little endian order, where higher index qubits
+                    correspond to larger changes in the state index.
+                "big": state vector is in little endian order, where higher index qubits correspond to
+                    smaller changes in the state index.
+
         Returns:
-            A `numpy.ndarray[numpy.complex64]` of computational basis amplitudes in little endian order.
-        
+            A `numpy.ndarray[numpy.complex64]` of computational basis amplitudes.
+
+            If the result is in little endian order then the amplitude at offset b_0 + b_1*2 + b_2*4 + ... + b_{n-1}*2^{n-1} is
+            the amplitude for the computational basis state where the qubit with index 0 is storing the bit b_0, the
+            qubit with index 1 is storing the bit b_1, etc.
+
+            If the result is in little endian order then the amplitude at offset b_0 + b_1*2 + b_2*4 + ... + b_{n-1}*2^{n-1} is
+            the amplitude for the computational basis state where the qubit with index 0 is storing the bit b_{n-1}, the
+            qubit with index 1 is storing the bit b_{n-2}, etc.
+
         Examples:
             >>> import stim
             >>> import numpy as np
-        
-            >>> # Check that the qubit-to-amplitude-index ordering is little-endian.
             >>> s = stim.TableauSimulator()
-            >>> s.x(1)
-            >>> s.x(4)
-            >>> vector = s.state_vector()
-            >>> np.abs(vector[0b_10010]).round(2)
-            1.0
-            >>> tensor = vector.reshape((2, 2, 2, 2, 2))
-            >>> np.abs(tensor[1, 0, 0, 1, 0]).round(2)
-            1.0
+            >>> s.x(2)
+            >>> list(s.state_vector(endian='little'))
+            [0j, 0j, 0j, 0j, (1+0j), 0j, 0j, 0j]
+
+            >>> list(s.state_vector(endian='big'))
+            [0j, (1+0j), 0j, 0j, 0j, 0j, 0j, 0j]
+
+            >>> s.sqrt_x(1, 2)
+            >>> list(s.state_vector())
+            [(0.5+0j), 0j, -0.5j, 0j, 0.5j, 0j, (0.5+0j), 0j]
         """
     def swap(self, *targets) -> None:
         """Applies a swap gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets, and so forth.
@@ -4259,13 +4491,13 @@ class TableauSimulator:
         """
     def x(self, *targets) -> None:
         """Applies a Pauli X gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
     def xcx(self, *targets) -> None:
         """Applies an X-controlled X gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets, and so forth.
@@ -4273,7 +4505,7 @@ class TableauSimulator:
         """
     def xcy(self, *targets) -> None:
         """Applies an X-controlled Y gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets, and so forth.
@@ -4281,7 +4513,7 @@ class TableauSimulator:
         """
     def xcz(self, *targets) -> None:
         """Applies an X-controlled Z gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets, and so forth.
@@ -4289,13 +4521,13 @@ class TableauSimulator:
         """
     def y(self, *targets) -> None:
         """Applies a Pauli Y gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
     def ycx(self, *targets) -> None:
         """Applies a Y-controlled X gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets, and so forth.
@@ -4303,7 +4535,7 @@ class TableauSimulator:
         """
     def ycy(self, *targets) -> None:
         """Applies a Y-controlled Y gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets, and so forth.
@@ -4311,7 +4543,7 @@ class TableauSimulator:
         """
     def ycz(self, *targets) -> None:
         """Applies a Y-controlled Z gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets, and so forth.
@@ -4319,27 +4551,27 @@ class TableauSimulator:
         """
     def z(self, *targets) -> None:
         """Applies a Pauli Z gate to the simulator's state.
-        
+
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
 def main(*, command_line_args: List[str]) -> int:
     """Runs the command line tool version of stim on the given arguments.
-    
+
     Note that by default any input will be read from stdin, any output
     will print to stdout (as opposed to being intercepted). For most
     commands, you can use arguments like `--out` to write to a file
     instead of stdout and `--in` to read from a file instead of stdin.
-    
+
     Returns:
         An exit code (0 means success, not zero means failure).
-    
+
     Raises:
         A large variety of errors, depending on what you are doing and
         how it failed! Beware that many errors are caught by the main
         method itself and printed to stderr, with the only indication
         that something went wrong being the return code.
-    
+
     Example:
         >>> stim.main(command_line_args=[
         ...     "gen",
@@ -4384,10 +4616,10 @@ def main(*, command_line_args: List[str]) -> int:
         DETECTOR(1, 1) rec[-1] rec[-2] rec[-3]
         OBSERVABLE_INCLUDE(0) rec[-1]
     """
-def read_shot_data_file(path: str, format: str, num_measurements: int = 0, num_detectors: int = 0, num_observables: int = 0, bit_pack: bool = False) -> np.ndarray:
+def read_shot_data_file(*, path: str, format: str, num_measurements: int = 0, num_detectors: int = 0, num_observables: int = 0, bit_pack: bool = False) -> np.ndarray:
 
     """Reads shot data, such as measurement samples, from a file.
-    
+
     Args:
         path: The path to the file to read the data from.
         format: The format that the data is stored in, such as 'b8'.
@@ -4399,10 +4631,10 @@ def read_shot_data_file(path: str, format: str, num_measurements: int = 0, num_d
         num_observables: How many observables there are per shot.
             Note that this only refers to observables *stored in the file*, not to
             observables from the original circuit that was sampled.
-    
+
     Returns:
         A numpy array containing the loaded data.
-    
+
         If bit_pack=False:
             dtype = np.bool8
             shape = (num_shots, num_measurements + num_detectors + num_observables)
@@ -4411,7 +4643,7 @@ def read_shot_data_file(path: str, format: str, num_measurements: int = 0, num_d
             dtype = np.uint8
             shape = (num_shots, math.ceil((num_measurements + num_detectors + num_observables) / 8))
             bit b from shot s is at result[s, b // 8] & (1 << (b % 8))
-    
+
     Examples:
         >>> import stim
         >>> import pathlib
@@ -4440,13 +4672,13 @@ def target_inv(qubit_index: int) -> stim.GateTarget:
     """
 def target_logical_observable_id(index: int) -> stim.DemTarget:
     """Returns a logical observable id identifying a frame change (e.g. "L5" in a .dem file).
-    
+
     Args:
         index: The index of the observable.
-    
+
     Returns:
         The logical observable target.
-    
+
     Examples:
         >>> import stim
         >>> m = stim.DetectorErrorModel()
@@ -4464,13 +4696,13 @@ def target_rec(lookback_index: int) -> stim.GateTarget:
     """
 def target_relative_detector_id(index: int) -> stim.DemTarget:
     """Returns a relative detector id (e.g. "D5" in a .dem file).
-    
+
     Args:
         index: The index of the detector, relative to the current detector offset.
-    
+
     Returns:
         The relative detector target.
-    
+
     Examples:
         >>> import stim
         >>> m = stim.DetectorErrorModel()
@@ -4484,7 +4716,7 @@ def target_relative_detector_id(index: int) -> stim.DemTarget:
     """
 def target_separator() -> stim.DemTarget:
     """Returns a target separator (e.g. "^" in a .dem file).
-    
+
     Examples:
         >>> import stim
         >>> m = stim.DetectorErrorModel()
@@ -4516,12 +4748,12 @@ def target_z(qubit_index: int, invert: bool = False) -> stim.GateTarget:
     """
 def write_shot_data_file(*, data: object, path: str, format: str, num_measurements: Any = None, num_detectors: Any = None, num_observables: Any = None) -> None:
     """Writes shot data, such as measurement samples, to a file.
-    
+
     Args:
         data: The data to write to the file. This must be a numpy array. The dtype
             of the array determines whether or not the data is bit packed, and the
             shape must match the bits per shot.
-    
+
             dtype=np.bool8: Not bit packed. Shape must be (num_shots, num_measurements + num_detectors + num_observables).
             dtype=np.uint8: Yes bit packed. Shape must be (num_shots, math.ceil((num_measurements + num_detectors + num_observables) / 8)).
         path: The path to the file to write the data to.
@@ -4532,7 +4764,7 @@ def write_shot_data_file(*, data: object, path: str, format: str, num_measuremen
         num_observables: How many observables there are per shot.
             Note that this only refers to observables *in the given shot data*, not to
             observables from the original circuit that was sampled.
-    
+
     Examples:
         >>> import stim
         >>> import pathlib

--- a/pybind11_bazel.patch
+++ b/pybind11_bazel.patch
@@ -1,0 +1,31 @@
+--- a/python_configure.bzl
++++ b/python_configure.bzl
+@@ -213,8 +213,8 @@ def _get_python_lib(repository_ctx, python_bin):
+                  "try:\n" +
+                  "  library_paths = site.getsitepackages()\n" +
+                  "except AttributeError:\n" +
+-                 " from distutils.sysconfig import get_python_lib\n" +
+-                 " library_paths = [get_python_lib()]\n" +
++                 " from sysconfig import get_path\n" +
++                 " library_paths = [get_path(\"purelib\")]\n" +
+                  "all_paths = set(python_paths + library_paths)\n" +
+                  "paths = []\n" +
+                  "for path in all_paths:\n" +
+@@ -252,13 +252,11 @@ def _get_python_include(repository_ctx, python_bin):
+             python_bin,
+             "-c",
+             "from __future__ import print_function;" +
+-            "from distutils import sysconfig;" +
+-            "print(sysconfig.get_python_inc())",
++            "import sysconfig;" +
++            "print(sysconfig.get_path(\"include\"))",
+         ],
+         error_msg = "Problem getting python include path.",
+-        error_details = ("Is the Python binary path set up right? " +
+-                         "(See ./configure or " + _PYTHON_BIN_PATH + ".) " +
+-                         "Is distutils installed?"),
++        error_details = "Is the Python binary path set up right?",
+     )
+     return result.stdout.splitlines()[0]
+ 
+ 

--- a/src/stim/io/read_write.pybind.cc
+++ b/src/stim/io/read_write.pybind.cc
@@ -261,7 +261,7 @@ void stim_pybind::pybind_read_write(pybind11::module &m) {
         pybind11::arg("bit_pack") = false,
         clean_doc_string(u8R"DOC(
             Reads shot data, such as measurement samples, from a file.
-            @signature def read_shot_data_file(path: str, format: str, num_measurements: int = 0, num_detectors: int = 0, num_observables: int = 0, bit_pack: bool = False) -> np.ndarray:
+            @signature def read_shot_data_file(*, path: str, format: str, num_measurements: int = 0, num_detectors: int = 0, num_observables: int = 0, bit_pack: bool = False) -> np.ndarray:
 
             Args:
                 path: The path to the file to read the data from.

--- a/src/stim/simulators/error_analyzer.cc
+++ b/src/stim/simulators/error_analyzer.cc
@@ -957,7 +957,11 @@ bool shifted_equals(int64_t shift, ConstPointerRange<DemTarget> unshifted, Const
     return true;
 }
 
-bool shifted_equals(int64_t m_shift, int64_t d_shift, const std::map<uint64_t, std::vector<DemTarget>> &unshifted, const std::map<uint64_t, std::vector<DemTarget>> &expected) {
+bool shifted_equals(
+    int64_t m_shift,
+    int64_t d_shift,
+    const std::map<uint64_t, std::vector<DemTarget>> &unshifted,
+    const std::map<uint64_t, std::vector<DemTarget>> &expected) {
     if (unshifted.size() != expected.size()) {
         return false;
     }

--- a/src/stim/simulators/error_analyzer.test.cc
+++ b/src/stim/simulators/error_analyzer.test.cc
@@ -3143,7 +3143,6 @@ TEST(ErrorAnalyzer, block_remnant_edge) {
         )MODEL"));
 }
 
-
 TEST(ErrorAnalyzer, dont_fold_when_observable_dependencies_cross_iterations) {
     Circuit c(R"CIRCUIT(
         RX 0 2
@@ -3157,14 +3156,5 @@ TEST(ErrorAnalyzer, dont_fold_when_observable_dependencies_cross_iterations) {
         # Doesn't include all elements from the loop.
         OBSERVABLE_INCLUDE(0) rec[-1] rec[-2] rec[-4]
     )CIRCUIT");
-    ASSERT_ANY_THROW({
-        ErrorAnalyzer::circuit_to_detector_error_model(
-        c,
-        true,
-        true,
-        false,
-        1,
-        false,
-        false);
-    });
+    ASSERT_ANY_THROW({ ErrorAnalyzer::circuit_to_detector_error_model(c, true, true, false, 1, false, false); });
 }

--- a/src/stim/simulators/measurements_to_detection_events.cc
+++ b/src/stim/simulators/measurements_to_detection_events.cc
@@ -47,8 +47,11 @@ void stim::measurements_to_detection_events_helper(
         throw std::invalid_argument("sweep_bits__minor_shot_index.num_minor_bits_padded() != batch_size");
     }
     // Tables should have the right number of bits per shot.
-    if (out_detection_results__minor_shot_index.num_major_bits_padded() < num_detectors + num_observables * append_observables) {
-        throw std::invalid_argument("out_detection_results__minor_shot_index.num_major_bits_padded() < num_detectors + num_observables * append_observables");
+    if (out_detection_results__minor_shot_index.num_major_bits_padded() <
+        num_detectors + num_observables * append_observables) {
+        throw std::invalid_argument(
+            "out_detection_results__minor_shot_index.num_major_bits_padded() < num_detectors + num_observables * "
+            "append_observables");
     }
     if (measurements__minor_shot_index.num_major_bits_padded() < num_measurements) {
         throw std::invalid_argument("measurements__minor_shot_index.num_major_bits_padded() < num_measurements");

--- a/src/stim/simulators/tableau_simulator.cc
+++ b/src/stim/simulators/tableau_simulator.cc
@@ -793,11 +793,17 @@ VectorSimulator TableauSimulator::to_vector_sim() const {
     for (size_t k = 0; k < inv.num_qubits; k++) {
         stabilizers.push_back(inv.zs[k]);
     }
-    return VectorSimulator::from_stabilizers(stabilizers, rng);
+    return VectorSimulator::from_stabilizers(stabilizers);
 }
 
-std::vector<std::complex<float>> TableauSimulator::to_state_vector() const {
-    return to_vector_sim().state;
+std::vector<std::complex<float>> TableauSimulator::to_state_vector(bool little_endian) const {
+    auto sim = to_vector_sim();
+    if (!little_endian) {
+        for (size_t q = 0; q < inv_state.num_qubits - q - 1; q++) {
+            sim.apply("SWAP", q, inv_state.num_qubits - q - 1);
+        }
+    }
+    return sim.state;
 }
 
 void TableauSimulator::collapse_x(ConstPointerRange<GateTarget> targets) {

--- a/src/stim/simulators/tableau_simulator.cc
+++ b/src/stim/simulators/tableau_simulator.cc
@@ -60,11 +60,11 @@ void TableauSimulator::MPP(const OperationData &target_data) {
 }
 
 void TableauSimulator::postselect_helper(
-        ConstPointerRange<GateTarget> targets,
-        bool desired_result,
-        void (TableauSimulator::*basis_change)(const OperationData &),
-        const char *false_name,
-        const char *true_name) {
+    ConstPointerRange<GateTarget> targets,
+    bool desired_result,
+    void (TableauSimulator::*basis_change)(const OperationData &),
+    const char *false_name,
+    const char *true_name) {
     std::set<GateTarget> unique_targets;
     unique_targets.insert(targets.begin(), targets.end());
     std::vector<GateTarget> unique_targets_vec;
@@ -92,7 +92,8 @@ void TableauSimulator::postselect_helper(
         std::stringstream msg;
         msg << "The requested postselection was impossible.\n";
         msg << "Desired state: |" << (desired_result ? true_name : false_name) << ">\n";
-        msg << "Qubit " << targets[finished] << " is in the perpendicular state |" << (desired_result ? false_name : true_name) << ">\n";
+        msg << "Qubit " << targets[finished] << " is in the perpendicular state |"
+            << (desired_result ? false_name : true_name) << ">\n";
         if (finished > 0) {
             msg << finished << " of the requested postselections were finished (";
             for (size_t k = 0; k < finished; k++) {
@@ -105,29 +106,14 @@ void TableauSimulator::postselect_helper(
 }
 
 void TableauSimulator::postselect_x(ConstPointerRange<GateTarget> targets, bool desired_result) {
-    postselect_helper(
-        targets,
-        desired_result,
-        &TableauSimulator::H_XZ,
-        "+",
-        "-");
+    postselect_helper(targets, desired_result, &TableauSimulator::H_XZ, "+", "-");
 }
 
 void TableauSimulator::postselect_y(ConstPointerRange<GateTarget> targets, bool desired_result) {
-    postselect_helper(
-        targets,
-        desired_result,
-        &TableauSimulator::H_YZ,
-        "i",
-        "-i");
+    postselect_helper(targets, desired_result, &TableauSimulator::H_YZ, "i", "-i");
 }
 void TableauSimulator::postselect_z(ConstPointerRange<GateTarget> targets, bool desired_result) {
-    postselect_helper(
-        targets,
-        desired_result,
-        &TableauSimulator::I,
-        "0",
-        "1");
+    postselect_helper(targets, desired_result, &TableauSimulator::I, "0", "1");
 }
 
 void TableauSimulator::measure_x(const OperationData &target_data) {
@@ -349,23 +335,17 @@ PauliString TableauSimulator::peek_bloch(uint32_t target) const {
 
 int8_t TableauSimulator::peek_x(uint32_t target) const {
     PauliStringRef x = inv_state.xs[target];
-    return x.xs.not_zero() ? 0
-         : x.sign ? -1
-         : +1;
+    return x.xs.not_zero() ? 0 : x.sign ? -1 : +1;
 }
 
 int8_t TableauSimulator::peek_y(uint32_t target) const {
     PauliString y = inv_state.eval_y_obs(target);
-    return y.xs.not_zero() ? 0
-         : y.sign ? -1
-         : +1;
+    return y.xs.not_zero() ? 0 : y.sign ? -1 : +1;
 }
 
 int8_t TableauSimulator::peek_z(uint32_t target) const {
     PauliStringRef z = inv_state.zs[target];
-    return z.xs.not_zero() ? 0
-         : z.sign ? -1
-         : +1;
+    return z.xs.not_zero() ? 0 : z.sign ? -1 : +1;
 }
 
 void TableauSimulator::SQRT_X(const OperationData &target_data) {

--- a/src/stim/simulators/tableau_simulator.h
+++ b/src/stim/simulators/tableau_simulator.h
@@ -69,7 +69,7 @@ struct TableauSimulator {
     VectorSimulator to_vector_sim() const;
 
     /// Returns a state vector satisfying the current stabilizer generators.
-    std::vector<std::complex<float>> to_state_vector() const;
+    std::vector<std::complex<float>> to_state_vector(bool little_endian) const;
 
     /// Collapses then records the X signs of the target qubits. Supports flipping the result.
     ///

--- a/src/stim/simulators/tableau_simulator.h
+++ b/src/stim/simulators/tableau_simulator.h
@@ -190,6 +190,20 @@ struct TableauSimulator {
     /// Returns the single-qubit stabilizer of a target or, if it is entangled, the identity operation.
     PauliString peek_bloch(uint32_t target) const;
 
+    /// Returns the expectation value of measuring the qubit in the X basis.
+    int8_t peek_x(uint32_t target) const;
+    /// Returns the expectation value of measuring the qubit in the Y basis.
+    int8_t peek_y(uint32_t target) const;
+    /// Returns the expectation value of measuring the qubit in the Z basis.
+    int8_t peek_z(uint32_t target) const;
+
+    /// Forces a desired X basis measurement result, or raises an exception if it was impossible.
+    void postselect_x(ConstPointerRange<GateTarget> targets, bool desired_result);
+    /// Forces a desired Y basis measurement result, or raises an exception if it was impossible.
+    void postselect_y(ConstPointerRange<GateTarget> targets, bool desired_result);
+    /// Forces a desired Z basis measurement result, or raises an exception if it was impossible.
+    void postselect_z(ConstPointerRange<GateTarget> targets, bool desired_result);
+
     /// Applies all of the Pauli operations in the given PauliString to the simulator's state.
     void paulis(const PauliString &paulis);
 
@@ -263,6 +277,12 @@ struct TableauSimulator {
 
    private:
     void noisify_new_measurements(const OperationData &target_data);
+    void postselect_helper(
+            ConstPointerRange<GateTarget> targets,
+            bool desired_result,
+            void (TableauSimulator::*basis_change)(const OperationData &),
+            const char *false_name,
+            const char *true_name);
 };
 
 template <size_t Q, typename RESET_FLAG, typename ELSE_CORR>

--- a/src/stim/simulators/tableau_simulator.h
+++ b/src/stim/simulators/tableau_simulator.h
@@ -278,11 +278,11 @@ struct TableauSimulator {
    private:
     void noisify_new_measurements(const OperationData &target_data);
     void postselect_helper(
-            ConstPointerRange<GateTarget> targets,
-            bool desired_result,
-            void (TableauSimulator::*basis_change)(const OperationData &),
-            const char *false_name,
-            const char *true_name);
+        ConstPointerRange<GateTarget> targets,
+        bool desired_result,
+        void (TableauSimulator::*basis_change)(const OperationData &),
+        const char *false_name,
+        const char *true_name);
 };
 
 template <size_t Q, typename RESET_FLAG, typename ELSE_CORR>

--- a/src/stim/simulators/tableau_simulator.pybind.cc
+++ b/src/stim/simulators/tableau_simulator.pybind.cc
@@ -54,6 +54,31 @@ PyTableauSimulator create_tableau_simulator() {
     return PyTableauSimulator(make_py_seeded_rng(pybind11::none()));
 }
 
+std::vector<GateTarget> arg_to_qubit_or_qubits(PyTableauSimulator &self, const pybind11::object &obj) {
+    std::vector<GateTarget> arguments;
+    uint32_t max_q = 0;
+    try {
+        try {
+            uint32_t q = pybind11::cast<uint32_t>(obj);
+            arguments.push_back(GateTarget::qubit(q));
+            max_q = q;
+        } catch (const pybind11::cast_error &) {
+            for (const auto &e : obj) {
+                uint32_t q = e.cast<uint32_t>();
+                max_q = std::max(max_q, q);
+                arguments.push_back(GateTarget::qubit(q));
+            }
+        }
+    } catch (const pybind11::cast_error &) {
+        throw std::out_of_range("'targets' must be a non-negative integer or iterable of non-negative integers.");
+    }
+
+    // Note: quadratic behavior.
+    self.ensure_large_enough_for_qubits(max_q + 1);
+
+    return arguments;
+}
+
 TempViewableData args_to_targets(PyTableauSimulator &self, const pybind11::args &args) {
     std::vector<GateTarget> arguments;
     uint32_t max_q = 0;
@@ -666,10 +691,187 @@ void pybind_tableau_simulator(pybind11::module &m) {
             self.reset_z(args_to_targets(self, args));
         },
         clean_doc_string(u8R"DOC(
-            Resets qubits to zero (e.g. by swapping them for zero'd qubit from the environment).
+            Resets qubits to the |0> state.
 
             Args:
                 *targets: The indices of the qubits to reset.
+
+            Example:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.X(0)
+                >>> s.reset(0)
+                >>> s.peek_bloch(0)
+                +Z
+        )DOC")
+            .data());
+
+    c.def(
+        "reset_x",
+        [](PyTableauSimulator &self, pybind11::args args) {
+            self.reset_x(args_to_targets(self, args));
+        },
+        clean_doc_string(u8R"DOC(
+            Resets qubits to the |+> state.
+
+            Args:
+                *targets: The indices of the qubits to reset.
+
+            Example:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0)
+                >>> s.peek_bloch(0)
+                +X
+        )DOC")
+            .data());
+
+    c.def(
+        "reset_y",
+        [](PyTableauSimulator &self, pybind11::args args) {
+            self.reset_y(args_to_targets(self, args));
+        },
+        clean_doc_string(u8R"DOC(
+            Resets qubits to the |i> state.
+
+            Args:
+                *targets: The indices of the qubits to reset.
+
+            Example:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_y(0)
+                >>> s.peek_bloch(0)
+                +Y
+        )DOC")
+            .data());
+
+    c.def(
+        "reset_z",
+        [](PyTableauSimulator &self, pybind11::args args) {
+            self.reset_z(args_to_targets(self, args));
+        },
+        clean_doc_string(u8R"DOC(
+            Resets qubits to the |0> state.
+
+            Args:
+                *targets: The indices of the qubits to reset.
+
+            Example:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.H(0)
+                >>> s.reset_z(0)
+                >>> s.peek_bloch(0)
+                +Z
+        )DOC")
+            .data());
+
+    c.def(
+        "peek_x",
+        [](PyTableauSimulator &self, uint32_t target) -> int8_t {
+            self.ensure_large_enough_for_qubits(target + 1);
+            return self.peek_x(target);
+        },
+        pybind11::arg("target"),
+        clean_doc_string(u8R"DOC(
+            Returns the expected value of a qubit's X observable (which will always be -1, 0, or +1).
+
+            This is a non-physical operation.
+            It reports information about the quantum state without disturbing it.
+
+            Args:
+                target: The qubit to analyze.
+
+            Returns:
+                +1: Qubit is in the |+> state.
+                -1: Qubit is in the |-> state.
+                0: Qubit is in some other state.
+
+            Example:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_z(0)
+                >>> s.peek_x(0)
+                0
+                >>> s.reset_x(0)
+                >>> s.peek_x(0)
+                1
+                >>> s.Z(0)
+                >>> s.peek_x(0)
+                -1
+        )DOC")
+            .data());
+
+    c.def(
+        "peek_y",
+        [](PyTableauSimulator &self, uint32_t target) -> int8_t {
+            self.ensure_large_enough_for_qubits(target + 1);
+            return self.peek_y(target);
+        },
+        pybind11::arg("target"),
+        clean_doc_string(u8R"DOC(
+            Returns the expected value of a qubit's Y observable (which will always be -1, 0, or +1).
+
+            This is a non-physical operation.
+            It reports information about the quantum state without disturbing it.
+
+            Args:
+                target: The qubit to analyze.
+
+            Returns:
+                +1: Qubit is in the |i> state.
+                -1: Qubit is in the |-i> state.
+                0: Qubit is in some other state.
+
+            Example:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_z(0)
+                >>> s.peek_y(0)
+                0
+                >>> s.reset_y(0)
+                >>> s.peek_y(0)
+                1
+                >>> s.Z(0)
+                >>> s.peek_y(0)
+                -1
+        )DOC")
+            .data());
+
+    c.def(
+        "peek_z",
+        [](PyTableauSimulator &self, uint32_t target) -> int8_t {
+            self.ensure_large_enough_for_qubits(target + 1);
+            return self.peek_z(target);
+        },
+        pybind11::arg("target"),
+        clean_doc_string(u8R"DOC(
+            Returns the expected value of a qubit's Z observable (which will always be -1, 0, or +1).
+
+            This is a non-physical operation.
+            It reports information about the quantum state without disturbing it.
+
+            Args:
+                target: The qubit to analyze.
+
+            Returns:
+                +1: Qubit is in the |0> state.
+                -1: Qubit is in the |1> state.
+                0: Qubit is in some other state.
+
+            Example:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0)
+                >>> s.peek_z(0)
+                0
+                >>> s.reset_z(0)
+                >>> s.peek_z(0)
+                1
+                >>> s.X(0)
+                >>> s.peek_z(0)
+                -1
         )DOC")
             .data());
 
@@ -810,6 +1012,99 @@ void pybind_tableau_simulator(pybind11::module &m) {
 
             Returns:
                 The measurement results as a list of bools.
+        )DOC")
+            .data());
+
+    c.def(
+        "postselect_x",
+        [](PyTableauSimulator &self, const pybind11::object &targets, bool desired_value) {
+            auto gate_targets = arg_to_qubit_or_qubits(self, targets);
+            self.postselect_x(gate_targets, desired_value);
+        },
+        pybind11::arg("targets"),
+        pybind11::kw_only(),
+        pybind11::arg("desired_value"),
+        clean_doc_string(u8R"DOC(
+            @signature def postselect_x(self, targets: Union[int, Iterable[int]], *, desired_value: bool) -> None:
+            Postselects qubits in the X basis, or raises an exception.
+
+            Postselecting a qubit forces it to collapse to a specific state, as
+            if it was measured and that state was the result of the measurement.
+
+            Args:
+                targets: The qubit index or indices to postselect.
+                desired_value:
+                    False: postselect targets into the |+> state.
+                    True: postselect targets into the |-> state.
+
+            Raises:
+                ValueError:
+                    The postselection failed. One of the qubits was in a state
+                    orthogonal to the desired state, so it was literally
+                    impossible for a measurement of the qubit to return the
+                    desired result.
+        )DOC")
+            .data());
+
+    c.def(
+        "postselect_y",
+        [](PyTableauSimulator &self, const pybind11::object &targets, bool desired_value) {
+            auto gate_targets = arg_to_qubit_or_qubits(self, targets);
+            self.postselect_y(gate_targets, desired_value);
+        },
+        pybind11::arg("targets"),
+        pybind11::kw_only(),
+        pybind11::arg("desired_value"),
+        clean_doc_string(u8R"DOC(
+            @signature def postselect_y(self, targets: Union[int, Iterable[int]], *, desired_value: bool) -> None:
+            Postselects qubits in the Y basis, or raises an exception.
+
+            Postselecting a qubit forces it to collapse to a specific state, as
+            if it was measured and that state was the result of the measurement.
+
+            Args:
+                targets: The qubit index or indices to postselect.
+                desired_value:
+                    False: postselect targets into the |i> state.
+                    True: postselect targets into the |-i> state.
+
+            Raises:
+                ValueError:
+                    The postselection failed. One of the qubits was in a state
+                    orthogonal to the desired state, so it was literally
+                    impossible for a measurement of the qubit to return the
+                    desired result.
+        )DOC")
+            .data());
+
+    c.def(
+        "postselect_z",
+        [](PyTableauSimulator &self, const pybind11::object &targets, bool desired_value) {
+            auto gate_targets = arg_to_qubit_or_qubits(self, targets);
+            self.postselect_z(gate_targets, desired_value);
+        },
+        pybind11::arg("targets"),
+        pybind11::kw_only(),
+        pybind11::arg("desired_value"),
+        clean_doc_string(u8R"DOC(
+            @signature def postselect_z(self, targets: Union[int, Iterable[int]], *, desired_value: bool) -> None:
+            Postselects qubits in the Z basis, or raises an exception.
+
+            Postselecting a qubit forces it to collapse to a specific state, as
+            if it was measured and that state was the result of the measurement.
+
+            Args:
+                targets: The qubit index or indices to postselect.
+                desired_value:
+                    False: postselect targets into the |0> state.
+                    True: postselect targets into the |1> state.
+
+            Raises:
+                ValueError:
+                    The postselection failed. One of the qubits was in a state
+                    orthogonal to the desired state, so it was literally
+                    impossible for a measurement of the qubit to return the
+                    desired result.
         )DOC")
             .data());
 

--- a/src/stim/simulators/tableau_simulator.test.cc
+++ b/src/stim/simulators/tableau_simulator.test.cc
@@ -1688,9 +1688,7 @@ TEST(TableauSimulator, postselect_x) {
     // Postselect from -X.
     sim.reset_x(OpDat(0));
     sim.Z(OpDat(0));
-    ASSERT_THROW({
-        sim.postselect_x(std::vector<GateTarget>{GateTarget::qubit(0)}, false);
-    }, std::invalid_argument);
+    ASSERT_THROW({ sim.postselect_x(std::vector<GateTarget>{GateTarget::qubit(0)}, false); }, std::invalid_argument);
     ASSERT_EQ(sim.peek_bloch(0), PauliString::from_str("-X"));
 
     // Postselect from +Y.
@@ -1750,9 +1748,11 @@ TEST(TableauSimulator, postselect_x) {
     sim.H_XZ(OpDat(0));
     sim.ZCX(OpDat({0, 1}));
     sim.Z(OpDat(0));
-    ASSERT_THROW({
-        sim.postselect_x(std::vector<GateTarget>{GateTarget::qubit(0), GateTarget::qubit(1)}, true);
-    }, std::invalid_argument);
+    ASSERT_THROW(
+        {
+            sim.postselect_x(std::vector<GateTarget>{GateTarget::qubit(0), GateTarget::qubit(1)}, true);
+        },
+        std::invalid_argument);
     ASSERT_EQ(sim.peek_bloch(0), PauliString::from_str("-X"));
     ASSERT_EQ(sim.peek_bloch(1), PauliString::from_str("+X"));
 }
@@ -1779,9 +1779,7 @@ TEST(TableauSimulator, postselect_y) {
     // Postselect from -Y.
     sim.reset_y(OpDat(0));
     sim.X(OpDat(0));
-    ASSERT_THROW({
-        sim.postselect_y(std::vector<GateTarget>{GateTarget::qubit(0)}, false);
-    }, std::invalid_argument);
+    ASSERT_THROW({ sim.postselect_y(std::vector<GateTarget>{GateTarget::qubit(0)}, false); }, std::invalid_argument);
     ASSERT_EQ(sim.peek_bloch(0), PauliString::from_str("-Y"));
 
     // Postselect from +Z.
@@ -1830,9 +1828,11 @@ TEST(TableauSimulator, postselect_y) {
     sim.reset_z(OpDat({0, 1}));
     sim.H_XZ(OpDat(0));
     sim.ZCX(OpDat({0, 1}));
-    ASSERT_THROW({
-        sim.postselect_y(std::vector<GateTarget>{GateTarget::qubit(0), GateTarget::qubit(1)}, true);
-    }, std::invalid_argument);
+    ASSERT_THROW(
+        {
+            sim.postselect_y(std::vector<GateTarget>{GateTarget::qubit(0), GateTarget::qubit(1)}, true);
+        },
+        std::invalid_argument);
     ASSERT_EQ(sim.peek_bloch(0), PauliString::from_str("-Y"));
     ASSERT_EQ(sim.peek_bloch(1), PauliString::from_str("+Y"));
 }
@@ -1870,9 +1870,7 @@ TEST(TableauSimulator, postselect_z) {
     // Postselect from -Z.
     sim.reset_z(OpDat(0));
     sim.X(OpDat(0));
-    ASSERT_THROW({
-        sim.postselect_z(std::vector<GateTarget>{GateTarget::qubit(0)}, false);
-    }, std::invalid_argument);
+    ASSERT_THROW({ sim.postselect_z(std::vector<GateTarget>{GateTarget::qubit(0)}, false); }, std::invalid_argument);
     ASSERT_EQ(sim.peek_bloch(0), PauliString::from_str("-Z"));
 
     // Postselect entangled.
@@ -1910,9 +1908,11 @@ TEST(TableauSimulator, postselect_z) {
     sim.H_XZ(OpDat(0));
     sim.ZCX(OpDat({0, 1}));
     sim.X(OpDat(0));
-    ASSERT_THROW({
-        sim.postselect_z(std::vector<GateTarget>{GateTarget::qubit(0), GateTarget::qubit(1)}, true);
-    }, std::invalid_argument);
+    ASSERT_THROW(
+        {
+            sim.postselect_z(std::vector<GateTarget>{GateTarget::qubit(0), GateTarget::qubit(1)}, true);
+        },
+        std::invalid_argument);
     ASSERT_EQ(sim.peek_bloch(0), PauliString::from_str("-Z"));
     ASSERT_EQ(sim.peek_bloch(1), PauliString::from_str("+Z"));
 }

--- a/src/stim/simulators/tableau_simulator_pybind_test.py
+++ b/src/stim/simulators/tableau_simulator_pybind_test.py
@@ -338,6 +338,29 @@ def test_to_state_vector():
     assert v[0, 1, 0] == 0
     assert v[0, 0, 1] == 0
 
+    s = stim.TableauSimulator()
+    s.set_num_qubits(3)
+    s.sqrt_x(2)
+    np.testing.assert_allclose(
+        s.state_vector(endian='little'),
+        [np.sqrt(0.5), 0, 0, 0, -1j*np.sqrt(0.5), 0, 0, 0],
+        atol=1e-4,
+    )
+    np.testing.assert_allclose(
+        s.state_vector(endian='big'),
+        [np.sqrt(0.5), -1j*np.sqrt(0.5), 0, 0, 0, 0, 0, 0],
+        atol=1e-4,
+    )
+    with pytest.raises(ValueError, match="endian"):
+        s.state_vector(endian='unknown')
+
+    # Exact precision.
+    s.h(1)
+    np.testing.assert_array_equal(
+        s.state_vector(),
+        [0.5, 0, 0.5, 0, -0.5j, 0, -0.5j, 0],
+    )
+
 
 def test_peek_observable_expectation():
     s = stim.TableauSimulator()

--- a/src/stim/simulators/tableau_simulator_pybind_test.py
+++ b/src/stim/simulators/tableau_simulator_pybind_test.py
@@ -365,3 +365,47 @@ def test_peek_observable_expectation():
         s.peek_observable_expectation(stim.PauliString("iZZ"))
     with pytest.raises(ValueError, match="imaginary sign"):
         s.peek_observable_expectation(stim.PauliString("-iZZ"))
+
+
+def test_postselect():
+    s = stim.TableauSimulator()
+    s.h(0)
+    s.cnot(0, 1)
+    s.postselect_x(0, desired_value=False)
+    assert s.peek_bloch(0) == stim.PauliString("+X")
+    assert s.peek_bloch(1) == stim.PauliString("+X")
+
+    s.postselect_y([2, 3, 4], desired_value=False)
+    assert s.peek_bloch(4) == stim.PauliString("+Y")
+    s.postselect_x(8, desired_value=True)
+    assert s.peek_bloch(8) == stim.PauliString("-X")
+
+    s.postselect_z(9, desired_value=False)
+    assert s.peek_bloch(9) == stim.PauliString("+Z")
+    with pytest.raises(ValueError, match="impossible"):
+        s.postselect_z(10, desired_value=True)
+
+    s.postselect_y(1000, desired_value=True)
+    assert s.peek_bloch(1000) == stim.PauliString("-Y")
+
+
+def test_peek_pauli():
+    s = stim.TableauSimulator()
+    assert s.peek_x(0) == 0
+    assert s.peek_y(0) == 0
+    assert s.peek_z(0) == +1
+
+    assert s.peek_x(1000) == 0
+    assert s.peek_y(1000) == 0
+    assert s.peek_z(1000) == +1
+
+    s.h(100)
+    s.z(100)
+    assert s.peek_x(100) == -1
+    assert s.peek_y(100) == 0
+    assert s.peek_z(100) == 0
+
+    s.h_xy(100)
+    assert s.peek_x(100) == 0
+    assert s.peek_y(100) == -1
+    assert s.peek_z(100) == 0

--- a/src/stim/simulators/vector_simulator.cc
+++ b/src/stim/simulators/vector_simulator.cc
@@ -18,8 +18,8 @@
 
 #include "stim/circuit/gate_data.h"
 #include "stim/mem/simd_util.h"
-#include "stim/stabilizers/pauli_string.h"
 #include "stim/probability_util.h"
+#include "stim/stabilizers/pauli_string.h"
 
 using namespace stim;
 
@@ -109,9 +109,7 @@ void VectorSimulator::apply(const PauliStringRef &gate, size_t qubit_offset) {
 }
 
 std::vector<std::complex<float>> VectorSimulator::state_vector_from_stabilizers(
-    const std::vector<PauliStringRef> &stabilizers,
-    float norm2) {
-
+    const std::vector<PauliStringRef> &stabilizers, float norm2) {
     size_t num_qubits = stabilizers.empty() ? 0 : stabilizers[0].num_qubits;
     VectorSimulator sim(num_qubits);
 
@@ -251,8 +249,7 @@ void VectorSimulator::canonicalize_assuming_stabilizer_state(double norm2) {
         } else if (abs(v - std::complex<float>{0, -1}) < 0.1) {
             v = std::complex<float>{0, -1};
         } else {
-            throw std::invalid_argument(
-                "State vector extraction failed. This shouldn't occur.");
+            throw std::invalid_argument("State vector extraction failed. This shouldn't occur.");
         }
     }
 

--- a/src/stim/simulators/vector_simulator.cc
+++ b/src/stim/simulators/vector_simulator.cc
@@ -19,6 +19,7 @@
 #include "stim/circuit/gate_data.h"
 #include "stim/mem/simd_util.h"
 #include "stim/stabilizers/pauli_string.h"
+#include "stim/probability_util.h"
 
 using namespace stim;
 
@@ -107,25 +108,37 @@ void VectorSimulator::apply(const PauliStringRef &gate, size_t qubit_offset) {
     }
 }
 
-VectorSimulator VectorSimulator::from_stabilizers(
-    const std::vector<PauliStringRef> &stabilizers, std::mt19937_64 &rng) {
+std::vector<std::complex<float>> VectorSimulator::state_vector_from_stabilizers(
+    const std::vector<PauliStringRef> &stabilizers,
+    float norm2) {
+
     size_t num_qubits = stabilizers.empty() ? 0 : stabilizers[0].num_qubits;
-    VectorSimulator result(num_qubits);
+    VectorSimulator sim(num_qubits);
 
     // Create an initial state $|A\rangle^{\otimes n}$ which overlaps with all possible stabilizers.
     std::uniform_real_distribution<float> dist(-1.0, +1.0);
-    for (auto &s : result.state) {
+
+    auto rng = externally_seeded_rng();
+    for (auto &s : sim.state) {
         s = {dist(rng), dist(rng)};
     }
 
     // Project out the non-overlapping parts.
     for (const auto &p : stabilizers) {
-        result.project(p);
+        sim.project(p);
     }
     if (stabilizers.empty()) {
-        result.project(PauliString(0));
+        sim.project(PauliString(0));
     }
 
+    sim.canonicalize_assuming_stabilizer_state(norm2);
+
+    return sim.state;
+}
+
+VectorSimulator VectorSimulator::from_stabilizers(const std::vector<PauliStringRef> &stabilizers) {
+    VectorSimulator result(0);
+    result.state = state_vector_from_stabilizers(stabilizers, 1);
     return result;
 }
 
@@ -208,4 +221,44 @@ std::ostream &stim::operator<<(std::ostream &out, const VectorSimulator &sim) {
     }
     out << "}";
     return out;
+}
+
+void VectorSimulator::canonicalize_assuming_stabilizer_state(double norm2) {
+    // Find a solid non-zero entry.
+    size_t nz = 0;
+    for (size_t k = 1; k < state.size(); k++) {
+        if (abs(state[k]) > abs(state[nz]) * 2) {
+            nz = k;
+        }
+    }
+
+    // Rescale so that the non-zero entries are 1, -1, 1j, or -1j.
+    size_t num_non_zero = 0;
+    std::complex<float> big_v = state[nz];
+    for (auto &v : state) {
+        v /= big_v;
+        if (abs(v) < 0.1) {
+            v = 0;
+            continue;
+        }
+        num_non_zero++;
+        if (abs(v - std::complex<float>{1, 0}) < 0.1) {
+            v = std::complex<float>{1, 0};
+        } else if (abs(v - std::complex<float>{0, 1}) < 0.1) {
+            v = std::complex<float>{0, 1};
+        } else if (abs(v - std::complex<float>{-1, 0}) < 0.1) {
+            v = std::complex<float>{-1, 0};
+        } else if (abs(v - std::complex<float>{0, -1}) < 0.1) {
+            v = std::complex<float>{0, -1};
+        } else {
+            throw std::invalid_argument(
+                "State vector extraction failed. This shouldn't occur.");
+        }
+    }
+
+    // Normalize the entries so the result is a unit vector.
+    std::complex<float> scale = (float)(sqrt(norm2 / (double)num_non_zero));
+    for (auto &v : state) {
+        v *= scale;
+    }
 }

--- a/src/stim/simulators/vector_simulator.h
+++ b/src/stim/simulators/vector_simulator.h
@@ -39,7 +39,11 @@ struct VectorSimulator {
     ///
     /// Assumes the stabilizers commute. Works by generating a random state vector and projecting onto
     /// each of the given stabilizers. Global phase will vary.
-    static VectorSimulator from_stabilizers(const std::vector<PauliStringRef> &stabilizers, std::mt19937_64 &rng);
+    static VectorSimulator from_stabilizers(const std::vector<PauliStringRef> &stabilizers);
+
+    static std::vector<std::complex<float>> state_vector_from_stabilizers(
+        const std::vector<PauliStringRef> &stabilizers,
+        float norm2 = 1);
 
     /// Applies a unitary operation to the given qubits, updating the state vector.
     void apply(const std::vector<std::vector<std::complex<float>>> &matrix, const std::vector<size_t> &qubits);
@@ -63,6 +67,8 @@ struct VectorSimulator {
 
     /// A description of the state vector's state.
     std::string str() const;
+
+    void canonicalize_assuming_stabilizer_state(double norm2);
 };
 
 /// Writes a description of the state vector's state to an output stream.

--- a/src/stim/simulators/vector_simulator.h
+++ b/src/stim/simulators/vector_simulator.h
@@ -42,8 +42,7 @@ struct VectorSimulator {
     static VectorSimulator from_stabilizers(const std::vector<PauliStringRef> &stabilizers);
 
     static std::vector<std::complex<float>> state_vector_from_stabilizers(
-        const std::vector<PauliStringRef> &stabilizers,
-        float norm2 = 1);
+        const std::vector<PauliStringRef> &stabilizers, float norm2 = 1);
 
     /// Applies a unitary operation to the given qubits, updating the state vector.
     void apply(const std::vector<std::vector<std::complex<float>>> &matrix, const std::vector<size_t> &qubits);

--- a/src/stim/simulators/vector_simulator.test.cc
+++ b/src/stim/simulators/vector_simulator.test.cc
@@ -17,7 +17,6 @@
 #include "gtest/gtest.h"
 
 #include "stim/circuit/gate_data.h"
-#include "stim/test_util.test.h"
 
 using namespace stim;
 
@@ -234,48 +233,47 @@ TEST(vector_sim, project) {
 TEST(VectorSim, from_stabilizers) {
     VectorSimulator ref(2);
     auto sim = VectorSimulator::from_stabilizers(
-        {PauliString::from_str("ZI"), PauliString::from_str("IZ")}, SHARED_TEST_RNG());
+        {PauliString::from_str("ZI"), PauliString::from_str("IZ")});
     ref.state = {1, 0, 0, 0};
     ASSERT_TRUE(sim.approximate_equals(ref, true));
 
     sim = VectorSimulator::from_stabilizers(
-        {PauliString::from_str("-YX"), PauliString::from_str("ZZ")}, SHARED_TEST_RNG());
+        {PauliString::from_str("-YX"), PauliString::from_str("ZZ")});
     ref.state = {sqrtf(0.5), 0, 0, {0, -sqrtf(0.5)}};
     ASSERT_TRUE(sim.approximate_equals(ref, true));
 
     sim = VectorSimulator::from_stabilizers(
-        {PauliString::from_str("ZI"), PauliString::from_str("ZZ")}, SHARED_TEST_RNG());
+        {PauliString::from_str("ZI"), PauliString::from_str("ZZ")});
     ref.state = {1, 0, 0, 0};
     ASSERT_TRUE(sim.approximate_equals(ref, true));
 
     sim = VectorSimulator::from_stabilizers(
-        {PauliString::from_str("ZI"), PauliString::from_str("-ZZ")}, SHARED_TEST_RNG());
+        {PauliString::from_str("ZI"), PauliString::from_str("-ZZ")});
     ref.state = {0, 0, 1, 0};
     ASSERT_TRUE(sim.approximate_equals(ref, true));
 
     sim = VectorSimulator::from_stabilizers(
-        {PauliString::from_str("ZI"), PauliString::from_str("IX")}, SHARED_TEST_RNG());
+        {PauliString::from_str("ZI"), PauliString::from_str("IX")});
     ref.state = {sqrtf(0.5), 0, sqrtf(0.5), 0};
     ASSERT_TRUE(sim.approximate_equals(ref, true));
 
     sim = VectorSimulator::from_stabilizers(
-        {PauliString::from_str("ZZ"), PauliString::from_str("XX")}, SHARED_TEST_RNG());
+        {PauliString::from_str("ZZ"), PauliString::from_str("XX")});
     ref.state = {sqrtf(0.5), 0, 0, sqrtf(0.5)};
     ASSERT_TRUE(sim.approximate_equals(ref, true));
 
     sim = VectorSimulator::from_stabilizers(
-        {PauliString::from_str("XXX"), PauliString::from_str("ZZI"), PauliString::from_str("IZZ")}, SHARED_TEST_RNG());
+        {PauliString::from_str("XXX"), PauliString::from_str("ZZI"), PauliString::from_str("IZZ")});
     ref.state = {sqrtf(0.5), 0, 0, 0, 0, 0, 0, sqrtf(0.5)};
     ASSERT_TRUE(sim.approximate_equals(ref, true));
 
     sim = VectorSimulator::from_stabilizers(
-        {PauliString::from_str("YYY"), PauliString::from_str("ZZI"), PauliString::from_str("IZZ")}, SHARED_TEST_RNG());
+        {PauliString::from_str("YYY"), PauliString::from_str("ZZI"), PauliString::from_str("IZZ")});
     ref.state = {sqrtf(0.5), 0, 0, 0, 0, 0, 0, {0, -sqrtf(0.5)}};
     ASSERT_TRUE(sim.approximate_equals(ref, true));
 
     sim = VectorSimulator::from_stabilizers(
-        {PauliString::from_str("-YYY"), PauliString::from_str("-ZZI"), PauliString::from_str("IZZ")},
-        SHARED_TEST_RNG());
+        {PauliString::from_str("-YYY"), PauliString::from_str("-ZZI"), PauliString::from_str("IZZ")});
     ref.state = {0, sqrtf(0.5), 0, 0, 0, 0, {0, -sqrtf(0.5)}, 0};
     ASSERT_TRUE(sim.approximate_equals(ref, true));
 }

--- a/src/stim/simulators/vector_simulator.test.cc
+++ b/src/stim/simulators/vector_simulator.test.cc
@@ -232,33 +232,27 @@ TEST(vector_sim, project) {
 
 TEST(VectorSim, from_stabilizers) {
     VectorSimulator ref(2);
-    auto sim = VectorSimulator::from_stabilizers(
-        {PauliString::from_str("ZI"), PauliString::from_str("IZ")});
+    auto sim = VectorSimulator::from_stabilizers({PauliString::from_str("ZI"), PauliString::from_str("IZ")});
     ref.state = {1, 0, 0, 0};
     ASSERT_TRUE(sim.approximate_equals(ref, true));
 
-    sim = VectorSimulator::from_stabilizers(
-        {PauliString::from_str("-YX"), PauliString::from_str("ZZ")});
+    sim = VectorSimulator::from_stabilizers({PauliString::from_str("-YX"), PauliString::from_str("ZZ")});
     ref.state = {sqrtf(0.5), 0, 0, {0, -sqrtf(0.5)}};
     ASSERT_TRUE(sim.approximate_equals(ref, true));
 
-    sim = VectorSimulator::from_stabilizers(
-        {PauliString::from_str("ZI"), PauliString::from_str("ZZ")});
+    sim = VectorSimulator::from_stabilizers({PauliString::from_str("ZI"), PauliString::from_str("ZZ")});
     ref.state = {1, 0, 0, 0};
     ASSERT_TRUE(sim.approximate_equals(ref, true));
 
-    sim = VectorSimulator::from_stabilizers(
-        {PauliString::from_str("ZI"), PauliString::from_str("-ZZ")});
+    sim = VectorSimulator::from_stabilizers({PauliString::from_str("ZI"), PauliString::from_str("-ZZ")});
     ref.state = {0, 0, 1, 0};
     ASSERT_TRUE(sim.approximate_equals(ref, true));
 
-    sim = VectorSimulator::from_stabilizers(
-        {PauliString::from_str("ZI"), PauliString::from_str("IX")});
+    sim = VectorSimulator::from_stabilizers({PauliString::from_str("ZI"), PauliString::from_str("IX")});
     ref.state = {sqrtf(0.5), 0, sqrtf(0.5), 0};
     ASSERT_TRUE(sim.approximate_equals(ref, true));
 
-    sim = VectorSimulator::from_stabilizers(
-        {PauliString::from_str("ZZ"), PauliString::from_str("XX")});
+    sim = VectorSimulator::from_stabilizers({PauliString::from_str("ZZ"), PauliString::from_str("XX")});
     ref.state = {sqrtf(0.5), 0, 0, sqrtf(0.5)};
     ASSERT_TRUE(sim.approximate_equals(ref, true));
 

--- a/src/stim/stabilizers/tableau.cc
+++ b/src/stim/stabilizers/tableau.cc
@@ -24,9 +24,9 @@
 #include <thread>
 
 #include "stim/circuit/gate_data.h"
+#include "stim/simulators/vector_simulator.h"
 #include "stim/stabilizers/pauli_string.h"
 #include "stim/stabilizers/tableau_transposed_raii.h"
-#include "stim/simulators/vector_simulator.h"
 
 using namespace stim;
 

--- a/src/stim/stabilizers/tableau.h
+++ b/src/stim/stabilizers/tableau.h
@@ -19,6 +19,7 @@
 
 #include <iostream>
 #include <unordered_map>
+#include <complex>
 
 #include "stim/mem/simd_bit_table.h"
 #include "stim/mem/simd_util.h"
@@ -70,6 +71,7 @@ struct Tableau {
     /// Returns the Tableau raised to an integer power (using repeated squaring).
     Tableau raised_to(int64_t exponent) const;
 
+    std::vector<std::complex<float>> to_flat_unitary_matrix(bool little_endian) const;
     bool satisfies_invariants() const;
 
     /// Creates a Tableau representing a single qubit gate.

--- a/src/stim/stabilizers/tableau.h
+++ b/src/stim/stabilizers/tableau.h
@@ -17,9 +17,9 @@
 #ifndef _STIM_STABILIZERS_TABLEAU_H
 #define _STIM_STABILIZERS_TABLEAU_H
 
+#include <complex>
 #include <iostream>
 #include <unordered_map>
-#include <complex>
 
 #include "stim/mem/simd_bit_table.h"
 #include "stim/mem/simd_util.h"

--- a/src/stim/stabilizers/tableau.test.cc
+++ b/src/stim/stabilizers/tableau.test.cc
@@ -914,81 +914,68 @@ TEST(tableau, unitary_little_endian) {
     ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{s, s, -s, s}));
 
     t = Tableau(2);
-    ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{
-        1, 0, 0, 0,
-        0, 1, 0, 0,
-        0, 0, 1, 0,
-        0, 0, 0, 1
-    }));
+    ASSERT_EQ(
+        t.to_flat_unitary_matrix(false),
+        (std::vector<std::complex<float>>{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}));
     t.prepend_X(1);
-    ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{
-        0, 1, 0, 0,
-        1, 0, 0, 0,
-        0, 0, 0, 1,
-        0, 0, 1, 0
-    }));
+    ASSERT_EQ(
+        t.to_flat_unitary_matrix(false),
+        (std::vector<std::complex<float>>{0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0}));
     t.prepend_X(0);
-    ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{
-        0, 0, 0, 1,
-        0, 0, 1, 0,
-        0, 1, 0, 0,
-        1, 0, 0, 0
-    }));
+    ASSERT_EQ(
+        t.to_flat_unitary_matrix(false),
+        (std::vector<std::complex<float>>{0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0}));
     t.prepend_X(1);
-    ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{
-        0, 0, 1, 0,
-        0, 0, 0, 1,
-        1, 0, 0, 0,
-        0, 1, 0, 0
-    }));
+    ASSERT_EQ(
+        t.to_flat_unitary_matrix(false),
+        (std::vector<std::complex<float>>{0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0}));
     t.prepend_X(0);
 
-    ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{
-        1, 0, 0, 0,
-        0, 1, 0, 0,
-        0, 0, 1, 0,
-        0, 0, 0, 1
-    }));
+    ASSERT_EQ(
+        t.to_flat_unitary_matrix(false),
+        (std::vector<std::complex<float>>{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}));
     t.prepend_Z(1);
-    ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{
-        1, 0, 0, 0,
-        0, -1, 0, 0,
-        0, 0, 1, 0,
-        0, 0, 0, -1
-    }));
+    ASSERT_EQ(
+        t.to_flat_unitary_matrix(false),
+        (std::vector<std::complex<float>>{1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1, 0, 0, 0, 0, -1}));
     t.prepend_Z(0);
-    ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{
-        1, 0, 0, 0,
-        0, -1, 0, 0,
-        0, 0, -1, 0,
-        0, 0, 0, 1
-    }));
+    ASSERT_EQ(
+        t.to_flat_unitary_matrix(false),
+        (std::vector<std::complex<float>>{1, 0, 0, 0, 0, -1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1}));
     t.prepend_Z(1);
-    ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{
-        1, 0, 0, 0,
-        0, 1, 0, 0,
-        0, 0, -1, 0,
-        0, 0, 0, -1
-    }));
+    ASSERT_EQ(
+        t.to_flat_unitary_matrix(false),
+        (std::vector<std::complex<float>>{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, -1, 0, 0, 0, 0, -1}));
     t.prepend_Z(0);
 
     t.prepend_SQRT_Z(0);
-    ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{
-        1, 0, 0, 0,
-        0, 1, 0, 0,
-        0, 0, {0, 1}, 0,
-        0, 0, 0, {0, 1}
-    }));
+    ASSERT_EQ(
+        t.to_flat_unitary_matrix(false),
+        (std::vector<std::complex<float>>{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, {0, 1}, 0, 0, 0, 0, {0, 1}}));
     t.prepend_SQRT_Z_DAG(0);
 
     t.prepend_H_XZ(0);
     t.prepend_H_XZ(1);
-    ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{
-        0.5, 0.5, 0.5, 0.5,
-        0.5, -0.5, 0.5, -0.5,
-        0.5, 0.5, -0.5, -0.5,
-        0.5, -0.5, -0.5, 0.5,
-    }));
+    ASSERT_EQ(
+        t.to_flat_unitary_matrix(false),
+        (std::vector<std::complex<float>>{
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+        }));
 }
 
 TEST(tableau, unitary_big_endian) {
@@ -1003,81 +990,68 @@ TEST(tableau, unitary_big_endian) {
     ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{s, s, -s, s}));
 
     t = Tableau(2);
-    ASSERT_EQ(t.to_flat_unitary_matrix(true), (std::vector<std::complex<float>>{
-        1, 0, 0, 0,
-        0, 1, 0, 0,
-        0, 0, 1, 0,
-        0, 0, 0, 1
-    }));
+    ASSERT_EQ(
+        t.to_flat_unitary_matrix(true),
+        (std::vector<std::complex<float>>{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}));
     t.prepend_X(1);
-    ASSERT_EQ(t.to_flat_unitary_matrix(true), (std::vector<std::complex<float>>{
-        0, 0, 1, 0,
-        0, 0, 0, 1,
-        1, 0, 0, 0,
-        0, 1, 0, 0
-    }));
+    ASSERT_EQ(
+        t.to_flat_unitary_matrix(true),
+        (std::vector<std::complex<float>>{0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0}));
     t.prepend_X(0);
-    ASSERT_EQ(t.to_flat_unitary_matrix(true), (std::vector<std::complex<float>>{
-        0, 0, 0, 1,
-        0, 0, 1, 0,
-        0, 1, 0, 0,
-        1, 0, 0, 0
-    }));
+    ASSERT_EQ(
+        t.to_flat_unitary_matrix(true),
+        (std::vector<std::complex<float>>{0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0}));
     t.prepend_X(1);
-    ASSERT_EQ(t.to_flat_unitary_matrix(true), (std::vector<std::complex<float>>{
-        0, 1, 0, 0,
-        1, 0, 0, 0,
-        0, 0, 0, 1,
-        0, 0, 1, 0
-    }));
+    ASSERT_EQ(
+        t.to_flat_unitary_matrix(true),
+        (std::vector<std::complex<float>>{0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0}));
     t.prepend_X(0);
 
-    ASSERT_EQ(t.to_flat_unitary_matrix(true), (std::vector<std::complex<float>>{
-        1, 0, 0, 0,
-        0, 1, 0, 0,
-        0, 0, 1, 0,
-        0, 0, 0, 1
-    }));
+    ASSERT_EQ(
+        t.to_flat_unitary_matrix(true),
+        (std::vector<std::complex<float>>{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}));
     t.prepend_Z(1);
-    ASSERT_EQ(t.to_flat_unitary_matrix(true), (std::vector<std::complex<float>>{
-        1, 0, 0, 0,
-        0, 1, 0, 0,
-        0, 0, -1, 0,
-        0, 0, 0, -1
-    }));
+    ASSERT_EQ(
+        t.to_flat_unitary_matrix(true),
+        (std::vector<std::complex<float>>{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, -1, 0, 0, 0, 0, -1}));
     t.prepend_Z(0);
-    ASSERT_EQ(t.to_flat_unitary_matrix(true), (std::vector<std::complex<float>>{
-        1, 0, 0, 0,
-        0, -1, 0, 0,
-        0, 0, -1, 0,
-        0, 0, 0, 1
-    }));
+    ASSERT_EQ(
+        t.to_flat_unitary_matrix(true),
+        (std::vector<std::complex<float>>{1, 0, 0, 0, 0, -1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1}));
     t.prepend_Z(1);
-    ASSERT_EQ(t.to_flat_unitary_matrix(true), (std::vector<std::complex<float>>{
-        1, 0, 0, 0,
-        0, -1, 0, 0,
-        0, 0, 1, 0,
-        0, 0, 0, -1
-    }));
+    ASSERT_EQ(
+        t.to_flat_unitary_matrix(true),
+        (std::vector<std::complex<float>>{1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1, 0, 0, 0, 0, -1}));
     t.prepend_Z(0);
 
     t.prepend_SQRT_Z(0);
-    ASSERT_EQ(t.to_flat_unitary_matrix(true), (std::vector<std::complex<float>>{
-        1, 0, 0, 0,
-        0, {0, 1}, 0, 0,
-        0, 0, 1, 0,
-        0, 0, 0, {0, 1}
-    }));
+    ASSERT_EQ(
+        t.to_flat_unitary_matrix(true),
+        (std::vector<std::complex<float>>{1, 0, 0, 0, 0, {0, 1}, 0, 0, 0, 0, 1, 0, 0, 0, 0, {0, 1}}));
     t.prepend_SQRT_Z_DAG(0);
 
     t.prepend_H_XZ(0);
     t.prepend_H_XZ(1);
-    ASSERT_EQ(t.to_flat_unitary_matrix(true), (std::vector<std::complex<float>>{
-        0.5, 0.5, 0.5, 0.5,
-        0.5, -0.5, 0.5, -0.5,
-        0.5, 0.5, -0.5, -0.5,
-        0.5, -0.5, -0.5, 0.5,
-    }));
+    ASSERT_EQ(
+        t.to_flat_unitary_matrix(true),
+        (std::vector<std::complex<float>>{
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+            -0.5,
+            -0.5,
+            0.5,
+        }));
 }
 
 TEST(tableau, unitary_vs_gate_data) {

--- a/src/stim/stabilizers/tableau.test.cc
+++ b/src/stim/stabilizers/tableau.test.cc
@@ -182,7 +182,7 @@ TEST(tableau, str) {
 TEST(tableau, gate_tableau_data_vs_unitary_data) {
     for (const auto &gate : GATE_DATA.gates()) {
         if (gate.flags & GATE_IS_UNITARY) {
-            ASSERT_TRUE(tableau_agrees_with_unitary(gate.tableau(), gate.unitary())) << gate.name;
+            EXPECT_TRUE(tableau_agrees_with_unitary(gate.tableau(), gate.unitary())) << gate.name;
         }
     }
 }
@@ -900,4 +900,197 @@ TEST(tableau, inverse_pauli_string_acces_methods) {
     ASSERT_EQ(t.inverse_z_output(0, true), t_inv.zs[0]);
     ASSERT_EQ(t.inverse_z_output(1, true), t_inv.zs[1]);
     ASSERT_EQ(t.inverse_z_output(2, true), t_inv.zs[2]);
+}
+
+TEST(tableau, unitary_little_endian) {
+    Tableau t(1);
+    ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{1, 0, 0, 1}));
+    t.prepend_SQRT_Y(0);
+    auto s = sqrtf(0.5);
+    ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{s, -s, s, s}));
+    t.prepend_SQRT_Y(0);
+    ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{0, 1, -1, 0}));
+    t.prepend_SQRT_Y(0);
+    ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{s, s, -s, s}));
+
+    t = Tableau(2);
+    ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1
+    }));
+    t.prepend_X(1);
+    ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{
+        0, 1, 0, 0,
+        1, 0, 0, 0,
+        0, 0, 0, 1,
+        0, 0, 1, 0
+    }));
+    t.prepend_X(0);
+    ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{
+        0, 0, 0, 1,
+        0, 0, 1, 0,
+        0, 1, 0, 0,
+        1, 0, 0, 0
+    }));
+    t.prepend_X(1);
+    ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{
+        0, 0, 1, 0,
+        0, 0, 0, 1,
+        1, 0, 0, 0,
+        0, 1, 0, 0
+    }));
+    t.prepend_X(0);
+
+    ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1
+    }));
+    t.prepend_Z(1);
+    ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{
+        1, 0, 0, 0,
+        0, -1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, -1
+    }));
+    t.prepend_Z(0);
+    ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{
+        1, 0, 0, 0,
+        0, -1, 0, 0,
+        0, 0, -1, 0,
+        0, 0, 0, 1
+    }));
+    t.prepend_Z(1);
+    ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, -1, 0,
+        0, 0, 0, -1
+    }));
+    t.prepend_Z(0);
+
+    t.prepend_SQRT_Z(0);
+    ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, {0, 1}, 0,
+        0, 0, 0, {0, 1}
+    }));
+    t.prepend_SQRT_Z_DAG(0);
+
+    t.prepend_H_XZ(0);
+    t.prepend_H_XZ(1);
+    ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{
+        0.5, 0.5, 0.5, 0.5,
+        0.5, -0.5, 0.5, -0.5,
+        0.5, 0.5, -0.5, -0.5,
+        0.5, -0.5, -0.5, 0.5,
+    }));
+}
+
+TEST(tableau, unitary_big_endian) {
+    Tableau t(1);
+    ASSERT_EQ(t.to_flat_unitary_matrix(true), (std::vector<std::complex<float>>{1, 0, 0, 1}));
+    t.prepend_SQRT_Y(0);
+    auto s = sqrtf(0.5);
+    ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{s, -s, s, s}));
+    t.prepend_SQRT_Y(0);
+    ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{0, 1, -1, 0}));
+    t.prepend_SQRT_Y(0);
+    ASSERT_EQ(t.to_flat_unitary_matrix(false), (std::vector<std::complex<float>>{s, s, -s, s}));
+
+    t = Tableau(2);
+    ASSERT_EQ(t.to_flat_unitary_matrix(true), (std::vector<std::complex<float>>{
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1
+    }));
+    t.prepend_X(1);
+    ASSERT_EQ(t.to_flat_unitary_matrix(true), (std::vector<std::complex<float>>{
+        0, 0, 1, 0,
+        0, 0, 0, 1,
+        1, 0, 0, 0,
+        0, 1, 0, 0
+    }));
+    t.prepend_X(0);
+    ASSERT_EQ(t.to_flat_unitary_matrix(true), (std::vector<std::complex<float>>{
+        0, 0, 0, 1,
+        0, 0, 1, 0,
+        0, 1, 0, 0,
+        1, 0, 0, 0
+    }));
+    t.prepend_X(1);
+    ASSERT_EQ(t.to_flat_unitary_matrix(true), (std::vector<std::complex<float>>{
+        0, 1, 0, 0,
+        1, 0, 0, 0,
+        0, 0, 0, 1,
+        0, 0, 1, 0
+    }));
+    t.prepend_X(0);
+
+    ASSERT_EQ(t.to_flat_unitary_matrix(true), (std::vector<std::complex<float>>{
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1
+    }));
+    t.prepend_Z(1);
+    ASSERT_EQ(t.to_flat_unitary_matrix(true), (std::vector<std::complex<float>>{
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, -1, 0,
+        0, 0, 0, -1
+    }));
+    t.prepend_Z(0);
+    ASSERT_EQ(t.to_flat_unitary_matrix(true), (std::vector<std::complex<float>>{
+        1, 0, 0, 0,
+        0, -1, 0, 0,
+        0, 0, -1, 0,
+        0, 0, 0, 1
+    }));
+    t.prepend_Z(1);
+    ASSERT_EQ(t.to_flat_unitary_matrix(true), (std::vector<std::complex<float>>{
+        1, 0, 0, 0,
+        0, -1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, -1
+    }));
+    t.prepend_Z(0);
+
+    t.prepend_SQRT_Z(0);
+    ASSERT_EQ(t.to_flat_unitary_matrix(true), (std::vector<std::complex<float>>{
+        1, 0, 0, 0,
+        0, {0, 1}, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, {0, 1}
+    }));
+    t.prepend_SQRT_Z_DAG(0);
+
+    t.prepend_H_XZ(0);
+    t.prepend_H_XZ(1);
+    ASSERT_EQ(t.to_flat_unitary_matrix(true), (std::vector<std::complex<float>>{
+        0.5, 0.5, 0.5, 0.5,
+        0.5, -0.5, 0.5, -0.5,
+        0.5, 0.5, -0.5, -0.5,
+        0.5, -0.5, -0.5, 0.5,
+    }));
+}
+
+TEST(tableau, unitary_vs_gate_data) {
+    for (const auto &gate : GATE_DATA.gates()) {
+        if (gate.flags & GATE_IS_UNITARY) {
+            std::vector<std::complex<float>> flat_expected;
+            for (const auto &row : gate.unitary()) {
+                flat_expected.insert(flat_expected.end(), row.begin(), row.end());
+            }
+            VectorSimulator v(0);
+            v.state = std::move(flat_expected);
+            v.canonicalize_assuming_stabilizer_state((gate.flags & stim::GATE_TARGETS_PAIRS) ? 4 : 2);
+            EXPECT_EQ(gate.tableau().to_flat_unitary_matrix(true), v.state) << gate.name;
+        }
+    }
 }

--- a/src/stim/stabilizers/tableau_pybind_test.py
+++ b/src/stim/stabilizers/tableau_pybind_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import re
 
+import numpy as np
 import stim
 import pytest
 
@@ -681,3 +682,13 @@ def test_pickle():
     t = stim.Tableau.random(4)
     a = pickle.dumps(t)
     assert pickle.loads(a) == t
+
+
+def test_unitary():
+    swap = stim.Tableau.from_named_gate("SWAP")
+    np.testing.assert_array_equal(swap.to_unitary_matrix(endian='big'), [
+        [1, 0, 0, 0],
+        [0, 0, 1, 0],
+        [0, 1, 0, 0],
+        [0, 0, 0, 1],
+    ])


### PR DESCRIPTION
- Fix read_shot_data_file `@signature`
- Fix bazel pywheel build for python 3.10 environments
- Add `stim.TableauSimulator.peek_{x,y,z}`
- Add `stim.TableauSimulator.postselect_{x,y,z}`
- Add `endian="little"` argument to `stim.TableauSimulator.state_vector`
- Add `stim.Tableau.to_unitary_matrix`
- Guarantee canonicalization of state vectors and unitary matrices derived from stabilizers
- Improve precision of state vectors derived from stabilizers (make zero exactly zero)
- Fix stimcirq json serialization compatibility issues with cirq0.15

Fixes https://github.com/quantumlib/Stim/issues/266
Fixes https://github.com/quantumlib/Stim/issues/268
Fixes https://github.com/quantumlib/Stim/issues/269