### PR TITLE
Add minimal support for ELSE_CORRELATED_ERROR

### DIFF
--- a/doc/gates.md
+++ b/doc/gates.md
@@ -1981,6 +1981,10 @@ Probabilistically applies a Pauli product error with a given probability, unless
 If the error occurs, sets the "correlated error occurred flag" to true.
 Otherwise leaves the flag alone.
 
+Note: when converting a circuit into a detector error model, every `ELSE_CORRELATED_ERROR` instruction must be preceded by
+an ELSE_CORRELATED_ERROR instruction or an E instruction. In other words, ELSE_CORRELATED_ERROR instructions should appear
+in contiguous chunks started by a CORRELATED_ERROR.
+
 See also: `CORRELATED_ERROR`.
 
 Parens Arguments:

--- a/doc/usage_command_line.md
+++ b/doc/usage_command_line.md
@@ -69,8 +69,6 @@ stderr:
     Circuit contained gauge detectors but `--allow_gauge_detectors` wasn't set.
     Circuit contained disjoint error channels but `--approximate_disjoint_errors` wasn't set.
 
-Note: currently, the `ELSE_CORRELATED_ERROR` instruction is not supported by this mode.
-
 - Example:
 
     ```

--- a/src/stim/circuit/circuit.cc
+++ b/src/stim/circuit/circuit.cc
@@ -785,7 +785,8 @@ Circuit Circuit::operator*(uint64_t repetitions) const {
 }
 
 template <typename T>
-ConstPointerRange<T> mono_extend(MonotonicBuffer<T> &cur, ConstPointerRange<T> original, ConstPointerRange<T> additional) {
+ConstPointerRange<T> mono_extend(
+    MonotonicBuffer<T> &cur, ConstPointerRange<T> original, ConstPointerRange<T> additional) {
     if (original.ptr_end == cur.tail.ptr_start) {
         // Try to append new data right after the original data.
         cur.ensure_available(additional.size());
@@ -806,7 +807,8 @@ ConstPointerRange<T> mono_extend(MonotonicBuffer<T> &cur, ConstPointerRange<T> o
 Circuit &Circuit::operator+=(const Circuit &other) {
     ConstPointerRange<Operation> ops_to_add = other.operations;
     if (!operations.empty() && !ops_to_add.empty() && operations.back().can_fuse(ops_to_add[0])) {
-        operations.back().target_data.targets = mono_extend(target_buf, operations.back().target_data.targets, ops_to_add[0].target_data.targets);
+        operations.back().target_data.targets =
+            mono_extend(target_buf, operations.back().target_data.targets, ops_to_add[0].target_data.targets);
         ops_to_add.ptr_start++;
     }
 

--- a/src/stim/circuit/gate_data_noisy.cc
+++ b/src/stim/circuit/gate_data_noisy.cc
@@ -415,6 +415,10 @@ Probabilistically applies a Pauli product error with a given probability, unless
 If the error occurs, sets the "correlated error occurred flag" to true.
 Otherwise leaves the flag alone.
 
+Note: when converting a circuit into a detector error model, every `ELSE_CORRELATED_ERROR` instruction must be preceded by
+an ELSE_CORRELATED_ERROR instruction or an E instruction. In other words, ELSE_CORRELATED_ERROR instructions should appear
+in contiguous chunks started by a CORRELATED_ERROR.
+
 See also: `CORRELATED_ERROR`.
 
 Parens Arguments:

--- a/src/stim/dem/detector_error_model.cc
+++ b/src/stim/dem/detector_error_model.cc
@@ -580,6 +580,29 @@ void DetectorErrorModel::clear() {
     blocks.clear();
 }
 
+DetectorErrorModel DetectorErrorModel::rounded(uint8_t sig_figs) const {
+    double scale = 1;
+    for (size_t k = 0; k < sig_figs; k++) {
+        scale *= 10;
+    }
+
+    DetectorErrorModel result;
+    for (const auto &e : instructions) {
+        if (e.type == DEM_REPEAT_BLOCK) {
+            auto reps = e.target_data[0].data;
+            auto &block = blocks[e.target_data[1].data];
+            result.append_repeat_block(reps, block.rounded(sig_figs));
+        } else {
+            std::vector<double> rounded_args;
+            for (auto a : e.arg_data) {
+                rounded_args.push_back(round(a * scale) / scale);
+            }
+            result.append_dem_instruction({rounded_args, e.target_data, e.type});
+        }
+    }
+    return result;
+}
+
 uint64_t DetectorErrorModel::total_detector_shift() const {
     uint64_t result = 0;
     for (const auto &e : instructions) {

--- a/src/stim/dem/detector_error_model.h
+++ b/src/stim/dem/detector_error_model.h
@@ -183,6 +183,8 @@ struct DetectorErrorModel {
 
     /// Gets a python-style slice of the error model's instructions.
     DetectorErrorModel py_get_slice(int64_t start, int64_t step, int64_t slice_length) const;
+
+    DetectorErrorModel rounded(uint8_t sig_figs) const;
 };
 
 void print_detector_error_model(std::ostream &out, const DetectorErrorModel &v, size_t indent);

--- a/src/stim/dem/detector_error_model.test.cc
+++ b/src/stim/dem/detector_error_model.test.cc
@@ -736,6 +736,53 @@ TEST(detector_error_model, final_detector_and_coord_shift) {
         (std::pair<uint64_t, std::vector<double>>{4000000, {2000000, 1000, 6000000000}}));
 }
 
+TEST(detector_error_model, rounded) {
+    DetectorErrorModel dem(R"DEM(
+        error(0.01000002) D0 D1
+        repeat 2 {
+            error(0.123456789) D1 D2 L3
+        }
+        detector(0.0200000334,0.12345) D0
+        shift_detectors(5.0300004,0.12345) 3
+    )DEM");
+
+    ASSERT_EQ(dem.rounded(0), DetectorErrorModel(R"DEM(
+        error(0) D0 D1
+        repeat 2 {
+            error(0) D1 D2 L3
+        }
+        detector(0,0) D0
+        shift_detectors(5,0) 3
+    )DEM"));
+
+    ASSERT_EQ(dem.rounded(1), DetectorErrorModel(R"DEM(
+        error(0) D0 D1
+        repeat 2 {
+            error(0.1) D1 D2 L3
+        }
+        detector(0,0.1) D0
+        shift_detectors(5,0.1) 3
+    )DEM"));
+
+    ASSERT_EQ(dem.rounded(2), DetectorErrorModel(R"DEM(
+        error(0.01) D0 D1
+        repeat 2 {
+            error(0.12) D1 D2 L3
+        }
+        detector(0.02,0.12) D0
+        shift_detectors(5.03,0.12) 3
+    )DEM"));
+
+    ASSERT_EQ(dem.rounded(3), DetectorErrorModel(R"DEM(
+        error(0.010) D0 D1
+        repeat 2 {
+            error(0.123) D1 D2 L3
+        }
+        detector(0.020,0.123) D0
+        shift_detectors(5.030,0.123) 3
+    )DEM"));
+}
+
 TEST(detector_error_model, surface_code_coords_dont_infinite_loop) {
     CircuitGenParameters params(7, 5, "rotated_memory_x");
     params.after_clifford_depolarization = 0.01;

--- a/src/stim/help.cc
+++ b/src/stim/help.cc
@@ -393,8 +393,6 @@ stderr:
     Circuit contained gauge detectors but `--allow_gauge_detectors` wasn't set.
     Circuit contained disjoint error channels but `--approximate_disjoint_errors` wasn't set.
 
-Note: currently, the `ELSE_CORRELATED_ERROR` instruction is not supported by this mode.
-
 - Example:
 
     ```

--- a/src/stim/main_namespaced.test.cc
+++ b/src/stim/main_namespaced.test.cc
@@ -759,16 +759,20 @@ PAULI_CHANNEL_1(0.125, 0.25, 0.375) 0
 M 0
 DETECTOR rec[-1]
             )input")),
-        trim(R"OUTPUT(
+        trim(
+            R"OUTPUT(
 [stderr=)OUTPUT"
-             "\x1B"
-             R"OUTPUT([31mHandling PAULI_CHANNEL_1 requires `approximate_disjoint_errors` argument to be specified.
+            "\x1B"
+            R"OUTPUT([31mEncountered the operation PAULI_CHANNEL_1 during error analysis, but this operation requires the `approximate_disjoint_errors` option to be enabled.
+If you're' calling from python, using stim.Circuit.detector_error_model, you need to add the argument approximate_disjoint_errors=True.
+
+If you're' calling from the command line, you need to specify --approximate_disjoint_errors.
 
 Circuit stack trace:
     at instruction #2 [which is PAULI_CHANNEL_1(0.125, 0.25, 0.375) 0]
 )OUTPUT"
-             "\x1B"
-             R"OUTPUT([0m]
+            "\x1B"
+            R"OUTPUT([0m]
 )OUTPUT"));
 
     ASSERT_EQ(

--- a/src/stim/simulators/error_analyzer.h
+++ b/src/stim/simulators/error_analyzer.h
@@ -340,6 +340,11 @@ struct ErrorAnalyzer {
 
     /// Checks whether there any errors that need decomposing.
     bool has_unflushed_ungraphlike_errors() const;
+
+   private:
+    void check_can_approximate_disjoint(const char *op_name);
+    void add_composite_error(double probability, ConstPointerRange<GateTarget> targets);
+    void correlated_error_block(const std::vector<OperationData> &dats);
 };
 
 /// Determines if an error's targets are graphlike.

--- a/src/stim/simulators/error_matcher.cc
+++ b/src/stim/simulators/error_matcher.cc
@@ -226,7 +226,7 @@ void ErrorMatcher::rev_process_instruction(const Operation &op) {
         }
     } else if (!(op.gate->flags & (GATE_IS_NOISE | GATE_PRODUCES_NOISY_RESULTS))) {
         (error_analyzer.*op.gate->reverse_error_analyzer_function)(op.target_data);
-    } else if (op.gate->id == gate_name_to_id("E")) {
+    } else if (op.gate->id == gate_name_to_id("E") || op.gate->id == gate_name_to_id("ELSE_CORRELATED_ERROR")) {
         cur_loc.instruction_targets.target_range_start = 0;
         cur_loc.instruction_targets.target_range_end = op.target_data.targets.size();
         resolve_paulis_into(op.target_data.targets, 0, cur_loc.flipped_pauli_product);


### PR DESCRIPTION
- Add `stim::DetectorErrorModel::rounded` (but don't expose to python as it doesn't work too well)

Fixes https://github.com/quantumlib/Stim/issues/190