### PR TITLE
Add `TableauSimulator.do_{circuit,pauli_string,tableau}`

### DIFF
--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -235,6 +235,9 @@
     - [`stim.TableauSimulator.cy`](#stim.TableauSimulator.cy)
     - [`stim.TableauSimulator.cz`](#stim.TableauSimulator.cz)
     - [`stim.TableauSimulator.do`](#stim.TableauSimulator.do)
+    - [`stim.TableauSimulator.do_circuit`](#stim.TableauSimulator.do_circuit)
+    - [`stim.TableauSimulator.do_pauli_string`](#stim.TableauSimulator.do_pauli_string)
+    - [`stim.TableauSimulator.do_tableau`](#stim.TableauSimulator.do_tableau)
     - [`stim.TableauSimulator.h`](#stim.TableauSimulator.h)
     - [`stim.TableauSimulator.h_xy`](#stim.TableauSimulator.h_xy)
     - [`stim.TableauSimulator.h_yz`](#stim.TableauSimulator.h_yz)
@@ -5137,6 +5140,81 @@
 >     >>> s.do(stim.PauliString("IXYZ"))
 >     >>> s.measure_many(0, 1, 2, 3)
 >     [False, True, True, False]
+> ```
+
+<a name="stim.TableauSimulator.do_circuit"></a>
+### `stim.TableauSimulator.do_circuit(self, circuit: stim.Circuit) -> None`
+> ```
+> Applies a circuit to the simulator's state.
+> 
+> Args:
+>     circuit: A stim.Circuit containing operations to apply.
+> 
+> Examples:
+>     >>> import stim
+>     >>> s = stim.TableauSimulator()
+>     >>> s.do_circuit(stim.Circuit('''
+>     ...     X 0
+>     ...     M 0
+>     ... '''))
+>     >>> s.current_measurement_record()
+>     [True]
+> ```
+
+<a name="stim.TableauSimulator.do_pauli_string"></a>
+### `stim.TableauSimulator.do_pauli_string(self, pauli_string: stim.PauliString) -> None`
+> ```
+> Applies the paulis from a pauli string to the simulator's state.
+> 
+> Args:
+>     pauli_string: A stim.PauliString containing Paulis to apply.
+> 
+> Examples:
+>     >>> s = stim.TableauSimulator()
+>     >>> s.do_pauli_string(stim.PauliString("IXYZ"))
+>     >>> s.measure_many(0, 1, 2, 3)
+>     [False, True, True, False]
+> ```
+
+<a name="stim.TableauSimulator.do_tableau"></a>
+### `stim.TableauSimulator.do_tableau(self, tableau: stim.Tableau, targets: List[int]) -> None`
+> ```
+> Applies a custom tableau operation to qubits in the simulator.
+> 
+> Note that this method has to compute the inverse of the tableau, because the
+> simulator's internal state is an inverse tableau.
+> 
+> Args:
+>     tableau: A stim.Tableau representing the Clifford operation to apply.
+>     targets: The indices of the qubits to operate on.
+> 
+> Examples:
+>     >>> import stim
+>     >>> sim = stim.TableauSimulator()
+>     >>> sim.h(1)
+>     >>> sim.h_yz(2)
+>     >>> [str(sim.peek_block(k)) for k in range(4)]
+>     ['+Z', '+X', '+Y', '+Z']
+>     >>> rot3 = stim.Tableau.from_conjugated_generators(
+>     ...     xs=[
+>     ...         stim.PauliString("_X_"),
+>     ...         stim.PauliString("__X"),
+>     ...         stim.PauliString("X__"),
+>     ...     ],
+>     ...     zs=[
+>     ...         stim.PauliString("_Z_"),
+>     ...         stim.PauliString("__Z"),
+>     ...         stim.PauliString("Z__"),
+>     ...     ],
+>     ... )
+> 
+>     >>> sim.do_tableau(rot3, [1, 2, 3])
+>     >>> [str(sim.peek_block(k)) for k in range(4)]
+>     ['+Z', '+Z', '+X', '+Y']
+> 
+>     >>> sim.do_tableau(rot3, [1, 2, 3])
+>     >>> [str(sim.peek_block(k)) for k in range(4)]
+>     ['+Z', '+Y', '+Z', '+X']
 > ```
 
 <a name="stim.TableauSimulator.h"></a>

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -3974,6 +3974,72 @@ class TableauSimulator:
             >>> s.measure_many(0, 1, 2, 3)
             [False, True, True, False]
         """
+    def do_circuit(self, circuit: stim.Circuit) -> None:
+        """Applies a circuit to the simulator's state.
+
+        Args:
+            circuit: A stim.Circuit containing operations to apply.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.do_circuit(stim.Circuit('''
+            ...     X 0
+            ...     M 0
+            ... '''))
+            >>> s.current_measurement_record()
+            [True]
+        """
+    def do_pauli_string(self, pauli_string: stim.PauliString) -> None:
+        """Applies the paulis from a pauli string to the simulator's state.
+
+        Args:
+            pauli_string: A stim.PauliString containing Paulis to apply.
+
+        Examples:
+            >>> s = stim.TableauSimulator()
+            >>> s.do_pauli_string(stim.PauliString("IXYZ"))
+            >>> s.measure_many(0, 1, 2, 3)
+            [False, True, True, False]
+        """
+    def do_tableau(self, tableau: stim.Tableau, targets: List[int]) -> None:
+        """Applies a custom tableau operation to qubits in the simulator.
+
+        Note that this method has to compute the inverse of the tableau, because the
+        simulator's internal state is an inverse tableau.
+
+        Args:
+            tableau: A stim.Tableau representing the Clifford operation to apply.
+            targets: The indices of the qubits to operate on.
+
+        Examples:
+            >>> import stim
+            >>> sim = stim.TableauSimulator()
+            >>> sim.h(1)
+            >>> sim.h_yz(2)
+            >>> [str(sim.peek_block(k)) for k in range(4)]
+            ['+Z', '+X', '+Y', '+Z']
+            >>> rot3 = stim.Tableau.from_conjugated_generators(
+            ...     xs=[
+            ...         stim.PauliString("_X_"),
+            ...         stim.PauliString("__X"),
+            ...         stim.PauliString("X__"),
+            ...     ],
+            ...     zs=[
+            ...         stim.PauliString("_Z_"),
+            ...         stim.PauliString("__Z"),
+            ...         stim.PauliString("Z__"),
+            ...     ],
+            ... )
+
+            >>> sim.do_tableau(rot3, [1, 2, 3])
+            >>> [str(sim.peek_block(k)) for k in range(4)]
+            ['+Z', '+Z', '+X', '+Y']
+
+            >>> sim.do_tableau(rot3, [1, 2, 3])
+            >>> [str(sim.peek_block(k)) for k in range(4)]
+            ['+Z', '+Y', '+Z', '+X']
+        """
     def h(self, *targets) -> None:
         """Applies a Hadamard gate to the simulator's state.
 

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -3974,6 +3974,72 @@ class TableauSimulator:
             >>> s.measure_many(0, 1, 2, 3)
             [False, True, True, False]
         """
+    def do_circuit(self, circuit: stim.Circuit) -> None:
+        """Applies a circuit to the simulator's state.
+
+        Args:
+            circuit: A stim.Circuit containing operations to apply.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.do_circuit(stim.Circuit('''
+            ...     X 0
+            ...     M 0
+            ... '''))
+            >>> s.current_measurement_record()
+            [True]
+        """
+    def do_pauli_string(self, pauli_string: stim.PauliString) -> None:
+        """Applies the paulis from a pauli string to the simulator's state.
+
+        Args:
+            pauli_string: A stim.PauliString containing Paulis to apply.
+
+        Examples:
+            >>> s = stim.TableauSimulator()
+            >>> s.do_pauli_string(stim.PauliString("IXYZ"))
+            >>> s.measure_many(0, 1, 2, 3)
+            [False, True, True, False]
+        """
+    def do_tableau(self, tableau: stim.Tableau, targets: List[int]) -> None:
+        """Applies a custom tableau operation to qubits in the simulator.
+
+        Note that this method has to compute the inverse of the tableau, because the
+        simulator's internal state is an inverse tableau.
+
+        Args:
+            tableau: A stim.Tableau representing the Clifford operation to apply.
+            targets: The indices of the qubits to operate on.
+
+        Examples:
+            >>> import stim
+            >>> sim = stim.TableauSimulator()
+            >>> sim.h(1)
+            >>> sim.h_yz(2)
+            >>> [str(sim.peek_block(k)) for k in range(4)]
+            ['+Z', '+X', '+Y', '+Z']
+            >>> rot3 = stim.Tableau.from_conjugated_generators(
+            ...     xs=[
+            ...         stim.PauliString("_X_"),
+            ...         stim.PauliString("__X"),
+            ...         stim.PauliString("X__"),
+            ...     ],
+            ...     zs=[
+            ...         stim.PauliString("_Z_"),
+            ...         stim.PauliString("__Z"),
+            ...         stim.PauliString("Z__"),
+            ...     ],
+            ... )
+
+            >>> sim.do_tableau(rot3, [1, 2, 3])
+            >>> [str(sim.peek_block(k)) for k in range(4)]
+            ['+Z', '+Z', '+X', '+Y']
+
+            >>> sim.do_tableau(rot3, [1, 2, 3])
+            >>> [str(sim.peek_block(k)) for k in range(4)]
+            ['+Z', '+Y', '+Z', '+X']
+        """
     def h(self, *targets) -> None:
         """Applies a Hadamard gate to the simulator's state.
 

--- a/src/stim/simulators/tableau_simulator.cc
+++ b/src/stim/simulators/tableau_simulator.cc
@@ -776,6 +776,10 @@ VectorSimulator TableauSimulator::to_vector_sim() const {
     return VectorSimulator::from_stabilizers(stabilizers);
 }
 
+void TableauSimulator::apply_tableau(const Tableau &tableau, const std::vector<size_t> &targets) {
+    inv_state.inplace_scatter_prepend(tableau.inverse(), targets);
+}
+
 std::vector<std::complex<float>> TableauSimulator::to_state_vector(bool little_endian) const {
     auto sim = to_vector_sim();
     if (!little_endian) {

--- a/src/stim/simulators/tableau_simulator.h
+++ b/src/stim/simulators/tableau_simulator.h
@@ -140,6 +140,8 @@ struct TableauSimulator {
     /// Automatically expands the tableau simulator's state, if needed.
     void expand_do_circuit(const Circuit &circuit);
 
+    void apply_tableau(const Tableau &tableau, const std::vector<size_t> &targets);
+
     std::vector<PauliString> canonical_stabilizers() const;
 
     /// === SPECIALIZED VECTORIZED OPERATION IMPLEMENTATIONS ===

--- a/src/stim/simulators/tableau_simulator.test.cc
+++ b/src/stim/simulators/tableau_simulator.test.cc
@@ -2034,3 +2034,29 @@ TEST(TableauSimulator, peek_x) {
     ASSERT_EQ(sim.peek_y(2), 0);
     ASSERT_EQ(sim.peek_z(2), 0);
 }
+
+TEST(TableauSimulator, apply_tableau) {
+    auto cnot = GATE_DATA.at("CNOT").tableau();
+    auto s = GATE_DATA.at("S").tableau();
+    auto h = GATE_DATA.at("H").tableau();
+    auto cxyz = GATE_DATA.at("C_XYZ").tableau();
+
+    TableauSimulator sim(SHARED_TEST_RNG(), 4);
+    sim.apply_tableau(h, {1});
+    ASSERT_EQ(sim.peek_bloch(1), PauliString::from_str("+X"));
+    sim.apply_tableau(s, {1});
+    ASSERT_EQ(sim.peek_bloch(1), PauliString::from_str("+Y"));
+    sim.apply_tableau(s, {1});
+    ASSERT_EQ(sim.peek_bloch(1), PauliString::from_str("-X"));
+    sim.apply_tableau(cnot, {2, 1});
+    ASSERT_EQ(sim.peek_bloch(1), PauliString::from_str("-X"));
+    sim.apply_tableau(cnot, {1, 2});
+    ASSERT_EQ(sim.peek_bloch(1), PauliString::from_str("I"));
+    ASSERT_EQ(sim.peek_observable_expectation(PauliString::from_str("IXXI")), -1);
+    ASSERT_EQ(sim.peek_observable_expectation(PauliString::from_str("IZZI")), +1);
+
+    sim.apply_tableau(cxyz, {2});
+    sim.apply_tableau(cxyz.inverse(), {1});
+    ASSERT_EQ(sim.peek_observable_expectation(PauliString::from_str("IZYI")), -1);
+    ASSERT_EQ(sim.peek_observable_expectation(PauliString::from_str("IYXI")), +1);
+}

--- a/src/stim/simulators/tableau_simulator_pybind_test.py
+++ b/src/stim/simulators/tableau_simulator_pybind_test.py
@@ -432,3 +432,37 @@ def test_peek_pauli():
     assert s.peek_x(100) == 0
     assert s.peek_y(100) == -1
     assert s.peek_z(100) == 0
+
+
+def test_do_circuit():
+    s = stim.TableauSimulator()
+    s.do_circuit(stim.Circuit("""
+        H 0
+    """))
+    assert s.peek_bloch(0) == stim.PauliString('+X')
+
+
+def test_do_pauli_string():
+    s = stim.TableauSimulator()
+    s.do_pauli_string(stim.PauliString("IXYZ"))
+    assert s.peek_bloch(0) == stim.PauliString('+Z')
+    assert s.peek_bloch(1) == stim.PauliString('-Z')
+    assert s.peek_bloch(2) == stim.PauliString('-Z')
+    assert s.peek_bloch(3) == stim.PauliString('+Z')
+
+
+def test_do_tableau():
+    s = stim.TableauSimulator()
+    s.do_tableau(stim.Tableau.from_named_gate("H"), [0])
+    assert s.peek_bloch(0) == stim.PauliString('+X')
+    s.do_tableau(stim.Tableau.from_named_gate("CNOT"), [0, 1])
+    assert s.peek_bloch(0) == stim.PauliString('+I')
+    assert s.peek_observable_expectation(stim.PauliString('XX')) == +1
+    assert s.peek_observable_expectation(stim.PauliString('ZZ')) == +1
+
+    with pytest.raises(ValueError, match='len'):
+        s.do_tableau(stim.Tableau(1), [1, 2])
+    with pytest.raises(ValueError, match='duplicates'):
+        s.do_tableau(stim.Tableau(3), [2, 3, 2])
+
+    s.do_tableau(stim.Tableau(0), [])

--- a/src/stim/stabilizers/tableau.h
+++ b/src/stim/stabilizers/tableau.h
@@ -176,7 +176,7 @@ struct Tableau {
     void prepend_YCX(size_t control, size_t target);
     void prepend_YCY(size_t control, size_t target);
     void prepend_YCZ(size_t control, size_t target);
-    void prepend(const PauliStringRef &op);
+    void prepend_pauli_product(const PauliStringRef &op);
 
     uint8_t x_output_pauli_xyz(size_t input_index, size_t output_index) const;
     uint8_t y_output_pauli_xyz(size_t input_index, size_t output_index) const;

--- a/src/stim/stabilizers/tableau.test.cc
+++ b/src/stim/stabilizers/tableau.test.cc
@@ -675,15 +675,15 @@ TEST(tableau, inverse) {
     }
 }
 
-TEST(tableau, prepend_pauli) {
+TEST(tableau, prepend_pauli_product) {
     Tableau t = Tableau::random(6, SHARED_TEST_RNG());
     Tableau ref = t;
-    t.prepend(PauliString::from_str("_XYZ__"));
+    t.prepend_pauli_product(PauliString::from_str("_XYZ__"));
     ref.prepend_X(1);
     ref.prepend_Y(2);
     ref.prepend_Z(3);
     ASSERT_EQ(t, ref);
-    t.prepend(PauliString::from_str("Y_ZX__"));
+    t.prepend_pauli_product(PauliString::from_str("Y_ZX__"));
     ref.prepend_X(3);
     ref.prepend_Y(0);
     ref.prepend_Z(2);

--- a/src/stim/stabilizers/tableau_specialized_prepend.cc
+++ b/src/stim/stabilizers/tableau_specialized_prepend.cc
@@ -31,7 +31,7 @@ void Tableau::prepend_Z(size_t q) {
     xs[q].sign ^= 1;
 }
 
-void Tableau::prepend(const PauliStringRef &op) {
+void Tableau::prepend_pauli_product(const PauliStringRef &op) {
     assert(op.num_qubits == num_qubits);
     zs.signs ^= op.xs;
     xs.signs ^= op.zs;


### PR DESCRIPTION
- Also: fix circuit's not fusing operations at boundaries when concatenated using `+`

Fixes https://github.com/quantumlib/Stim/issues/261
Fixes https://github.com/quantumlib/Stim/issues/130