### PR TITLE
Add several Tableau conversions + misc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ set(SOURCE_FILES_NO_MAIN
         src/stim/simulators/measurements_to_detection_events.cc
         src/stim/simulators/tableau_simulator.cc
         src/stim/simulators/vector_simulator.cc
+        src/stim/stabilizers/conversions.cc
         src/stim/stabilizers/pauli_string.cc
         src/stim/stabilizers/pauli_string_ref.cc
         src/stim/stabilizers/tableau.cc
@@ -143,6 +144,7 @@ set(TEST_FILES
         src/stim/simulators/measurements_to_detection_events.test.cc
         src/stim/simulators/tableau_simulator.test.cc
         src/stim/simulators/vector_simulator.test.cc
+        src/stim/stabilizers/conversions.test.cc
         src/stim/stabilizers/pauli_string.test.cc
         src/stim/stabilizers/tableau.test.cc
         src/stim/stabilizers/tableau_iter.test.cc

--- a/doc/gates.md
+++ b/doc/gates.md
@@ -95,39 +95,29 @@ Targets:
 
 - Example:
 
-    ```
     I 5
     I 42
     I 5 42
-    ```
     
 Stabilizer Generators:
 
-    ```
     X -> +X
     Z -> +Z
-    ```
     
 Bloch Rotation:
 
-    ```
     Axis: 
     Angle: 0 degrees
-    ```
     
 Unitary Matrix:
 
-    ```
     [+1  ,     ]
     [    , +1  ]
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `I 0`
     # (no operations)
-    ```
     
 
 <a name="X"></a>
@@ -146,42 +136,32 @@ Targets:
 
 - Example:
 
-    ```
     X 5
     X 42
     X 5 42
-    ```
     
 Stabilizer Generators:
 
-    ```
     X -> +X
     Z -> -Z
-    ```
     
 Bloch Rotation:
 
-    ```
     Axis: +X
     Angle: 180 degrees
-    ```
     
 Unitary Matrix:
 
-    ```
     [    , +1  ]
     [+1  ,     ]
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `X 0`
     H 0
     S 0
     S 0
     H 0
-    ```
     
 
 <a name="Y"></a>
@@ -199,36 +179,27 @@ Targets:
 
 - Example:
 
-    ```
     Y 5
     Y 42
     Y 5 42
-    ```
     
 Stabilizer Generators:
 
-    ```
     X -> -X
     Z -> -Z
-    ```
     
 Bloch Rotation:
 
-    ```
     Axis: +Y
     Angle: 180 degrees
-    ```
     
 Unitary Matrix:
 
-    ```
     [    ,   -i]
     [  +i,     ]
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `Y 0`
     S 0
     S 0
@@ -236,7 +207,6 @@ Decomposition (into H, S, CX, M, R):
     S 0
     S 0
     H 0
-    ```
     
 
 <a name="Z"></a>
@@ -255,40 +225,30 @@ Targets:
 
 - Example:
 
-    ```
     Z 5
     Z 42
     Z 5 42
-    ```
     
 Stabilizer Generators:
 
-    ```
     X -> -X
     Z -> +Z
-    ```
     
 Bloch Rotation:
 
-    ```
     Axis: +Z
     Angle: 180 degrees
-    ```
     
 Unitary Matrix:
 
-    ```
     [+1  ,     ]
     [    , -1  ]
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `Z 0`
     S 0
     S 0
-    ```
     
 
 ## Single Qubit Clifford Gates
@@ -308,42 +268,32 @@ Targets:
 
 - Example:
 
-    ```
     C_XYZ 5
     C_XYZ 42
     C_XYZ 5 42
-    ```
     
 Stabilizer Generators:
 
-    ```
     X -> +Y
     Z -> +X
-    ```
     
 Bloch Rotation:
 
-    ```
     Axis: +X+Y+Z
     Angle: 120 degrees
-    ```
     
 Unitary Matrix:
 
-    ```
     [+1-i, -1-i]
     [+1-i, +1+i] / 2
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `C_XYZ 0`
     S 0
     S 0
     S 0
     H 0
-    ```
     
 
 <a name="C_ZYX"></a>
@@ -361,40 +311,30 @@ Targets:
 
 - Example:
 
-    ```
     C_ZYX 5
     C_ZYX 42
     C_ZYX 5 42
-    ```
     
 Stabilizer Generators:
 
-    ```
     X -> +Z
     Z -> +Y
-    ```
     
 Bloch Rotation:
 
-    ```
     Axis: +X+Y+Z
     Angle: -120 degrees
-    ```
     
 Unitary Matrix:
 
-    ```
     [+1+i, +1+i]
     [-1+i, +1-i] / 2
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `C_ZYX 0`
     H 0
     S 0
-    ```
     
 
 <a name="H"></a>
@@ -415,41 +355,31 @@ Targets:
 
 - Example:
 
-    ```
     H 5
     H 42
     H 5 42
-    ```
     
 Stabilizer Generators:
 
-    ```
     X -> +Z
     Z -> +X
-    ```
     
 Bloch Rotation:
 
-    ```
     Axis: +X+Z
     Angle: 180 degrees
-    ```
     
 Unitary Matrix:
 
-    ```
     [+1  , +1  ]
     [+1  , -1  ] / sqrt(2)
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `H 0`
     H 0
     
     # (The decomposition is trivial because this gate is in the target gate set.)
-    ```
     
 
 <a name="H_XY"></a>
@@ -467,43 +397,33 @@ Targets:
 
 - Example:
 
-    ```
     H_XY 5
     H_XY 42
     H_XY 5 42
-    ```
     
 Stabilizer Generators:
 
-    ```
     X -> +Y
     Z -> -Z
-    ```
     
 Bloch Rotation:
 
-    ```
     Axis: +X+Y
     Angle: 180 degrees
-    ```
     
 Unitary Matrix:
 
-    ```
     [    , +1-i]
     [+1+i,     ] / sqrt(2)
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `H_XY 0`
     H 0
     S 0
     S 0
     H 0
     S 0
-    ```
     
 
 <a name="H_YZ"></a>
@@ -521,43 +441,33 @@ Targets:
 
 - Example:
 
-    ```
     H_YZ 5
     H_YZ 42
     H_YZ 5 42
-    ```
     
 Stabilizer Generators:
 
-    ```
     X -> -X
     Z -> +Y
-    ```
     
 Bloch Rotation:
 
-    ```
     Axis: +Y+Z
     Angle: 180 degrees
-    ```
     
 Unitary Matrix:
 
-    ```
     [+1  ,   -i]
     [  +i, -1  ] / sqrt(2)
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `H_YZ 0`
     H 0
     S 0
     H 0
     S 0
     S 0
-    ```
     
 
 <a name="S"></a>
@@ -578,41 +488,31 @@ Targets:
 
 - Example:
 
-    ```
     S 5
     S 42
     S 5 42
-    ```
     
 Stabilizer Generators:
 
-    ```
     X -> +Y
     Z -> +Z
-    ```
     
 Bloch Rotation:
 
-    ```
     Axis: +Z
     Angle: 90 degrees
-    ```
     
 Unitary Matrix:
 
-    ```
     [+1  ,     ]
     [    ,   +i]
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `S 0`
     S 0
     
     # (The decomposition is trivial because this gate is in the target gate set.)
-    ```
     
 
 <a name="SQRT_X"></a>
@@ -631,41 +531,31 @@ Targets:
 
 - Example:
 
-    ```
     SQRT_X 5
     SQRT_X 42
     SQRT_X 5 42
-    ```
     
 Stabilizer Generators:
 
-    ```
     X -> +X
     Z -> -Y
-    ```
     
 Bloch Rotation:
 
-    ```
     Axis: +X
     Angle: 90 degrees
-    ```
     
 Unitary Matrix:
 
-    ```
     [+1+i, +1-i]
     [+1-i, +1+i] / 2
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `SQRT_X 0`
     H 0
     S 0
     H 0
-    ```
     
 
 <a name="SQRT_X_DAG"></a>
@@ -684,41 +574,31 @@ Targets:
 
 - Example:
 
-    ```
     SQRT_X_DAG 5
     SQRT_X_DAG 42
     SQRT_X_DAG 5 42
-    ```
     
 Stabilizer Generators:
 
-    ```
     X -> +X
     Z -> +Y
-    ```
     
 Bloch Rotation:
 
-    ```
     Axis: +X
     Angle: -90 degrees
-    ```
     
 Unitary Matrix:
 
-    ```
     [+1-i, +1+i]
     [+1+i, +1-i] / 2
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `SQRT_X_DAG 0`
     S 0
     H 0
     S 0
-    ```
     
 
 <a name="SQRT_Y"></a>
@@ -737,41 +617,31 @@ Targets:
 
 - Example:
 
-    ```
     SQRT_Y 5
     SQRT_Y 42
     SQRT_Y 5 42
-    ```
     
 Stabilizer Generators:
 
-    ```
     X -> -Z
     Z -> +X
-    ```
     
 Bloch Rotation:
 
-    ```
     Axis: +Y
     Angle: 90 degrees
-    ```
     
 Unitary Matrix:
 
-    ```
     [+1+i, -1-i]
     [+1+i, +1+i] / 2
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `SQRT_Y 0`
     S 0
     S 0
     H 0
-    ```
     
 
 <a name="SQRT_Y_DAG"></a>
@@ -790,41 +660,31 @@ Targets:
 
 - Example:
 
-    ```
     SQRT_Y_DAG 5
     SQRT_Y_DAG 42
     SQRT_Y_DAG 5 42
-    ```
     
 Stabilizer Generators:
 
-    ```
     X -> +Z
     Z -> -X
-    ```
     
 Bloch Rotation:
 
-    ```
     Axis: +Y
     Angle: -90 degrees
-    ```
     
 Unitary Matrix:
 
-    ```
     [+1-i, +1-i]
     [-1+i, +1-i] / 2
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `SQRT_Y_DAG 0`
     H 0
     S 0
     S 0
-    ```
     
 
 <a name="S_DAG"></a>
@@ -845,41 +705,31 @@ Targets:
 
 - Example:
 
-    ```
     S_DAG 5
     S_DAG 42
     S_DAG 5 42
-    ```
     
 Stabilizer Generators:
 
-    ```
     X -> -Y
     Z -> +Z
-    ```
     
 Bloch Rotation:
 
-    ```
     Axis: +Z
     Angle: -90 degrees
-    ```
     
 Unitary Matrix:
 
-    ```
     [+1  ,     ]
     [    ,   -i]
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `S_DAG 0`
     S 0
     S 0
     S 0
-    ```
     
 
 ## Two Qubit Clifford Gates
@@ -909,39 +759,31 @@ Targets:
 
 - Example:
 
-    ```
     CX 5 6
     CX 42 43
     CX 5 6 42 43
     CX rec[-1] 111
-    ```
     
 Stabilizer Generators:
 
-    ```
     X_ -> +XX
     Z_ -> +Z_
     _X -> +_X
     _Z -> +ZZ
-    ```
     
-Unitary Matrix:
+Unitary Matrix (little endian):
 
-    ```
     [+1  ,     ,     ,     ]
     [    ,     ,     , +1  ]
     [    ,     , +1  ,     ]
     [    , +1  ,     ,     ]
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `CX 0 1`
     CNOT 0 1
     
     # (The decomposition is trivial because this gate is in the target gate set.)
-    ```
     
 
 <a name="CY"></a>
@@ -967,41 +809,33 @@ Targets:
 
 - Example:
 
-    ```
     CY 5 6
     CY 42 43
     CY 5 6 42 43
     CY rec[-1] 111
-    ```
     
 Stabilizer Generators:
 
-    ```
     X_ -> +XY
     Z_ -> +Z_
     _X -> +ZX
     _Z -> +ZZ
-    ```
     
-Unitary Matrix:
+Unitary Matrix (little endian):
 
-    ```
     [+1  ,     ,     ,     ]
     [    ,     ,     ,   -i]
     [    ,     , +1  ,     ]
     [    ,   +i,     ,     ]
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `CY 0 1`
     S 1
     S 1
     S 1
     CNOT 0 1
     S 1
-    ```
     
 
 <a name="CZ"></a>
@@ -1027,40 +861,32 @@ Targets:
 
 - Example:
 
-    ```
     CZ 5 6
     CZ 42 43
     CZ 5 6 42 43
     CZ rec[-1] 111
     CZ 111 rec[-1]
-    ```
     
 Stabilizer Generators:
 
-    ```
     X_ -> +XZ
     Z_ -> +Z_
     _X -> +ZX
     _Z -> +_Z
-    ```
     
-Unitary Matrix:
+Unitary Matrix (little endian):
 
-    ```
     [+1  ,     ,     ,     ]
     [    , +1  ,     ,     ]
     [    ,     , +1  ,     ]
     [    ,     ,     , -1  ]
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `CZ 0 1`
     H 1
     CNOT 0 1
     H 1
-    ```
     
 
 <a name="ISWAP"></a>
@@ -1079,39 +905,31 @@ Targets:
 
 - Example:
 
-    ```
     ISWAP 5 6
     ISWAP 42 43
     ISWAP 5 6 42 43
-    ```
     
 Stabilizer Generators:
 
-    ```
     X_ -> +ZY
     Z_ -> +_Z
     _X -> +YZ
     _Z -> +Z_
-    ```
     
-Unitary Matrix:
+Unitary Matrix (little endian):
 
-    ```
     [+1  ,     ,     ,     ]
     [    ,     ,   +i,     ]
     [    ,   +i,     ,     ]
     [    ,     ,     , +1  ]
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `ISWAP 0 1`
     CNOT 0 1
     S 1
     CNOT 1 0
     CNOT 0 1
-    ```
     
 
 <a name="ISWAP_DAG"></a>
@@ -1130,33 +948,26 @@ Targets:
 
 - Example:
 
-    ```
     ISWAP_DAG 5 6
     ISWAP_DAG 42 43
     ISWAP_DAG 5 6 42 43
-    ```
     
 Stabilizer Generators:
 
-    ```
     X_ -> -ZY
     Z_ -> +_Z
     _X -> -YZ
     _Z -> +Z_
-    ```
     
-Unitary Matrix:
+Unitary Matrix (little endian):
 
-    ```
     [+1  ,     ,     ,     ]
     [    ,     ,   -i,     ]
     [    ,   -i,     ,     ]
     [    ,     ,     , +1  ]
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `ISWAP_DAG 0 1`
     CNOT 0 1
     S 1
@@ -1164,7 +975,6 @@ Decomposition (into H, S, CX, M, R):
     S 1
     CNOT 1 0
     CNOT 0 1
-    ```
     
 
 <a name="SQRT_XX"></a>
@@ -1182,40 +992,32 @@ Targets:
 
 - Example:
 
-    ```
     SQRT_XX 5 6
     SQRT_XX 42 43
     SQRT_XX 5 6 42 43
-    ```
     
 Stabilizer Generators:
 
-    ```
     X_ -> +X_
     Z_ -> -YX
     _X -> +_X
     _Z -> -XY
-    ```
     
-Unitary Matrix:
+Unitary Matrix (little endian):
 
-    ```
     [+1+i,     ,     , +1-i]
     [    , +1+i, +1-i,     ]
     [    , +1-i, +1+i,     ]
     [+1-i,     ,     , +1+i] / 2
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `SQRT_XX 0 1`
     CNOT 0 1
     H 0
     S 0
     H 0
     CNOT 0 1
-    ```
     
 
 <a name="SQRT_XX_DAG"></a>
@@ -1233,40 +1035,32 @@ Targets:
 
 - Example:
 
-    ```
     SQRT_XX_DAG 5 6
     SQRT_XX_DAG 42 43
     SQRT_XX_DAG 5 6 42 43
-    ```
     
 Stabilizer Generators:
 
-    ```
     X_ -> +X_
     Z_ -> +YX
     _X -> +_X
     _Z -> +XY
-    ```
     
-Unitary Matrix:
+Unitary Matrix (little endian):
 
-    ```
     [+1-i,     ,     , +1+i]
     [    , +1-i, +1+i,     ]
     [    , +1+i, +1-i,     ]
     [+1+i,     ,     , +1-i] / 2
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `SQRT_XX_DAG 0 1`
     S 0
     CNOT 0 1
     H 0
     S 0
     CNOT 0 1
-    ```
     
 
 <a name="SQRT_YY"></a>
@@ -1284,33 +1078,26 @@ Targets:
 
 - Example:
 
-    ```
     SQRT_YY 5 6
     SQRT_YY 42 43
     SQRT_YY 5 6 42 43
-    ```
     
 Stabilizer Generators:
 
-    ```
     X_ -> -ZY
     Z_ -> +XY
     _X -> -YZ
     _Z -> +YX
-    ```
     
-Unitary Matrix:
+Unitary Matrix (little endian):
 
-    ```
     [+1+i,     ,     , -1+i]
     [    , +1+i, +1-i,     ]
     [    , +1-i, +1+i,     ]
     [-1+i,     ,     , +1+i] / 2
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `SQRT_YY 0 1`
     S 0
     CNOT 1 0
@@ -1319,7 +1106,6 @@ Decomposition (into H, S, CX, M, R):
     H 1
     CNOT 1 0
     S 0
-    ```
     
 
 <a name="SQRT_YY_DAG"></a>
@@ -1337,33 +1123,26 @@ Targets:
 
 - Example:
 
-    ```
     SQRT_YY_DAG 5 6
     SQRT_YY_DAG 42 43
     SQRT_YY_DAG 5 6 42 43
-    ```
     
 Stabilizer Generators:
 
-    ```
     X_ -> +ZY
     Z_ -> -XY
     _X -> +YZ
     _Z -> -YX
-    ```
     
-Unitary Matrix:
+Unitary Matrix (little endian):
 
-    ```
     [+1-i,     ,     , -1-i]
     [    , +1-i, +1+i,     ]
     [    , +1+i, +1-i,     ]
     [-1-i,     ,     , +1-i] / 2
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `SQRT_YY_DAG 0 1`
     CNOT 0 1
     S 1
@@ -1372,7 +1151,6 @@ Decomposition (into H, S, CX, M, R):
     H 0
     CNOT 1 0
     CNOT 0 1
-    ```
     
 
 <a name="SQRT_ZZ"></a>
@@ -1390,38 +1168,30 @@ Targets:
 
 - Example:
 
-    ```
     SQRT_ZZ 5 6
     SQRT_ZZ 42 43
     SQRT_ZZ 5 6 42 43
-    ```
     
 Stabilizer Generators:
 
-    ```
     X_ -> +YZ
     Z_ -> +Z_
     _X -> +ZY
     _Z -> +_Z
-    ```
     
-Unitary Matrix:
+Unitary Matrix (little endian):
 
-    ```
     [+1  ,     ,     ,     ]
     [    ,   +i,     ,     ]
     [    ,     ,   +i,     ]
     [    ,     ,     , +1  ]
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `SQRT_ZZ 0 1`
     CNOT 0 1
     S 1
     CNOT 0 1
-    ```
     
 
 <a name="SQRT_ZZ_DAG"></a>
@@ -1439,33 +1209,26 @@ Targets:
 
 - Example:
 
-    ```
     SQRT_ZZ_DAG 5 6
     SQRT_ZZ_DAG 42 43
     SQRT_ZZ_DAG 5 6 42 43
-    ```
     
 Stabilizer Generators:
 
-    ```
     X_ -> -YZ
     Z_ -> +Z_
     _X -> -ZY
     _Z -> +_Z
-    ```
     
-Unitary Matrix:
+Unitary Matrix (little endian):
 
-    ```
     [+1  ,     ,     ,     ]
     [    ,   -i,     ,     ]
     [    ,     ,   -i,     ]
     [    ,     ,     , +1  ]
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `SQRT_ZZ_DAG 0 1`
     H 1
     CNOT 0 1
@@ -1476,7 +1239,6 @@ Decomposition (into H, S, CX, M, R):
     S 1
     S 1
     S 1
-    ```
     
 
 <a name="SWAP"></a>
@@ -1494,38 +1256,30 @@ Targets:
 
 - Example:
 
-    ```
     SWAP 5 6
     SWAP 42 43
     SWAP 5 6 42 43
-    ```
     
 Stabilizer Generators:
 
-    ```
     X_ -> +_X
     Z_ -> +_Z
     _X -> +X_
     _Z -> +Z_
-    ```
     
-Unitary Matrix:
+Unitary Matrix (little endian):
 
-    ```
     [+1  ,     ,     ,     ]
     [    ,     , +1  ,     ]
     [    , +1  ,     ,     ]
     [    ,     ,     , +1  ]
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `SWAP 0 1`
     CNOT 0 1
     CNOT 1 0
     CNOT 0 1
-    ```
     
 
 <a name="XCX"></a>
@@ -1548,38 +1302,30 @@ Targets:
 
 - Example:
 
-    ```
     XCX 5 6
     XCX 42 43
     XCX 5 6 42 43
-    ```
     
 Stabilizer Generators:
 
-    ```
     X_ -> +X_
     Z_ -> +ZX
     _X -> +_X
     _Z -> +XZ
-    ```
     
-Unitary Matrix:
+Unitary Matrix (little endian):
 
-    ```
     [+1  , +1  , +1  , -1  ]
     [+1  , +1  , -1  , +1  ]
     [+1  , -1  , +1  , +1  ]
     [-1  , +1  , +1  , +1  ] / 2
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `XCX 0 1`
     H 0
     CNOT 0 1
     H 0
-    ```
     
 
 <a name="XCY"></a>
@@ -1602,40 +1348,32 @@ Targets:
 
 - Example:
 
-    ```
     XCY 5 6
     XCY 42 43
     XCY 5 6 42 43
-    ```
     
 Stabilizer Generators:
 
-    ```
     X_ -> +X_
     Z_ -> +ZY
     _X -> +XX
     _Z -> +XZ
-    ```
     
-Unitary Matrix:
+Unitary Matrix (little endian):
 
-    ```
     [+1  , +1  ,   -i,   +i]
     [+1  , +1  ,   +i,   -i]
     [  +i,   -i, +1  , +1  ]
     [  -i,   +i, +1  , +1  ] / 2
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `XCY 0 1`
     CNOT 1 0
     H 0
     S 0
     CNOT 0 1
     H 0
-    ```
     
 
 <a name="XCZ"></a>
@@ -1659,37 +1397,29 @@ Targets:
 
 - Example:
 
-    ```
     XCZ 5 6
     XCZ 42 43
     XCZ 5 6 42 43
     XCZ 111 rec[-1]
-    ```
     
 Stabilizer Generators:
 
-    ```
     X_ -> +X_
     Z_ -> +ZZ
     _X -> +XX
     _Z -> +_Z
-    ```
     
-Unitary Matrix:
+Unitary Matrix (little endian):
 
-    ```
     [+1  ,     ,     ,     ]
     [    , +1  ,     ,     ]
     [    ,     ,     , +1  ]
     [    ,     , +1  ,     ]
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `XCZ 0 1`
     CNOT 1 0
-    ```
     
 
 <a name="YCX"></a>
@@ -1712,40 +1442,32 @@ Targets:
 
 - Example:
 
-    ```
     YCX 5 6
     YCX 42 43
     YCX 5 6 42 43
-    ```
     
 Stabilizer Generators:
 
-    ```
     X_ -> +XX
     Z_ -> +ZX
     _X -> +_X
     _Z -> +YZ
-    ```
     
-Unitary Matrix:
+Unitary Matrix (little endian):
 
-    ```
     [+1  ,   -i, +1  ,   +i]
     [  +i, +1  ,   -i, +1  ]
     [+1  ,   +i, +1  ,   -i]
     [  -i, +1  ,   +i, +1  ] / 2
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `YCX 0 1`
     CX 0 1
     H 1
     S 1
     CX 1 0
     H 1
-    ```
     
 
 <a name="YCY"></a>
@@ -1768,33 +1490,26 @@ Targets:
 
 - Example:
 
-    ```
     YCY 5 6
     YCY 42 43
     YCY 5 6 42 43
-    ```
     
 Stabilizer Generators:
 
-    ```
     X_ -> +XY
     Z_ -> +ZY
     _X -> +YX
     _Z -> +YZ
-    ```
     
-Unitary Matrix:
+Unitary Matrix (little endian):
 
-    ```
     [+1  ,   -i,   -i, +1  ]
     [  +i, +1  , -1  ,   -i]
     [  +i, -1  , +1  ,   -i]
     [+1  ,   +i,   +i, +1  ] / 2
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `YCY 0 1`
     H 0
     S 0
@@ -1803,7 +1518,6 @@ Decomposition (into H, S, CX, M, R):
     H 0
     CX 1 0
     S 0
-    ```
     
 
 <a name="YCZ"></a>
@@ -1827,41 +1541,33 @@ Targets:
 
 - Example:
 
-    ```
     YCZ 5 6
     YCZ 42 43
     YCZ 5 6 42 43
     YCZ 111 rec[-1]
-    ```
     
 Stabilizer Generators:
 
-    ```
     X_ -> +XZ
     Z_ -> +ZZ
     _X -> +YX
     _Z -> +_Z
-    ```
     
-Unitary Matrix:
+Unitary Matrix (little endian):
 
-    ```
     [+1  ,     ,     ,     ]
     [    , +1  ,     ,     ]
     [    ,     ,     ,   -i]
     [    ,     ,   +i,     ]
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `YCZ 0 1`
     S 0
     S 0
     S 0
     CNOT 1 0
     S 0
-    ```
     
 
 ## Noise Channels
@@ -1892,11 +1598,9 @@ Pauli Mixture:
 
 - Example:
 
-    ```
     DEPOLARIZE1(0.001) 5
     DEPOLARIZE1(0.001) 42
     DEPOLARIZE1(0.001) 5 42
-    ```
     
 
 <a name="DEPOLARIZE2"></a>
@@ -1937,11 +1641,9 @@ Pauli Mixture:
 
 - Example:
 
-    ```
     DEPOLARIZE2(0.001) 5 6
     DEPOLARIZE2(0.001) 42 43
     DEPOLARIZE2(0.001) 5 6 42 43
-    ```
     
 
 <a name="E"></a>
@@ -2123,11 +1825,9 @@ Pauli Mixture:
 
 - Example:
 
-    ```
     X_ERROR(0.001) 5
     X_ERROR(0.001) 42
     X_ERROR(0.001) 5 42
-    ```
     
 
 <a name="Y_ERROR"></a>
@@ -2152,11 +1852,9 @@ Pauli Mixture:
 
 - Example:
 
-    ```
     Y_ERROR(0.001) 5
     Y_ERROR(0.001) 42
     Y_ERROR(0.001) 5 42
-    ```
     
 
 <a name="Z_ERROR"></a>
@@ -2181,11 +1879,9 @@ Pauli Mixture:
 
 - Example:
 
-    ```
     Z_ERROR(0.001) 5
     Z_ERROR(0.001) 42
     Z_ERROR(0.001) 5 42
-    ```
     
 
 ## Collapsing Gates
@@ -2195,45 +1891,60 @@ Pauli Mixture:
 
 Alternate name: <a name="MZ"></a>`MZ`
 
-Z-basis measurement (optionally noisy).
+Z-basis measurement.
 Projects each target qubit into `|0>` or `|1>` and reports its value (false=`|0>`, true=`|1>`).
 
 Parens Arguments:
 
-    Optional.
-    A single float specifying the probability of flipping each reported measurement result.
+    If no parens argument is given, the measurement is perfect.
+    If one parens argument is given, the measurement result is noisy.
+    The argument is the probability of returning the wrong result.
 
 Targets:
 
     The qubits to measure in the Z basis.
     Prefixing a qubit target with `!` flips its reported measurement result.
+
+Examples:
+
+    # Measure qubit 5 in the Z basis, and append the result into the measurement record.
+    M 5
+
+    # 'MZ' is the same as 'M'. This also measures qubit 5 in the Z basis.
+    MZ 5
+
+    # Measure qubit 5 in the Z basis, and append the INVERSE of its result into the measurement record.
+    MZ !5
+
+    # Do a noisy measurement where the result put into the measurement record is wrong 1% of the time.
+    MZ(0.01) 5
+
+    # Measure multiple qubits in the Z basis, putting 3 bits into the measurement record.
+    MZ 2 3 5
+
+    # Perform multiple noisy measurements. Each measurement fails independently with 2% probability.
+    MZ(0.02) 2 3 5
 If this gate is parameterized by a probability argument, the recorded result will be flipped with that probability. If not, the recorded result is noiseless. Note that the noise only affects the recorded result, not the target qubit's state.
 
 Prefixing a target with ! inverts its recorded measurement result.
 
 - Example:
 
-    ```
     M 5
     M !42
     M(0.001) 5 !42
-    ```
     
 Stabilizer Generators:
 
-    ```
     Z -> m xor chance(p)
     Z -> +Z
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `M 0`
     M 0
     
     # (The decomposition is trivial because this gate is in the target gate set.)
-    ```
     
 
 <a name="MPP"></a>
@@ -2253,9 +1964,8 @@ Targets:
     Each Pauli product is a series of Pauli targets (`[XYZ]#`) separated by combiners (`*`).
     Products can be negated by prefixing a Pauli target in the product with an inverter (`!`)
 
-- Example:
+Examples:
 
-    ```
     # Measure the two-body +X1*Y2 observable.
     MPP X1*Y2
 
@@ -2267,17 +1977,21 @@ Targets:
 
     # Noisily measure +Z1+Z2 and +X1*X2 (independently flip each reported result 0.1% of the time).
     MPP(0.001) Z1*Z2 X1*X2
-    ```
 
 If this gate is parameterized by a probability argument, the recorded result will be flipped with that probability. If not, the recorded result is noiseless. Note that the noise only affects the recorded result, not the target qubit's state.
 
 Prefixing a target with ! inverts its recorded measurement result.
+
+- Example:
+
+    MPP 5
+    MPP !42
+    MPP(0.001) 5 !42
+    
 Stabilizer Generators:
 
-    ```
     P -> m xor chance(p)
     P -> P
-    ```
     
 
 <a name="MR"></a>
@@ -2290,39 +2004,55 @@ Projects each target qubit into `|0>` or `|1>`, reports its value (false=`|0>`, 
 
 Parens Arguments:
 
-    Optional.
-    A single float specifying the probability of flipping each reported measurement result.
+    If no parens argument is given, the demolition measurement is perfect.
+    If one parens argument is given, the demolition measurement's result is noisy.
+    The argument is the probability of returning the wrong result.
+    The argument does not affect the fidelity of the reset.
 
 Targets:
 
     The qubits to measure and reset in the Z basis.
     Prefixing a qubit target with `!` flips its reported measurement result.
+
+Examples:
+
+    # Measure qubit 5 in the Z basis, reset it to the |0> state, append the measurement result into the measurement record.
+    MRZ 5
+
+    # MR is also a Z-basis demolition measurement.
+    MR 5
+
+    # Demolition measure qubit 5 in the Z basis, but append the INVERSE of its result into the measurement record.
+    MRZ !5
+
+    # Do a noisy demolition measurement where the result put into the measurement record is wrong 1% of the time.
+    MRZ(0.01) 5
+
+    # Demolition measure multiple qubits in the Z basis, putting 3 bits into the measurement record.
+    MRZ 2 3 5
+
+    # Perform multiple noisy demolition measurements. Each measurement result is flipped independently with 2% probability.
+    MRZ(0.02) 2 3 5
 If this gate is parameterized by a probability argument, the recorded result will be flipped with that probability. If not, the recorded result is noiseless. Note that the noise only affects the recorded result, not the target qubit's state.
 
 Prefixing a target with ! inverts its recorded measurement result.
 
 - Example:
 
-    ```
     MR 5
     MR !42
     MR(0.001) 5 !42
-    ```
     
 Stabilizer Generators:
 
-    ```
     Z -> m xor chance(p)
     1 -> +Z
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `MR 0`
     M 0
     R 0
-    ```
     
 
 <a name="MRX"></a>
@@ -2333,41 +2063,54 @@ Projects each target qubit into `|+>` or `|->`, reports its value (false=`|+>`, 
 
 Parens Arguments:
 
-    Optional.
-    A single float specifying the probability of flipping each reported measurement result.
+    If no parens argument is given, the demolition measurement is perfect.
+    If one parens argument is given, the demolition measurement's result is noisy.
+    The argument is the probability of returning the wrong result.
+    The argument does not affect the fidelity of the reset.
 
 Targets:
 
     The qubits to measure and reset in the X basis.
     Prefixing a qubit target with `!` flips its reported measurement result.
+
+Examples:
+
+    # Measure qubit 5 in the X basis, reset it to the |+> state, append the measurement result into the measurement record.
+    MRX 5
+
+    # Demolition measure qubit 5 in the X basis, but append the INVERSE of its result into the measurement record.
+    MRX !5
+
+    # Do a noisy demolition measurement where the result put into the measurement record is wrong 1% of the time.
+    MRX(0.01) 5
+
+    # Demolition measure multiple qubits in the X basis, putting 3 bits into the measurement record.
+    MRX 2 3 5
+
+    # Perform multiple noisy demolition measurements. Each measurement result is flipped independently with 2% probability.
+    MRX(0.02) 2 3 5
 If this gate is parameterized by a probability argument, the recorded result will be flipped with that probability. If not, the recorded result is noiseless. Note that the noise only affects the recorded result, not the target qubit's state.
 
 Prefixing a target with ! inverts its recorded measurement result.
 
 - Example:
 
-    ```
     MRX 5
     MRX !42
     MRX(0.001) 5 !42
-    ```
     
 Stabilizer Generators:
 
-    ```
     X -> m xor chance(p)
     1 -> +X
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `MRX 0`
     H 0
     M 0
     R 0
     H 0
-    ```
     
 
 <a name="MRY"></a>
@@ -2378,35 +2121,49 @@ Projects each target qubit into `|i>` or `|-i>`, reports its value (false=`|i>`,
 
 Parens Arguments:
 
-    Optional.
-    A single float specifying the probability of flipping each reported measurement result.
+    If no parens argument is given, the demolition measurement is perfect.
+    If one parens argument is given, the demolition measurement's result is noisy.
+    The argument is the probability of returning the wrong result.
+    The argument does not affect the fidelity of the reset.
 
 Targets:
 
     The qubits to measure and reset in the Y basis.
     Prefixing a qubit target with `!` flips its reported measurement result.
+
+Examples:
+
+    # Measure qubit 5 in the Y basis, reset it to the |i> state, append the measurement result into the measurement record.
+    MRY 5
+
+    # Demolition measure qubit 5 in the Y basis, but append the INVERSE of its result into the measurement record.
+    MRY !5
+
+    # Do a noisy demolition measurement where the result put into the measurement record is wrong 1% of the time.
+    MRY(0.01) 5
+
+    # Demolition measure multiple qubits in the Y basis, putting 3 bits into the measurement record.
+    MRY 2 3 5
+
+    # Perform multiple noisy demolition measurements. Each measurement result is flipped independently with 2% probability.
+    MRY(0.02) 2 3 5
 If this gate is parameterized by a probability argument, the recorded result will be flipped with that probability. If not, the recorded result is noiseless. Note that the noise only affects the recorded result, not the target qubit's state.
 
 Prefixing a target with ! inverts its recorded measurement result.
 
 - Example:
 
-    ```
     MRY 5
     MRY !42
     MRY(0.001) 5 !42
-    ```
     
 Stabilizer Generators:
 
-    ```
     Y -> m xor chance(p)
     1 -> +Y
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `MRY 0`
     S 0
     S 0
@@ -2416,90 +2173,114 @@ Decomposition (into H, S, CX, M, R):
     M 0
     H 0
     S 0
-    ```
     
 
 <a name="MX"></a>
 ### The 'MX' Instruction
 
-X-basis measurement (optionally noisy).
+X-basis measurement.
 Projects each target qubit into `|+>` or `|->` and reports its value (false=`|+>`, true=`|->`).
 
 Parens Arguments:
 
-    Optional.
-    A single float specifying A single float specifying the probability of flipping each reported measurement result.
+    If no parens argument is given, the measurement is perfect.
+    If one parens argument is given, the measurement result is noisy.
+    The argument is the probability of returning the wrong result.
 
 Targets:
 
     The qubits to measure in the X basis.
     Prefixing a qubit target with `!` flips its reported measurement result.
+
+Examples:
+
+    # Measure qubit 5 in the X basis, and append the result into the measurement record.
+    MX 5
+
+    # Measure qubit 5 in the X basis, and append the INVERSE of its result into the measurement record.
+    MX !5
+
+    # Do a noisy measurement where the result put into the measurement record is wrong 1% of the time.
+    MX(0.01) 5
+
+    # Measure multiple qubits in the X basis, putting 3 bits into the measurement record.
+    MX 2 3 5
+
+    # Perform multiple noisy measurements. Each measurement fails independently with 2% probability.
+    MX(0.02) 2 3 5
 If this gate is parameterized by a probability argument, the recorded result will be flipped with that probability. If not, the recorded result is noiseless. Note that the noise only affects the recorded result, not the target qubit's state.
 
 Prefixing a target with ! inverts its recorded measurement result.
 
 - Example:
 
-    ```
     MX 5
     MX !42
     MX(0.001) 5 !42
-    ```
     
 Stabilizer Generators:
 
-    ```
     X -> +m xor chance(p)
     X -> +X
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `MX 0`
     H 0
     M 0
     H 0
-    ```
     
 
 <a name="MY"></a>
 ### The 'MY' Instruction
 
-Y-basis measurement (optionally noisy).
+Y-basis measurement.
 Projects each target qubit into `|i>` or `|-i>` and reports its value (false=`|i>`, true=`|-i>`).
 
 Parens Arguments:
 
-    Optional.
-    A single float specifying the probability of flipping each reported measurement result.
+    If no parens argument is given, the measurement is perfect.
+    If one parens argument is given, the measurement result is noisy.
+    The argument is the probability of returning the wrong result.
 
 Targets:
 
     The qubits to measure in the Y basis.
     Prefixing a qubit target with `!` flips its reported measurement result.
+
+Examples:
+
+    # Measure qubit 5 in the Y basis, and append the result into the measurement record.
+    MY 5
+
+    # Measure qubit 5 in the Y basis, and append the INVERSE of its result into the measurement record.
+    MY !5
+
+    # Do a noisy measurement where the result put into the measurement record is wrong 1% of the time.
+    MY(0.01) 5
+
+    # Measure multiple qubits in the X basis, putting 3 bits into the measurement record.
+    MY 2 3 5
+
+    # Perform multiple noisy measurements. Each measurement fails independently with 2% probability.
+    MY(0.02) 2 3 5
 If this gate is parameterized by a probability argument, the recorded result will be flipped with that probability. If not, the recorded result is noiseless. Note that the noise only affects the recorded result, not the target qubit's state.
 
 Prefixing a target with ! inverts its recorded measurement result.
 
 - Example:
 
-    ```
     MY 5
     MY !42
     MY(0.001) 5 !42
-    ```
     
 Stabilizer Generators:
 
-    ```
     Y -> m xor chance(p)
     Y -> +Y
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `MY 0`
     S 0
     S 0
@@ -2508,7 +2289,6 @@ Decomposition (into H, S, CX, M, R):
     M 0
     H 0
     S 0
-    ```
     
 
 <a name="R"></a>
@@ -2527,28 +2307,33 @@ Targets:
 
     The qubits to reset in the Z basis.
 
+Examples:
+
+    # Reset qubit 5 into the |0> state.
+    RZ 5
+
+    # R means the same thing as RZ.
+    R 5
+
+    # Reset multiple qubits into the |0> state.
+    RZ 2 3 5
+
 - Example:
 
-    ```
     R 5
     R 42
     R 5 42
-    ```
     
 Stabilizer Generators:
 
-    ```
     1 -> +Z
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `R 0`
     R 0
     
     # (The decomposition is trivial because this gate is in the target gate set.)
-    ```
     
 
 <a name="RX"></a>
@@ -2565,28 +2350,30 @@ Targets:
 
     The qubits to reset in the X basis.
 
+Examples:
+
+    # Reset qubit 5 into the |+> state.
+    RX 5
+
+    # Result multiple qubits into the |+> state.
+    RX 2 3 5
+
 - Example:
 
-    ```
     RX 5
     RX 42
     RX 5 42
-    ```
     
 Stabilizer Generators:
 
-    ```
     1 -> +X
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `RX 0`
     H 0
     R 0
     H 0
-    ```
     
 
 <a name="RY"></a>
@@ -2603,23 +2390,26 @@ Targets:
 
     The qubits to reset in the Y basis.
 
+Examples:
+
+    # Reset qubit 5 into the |i> state.
+    RY 5
+
+    # Result multiple qubits into the |i> state.
+    RY 2 3 5
+
 - Example:
 
-    ```
     RY 5
     RY 42
     RY 5 42
-    ```
     
 Stabilizer Generators:
 
-    ```
     1 -> +Y
-    ```
     
 Decomposition (into H, S, CX, M, R):
 
-    ```
     # The following circuit is equivalent (up to global phase) to `RY 0`
     S 0
     S 0
@@ -2628,7 +2418,6 @@ Decomposition (into H, S, CX, M, R):
     R 0
     H 0
     S 0
-    ```
     
 
 ## Control Flow

--- a/doc/gates.md
+++ b/doc/gates.md
@@ -93,7 +93,7 @@ Targets:
 
     Qubits to do nothing to.
 
-- Example:
+Example:
 
     I 5
     I 42
@@ -134,7 +134,7 @@ Targets:
 
     Qubits to operate on.
 
-- Example:
+Example:
 
     X 5
     X 42
@@ -177,7 +177,7 @@ Targets:
 
     Qubits to operate on.
 
-- Example:
+Example:
 
     Y 5
     Y 42
@@ -223,7 +223,7 @@ Targets:
 
     Qubits to operate on.
 
-- Example:
+Example:
 
     Z 5
     Z 42
@@ -266,7 +266,7 @@ Targets:
 
     Qubits to operate on.
 
-- Example:
+Example:
 
     C_XYZ 5
     C_XYZ 42
@@ -309,7 +309,7 @@ Targets:
 
     Qubits to operate on.
 
-- Example:
+Example:
 
     C_ZYX 5
     C_ZYX 42
@@ -353,7 +353,7 @@ Targets:
 
     Qubits to operate on.
 
-- Example:
+Example:
 
     H 5
     H 42
@@ -395,7 +395,7 @@ Targets:
 
     Qubits to operate on.
 
-- Example:
+Example:
 
     H_XY 5
     H_XY 42
@@ -439,7 +439,7 @@ Targets:
 
     Qubits to operate on.
 
-- Example:
+Example:
 
     H_YZ 5
     H_YZ 42
@@ -486,7 +486,7 @@ Targets:
 
     Qubits to operate on.
 
-- Example:
+Example:
 
     S 5
     S 42
@@ -529,7 +529,7 @@ Targets:
 
     Qubits to operate on.
 
-- Example:
+Example:
 
     SQRT_X 5
     SQRT_X 42
@@ -572,7 +572,7 @@ Targets:
 
     Qubits to operate on.
 
-- Example:
+Example:
 
     SQRT_X_DAG 5
     SQRT_X_DAG 42
@@ -615,7 +615,7 @@ Targets:
 
     Qubits to operate on.
 
-- Example:
+Example:
 
     SQRT_Y 5
     SQRT_Y 42
@@ -658,7 +658,7 @@ Targets:
 
     Qubits to operate on.
 
-- Example:
+Example:
 
     SQRT_Y_DAG 5
     SQRT_Y_DAG 42
@@ -703,7 +703,7 @@ Targets:
 
     Qubits to operate on.
 
-- Example:
+Example:
 
     S_DAG 5
     S_DAG 42
@@ -757,7 +757,7 @@ Targets:
 
     Qubit pairs to operate on.
 
-- Example:
+Example:
 
     CX 5 6
     CX 42 43
@@ -807,7 +807,7 @@ Targets:
 
     Qubit pairs to operate on.
 
-- Example:
+Example:
 
     CY 5 6
     CY 42 43
@@ -859,7 +859,7 @@ Targets:
 
     Qubit pairs to operate on.
 
-- Example:
+Example:
 
     CZ 5 6
     CZ 42 43
@@ -903,7 +903,7 @@ Targets:
 
     Qubit pairs to operate on.
 
-- Example:
+Example:
 
     ISWAP 5 6
     ISWAP 42 43
@@ -946,7 +946,7 @@ Targets:
 
     Qubit pairs to operate on.
 
-- Example:
+Example:
 
     ISWAP_DAG 5 6
     ISWAP_DAG 42 43
@@ -990,7 +990,7 @@ Targets:
 
     Qubit pairs to operate on.
 
-- Example:
+Example:
 
     SQRT_XX 5 6
     SQRT_XX 42 43
@@ -1033,7 +1033,7 @@ Targets:
 
     Qubit pairs to operate on.
 
-- Example:
+Example:
 
     SQRT_XX_DAG 5 6
     SQRT_XX_DAG 42 43
@@ -1076,7 +1076,7 @@ Targets:
 
     Qubit pairs to operate on.
 
-- Example:
+Example:
 
     SQRT_YY 5 6
     SQRT_YY 42 43
@@ -1121,7 +1121,7 @@ Targets:
 
     Qubit pairs to operate on.
 
-- Example:
+Example:
 
     SQRT_YY_DAG 5 6
     SQRT_YY_DAG 42 43
@@ -1166,7 +1166,7 @@ Targets:
 
     Qubit pairs to operate on.
 
-- Example:
+Example:
 
     SQRT_ZZ 5 6
     SQRT_ZZ 42 43
@@ -1207,7 +1207,7 @@ Targets:
 
     Qubit pairs to operate on.
 
-- Example:
+Example:
 
     SQRT_ZZ_DAG 5 6
     SQRT_ZZ_DAG 42 43
@@ -1254,7 +1254,7 @@ Targets:
 
     Qubit pairs to operate on.
 
-- Example:
+Example:
 
     SWAP 5 6
     SWAP 42 43
@@ -1300,7 +1300,7 @@ Targets:
 
     Qubit pairs to operate on.
 
-- Example:
+Example:
 
     XCX 5 6
     XCX 42 43
@@ -1346,7 +1346,7 @@ Targets:
 
     Qubit pairs to operate on.
 
-- Example:
+Example:
 
     XCY 5 6
     XCY 42 43
@@ -1395,7 +1395,7 @@ Targets:
 
     Qubit pairs to operate on.
 
-- Example:
+Example:
 
     XCZ 5 6
     XCZ 42 43
@@ -1440,7 +1440,7 @@ Targets:
 
     Qubit pairs to operate on.
 
-- Example:
+Example:
 
     YCX 5 6
     YCX 42 43
@@ -1488,7 +1488,7 @@ Targets:
 
     Qubit pairs to operate on.
 
-- Example:
+Example:
 
     YCY 5 6
     YCY 42 43
@@ -1539,7 +1539,7 @@ Targets:
 
     Qubit pairs to operate on.
 
-- Example:
+Example:
 
     YCZ 5 6
     YCZ 42 43
@@ -1589,14 +1589,12 @@ Targets:
 
 Pauli Mixture:
 
-    ```
     1-p: I
     p/3: X
     p/3: Y
     p/3: Z
-    ```
 
-- Example:
+Example:
 
     DEPOLARIZE1(0.001) 5
     DEPOLARIZE1(0.001) 42
@@ -1620,7 +1618,6 @@ Targets:
 
 Pauli Mixture:
 
-    ```
      1-p: II
     p/15: IX
     p/15: IY
@@ -1637,9 +1634,8 @@ Pauli Mixture:
     p/15: ZX
     p/15: ZY
     p/15: ZZ
-    ```
 
-- Example:
+Example:
 
     DEPOLARIZE2(0.001) 5 6
     DEPOLARIZE2(0.001) 42 43
@@ -1669,12 +1665,10 @@ Targets:
 
 - Example:
 
-    ```
     # With 60% probability, uniformly pick X1*Y2 or Z2*Z3 or X1*Y2*Z3.
     CORRELATED_ERROR(0.2) X1 Y2
     ELSE_CORRELATED_ERROR(0.25) Z2 Z3
     ELSE_CORRELATED_ERROR(0.33333333333) X1 Y2 Z3
-    ```
 
 <a name="ELSE_CORRELATED_ERROR"></a>
 ### The 'ELSE_CORRELATED_ERROR' Instruction
@@ -1700,14 +1694,12 @@ Targets:
     Note that, for backwards compatibility reasons, the targets are not combined using combiners (`*`).
     They are implicitly all combined.
 
-- Example:
+Example:
 
-    ```
     # With 60% probability, uniformly pick X1*Y2 or Z2*Z3 or X1*Y2*Z3.
     CORRELATED_ERROR(0.2) X1 Y2
     ELSE_CORRELATED_ERROR(0.25) Z2 Z3
     ELSE_CORRELATED_ERROR(0.33333333333) X1 Y2 Z3
-    ```
 
 <a name="PAULI_CHANNEL_1"></a>
 ### The 'PAULI_CHANNEL_1' Instruction
@@ -1725,22 +1717,18 @@ Targets:
 
     Qubits to apply the custom noise channel to.
 
-- Example:
+Example:
 
-    ```
     # Sample errors from the distribution 10% X, 15% Y, 20% Z, 55% I.
     # Apply independently to qubits 1, 2, 4.
     PAULI_CHANNEL_1(0.1, 0.15, 0.2) 1 2 4
-    ```
 
 Pauli Mixture:
 
-    ```
     1-px-py-pz: I
     px: X
     py: Y
     pz: Z
-    ```
 
 <a name="PAULI_CHANNEL_2"></a>
 ### The 'PAULI_CHANNEL_2' Instruction
@@ -1774,17 +1762,14 @@ Targets:
     Pairs of qubits to apply the custom noise channel to.
     There must be an even number of targets.
 
-- Example:
+Example:
 
-    ```
     # Sample errors from the distribution 10% XX, 20% YZ, 70% II.
     # Apply independently to qubit pairs (1,2), (5,6), and (8,3)
     PAULI_CHANNEL_2(0,0,0, 0.1,0,0,0, 0,0,0,0.2, 0,0,0,0) 1 2 5 6 8 3
-    ```
 
 Pauli Mixture:
 
-    ```
     1-pix-piy-piz-pxi-pxx-pxy-pxz-pyi-pyx-pyy-pyz-pzi-pzx-pzy-pzz: II
     pix: IX
     piy: IY
@@ -1801,7 +1786,6 @@ Pauli Mixture:
     pzx: ZX
     pzy: ZY
     pzz: ZZ
-    ```
 
 <a name="X_ERROR"></a>
 ### The 'X_ERROR' Instruction
@@ -1818,12 +1802,10 @@ Targets:
 
 Pauli Mixture:
 
-    ```
     1-p: I
      p : X
-    ```
 
-- Example:
+Example:
 
     X_ERROR(0.001) 5
     X_ERROR(0.001) 42
@@ -1845,12 +1827,10 @@ Targets:
 
 Pauli Mixture:
 
-    ```
     1-p: I
      p : Y
-    ```
 
-- Example:
+Example:
 
     Y_ERROR(0.001) 5
     Y_ERROR(0.001) 42
@@ -1872,12 +1852,10 @@ Targets:
 
 Pauli Mixture:
 
-    ```
     1-p: I
      p : Z
-    ```
 
-- Example:
+Example:
 
     Z_ERROR(0.001) 5
     Z_ERROR(0.001) 42
@@ -1928,7 +1906,7 @@ If this gate is parameterized by a probability argument, the recorded result wil
 
 Prefixing a target with ! inverts its recorded measurement result.
 
-- Example:
+Example:
 
     M 5
     M !42
@@ -1982,7 +1960,7 @@ If this gate is parameterized by a probability argument, the recorded result wil
 
 Prefixing a target with ! inverts its recorded measurement result.
 
-- Example:
+Example:
 
     MPP 5
     MPP !42
@@ -2037,7 +2015,7 @@ If this gate is parameterized by a probability argument, the recorded result wil
 
 Prefixing a target with ! inverts its recorded measurement result.
 
-- Example:
+Example:
 
     MR 5
     MR !42
@@ -2093,7 +2071,7 @@ If this gate is parameterized by a probability argument, the recorded result wil
 
 Prefixing a target with ! inverts its recorded measurement result.
 
-- Example:
+Example:
 
     MRX 5
     MRX !42
@@ -2151,7 +2129,7 @@ If this gate is parameterized by a probability argument, the recorded result wil
 
 Prefixing a target with ! inverts its recorded measurement result.
 
-- Example:
+Example:
 
     MRY 5
     MRY !42
@@ -2212,7 +2190,7 @@ If this gate is parameterized by a probability argument, the recorded result wil
 
 Prefixing a target with ! inverts its recorded measurement result.
 
-- Example:
+Example:
 
     MX 5
     MX !42
@@ -2268,7 +2246,7 @@ If this gate is parameterized by a probability argument, the recorded result wil
 
 Prefixing a target with ! inverts its recorded measurement result.
 
-- Example:
+Example:
 
     MY 5
     MY !42
@@ -2318,7 +2296,7 @@ Examples:
     # Reset multiple qubits into the |0> state.
     RZ 2 3 5
 
-- Example:
+Example:
 
     R 5
     R 42
@@ -2358,7 +2336,7 @@ Examples:
     # Result multiple qubits into the |+> state.
     RX 2 3 5
 
-- Example:
+Example:
 
     RX 5
     RX 42
@@ -2398,7 +2376,7 @@ Examples:
     # Result multiple qubits into the |i> state.
     RY 2 3 5
 
-- Example:
+Example:
 
     RY 5
     RY 42
@@ -2439,9 +2417,8 @@ Targets:
 
     A positive integer in [1, 10^18] specifying the number of repetitions.
 
-- Example:
+Example:
 
-    ```
     REPEAT 2 {
         CNOT 0 1
         CNOT 2 1
@@ -2453,7 +2430,6 @@ Targets:
         M 1
         DETECTOR rec[-1] rec[-3]
     }
-    ```
 
 ## Annotations
 
@@ -2498,9 +2474,8 @@ Targets:
 
     The measurement records to XOR together to get the deterministic-under-noiseless-execution parity.
 
-- Example:
+Example:
 
-    ```
     R 0
     X_ERROR(0.1) 0
     M 0  # This measurement is always False under noiseless execution.
@@ -2529,7 +2504,6 @@ Targets:
         SHIFT_COORDS(1, 2)
         DETECTOR(0, 3) rec[-1]
     }
-    ```
 
 <a name="OBSERVABLE_INCLUDE"></a>
 ### The 'OBSERVABLE_INCLUDE' Instruction
@@ -2571,9 +2545,8 @@ Targets:
 
     The measurement records to add to the specified observable.
 
-- Example:
+Example:
 
-    ```
     R 0 1
     H 0
     CNOT 0 1
@@ -2589,7 +2562,6 @@ Targets:
     OBSERVABLE_INCLUDE(1) rec[-1]
     # ...and the one before that.
     OBSERVABLE_INCLUDE(1) rec[-2]
-    ```
 
 <a name="QUBIT_COORDS"></a>
 ### The 'QUBIT_COORDS' Instruction
@@ -2616,15 +2588,13 @@ Targets:
 
     The qubit or qubits the coordinates apply to.
 
-- Example:
+Example:
 
-    ```
     # Annotate that qubits 0 to 3 are at the corners of a square.
     QUBIT_COORDS(0, 0) 0
     QUBIT_COORDS(0, 1) 1
     QUBIT_COORDS(1, 0) 2
     QUBIT_COORDS(1, 1) 3
-    ```
 
 <a name="SHIFT_COORDS"></a>
 ### The 'SHIFT_COORDS' Instruction
@@ -2646,9 +2616,8 @@ Targets:
 
     This instruction takes no targets.
 
-- Example:
+Example:
 
-    ```
     SHIFT_COORDS(500.5)
     QUBIT_COORDS(1510) 0  # Actually at 2010.5
     SHIFT_COORDS(1500)
@@ -2663,7 +2632,6 @@ Targets:
         DETECTOR(10.5, 0) rec[-1] rec[-2]  # Actually at (2011.0, iteration_count).
         SHIFT_COORDS(0, 1)  # Advance 2nd coordinate to track loop iterations.
     }
-    ```
 
 <a name="TICK"></a>
 ### The 'TICK' Instruction
@@ -2685,9 +2653,8 @@ Targets:
 
     This instruction takes no targets.
 
-- Example:
+Example:
 
-    ```
     # First time step.
     H 0
     CZ 1 2
@@ -2699,5 +2666,4 @@ Targets:
 
     # Empty time step.
     TICK
-    ```
 

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -355,7 +355,10 @@ class Circuit:
 # stim.Circuit.__add__
 
 # (in class stim.Circuit)
-def __add__(self, second: stim.Circuit) -> stim.Circuit:
+def __add__(
+    self,
+    second: stim.Circuit,
+) -> stim.Circuit:
     """Creates a circuit by appending two circuits.
 
     Examples:
@@ -381,7 +384,10 @@ def __add__(self, second: stim.Circuit) -> stim.Circuit:
 # stim.Circuit.__eq__
 
 # (in class stim.Circuit)
-def __eq__(self, arg0: stim.Circuit) -> bool:
+def __eq__(
+    self,
+    arg0: stim.Circuit,
+) -> bool:
     """Determines if two circuits have identical contents.
     """
 ```
@@ -392,12 +398,21 @@ def __eq__(self, arg0: stim.Circuit) -> bool:
 
 # (in class stim.Circuit)
 @overload
-def __getitem__(self, index_or_slice: int) -> Union[stim.CircuitInstruction, stim.CircuitRepeatBlock]:
+def __getitem__(
+    self,
+    index_or_slice: int,
+) -> Union[stim.CircuitInstruction, stim.CircuitRepeatBlock]:
     pass
 @overload
-def __getitem__(self, index_or_slice: slice) -> stim.Circuit:
+def __getitem__(
+    self,
+    index_or_slice: slice,
+) -> stim.Circuit:
     pass
-def __getitem__(self, index_or_slice: object) -> object:
+def __getitem__(
+    self,
+    index_or_slice: object,
+) -> object:
     """Returns copies of instructions from the circuit.
 
     Args:
@@ -442,7 +457,10 @@ def __getitem__(self, index_or_slice: object) -> object:
 # stim.Circuit.__iadd__
 
 # (in class stim.Circuit)
-def __iadd__(self, second: stim.Circuit) -> stim.Circuit:
+def __iadd__(
+    self,
+    second: stim.Circuit,
+) -> stim.Circuit:
     """Appends a circuit into the receiving circuit (mutating it).
 
     Examples:
@@ -469,7 +487,10 @@ def __iadd__(self, second: stim.Circuit) -> stim.Circuit:
 # stim.Circuit.__imul__
 
 # (in class stim.Circuit)
-def __imul__(self, repetitions: int) -> stim.Circuit:
+def __imul__(
+    self,
+    repetitions: int,
+) -> stim.Circuit:
     """Mutates the circuit by putting its contents into a REPEAT block.
 
     Special case: if the repetition count is 0, the circuit is cleared.
@@ -500,7 +521,10 @@ def __imul__(self, repetitions: int) -> stim.Circuit:
 # stim.Circuit.__init__
 
 # (in class stim.Circuit)
-def __init__(self, stim_program_text: str = '') -> None:
+def __init__(
+    self,
+    stim_program_text: str = '',
+) -> None:
     """Creates a stim.Circuit.
 
     Args:
@@ -522,7 +546,9 @@ def __init__(self, stim_program_text: str = '') -> None:
 # stim.Circuit.__len__
 
 # (in class stim.Circuit)
-def __len__(self) -> int:
+def __len__(
+    self,
+) -> int:
     """Returns the number of top-level instructions and blocks in the circuit.
 
     Instructions inside of blocks are not included in this count.
@@ -554,7 +580,10 @@ def __len__(self) -> int:
 # stim.Circuit.__mul__
 
 # (in class stim.Circuit)
-def __mul__(self, repetitions: int) -> stim.Circuit:
+def __mul__(
+    self,
+    repetitions: int,
+) -> stim.Circuit:
     """Returns a circuit with a REPEAT block containing the current circuit's instructions.
 
     Special case: if the repetition count is 0, an empty circuit is returned.
@@ -584,7 +613,10 @@ def __mul__(self, repetitions: int) -> stim.Circuit:
 # stim.Circuit.__ne__
 
 # (in class stim.Circuit)
-def __ne__(self, arg0: stim.Circuit) -> bool:
+def __ne__(
+    self,
+    arg0: stim.Circuit,
+) -> bool:
     """Determines if two circuits have non-identical contents.
     """
 ```
@@ -594,7 +626,9 @@ def __ne__(self, arg0: stim.Circuit) -> bool:
 # stim.Circuit.__repr__
 
 # (in class stim.Circuit)
-def __repr__(self) -> str:
+def __repr__(
+    self,
+) -> str:
     """Returns text that is a valid python expression evaluating to an equivalent `stim.Circuit`.
     """
 ```
@@ -604,7 +638,10 @@ def __repr__(self) -> str:
 # stim.Circuit.__rmul__
 
 # (in class stim.Circuit)
-def __rmul__(self, repetitions: int) -> stim.Circuit:
+def __rmul__(
+    self,
+    repetitions: int,
+) -> stim.Circuit:
     """Returns a circuit with a REPEAT block containing the current circuit's instructions.
 
     Special case: if the repetition count is 0, an empty circuit is returned.
@@ -634,7 +671,9 @@ def __rmul__(self, repetitions: int) -> stim.Circuit:
 # stim.Circuit.__str__
 
 # (in class stim.Circuit)
-def __str__(self) -> str:
+def __str__(
+    self,
+) -> str:
     """Returns stim instructions (that can be saved to a file and parsed by stim) for the current circuit.
     """
 ```
@@ -645,12 +684,25 @@ def __str__(self) -> str:
 
 # (in class stim.Circuit)
 @overload
-def append(self, name: str, targets: Union[int, stim.GateTarget, Iterable[Union[int, stim.GateTarget]]], arg: Union[float, Iterable[float]]) -> None:
+def append(
+    self,
+    name: str,
+    targets: Union[int, stim.GateTarget, Iterable[Union[int, stim.GateTarget]]],
+    arg: Union[float, Iterable[float]],
+) -> None:
     pass
 @overload
-def append(self, name: Union[stim.CircuitOperation, stim.CircuitRepeatBlock]) -> None:
+def append(
+    self,
+    name: Union[stim.CircuitOperation, stim.CircuitRepeatBlock],
+) -> None:
     pass
-def append(self, name: object, targets: object = (), arg: object = None) -> None:
+def append(
+    self,
+    name: object,
+    targets: object = (),
+    arg: object = None,
+) -> None:
     """Appends an operation into the circuit.
 
     Note: `stim.Circuit.append_operation` is an alias of `stim.Circuit.append`.
@@ -702,7 +754,10 @@ def append(self, name: object, targets: object = (), arg: object = None) -> None
 # stim.Circuit.append_from_stim_program_text
 
 # (in class stim.Circuit)
-def append_from_stim_program_text(self, stim_program_text: str) -> None:
+def append_from_stim_program_text(
+    self,
+    stim_program_text: str,
+) -> None:
     """Appends operations described by a STIM format program into the circuit.
 
     Examples:
@@ -731,7 +786,12 @@ def append_from_stim_program_text(self, stim_program_text: str) -> None:
 # stim.Circuit.append_operation
 
 # (in class stim.Circuit)
-def append_operation(self, name: object, targets: object = (), arg: object = None) -> None:
+def append_operation(
+    self,
+    name: object,
+    targets: object = (),
+    arg: object = None,
+) -> None:
     """[DEPRECATED] use stim.Circuit.append instead
     """
 ```
@@ -741,7 +801,12 @@ def append_operation(self, name: object, targets: object = (), arg: object = Non
 # stim.Circuit.approx_equals
 
 # (in class stim.Circuit)
-def approx_equals(self, other: object, *, atol: float) -> bool:
+def approx_equals(
+    self,
+    other: object,
+    *,
+    atol: float,
+) -> bool:
     """Checks if a circuit is approximately equal to another circuit.
 
     Two circuits are approximately equal if they are equal up to slight perturbations of instruction arguments
@@ -798,7 +863,9 @@ def approx_equals(self, other: object, *, atol: float) -> bool:
 # stim.Circuit.clear
 
 # (in class stim.Circuit)
-def clear(self) -> None:
+def clear(
+    self,
+) -> None:
     """Clears the contents of the circuit.
 
     Examples:
@@ -818,7 +885,11 @@ def clear(self) -> None:
 # stim.Circuit.compile_detector_sampler
 
 # (in class stim.Circuit)
-def compile_detector_sampler(self, *, seed: object = None) -> stim.CompiledDetectorSampler:
+def compile_detector_sampler(
+    self,
+    *,
+    seed: object = None,
+) -> stim.CompiledDetectorSampler:
     """Returns a CompiledDetectorSampler, which can quickly batch sample detection events, for the circuit.
 
     Args:
@@ -861,7 +932,11 @@ def compile_detector_sampler(self, *, seed: object = None) -> stim.CompiledDetec
 # stim.Circuit.compile_m2d_converter
 
 # (in class stim.Circuit)
-def compile_m2d_converter(self, *, skip_reference_sample: bool = False) -> stim.CompiledMeasurementsToDetectionEventsConverter:
+def compile_m2d_converter(
+    self,
+    *,
+    skip_reference_sample: bool = False,
+) -> stim.CompiledMeasurementsToDetectionEventsConverter:
     """Returns an object that can efficiently convert measurements into detection events for the given circuit.
 
     The converter uses a noiseless reference sample, collected from the circuit using stim's Tableau simulator
@@ -903,7 +978,12 @@ def compile_m2d_converter(self, *, skip_reference_sample: bool = False) -> stim.
 # stim.Circuit.compile_sampler
 
 # (in class stim.Circuit)
-def compile_sampler(self, *, skip_reference_sample: bool = False, seed: object = None) -> stim.CompiledMeasurementSampler:
+def compile_sampler(
+    self,
+    *,
+    skip_reference_sample: bool = False,
+    seed: object = None,
+) -> stim.CompiledMeasurementSampler:
     """Returns a CompiledMeasurementSampler, which can quickly batch sample measurements, for the circuit.
 
     Args:
@@ -956,7 +1036,9 @@ def compile_sampler(self, *, skip_reference_sample: bool = False, seed: object =
 # stim.Circuit.copy
 
 # (in class stim.Circuit)
-def copy(self) -> stim.Circuit:
+def copy(
+    self,
+) -> stim.Circuit:
     """Returns a copy of the circuit. An independent circuit with the same contents.
 
     Examples:
@@ -976,7 +1058,16 @@ def copy(self) -> stim.Circuit:
 # stim.Circuit.detector_error_model
 
 # (in class stim.Circuit)
-def detector_error_model(self, *, decompose_errors: bool = False, flatten_loops: bool = False, allow_gauge_detectors: bool = False, approximate_disjoint_errors: float = False, ignore_decomposition_failures: bool = False, block_decomposition_from_introducing_remnant_edges: bool = False) -> stim.DetectorErrorModel:
+def detector_error_model(
+    self,
+    *,
+    decompose_errors: bool = False,
+    flatten_loops: bool = False,
+    allow_gauge_detectors: bool = False,
+    approximate_disjoint_errors: float = False,
+    ignore_decomposition_failures: bool = False,
+    block_decomposition_from_introducing_remnant_edges: bool = False,
+) -> stim.DetectorErrorModel:
     """Returns a stim.DetectorErrorModel describing the error processes in the circuit.
 
     Args:
@@ -1055,7 +1146,12 @@ def detector_error_model(self, *, decompose_errors: bool = False, flatten_loops:
 # stim.Circuit.explain_detector_error_model_errors
 
 # (in class stim.Circuit)
-def explain_detector_error_model_errors(self, *, dem_filter: object = None, reduce_to_one_representative_error: bool = False) -> List[stim.ExplainedError]:
+def explain_detector_error_model_errors(
+    self,
+    *,
+    dem_filter: object = None,
+    reduce_to_one_representative_error: bool = False,
+) -> List[stim.ExplainedError]:
     """Explains how detector error model errors are produced by circuit errors.
 
     Args:
@@ -1110,7 +1206,9 @@ def explain_detector_error_model_errors(self, *, dem_filter: object = None, redu
 # stim.Circuit.flattened
 
 # (in class stim.Circuit)
-def flattened(self) -> stim.Circuit:
+def flattened(
+    self,
+) -> stim.Circuit:
     """Creates an equivalent circuit without REPEAT or SHIFT_COORDS.
 
     Returns:
@@ -1153,7 +1251,9 @@ def flattened(self) -> stim.Circuit:
 # stim.Circuit.flattened_operations
 
 # (in class stim.Circuit)
-def flattened_operations(self) -> list:
+def flattened_operations(
+    self,
+) -> list:
     """[DEPRECATED]
 
     Returns a list of tuples encoding the contents of the circuit.
@@ -1184,7 +1284,9 @@ def flattened_operations(self) -> list:
 
 # (in class stim.Circuit)
 @staticmethod
-def from_file(file: object) -> stim.Circuit:
+def from_file(
+    file: object,
+) -> stim.Circuit:
     """Args:
         file: A file path or open file object to read from.
 
@@ -1224,7 +1326,16 @@ def from_file(file: object) -> stim.Circuit:
 
 # (in class stim.Circuit)
 @staticmethod
-def generated(code_task: str, *, distance: int, rounds: int, after_clifford_depolarization: float = 0.0, before_round_data_depolarization: float = 0.0, before_measure_flip_probability: float = 0.0, after_reset_flip_probability: float = 0.0) -> stim.Circuit:
+def generated(
+    code_task: str,
+    *,
+    distance: int,
+    rounds: int,
+    after_clifford_depolarization: float = 0.0,
+    before_round_data_depolarization: float = 0.0,
+    before_measure_flip_probability: float = 0.0,
+    after_reset_flip_probability: float = 0.0,
+) -> stim.Circuit:
     """Generates common circuits.
 
     The generated circuits can include configurable noise.
@@ -1313,7 +1424,10 @@ def generated(code_task: str, *, distance: int, rounds: int, after_clifford_depo
 # stim.Circuit.get_detector_coordinates
 
 # (in class stim.Circuit)
-def get_detector_coordinates(self, only: object = None) -> Dict[int, List[float]]:
+def get_detector_coordinates(
+    self,
+    only: object = None,
+) -> Dict[int, List[float]]:
     """Returns the coordinate metadata of detectors in the circuit.
 
     Args:
@@ -1349,7 +1463,9 @@ def get_detector_coordinates(self, only: object = None) -> Dict[int, List[float]
 # stim.Circuit.get_final_qubit_coordinates
 
 # (in class stim.Circuit)
-def get_final_qubit_coordinates(self) -> Dict[int, List[float]]:
+def get_final_qubit_coordinates(
+    self,
+) -> Dict[int, List[float]]:
     """Returns the coordinate metadata of qubits in the circuit.
 
     If a qubit's coordinates are specified multiple times, only the last specified coordinates are returned.
@@ -1374,7 +1490,9 @@ def get_final_qubit_coordinates(self) -> Dict[int, List[float]]:
 
 # (in class stim.Circuit)
 @property
-def num_detectors(self) -> int:
+def num_detectors(
+    self,
+) -> int:
     """Counts the number of bits produced when sampling the circuit's detectors.
 
     Examples:
@@ -1399,7 +1517,9 @@ def num_detectors(self) -> int:
 
 # (in class stim.Circuit)
 @property
-def num_measurements(self) -> int:
+def num_measurements(
+    self,
+) -> int:
     """Counts the number of bits produced when sampling the circuit's measurements.
 
     Examples:
@@ -1421,7 +1541,9 @@ def num_measurements(self) -> int:
 
 # (in class stim.Circuit)
 @property
-def num_observables(self) -> int:
+def num_observables(
+    self,
+) -> int:
     """Counts the number of bits produced when sampling the circuit's logical observables.
 
     This is one more than the largest observable index given to OBSERVABLE_INCLUDE.
@@ -1444,7 +1566,9 @@ def num_observables(self) -> int:
 
 # (in class stim.Circuit)
 @property
-def num_qubits(self) -> int:
+def num_qubits(
+    self,
+) -> int:
     """Counts the number of qubits used when simulating the circuit.
 
     This is always one more than the largest qubit index used by the circuit.
@@ -1471,7 +1595,9 @@ def num_qubits(self) -> int:
 
 # (in class stim.Circuit)
 @property
-def num_sweep_bits(self) -> int:
+def num_sweep_bits(
+    self,
+) -> int:
     """Returns the number of sweep bits needed to completely configure the circuit.
 
     This is always one more than the largest sweep bit index used by the circuit.
@@ -1495,7 +1621,14 @@ def num_sweep_bits(self) -> int:
 # stim.Circuit.search_for_undetectable_logical_errors
 
 # (in class stim.Circuit)
-def search_for_undetectable_logical_errors(self, *, dont_explore_detection_event_sets_with_size_above: int, dont_explore_edges_with_degree_above: int, dont_explore_edges_increasing_symptom_degree: bool, canonicalize_circuit_errors: bool = False) -> List[stim.ExplainedError]:
+def search_for_undetectable_logical_errors(
+    self,
+    *,
+    dont_explore_detection_event_sets_with_size_above: int,
+    dont_explore_edges_with_degree_above: int,
+    dont_explore_edges_increasing_symptom_degree: bool,
+    canonicalize_circuit_errors: bool = False,
+) -> List[stim.ExplainedError]:
     """Searches for lists of errors from the model that form an undetectable logical error.
 
     THIS IS A HEURISTIC METHOD. It does not guarantee that it will find errors of particular
@@ -1574,7 +1707,12 @@ def search_for_undetectable_logical_errors(self, *, dont_explore_detection_event
 # stim.Circuit.shortest_graphlike_error
 
 # (in class stim.Circuit)
-def shortest_graphlike_error(self, *, ignore_ungraphlike_errors: bool = True, canonicalize_circuit_errors: bool = False) -> List[stim.ExplainedError]:
+def shortest_graphlike_error(
+    self,
+    *,
+    ignore_ungraphlike_errors: bool = True,
+    canonicalize_circuit_errors: bool = False,
+) -> List[stim.ExplainedError]:
     """Finds a minimum sized set of graphlike errors that produce an undetected logical error.
 
     A "graphlike error" is an error that creates at most two detection events (causes a change in the parity of
@@ -1632,7 +1770,10 @@ def shortest_graphlike_error(self, *, ignore_ungraphlike_errors: bool = True, ca
 # stim.Circuit.to_file
 
 # (in class stim.Circuit)
-def to_file(self, file: Union[io.TextIOBase, str, pathlib.Path]) -> None:
+def to_file(
+    self,
+    file: Union[io.TextIOBase, str, pathlib.Path],
+) -> None:
 
     """Writes the stim circuit to a file.
 
@@ -1668,7 +1809,9 @@ def to_file(self, file: Union[io.TextIOBase, str, pathlib.Path]) -> None:
 # stim.Circuit.without_noise
 
 # (in class stim.Circuit)
-def without_noise(self) -> stim.Circuit:
+def without_noise(
+    self,
+) -> stim.Circuit:
     """Returns a copy of the circuit with all noise processes removed.
 
     Pure noise instructions, such as X_ERROR and DEPOLARIZE2, are not
@@ -1710,7 +1853,15 @@ class CircuitErrorLocation:
 # stim.CircuitErrorLocation.__init__
 
 # (in class stim.CircuitErrorLocation)
-def __init__(self, *, tick_offset: int, flipped_pauli_product: List[stim.GateTargetWithCoords], flipped_measurement: object, instruction_targets: stim.CircuitTargetsInsideInstruction, stack_frames: List[stim.CircuitErrorLocationStackFrame]) -> None:
+def __init__(
+    self,
+    *,
+    tick_offset: int,
+    flipped_pauli_product: List[stim.GateTargetWithCoords],
+    flipped_measurement: object,
+    instruction_targets: stim.CircuitTargetsInsideInstruction,
+    stack_frames: List[stim.CircuitErrorLocationStackFrame],
+) -> None:
     """Creates a stim.CircuitErrorLocation.
     """
 ```
@@ -1721,7 +1872,9 @@ def __init__(self, *, tick_offset: int, flipped_pauli_product: List[stim.GateTar
 
 # (in class stim.CircuitErrorLocation)
 @property
-def flipped_measurement(self) -> Optional[stim.FlippedMeasurement]:
+def flipped_measurement(
+    self,
+) -> Optional[stim.FlippedMeasurement]:
 
     """The measurement that was flipped by the error mechanism.
     If the error isn't a measurement error, this will be None.
@@ -1734,7 +1887,9 @@ def flipped_measurement(self) -> Optional[stim.FlippedMeasurement]:
 
 # (in class stim.CircuitErrorLocation)
 @property
-def flipped_pauli_product(self) -> List[stim.GateTargetWithCoords]:
+def flipped_pauli_product(
+    self,
+) -> List[stim.GateTargetWithCoords]:
     """The Pauli errors that the error mechanism applied to qubits.
     When the error is a measurement error, this will be an empty list.
     """
@@ -1746,7 +1901,9 @@ def flipped_pauli_product(self) -> List[stim.GateTargetWithCoords]:
 
 # (in class stim.CircuitErrorLocation)
 @property
-def instruction_targets(self) -> stim.CircuitTargetsInsideInstruction:
+def instruction_targets(
+    self,
+) -> stim.CircuitTargetsInsideInstruction:
     """Within the error instruction, which may have hundreds of
     targets, which specific targets were being executed to
     produce the error.
@@ -1759,7 +1916,9 @@ def instruction_targets(self) -> stim.CircuitTargetsInsideInstruction:
 
 # (in class stim.CircuitErrorLocation)
 @property
-def stack_frames(self) -> List[stim.CircuitErrorLocationStackFrame]:
+def stack_frames(
+    self,
+) -> List[stim.CircuitErrorLocationStackFrame]:
     """Where in the circuit's execution does the error mechanism occur,
     accounting for things like nested loops that iterate multiple times.
     """
@@ -1771,7 +1930,9 @@ def stack_frames(self) -> List[stim.CircuitErrorLocationStackFrame]:
 
 # (in class stim.CircuitErrorLocation)
 @property
-def tick_offset(self) -> int:
+def tick_offset(
+    self,
+) -> int:
     """The number of TICKs that executed before the error mechanism being discussed,
     including TICKs that occurred multiple times during loops.
     """
@@ -1797,7 +1958,13 @@ class CircuitErrorLocationStackFrame:
 # stim.CircuitErrorLocationStackFrame.__init__
 
 # (in class stim.CircuitErrorLocationStackFrame)
-def __init__(self, *, instruction_offset: int, iteration_index: int, instruction_repetitions_arg: int) -> None:
+def __init__(
+    self,
+    *,
+    instruction_offset: int,
+    iteration_index: int,
+    instruction_repetitions_arg: int,
+) -> None:
     """Creates a stim.CircuitErrorLocationStackFrame.
     """
 ```
@@ -1808,7 +1975,9 @@ def __init__(self, *, instruction_offset: int, iteration_index: int, instruction
 
 # (in class stim.CircuitErrorLocationStackFrame)
 @property
-def instruction_offset(self) -> int:
+def instruction_offset(
+    self,
+) -> int:
     """The index of the instruction within the circuit, or within the
     instruction's parent REPEAT block. This is slightly different
     from the line number, because blank lines and commented lines
@@ -1823,7 +1992,9 @@ def instruction_offset(self) -> int:
 
 # (in class stim.CircuitErrorLocationStackFrame)
 @property
-def instruction_repetitions_arg(self) -> int:
+def instruction_repetitions_arg(
+    self,
+) -> int:
     """If the instruction being referred to is a REPEAT block,
     this is the repetition count of that REPEAT block. Otherwise
     this field defaults to 0.
@@ -1836,7 +2007,9 @@ def instruction_repetitions_arg(self) -> int:
 
 # (in class stim.CircuitErrorLocationStackFrame)
 @property
-def iteration_index(self) -> int:
+def iteration_index(
+    self,
+) -> int:
     """Disambiguates which iteration of the loop containing this instruction
     is being referred to. If the instruction isn't in a REPEAT block, this
     field defaults to 0.
@@ -1872,7 +2045,10 @@ class CircuitInstruction:
 # stim.CircuitInstruction.__eq__
 
 # (in class stim.CircuitInstruction)
-def __eq__(self, arg0: stim.CircuitInstruction) -> bool:
+def __eq__(
+    self,
+    arg0: stim.CircuitInstruction,
+) -> bool:
     """Determines if two `stim.CircuitInstruction`s are identical.
     """
 ```
@@ -1882,7 +2058,12 @@ def __eq__(self, arg0: stim.CircuitInstruction) -> bool:
 # stim.CircuitInstruction.__init__
 
 # (in class stim.CircuitInstruction)
-def __init__(self, name: str, targets: List[object], gate_args: List[float] = ()) -> None:
+def __init__(
+    self,
+    name: str,
+    targets: List[object],
+    gate_args: List[float] = (),
+) -> None:
     """Initializes a `stim.CircuitInstruction`.
 
     Args:
@@ -1899,7 +2080,10 @@ def __init__(self, name: str, targets: List[object], gate_args: List[float] = ()
 # stim.CircuitInstruction.__ne__
 
 # (in class stim.CircuitInstruction)
-def __ne__(self, arg0: stim.CircuitInstruction) -> bool:
+def __ne__(
+    self,
+    arg0: stim.CircuitInstruction,
+) -> bool:
     """Determines if two `stim.CircuitInstruction`s are different.
     """
 ```
@@ -1909,7 +2093,9 @@ def __ne__(self, arg0: stim.CircuitInstruction) -> bool:
 # stim.CircuitInstruction.__repr__
 
 # (in class stim.CircuitInstruction)
-def __repr__(self) -> str:
+def __repr__(
+    self,
+) -> str:
     """Returns text that is a valid python expression evaluating to an equivalent `stim.CircuitInstruction`.
     """
 ```
@@ -1919,7 +2105,9 @@ def __repr__(self) -> str:
 # stim.CircuitInstruction.__str__
 
 # (in class stim.CircuitInstruction)
-def __str__(self) -> str:
+def __str__(
+    self,
+) -> str:
     """Returns a text description of the instruction as a stim circuit file line.
     """
 ```
@@ -1929,7 +2117,9 @@ def __str__(self) -> str:
 # stim.CircuitInstruction.gate_args_copy
 
 # (in class stim.CircuitInstruction)
-def gate_args_copy(self) -> List[float]:
+def gate_args_copy(
+    self,
+) -> List[float]:
     """Returns the gate's arguments (numbers parameterizing the instruction).
 
     For noisy gates this typically a list of probabilities.
@@ -1943,7 +2133,9 @@ def gate_args_copy(self) -> List[float]:
 
 # (in class stim.CircuitInstruction)
 @property
-def name(self) -> str:
+def name(
+    self,
+) -> str:
     """The name of the instruction (e.g. `H` or `X_ERROR` or `DETECTOR`).
     """
 ```
@@ -1953,7 +2145,9 @@ def name(self) -> str:
 # stim.CircuitInstruction.targets_copy
 
 # (in class stim.CircuitInstruction)
-def targets_copy(self) -> List[stim.GateTarget]:
+def targets_copy(
+    self,
+) -> List[stim.GateTarget]:
     """Returns a copy of the targets of the instruction.
     """
 ```
@@ -1991,7 +2185,10 @@ class CircuitRepeatBlock:
 # stim.CircuitRepeatBlock.__eq__
 
 # (in class stim.CircuitRepeatBlock)
-def __eq__(self, arg0: stim.CircuitRepeatBlock) -> bool:
+def __eq__(
+    self,
+    arg0: stim.CircuitRepeatBlock,
+) -> bool:
     """Determines if two `stim.CircuitRepeatBlock`s are identical.
     """
 ```
@@ -2001,7 +2198,11 @@ def __eq__(self, arg0: stim.CircuitRepeatBlock) -> bool:
 # stim.CircuitRepeatBlock.__init__
 
 # (in class stim.CircuitRepeatBlock)
-def __init__(self, repeat_count: int, body: stim.Circuit) -> None:
+def __init__(
+    self,
+    repeat_count: int,
+    body: stim.Circuit,
+) -> None:
     """Initializes a `stim.CircuitRepeatBlock`.
 
     Args:
@@ -2015,7 +2216,10 @@ def __init__(self, repeat_count: int, body: stim.Circuit) -> None:
 # stim.CircuitRepeatBlock.__ne__
 
 # (in class stim.CircuitRepeatBlock)
-def __ne__(self, arg0: stim.CircuitRepeatBlock) -> bool:
+def __ne__(
+    self,
+    arg0: stim.CircuitRepeatBlock,
+) -> bool:
     """Determines if two `stim.CircuitRepeatBlock`s are different.
     """
 ```
@@ -2025,7 +2229,9 @@ def __ne__(self, arg0: stim.CircuitRepeatBlock) -> bool:
 # stim.CircuitRepeatBlock.__repr__
 
 # (in class stim.CircuitRepeatBlock)
-def __repr__(self) -> str:
+def __repr__(
+    self,
+) -> str:
     """Returns text that is a valid python expression evaluating to an equivalent `stim.CircuitRepeatBlock`.
     """
 ```
@@ -2035,7 +2241,9 @@ def __repr__(self) -> str:
 # stim.CircuitRepeatBlock.body_copy
 
 # (in class stim.CircuitRepeatBlock)
-def body_copy(self) -> stim.Circuit:
+def body_copy(
+    self,
+) -> stim.Circuit:
     """Returns a copy of the body of the repeat block.
 
     The copy is forced to ensure it's clear that editing the result will not change the circuit that the repeat
@@ -2065,7 +2273,9 @@ def body_copy(self) -> stim.Circuit:
 
 # (in class stim.CircuitRepeatBlock)
 @property
-def repeat_count(self) -> int:
+def repeat_count(
+    self,
+) -> int:
     """The repetition count of the repeat block.
 
     Examples:
@@ -2098,7 +2308,15 @@ class CircuitTargetsInsideInstruction:
 # stim.CircuitTargetsInsideInstruction.__init__
 
 # (in class stim.CircuitTargetsInsideInstruction)
-def __init__(self, *, gate: str, args: List[float], target_range_start: int, target_range_end: int, targets_in_range: List[stim.GateTargetWithCoords]) -> None:
+def __init__(
+    self,
+    *,
+    gate: str,
+    args: List[float],
+    target_range_start: int,
+    target_range_end: int,
+    targets_in_range: List[stim.GateTargetWithCoords],
+) -> None:
     """Creates a stim.CircuitTargetsInsideInstruction.
     """
 ```
@@ -2109,7 +2327,9 @@ def __init__(self, *, gate: str, args: List[float], target_range_start: int, tar
 
 # (in class stim.CircuitTargetsInsideInstruction)
 @property
-def args(self) -> List[float]:
+def args(
+    self,
+) -> List[float]:
     """Returns parens arguments of the gate / instruction that was being executed.
     """
 ```
@@ -2120,7 +2340,9 @@ def args(self) -> List[float]:
 
 # (in class stim.CircuitTargetsInsideInstruction)
 @property
-def gate(self) -> Optional[str]:
+def gate(
+    self,
+) -> Optional[str]:
 
     """Returns the name of the gate / instruction that was being executed.
     """
@@ -2132,7 +2354,9 @@ def gate(self) -> Optional[str]:
 
 # (in class stim.CircuitTargetsInsideInstruction)
 @property
-def target_range_end(self) -> int:
+def target_range_end(
+    self,
+) -> int:
     """Returns the exclusive end of the range of targets that were executing
     within the gate / instruction.
     """
@@ -2144,7 +2368,9 @@ def target_range_end(self) -> int:
 
 # (in class stim.CircuitTargetsInsideInstruction)
 @property
-def target_range_start(self) -> int:
+def target_range_start(
+    self,
+) -> int:
     """Returns the inclusive start of the range of targets that were executing
     within the gate / instruction.
     """
@@ -2156,7 +2382,9 @@ def target_range_start(self) -> int:
 
 # (in class stim.CircuitTargetsInsideInstruction)
 @property
-def targets_in_range(self) -> List[stim.GateTargetWithCoords]:
+def targets_in_range(
+    self,
+) -> List[stim.GateTargetWithCoords]:
     """Returns the subset of targets of the gate / instruction that were being executed.
 
     Includes coordinate data with the targets.
@@ -2178,7 +2406,12 @@ class CompiledDetectorSampler:
 # stim.CompiledDetectorSampler.__init__
 
 # (in class stim.CompiledDetectorSampler)
-def __init__(self, circuit: stim.Circuit, *, seed: object = None) -> None:
+def __init__(
+    self,
+    circuit: stim.Circuit,
+    *,
+    seed: object = None,
+) -> None:
     """Creates a detector sampler, which can sample the detectors (and optionally observables) in a circuit.
 
     Args:
@@ -2226,7 +2459,9 @@ def __init__(self, circuit: stim.Circuit, *, seed: object = None) -> None:
 # stim.CompiledDetectorSampler.__repr__
 
 # (in class stim.CompiledDetectorSampler)
-def __repr__(self) -> str:
+def __repr__(
+    self,
+) -> str:
     """Returns text that is a valid python expression evaluating to an equivalent `stim.CompiledDetectorSampler`.
     """
 ```
@@ -2236,7 +2471,13 @@ def __repr__(self) -> str:
 # stim.CompiledDetectorSampler.sample
 
 # (in class stim.CompiledDetectorSampler)
-def sample(self, shots: int, *, prepend_observables: bool = False, append_observables: bool = False) -> np.ndarray[bool]:
+def sample(
+    self,
+    shots: int,
+    *,
+    prepend_observables: bool = False,
+    append_observables: bool = False,
+) -> np.ndarray[bool]:
     """Returns a numpy array containing a batch of detector samples from the circuit.
 
     The circuit must define the detectors using DETECTOR instructions. Observables defined by OBSERVABLE_INCLUDE
@@ -2261,7 +2502,13 @@ def sample(self, shots: int, *, prepend_observables: bool = False, append_observ
 # stim.CompiledDetectorSampler.sample_bit_packed
 
 # (in class stim.CompiledDetectorSampler)
-def sample_bit_packed(self, shots: int, *, prepend_observables: bool = False, append_observables: bool = False) -> np.ndarray[np.uint8]:
+def sample_bit_packed(
+    self,
+    shots: int,
+    *,
+    prepend_observables: bool = False,
+    append_observables: bool = False,
+) -> np.ndarray[np.uint8]:
     """Returns a numpy array containing bit packed batch of detector samples from the circuit.
 
     The circuit must define the detectors using DETECTOR instructions. Observables defined by OBSERVABLE_INCLUDE
@@ -2286,7 +2533,17 @@ def sample_bit_packed(self, shots: int, *, prepend_observables: bool = False, ap
 # stim.CompiledDetectorSampler.sample_write
 
 # (in class stim.CompiledDetectorSampler)
-def sample_write(self, shots: int, *, filepath: str, format: str = '01', prepend_observables: bool = False, append_observables: bool = False, obs_out_filepath: str = None, obs_out_format: str = '01') -> None:
+def sample_write(
+    self,
+    shots: int,
+    *,
+    filepath: str,
+    format: str = '01',
+    prepend_observables: bool = False,
+    append_observables: bool = False,
+    obs_out_filepath: str = None,
+    obs_out_format: str = '01',
+) -> None:
     """Samples detection events from the circuit and writes them to a file.
 
     Examples:
@@ -2343,7 +2600,13 @@ class CompiledMeasurementSampler:
 # stim.CompiledMeasurementSampler.__init__
 
 # (in class stim.CompiledMeasurementSampler)
-def __init__(self, circuit: stim.Circuit, *, skip_reference_sample: bool = False, seed: object = None) -> None:
+def __init__(
+    self,
+    circuit: stim.Circuit,
+    *,
+    skip_reference_sample: bool = False,
+    seed: object = None,
+) -> None:
     """Creates a measurement sampler for the given circuit.
 
     The sampler uses a noiseless reference sample, collected from the circuit using stim's Tableau simulator
@@ -2404,7 +2667,9 @@ def __init__(self, circuit: stim.Circuit, *, skip_reference_sample: bool = False
 # stim.CompiledMeasurementSampler.__repr__
 
 # (in class stim.CompiledMeasurementSampler)
-def __repr__(self) -> str:
+def __repr__(
+    self,
+) -> str:
     """Returns text that is a valid python expression evaluating to an equivalent `stim.CompiledMeasurementSampler`.
     """
 ```
@@ -2414,7 +2679,10 @@ def __repr__(self) -> str:
 # stim.CompiledMeasurementSampler.sample
 
 # (in class stim.CompiledMeasurementSampler)
-def sample(self, shots: int) -> np.ndarray[bool]:
+def sample(
+    self,
+    shots: int,
+) -> np.ndarray[bool]:
     """Returns a numpy array containing a batch of measurement samples from the circuit.
 
     Examples:
@@ -2441,7 +2709,10 @@ def sample(self, shots: int) -> np.ndarray[bool]:
 # stim.CompiledMeasurementSampler.sample_bit_packed
 
 # (in class stim.CompiledMeasurementSampler)
-def sample_bit_packed(self, shots: int) -> np.ndarray[np.uint8]:
+def sample_bit_packed(
+    self,
+    shots: int,
+) -> np.ndarray[np.uint8]:
     """Returns a numpy array containing a bit packed batch of measurement samples from the circuit.
 
     Examples:
@@ -2468,7 +2739,13 @@ def sample_bit_packed(self, shots: int) -> np.ndarray[np.uint8]:
 # stim.CompiledMeasurementSampler.sample_write
 
 # (in class stim.CompiledMeasurementSampler)
-def sample_write(self, shots: int, *, filepath: str, format: str = '01') -> None:
+def sample_write(
+    self,
+    shots: int,
+    *,
+    filepath: str,
+    format: str = '01',
+) -> None:
     """Samples measurements from the circuit and writes them to a file.
 
     Examples:
@@ -2516,7 +2793,12 @@ class CompiledMeasurementsToDetectionEventsConverter:
 # stim.CompiledMeasurementsToDetectionEventsConverter.__init__
 
 # (in class stim.CompiledMeasurementsToDetectionEventsConverter)
-def __init__(self, circuit: stim.Circuit, *, skip_reference_sample: bool = False) -> None:
+def __init__(
+    self,
+    circuit: stim.Circuit,
+    *,
+    skip_reference_sample: bool = False,
+) -> None:
     """Creates a measurement-to-detection-events converter for the given circuit.
 
     The converter uses a noiseless reference sample, collected from the circuit using stim's Tableau simulator
@@ -2559,7 +2841,9 @@ def __init__(self, circuit: stim.Circuit, *, skip_reference_sample: bool = False
 # stim.CompiledMeasurementsToDetectionEventsConverter.__repr__
 
 # (in class stim.CompiledMeasurementsToDetectionEventsConverter)
-def __repr__(self) -> str:
+def __repr__(
+    self,
+) -> str:
     """Returns text that is a valid python expression evaluating to an equivalent `stim.CompiledMeasurementsToDetectionEventsConverter`.
     """
 ```
@@ -2569,7 +2853,15 @@ def __repr__(self) -> str:
 # stim.CompiledMeasurementsToDetectionEventsConverter.convert
 
 # (in class stim.CompiledMeasurementsToDetectionEventsConverter)
-def convert(self, *, measurements: np.ndarray, sweep_bits: Optional[np.ndarray] = None, separate_observables: bool = False, append_observables: bool = False, bit_pack_result: bool = False) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
+def convert(
+    self,
+    *,
+    measurements: np.ndarray,
+    sweep_bits: Optional[np.ndarray] = None,
+    separate_observables: bool = False,
+    append_observables: bool = False,
+    bit_pack_result: bool = False,
+) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
 
     """Converts measurement data into detection event data.
 
@@ -2642,7 +2934,19 @@ def convert(self, *, measurements: np.ndarray, sweep_bits: Optional[np.ndarray] 
 # stim.CompiledMeasurementsToDetectionEventsConverter.convert_file
 
 # (in class stim.CompiledMeasurementsToDetectionEventsConverter)
-def convert_file(self, *, measurements_filepath: str, measurements_format: str = '01', sweep_bits_filepath: str = None, sweep_bits_format: str = '01', detection_events_filepath: str, detection_events_format: str = '01', append_observables: bool = False, obs_out_filepath: str = None, obs_out_format: str = '01') -> None:
+def convert_file(
+    self,
+    *,
+    measurements_filepath: str,
+    measurements_format: str = '01',
+    sweep_bits_filepath: str = None,
+    sweep_bits_format: str = '01',
+    detection_events_filepath: str,
+    detection_events_format: str = '01',
+    append_observables: bool = False,
+    obs_out_filepath: str = None,
+    obs_out_format: str = '01',
+) -> None:
     """Reads measurement data from a file, converts it, and writes the detection events to another file.
 
     Args:
@@ -2722,7 +3026,10 @@ class DemInstruction:
 # stim.DemInstruction.__eq__
 
 # (in class stim.DemInstruction)
-def __eq__(self, arg0: stim.DemInstruction) -> bool:
+def __eq__(
+    self,
+    arg0: stim.DemInstruction,
+) -> bool:
     """Determines if two instructions have identical contents.
     """
 ```
@@ -2732,7 +3039,12 @@ def __eq__(self, arg0: stim.DemInstruction) -> bool:
 # stim.DemInstruction.__init__
 
 # (in class stim.DemInstruction)
-def __init__(self, type: str, args: List[float], targets: List[object]) -> None:
+def __init__(
+    self,
+    type: str,
+    args: List[float],
+    targets: List[object],
+) -> None:
     """Creates a stim.DemInstruction.
 
     Args:
@@ -2753,7 +3065,10 @@ def __init__(self, type: str, args: List[float], targets: List[object]) -> None:
 # stim.DemInstruction.__ne__
 
 # (in class stim.DemInstruction)
-def __ne__(self, arg0: stim.DemInstruction) -> bool:
+def __ne__(
+    self,
+    arg0: stim.DemInstruction,
+) -> bool:
     """Determines if two instructions have non-identical contents.
     """
 ```
@@ -2763,7 +3078,9 @@ def __ne__(self, arg0: stim.DemInstruction) -> bool:
 # stim.DemInstruction.__repr__
 
 # (in class stim.DemInstruction)
-def __repr__(self) -> str:
+def __repr__(
+    self,
+) -> str:
     """Returns text that is a valid python expression evaluating to an equivalent `stim.DetectorErrorModel`.
     """
 ```
@@ -2773,7 +3090,9 @@ def __repr__(self) -> str:
 # stim.DemInstruction.__str__
 
 # (in class stim.DemInstruction)
-def __str__(self) -> str:
+def __str__(
+    self,
+) -> str:
     """Returns detector error model (.dem) instructions (that can be parsed by stim) for the model.
     """
 ```
@@ -2783,7 +3102,9 @@ def __str__(self) -> str:
 # stim.DemInstruction.args_copy
 
 # (in class stim.DemInstruction)
-def args_copy(self) -> List[float]:
+def args_copy(
+    self,
+) -> List[float]:
     """Returns a copy of the list of numbers parameterizing the instruction (e.g. the probability of an error).
     """
 ```
@@ -2793,7 +3114,9 @@ def args_copy(self) -> List[float]:
 # stim.DemInstruction.targets_copy
 
 # (in class stim.DemInstruction)
-def targets_copy(self) -> List[Union[int, stim.DemTarget]]:
+def targets_copy(
+    self,
+) -> List[Union[int, stim.DemTarget]]:
 
     """Returns a copy of the list of objects the instruction applies to (e.g. affected detectors.
     """
@@ -2805,7 +3128,9 @@ def targets_copy(self) -> List[Union[int, stim.DemTarget]]:
 
 # (in class stim.DemInstruction)
 @property
-def type(self) -> str:
+def type(
+    self,
+) -> str:
     """The name of the instruction type (e.g. "error" or "shift_detectors").
     """
 ```
@@ -2839,7 +3164,10 @@ class DemRepeatBlock:
 # stim.DemRepeatBlock.__eq__
 
 # (in class stim.DemRepeatBlock)
-def __eq__(self, arg0: stim.DemRepeatBlock) -> bool:
+def __eq__(
+    self,
+    arg0: stim.DemRepeatBlock,
+) -> bool:
     """Determines if two repeat blocks are identical.
     """
 ```
@@ -2849,7 +3177,11 @@ def __eq__(self, arg0: stim.DemRepeatBlock) -> bool:
 # stim.DemRepeatBlock.__init__
 
 # (in class stim.DemRepeatBlock)
-def __init__(self, repeat_count: int, block: stim.DetectorErrorModel) -> None:
+def __init__(
+    self,
+    repeat_count: int,
+    block: stim.DetectorErrorModel,
+) -> None:
     """Creates a stim.DemRepeatBlock.
 
     Args:
@@ -2870,7 +3202,10 @@ def __init__(self, repeat_count: int, block: stim.DetectorErrorModel) -> None:
 # stim.DemRepeatBlock.__ne__
 
 # (in class stim.DemRepeatBlock)
-def __ne__(self, arg0: stim.DemRepeatBlock) -> bool:
+def __ne__(
+    self,
+    arg0: stim.DemRepeatBlock,
+) -> bool:
     """Determines if two repeat blocks are different.
     """
 ```
@@ -2880,7 +3215,9 @@ def __ne__(self, arg0: stim.DemRepeatBlock) -> bool:
 # stim.DemRepeatBlock.__repr__
 
 # (in class stim.DemRepeatBlock)
-def __repr__(self) -> str:
+def __repr__(
+    self,
+) -> str:
     """Returns text that is a valid python expression evaluating to an equivalent `stim.DemRepeatBlock`.
     """
 ```
@@ -2890,7 +3227,9 @@ def __repr__(self) -> str:
 # stim.DemRepeatBlock.body_copy
 
 # (in class stim.DemRepeatBlock)
-def body_copy(self) -> stim.DetectorErrorModel:
+def body_copy(
+    self,
+) -> stim.DetectorErrorModel:
     """Returns a copy of the block's body, as a stim.DetectorErrorModel.
     """
 ```
@@ -2901,7 +3240,9 @@ def body_copy(self) -> stim.DetectorErrorModel:
 
 # (in class stim.DemRepeatBlock)
 @property
-def repeat_count(self) -> int:
+def repeat_count(
+    self,
+) -> int:
     """The number of times the repeat block's body is supposed to execute.
     """
 ```
@@ -2921,7 +3262,10 @@ class DemTarget:
 # stim.DemTarget.__eq__
 
 # (in class stim.DemTarget)
-def __eq__(self, arg0: stim.DemTarget) -> bool:
+def __eq__(
+    self,
+    arg0: stim.DemTarget,
+) -> bool:
     """Determines if two `stim.DemTarget`s are identical.
     """
 ```
@@ -2931,7 +3275,10 @@ def __eq__(self, arg0: stim.DemTarget) -> bool:
 # stim.DemTarget.__ne__
 
 # (in class stim.DemTarget)
-def __ne__(self, arg0: stim.DemTarget) -> bool:
+def __ne__(
+    self,
+    arg0: stim.DemTarget,
+) -> bool:
     """Determines if two `stim.DemTarget`s are different.
     """
 ```
@@ -2941,7 +3288,9 @@ def __ne__(self, arg0: stim.DemTarget) -> bool:
 # stim.DemTarget.__repr__
 
 # (in class stim.DemTarget)
-def __repr__(self) -> str:
+def __repr__(
+    self,
+) -> str:
     """Returns text that is a valid python expression evaluating to an equivalent `stim.DemTarget`.
     """
 ```
@@ -2951,7 +3300,9 @@ def __repr__(self) -> str:
 # stim.DemTarget.__str__
 
 # (in class stim.DemTarget)
-def __str__(self) -> str:
+def __str__(
+    self,
+) -> str:
     """Returns a text description of the detector error model target.
     """
 ```
@@ -2961,7 +3312,9 @@ def __str__(self) -> str:
 # stim.DemTarget.is_logical_observable_id
 
 # (in class stim.DemTarget)
-def is_logical_observable_id(self) -> bool:
+def is_logical_observable_id(
+    self,
+) -> bool:
     """Determines if the detector error model target is a logical observable id target (like "L5" in a .dem file).
     """
 ```
@@ -2971,7 +3324,9 @@ def is_logical_observable_id(self) -> bool:
 # stim.DemTarget.is_relative_detector_id
 
 # (in class stim.DemTarget)
-def is_relative_detector_id(self) -> bool:
+def is_relative_detector_id(
+    self,
+) -> bool:
     """Determines if the detector error model target is a relative detector id target (like "D4" in a .dem file).
     """
 ```
@@ -2981,7 +3336,9 @@ def is_relative_detector_id(self) -> bool:
 # stim.DemTarget.is_separator
 
 # (in class stim.DemTarget)
-def is_separator(self) -> bool:
+def is_separator(
+    self,
+) -> bool:
     """Determines if the detector error model target is a separator (like "^" in a .dem file).
     """
 ```
@@ -2992,7 +3349,9 @@ def is_separator(self) -> bool:
 
 # (in class stim.DemTarget)
 @staticmethod
-def logical_observable_id(index: int) -> stim.DemTarget:
+def logical_observable_id(
+    index: int,
+) -> stim.DemTarget:
     """Returns a logical observable id identifying a frame change (e.g. "L5" in a .dem file).
 
     Args:
@@ -3020,7 +3379,9 @@ def logical_observable_id(index: int) -> stim.DemTarget:
 
 # (in class stim.DemTarget)
 @staticmethod
-def relative_detector_id(index: int) -> stim.DemTarget:
+def relative_detector_id(
+    index: int,
+) -> stim.DemTarget:
     """Returns a relative detector id (e.g. "D5" in a .dem file).
 
     Args:
@@ -3048,7 +3409,8 @@ def relative_detector_id(index: int) -> stim.DemTarget:
 
 # (in class stim.DemTarget)
 @staticmethod
-def separator() -> stim.DemTarget:
+def separator(
+) -> stim.DemTarget:
     """Returns a target separator (e.g. "^" in a .dem file).
 
     Examples:
@@ -3072,7 +3434,9 @@ def separator() -> stim.DemTarget:
 
 # (in class stim.DemTarget)
 @property
-def val(self) -> int:
+def val(
+    self,
+) -> int:
     """Returns the target's integer value.
 
     Example:
@@ -3113,7 +3477,12 @@ class DemTargetWithCoords:
 # stim.DemTargetWithCoords.__init__
 
 # (in class stim.DemTargetWithCoords)
-def __init__(self, *, dem_target: stim.DemTarget, coords: List[float]) -> None:
+def __init__(
+    self,
+    *,
+    dem_target: stim.DemTarget,
+    coords: List[float],
+) -> None:
     """Creates a stim.DemTargetWithCoords.
     """
 ```
@@ -3124,7 +3493,9 @@ def __init__(self, *, dem_target: stim.DemTarget, coords: List[float]) -> None:
 
 # (in class stim.DemTargetWithCoords)
 @property
-def coords(self) -> List[float]:
+def coords(
+    self,
+) -> List[float]:
     """Returns the associated coordinate information as a list of flaots.
 
     If there is no coordinate information, returns an empty list.
@@ -3137,7 +3508,9 @@ def coords(self) -> List[float]:
 
 # (in class stim.DemTargetWithCoords)
 @property
-def dem_target(self) -> stim.DemTarget:
+def dem_target(
+    self,
+) -> stim.DemTarget:
     """Returns the actual DEM target as a `stim.DemTarget`.
     """
 ```
@@ -3183,7 +3556,10 @@ class DetectorErrorModel:
 # stim.DetectorErrorModel.__add__
 
 # (in class stim.DetectorErrorModel)
-def __add__(self, second: stim.DetectorErrorModel) -> stim.DetectorErrorModel:
+def __add__(
+    self,
+    second: stim.DetectorErrorModel,
+) -> stim.DetectorErrorModel:
     """Creates a detector error model by appending two models.
 
     Examples:
@@ -3207,7 +3583,10 @@ def __add__(self, second: stim.DetectorErrorModel) -> stim.DetectorErrorModel:
 # stim.DetectorErrorModel.__eq__
 
 # (in class stim.DetectorErrorModel)
-def __eq__(self, arg0: stim.DetectorErrorModel) -> bool:
+def __eq__(
+    self,
+    arg0: stim.DetectorErrorModel,
+) -> bool:
     """Determines if two detector error models have identical contents.
     """
 ```
@@ -3218,12 +3597,21 @@ def __eq__(self, arg0: stim.DetectorErrorModel) -> bool:
 
 # (in class stim.DetectorErrorModel)
 @overload
-def __getitem__(self, index_or_slice: int) -> Union[stim.DemInstruction, stim.DemRepeatBlock]:
+def __getitem__(
+    self,
+    index_or_slice: int,
+) -> Union[stim.DemInstruction, stim.DemRepeatBlock]:
     pass
 @overload
-def __getitem__(self, index_or_slice: slice) -> stim.DetectorErrorModel:
+def __getitem__(
+    self,
+    index_or_slice: slice,
+) -> stim.DetectorErrorModel:
     pass
-def __getitem__(self, index_or_slice: object) -> object:
+def __getitem__(
+    self,
+    index_or_slice: object,
+) -> object:
     """Returns copies of instructions from the detector error model.
 
     Args:
@@ -3265,7 +3653,10 @@ def __getitem__(self, index_or_slice: object) -> object:
 # stim.DetectorErrorModel.__iadd__
 
 # (in class stim.DetectorErrorModel)
-def __iadd__(self, second: stim.DetectorErrorModel) -> stim.DetectorErrorModel:
+def __iadd__(
+    self,
+    second: stim.DetectorErrorModel,
+) -> stim.DetectorErrorModel:
     """Appends a detector error model into the receiving model (mutating it).
 
     Examples:
@@ -3290,7 +3681,10 @@ def __iadd__(self, second: stim.DetectorErrorModel) -> stim.DetectorErrorModel:
 # stim.DetectorErrorModel.__imul__
 
 # (in class stim.DetectorErrorModel)
-def __imul__(self, repetitions: int) -> stim.DetectorErrorModel:
+def __imul__(
+    self,
+    repetitions: int,
+) -> stim.DetectorErrorModel:
     """Mutates the detector error model by putting its contents into a repeat block.
 
     Special case: if the repetition count is 0, the model is cleared.
@@ -3319,7 +3713,10 @@ def __imul__(self, repetitions: int) -> stim.DetectorErrorModel:
 # stim.DetectorErrorModel.__init__
 
 # (in class stim.DetectorErrorModel)
-def __init__(self, detector_error_model_text: str = '') -> None:
+def __init__(
+    self,
+    detector_error_model_text: str = '',
+) -> None:
     """Creates a stim.DetectorErrorModel.
 
     Args:
@@ -3340,7 +3737,9 @@ def __init__(self, detector_error_model_text: str = '') -> None:
 # stim.DetectorErrorModel.__len__
 
 # (in class stim.DetectorErrorModel)
-def __len__(self) -> int:
+def __len__(
+    self,
+) -> int:
     """Returns the number of top-level instructions and blocks in the detector error model.
 
     Instructions inside of blocks are not included in this count.
@@ -3370,7 +3769,10 @@ def __len__(self) -> int:
 # stim.DetectorErrorModel.__mul__
 
 # (in class stim.DetectorErrorModel)
-def __mul__(self, repetitions: int) -> stim.DetectorErrorModel:
+def __mul__(
+    self,
+    repetitions: int,
+) -> stim.DetectorErrorModel:
     """Returns a detector error model with a repeat block containing the current model's instructions.
 
     Special case: if the repetition count is 0, an empty model is returned.
@@ -3400,7 +3802,10 @@ def __mul__(self, repetitions: int) -> stim.DetectorErrorModel:
 # stim.DetectorErrorModel.__ne__
 
 # (in class stim.DetectorErrorModel)
-def __ne__(self, arg0: stim.DetectorErrorModel) -> bool:
+def __ne__(
+    self,
+    arg0: stim.DetectorErrorModel,
+) -> bool:
     """Determines if two detector error models have non-identical contents.
     """
 ```
@@ -3410,7 +3815,9 @@ def __ne__(self, arg0: stim.DetectorErrorModel) -> bool:
 # stim.DetectorErrorModel.__repr__
 
 # (in class stim.DetectorErrorModel)
-def __repr__(self) -> str:
+def __repr__(
+    self,
+) -> str:
     """"Returns text that is a valid python expression evaluating to an equivalent `stim.DetectorErrorModel`."
     """
 ```
@@ -3420,7 +3827,10 @@ def __repr__(self) -> str:
 # stim.DetectorErrorModel.__rmul__
 
 # (in class stim.DetectorErrorModel)
-def __rmul__(self, repetitions: int) -> stim.DetectorErrorModel:
+def __rmul__(
+    self,
+    repetitions: int,
+) -> stim.DetectorErrorModel:
     """Returns a detector error model with a repeat block containing the current model's instructions.
 
     Special case: if the repetition count is 0, an empty model is returned.
@@ -3450,7 +3860,9 @@ def __rmul__(self, repetitions: int) -> stim.DetectorErrorModel:
 # stim.DetectorErrorModel.__str__
 
 # (in class stim.DetectorErrorModel)
-def __str__(self) -> str:
+def __str__(
+    self,
+) -> str:
     """"Returns detector error model (.dem) instructions (that can be parsed by stim) for the model.");
     """
 ```
@@ -3460,7 +3872,12 @@ def __str__(self) -> str:
 # stim.DetectorErrorModel.append
 
 # (in class stim.DetectorErrorModel)
-def append(self, instruction: object, parens_arguments: object = None, targets: List[object] = ()) -> None:
+def append(
+    self,
+    instruction: object,
+    parens_arguments: object = None,
+    targets: List[object] = (),
+) -> None:
     """Appends an instruction to the detector error model.
 
     Args:
@@ -3525,7 +3942,12 @@ def append(self, instruction: object, parens_arguments: object = None, targets: 
 # stim.DetectorErrorModel.approx_equals
 
 # (in class stim.DetectorErrorModel)
-def approx_equals(self, other: object, *, atol: float) -> bool:
+def approx_equals(
+    self,
+    other: object,
+    *,
+    atol: float,
+) -> bool:
     """Checks if a detector error model is approximately equal to another detector error model.
 
     Two detector error model are approximately equal if they are equal up to slight perturbations of instruction
@@ -3577,7 +3999,9 @@ def approx_equals(self, other: object, *, atol: float) -> bool:
 # stim.DetectorErrorModel.clear
 
 # (in class stim.DetectorErrorModel)
-def clear(self) -> None:
+def clear(
+    self,
+) -> None:
     """Clears the contents of the detector error model.
 
     Examples:
@@ -3596,7 +4020,9 @@ def clear(self) -> None:
 # stim.DetectorErrorModel.copy
 
 # (in class stim.DetectorErrorModel)
-def copy(self) -> stim.DetectorErrorModel:
+def copy(
+    self,
+) -> stim.DetectorErrorModel:
     """Returns a copy of the detector error model. An independent model with the same contents.
 
     Examples:
@@ -3617,7 +4043,9 @@ def copy(self) -> stim.DetectorErrorModel:
 
 # (in class stim.DetectorErrorModel)
 @staticmethod
-def from_file(file: object) -> stim.DetectorErrorModel:
+def from_file(
+    file: object,
+) -> stim.DetectorErrorModel:
     """Args:
         file: A file path or open file object to read from.
 
@@ -3656,7 +4084,10 @@ def from_file(file: object) -> stim.DetectorErrorModel:
 # stim.DetectorErrorModel.get_detector_coordinates
 
 # (in class stim.DetectorErrorModel)
-def get_detector_coordinates(self, only: object = None) -> Dict[int, List[float]]:
+def get_detector_coordinates(
+    self,
+    only: object = None,
+) -> Dict[int, List[float]]:
     """Returns the coordinate metadata of detectors in the detector error model.
 
     Args:
@@ -3689,7 +4120,9 @@ def get_detector_coordinates(self, only: object = None) -> Dict[int, List[float]
 
 # (in class stim.DetectorErrorModel)
 @property
-def num_detectors(self) -> int:
+def num_detectors(
+    self,
+) -> int:
     """Counts the number of detectors (e.g. `D2`) in the error model.
 
     Detector indices are assumed to be contiguous from 0 up to whatever the maximum detector id is.
@@ -3727,7 +4160,9 @@ def num_detectors(self) -> int:
 
 # (in class stim.DetectorErrorModel)
 @property
-def num_errors(self) -> int:
+def num_errors(
+    self,
+) -> int:
     """Counts the number of errors (e.g. `error(0.1) D0`) in the error model.
 
     Error instructions inside repeat blocks count once per repetition.
@@ -3754,7 +4189,9 @@ def num_errors(self) -> int:
 
 # (in class stim.DetectorErrorModel)
 @property
-def num_observables(self) -> int:
+def num_observables(
+    self,
+) -> int:
     """Counts the number of frame changes (e.g. `L2`) in the error model.
 
     Observable indices are assumed to be contiguous from 0 up to whatever the maximum observable id is.
@@ -3782,7 +4219,10 @@ def num_observables(self) -> int:
 # stim.DetectorErrorModel.shortest_graphlike_error
 
 # (in class stim.DetectorErrorModel)
-def shortest_graphlike_error(self, ignore_ungraphlike_errors: bool = False) -> stim.DetectorErrorModel:
+def shortest_graphlike_error(
+    self,
+    ignore_ungraphlike_errors: bool = False,
+) -> stim.DetectorErrorModel:
     """Finds a minimum sized set of graphlike errors that produce an undetected logical error.
 
     Note that this method does not pay attention to error probabilities (other than ignoring errors with
@@ -3864,7 +4304,10 @@ def shortest_graphlike_error(self, ignore_ungraphlike_errors: bool = False) -> s
 # stim.DetectorErrorModel.to_file
 
 # (in class stim.DetectorErrorModel)
-def to_file(self, file: Union[io.TextIOBase, str, pathlib.Path]) -> None:
+def to_file(
+    self,
+    file: Union[io.TextIOBase, str, pathlib.Path],
+) -> None:
 
     """Writes the stim circuit to a file.
 
@@ -3910,7 +4353,12 @@ class ExplainedError:
 # stim.ExplainedError.__init__
 
 # (in class stim.ExplainedError)
-def __init__(self, *, dem_error_terms: List[stim.DemTargetWithCoords], circuit_error_locations: List[stim.CircuitErrorLocation]) -> None:
+def __init__(
+    self,
+    *,
+    dem_error_terms: List[stim.DemTargetWithCoords],
+    circuit_error_locations: List[stim.CircuitErrorLocation],
+) -> None:
     """Creates a stim.ExplainedError.
     """
 ```
@@ -3921,7 +4369,9 @@ def __init__(self, *, dem_error_terms: List[stim.DemTargetWithCoords], circuit_e
 
 # (in class stim.ExplainedError)
 @property
-def circuit_error_locations(self) -> List[stim.CircuitErrorLocation]:
+def circuit_error_locations(
+    self,
+) -> List[stim.CircuitErrorLocation]:
     """The locations of circuit errors that produce the symptoms in dem_error_terms.
 
     Note: if this list contains a single entry, it may be because a result
@@ -3940,7 +4390,9 @@ def circuit_error_locations(self) -> List[stim.CircuitErrorLocation]:
 
 # (in class stim.ExplainedError)
 @property
-def dem_error_terms(self) -> List[stim.DemTargetWithCoords]:
+def dem_error_terms(
+    self,
+) -> List[stim.DemTargetWithCoords]:
     """The detectors and observables flipped by this error mechanism.
     """
 ```
@@ -3963,7 +4415,12 @@ class FlippedMeasurement:
 # stim.FlippedMeasurement.__init__
 
 # (in class stim.FlippedMeasurement)
-def __init__(self, *, record_index: int, observable: object) -> None:
+def __init__(
+    self,
+    *,
+    record_index: int,
+    observable: object,
+) -> None:
     """Creates a stim.FlippedMeasurement.
     """
 ```
@@ -3974,7 +4431,9 @@ def __init__(self, *, record_index: int, observable: object) -> None:
 
 # (in class stim.FlippedMeasurement)
 @property
-def observable(self) -> List[stim.GateTargetWithCoords]:
+def observable(
+    self,
+) -> List[stim.GateTargetWithCoords]:
     """Returns the observable of the flipped measurement.
 
     For example, an `MX 5` measurement will have the observable X5.
@@ -3987,7 +4446,9 @@ def observable(self) -> List[stim.GateTargetWithCoords]:
 
 # (in class stim.FlippedMeasurement)
 @property
-def record_index(self) -> int:
+def record_index(
+    self,
+) -> int:
     """The measurement record index of the flipped measurement.
     For example, the fifth measurement in a circuit has a measurement
     record index of 4.
@@ -4019,7 +4480,10 @@ class GateTarget:
 # stim.GateTarget.__eq__
 
 # (in class stim.GateTarget)
-def __eq__(self, arg0: stim.GateTarget) -> bool:
+def __eq__(
+    self,
+    arg0: stim.GateTarget,
+) -> bool:
     """Determines if two `stim.GateTarget`s are identical.
     """
 ```
@@ -4029,7 +4493,10 @@ def __eq__(self, arg0: stim.GateTarget) -> bool:
 # stim.GateTarget.__init__
 
 # (in class stim.GateTarget)
-def __init__(self, value: object) -> None:
+def __init__(
+    self,
+    value: object,
+) -> None:
     """Initializes a `stim.GateTarget`.
 
     Args:
@@ -4042,7 +4509,10 @@ def __init__(self, value: object) -> None:
 # stim.GateTarget.__ne__
 
 # (in class stim.GateTarget)
-def __ne__(self, arg0: stim.GateTarget) -> bool:
+def __ne__(
+    self,
+    arg0: stim.GateTarget,
+) -> bool:
     """Determines if two `stim.GateTarget`s are different.
     """
 ```
@@ -4052,7 +4522,9 @@ def __ne__(self, arg0: stim.GateTarget) -> bool:
 # stim.GateTarget.__repr__
 
 # (in class stim.GateTarget)
-def __repr__(self) -> str:
+def __repr__(
+    self,
+) -> str:
     """Returns text that is a valid python expression evaluating to an equivalent `stim.GateTarget`.
     """
 ```
@@ -4063,7 +4535,9 @@ def __repr__(self) -> str:
 
 # (in class stim.GateTarget)
 @property
-def is_combiner(self) -> bool:
+def is_combiner(
+    self,
+) -> bool:
     """Returns whether or not this is a `stim.target_combiner()` (a `*` in a circuit file).
     """
 ```
@@ -4074,7 +4548,9 @@ def is_combiner(self) -> bool:
 
 # (in class stim.GateTarget)
 @property
-def is_inverted_result_target(self) -> bool:
+def is_inverted_result_target(
+    self,
+) -> bool:
     """Returns whether or not this is an inverted target.
 
     Inverted targets include inverted qubit targets `stim.target_inv(5)` (`!5` in a circuit file) and
@@ -4088,7 +4564,9 @@ def is_inverted_result_target(self) -> bool:
 
 # (in class stim.GateTarget)
 @property
-def is_measurement_record_target(self) -> bool:
+def is_measurement_record_target(
+    self,
+) -> bool:
     """Returns whether or not this is a `stim.target_rec` target (e.g. `rec[-5]` in a circuit file).
     """
 ```
@@ -4099,7 +4577,9 @@ def is_measurement_record_target(self) -> bool:
 
 # (in class stim.GateTarget)
 @property
-def is_qubit_target(self) -> bool:
+def is_qubit_target(
+    self,
+) -> bool:
     """Returns true if this is a qubit target (e.g. `5`) or an inverted qubit target (e.g. `stim.target_inv(4)`).
     """
 ```
@@ -4110,7 +4590,9 @@ def is_qubit_target(self) -> bool:
 
 # (in class stim.GateTarget)
 @property
-def is_sweep_bit_target(self) -> bool:
+def is_sweep_bit_target(
+    self,
+) -> bool:
     """Returns whether or not this is a `stim.target_sweep_bit` target (e.g. `sweep[5]` in a circuit file).
     """
 ```
@@ -4121,7 +4603,9 @@ def is_sweep_bit_target(self) -> bool:
 
 # (in class stim.GateTarget)
 @property
-def is_x_target(self) -> bool:
+def is_x_target(
+    self,
+) -> bool:
     """Returns whether or not this is a `stim.target_x` target (e.g. `X5` in a circuit file).
     """
 ```
@@ -4132,7 +4616,9 @@ def is_x_target(self) -> bool:
 
 # (in class stim.GateTarget)
 @property
-def is_y_target(self) -> bool:
+def is_y_target(
+    self,
+) -> bool:
     """Returns whether or not this is a `stim.target_y` target (e.g. `Y5` in a circuit file).
     """
 ```
@@ -4143,7 +4629,9 @@ def is_y_target(self) -> bool:
 
 # (in class stim.GateTarget)
 @property
-def is_z_target(self) -> bool:
+def is_z_target(
+    self,
+) -> bool:
     """Returns whether or not this is a `stim.target_z` target (e.g. `Z5` in a circuit file).
     """
 ```
@@ -4154,7 +4642,9 @@ def is_z_target(self) -> bool:
 
 # (in class stim.GateTarget)
 @property
-def value(self) -> int:
+def value(
+    self,
+) -> int:
     """The numeric part of the target. Positive for qubit targets, negative for measurement record targets.
     """
 ```
@@ -4183,7 +4673,12 @@ class GateTargetWithCoords:
 # stim.GateTargetWithCoords.__init__
 
 # (in class stim.GateTargetWithCoords)
-def __init__(self, *, gate_target: object, coords: List[float]) -> None:
+def __init__(
+    self,
+    *,
+    gate_target: object,
+    coords: List[float],
+) -> None:
     """Creates a stim.GateTargetWithCoords.
     """
 ```
@@ -4194,7 +4689,9 @@ def __init__(self, *, gate_target: object, coords: List[float]) -> None:
 
 # (in class stim.GateTargetWithCoords)
 @property
-def coords(self) -> List[float]:
+def coords(
+    self,
+) -> List[float]:
     """Returns the associated coordinate information as a list of flaots.
 
     If there is no coordinate information, returns an empty list.
@@ -4207,7 +4704,9 @@ def coords(self) -> List[float]:
 
 # (in class stim.GateTargetWithCoords)
 @property
-def gate_target(self) -> stim.GateTarget:
+def gate_target(
+    self,
+) -> stim.GateTarget:
     """Returns the actual gate target as a `stim.GateTarget`.
     """
 ```
@@ -4236,7 +4735,10 @@ class PauliString:
 # stim.PauliString.__add__
 
 # (in class stim.PauliString)
-def __add__(self, rhs: stim.PauliString) -> stim.PauliString:
+def __add__(
+    self,
+    rhs: stim.PauliString,
+) -> stim.PauliString:
     """Returns the tensor product of two Pauli strings.
 
     Concatenates the Pauli strings and multiplies their signs.
@@ -4263,7 +4765,10 @@ def __add__(self, rhs: stim.PauliString) -> stim.PauliString:
 # stim.PauliString.__eq__
 
 # (in class stim.PauliString)
-def __eq__(self, arg0: stim.PauliString) -> bool:
+def __eq__(
+    self,
+    arg0: stim.PauliString,
+) -> bool:
     """Determines if two Pauli strings have identical contents.
     """
 ```
@@ -4274,12 +4779,21 @@ def __eq__(self, arg0: stim.PauliString) -> bool:
 
 # (in class stim.PauliString)
 @overload
-def __getitem__(self, index_or_slice: int) -> int:
+def __getitem__(
+    self,
+    index_or_slice: int,
+) -> int:
     pass
 @overload
-def __getitem__(self, index_or_slice: slice) -> stim.PauliString:
+def __getitem__(
+    self,
+    index_or_slice: slice,
+) -> stim.PauliString:
     pass
-def __getitem__(self, index_or_slice: object) -> object:
+def __getitem__(
+    self,
+    index_or_slice: object,
+) -> object:
     """Returns an individual Pauli or Pauli string slice from the pauli string.
 
     Individual Paulis are returned as an int using the encoding 0=I, 1=X, 2=Y, 3=Z.
@@ -4313,7 +4827,10 @@ def __getitem__(self, index_or_slice: object) -> object:
 # stim.PauliString.__iadd__
 
 # (in class stim.PauliString)
-def __iadd__(self, rhs: stim.PauliString) -> stim.PauliString:
+def __iadd__(
+    self,
+    rhs: stim.PauliString,
+) -> stim.PauliString:
     """Performs an inplace tensor product.
 
     Concatenates the given Pauli string onto the receiving string and multiplies their signs.
@@ -4342,7 +4859,10 @@ def __iadd__(self, rhs: stim.PauliString) -> stim.PauliString:
 # stim.PauliString.__imul__
 
 # (in class stim.PauliString)
-def __imul__(self, rhs: object) -> stim.PauliString:
+def __imul__(
+    self,
+    rhs: object,
+) -> stim.PauliString:
     """Inplace right-multiplies the Pauli string by another Pauli string, a complex unit, or a tensor power.
 
     Args:
@@ -4386,7 +4906,10 @@ def __imul__(self, rhs: object) -> stim.PauliString:
 
 # (in class stim.PauliString)
 @staticmethod
-def __init__(*args, **kwargs):
+def __init__(
+    *args,
+    **kwargs,
+):
     """Overloaded function.
 
     1. __init__(self: stim.PauliString, num_qubits: int) -> None
@@ -4468,7 +4991,10 @@ def __init__(*args, **kwargs):
 # stim.PauliString.__itruediv__
 
 # (in class stim.PauliString)
-def __itruediv__(self, rhs: complex) -> stim.PauliString:
+def __itruediv__(
+    self,
+    rhs: complex,
+) -> stim.PauliString:
     """Inplace divides the Pauli string by a complex unit.
 
     Args:
@@ -4495,7 +5021,9 @@ def __itruediv__(self, rhs: complex) -> stim.PauliString:
 # stim.PauliString.__len__
 
 # (in class stim.PauliString)
-def __len__(self) -> int:
+def __len__(
+    self,
+) -> int:
     """Returns the length the pauli string; the number of qubits it operates on.
     """
 ```
@@ -4505,7 +5033,10 @@ def __len__(self) -> int:
 # stim.PauliString.__mul__
 
 # (in class stim.PauliString)
-def __mul__(self, rhs: object) -> stim.PauliString:
+def __mul__(
+    self,
+    rhs: object,
+) -> stim.PauliString:
     """Right-multiplies the Pauli string by another Pauli string, a complex unit, or a tensor power.
 
     Args:
@@ -4555,7 +5086,10 @@ def __mul__(self, rhs: object) -> stim.PauliString:
 # stim.PauliString.__ne__
 
 # (in class stim.PauliString)
-def __ne__(self, arg0: stim.PauliString) -> bool:
+def __ne__(
+    self,
+    arg0: stim.PauliString,
+) -> bool:
     """Determines if two Pauli strings have non-identical contents.
     """
 ```
@@ -4565,7 +5099,9 @@ def __ne__(self, arg0: stim.PauliString) -> bool:
 # stim.PauliString.__neg__
 
 # (in class stim.PauliString)
-def __neg__(self) -> stim.PauliString:
+def __neg__(
+    self,
+) -> stim.PauliString:
     """Returns the negation of the pauli string.
 
     Examples:
@@ -4584,7 +5120,9 @@ def __neg__(self) -> stim.PauliString:
 # stim.PauliString.__pos__
 
 # (in class stim.PauliString)
-def __pos__(self) -> stim.PauliString:
+def __pos__(
+    self,
+) -> stim.PauliString:
     """Returns a pauli string with the same contents.
 
     Examples:
@@ -4603,7 +5141,9 @@ def __pos__(self) -> stim.PauliString:
 # stim.PauliString.__repr__
 
 # (in class stim.PauliString)
-def __repr__(self) -> str:
+def __repr__(
+    self,
+) -> str:
     """Returns text that is a valid python expression evaluating to an equivalent `stim.PauliString`.
     """
 ```
@@ -4613,7 +5153,10 @@ def __repr__(self) -> str:
 # stim.PauliString.__rmul__
 
 # (in class stim.PauliString)
-def __rmul__(self, lhs: object) -> stim.PauliString:
+def __rmul__(
+    self,
+    lhs: object,
+) -> stim.PauliString:
     """Left-multiplies the Pauli string by another Pauli string, a complex unit, or a tensor power.
 
     Args:
@@ -4663,7 +5206,11 @@ def __rmul__(self, lhs: object) -> stim.PauliString:
 # stim.PauliString.__setitem__
 
 # (in class stim.PauliString)
-def __setitem__(self, index: int, new_pauli: object) -> None:
+def __setitem__(
+    self,
+    index: int,
+    new_pauli: object,
+) -> None:
     """Mutates an entry in the pauli string using the encoding 0=I, 1=X, 2=Y, 3=Z.
 
     Args:
@@ -4698,7 +5245,9 @@ def __setitem__(self, index: int, new_pauli: object) -> None:
 # stim.PauliString.__str__
 
 # (in class stim.PauliString)
-def __str__(self) -> str:
+def __str__(
+    self,
+) -> str:
     """Returns a text description.
     """
 ```
@@ -4708,7 +5257,10 @@ def __str__(self) -> str:
 # stim.PauliString.__truediv__
 
 # (in class stim.PauliString)
-def __truediv__(self, rhs: complex) -> stim.PauliString:
+def __truediv__(
+    self,
+    rhs: complex,
+) -> stim.PauliString:
     """Divides the Pauli string by a complex unit.
 
     Args:
@@ -4733,7 +5285,10 @@ def __truediv__(self, rhs: complex) -> stim.PauliString:
 # stim.PauliString.commutes
 
 # (in class stim.PauliString)
-def commutes(self, other: stim.PauliString) -> bool:
+def commutes(
+    self,
+    other: stim.PauliString,
+) -> bool:
     """Determines if two Pauli strings commute or not.
 
     Two Pauli strings commute if they have an even number of matched
@@ -4770,7 +5325,9 @@ def commutes(self, other: stim.PauliString) -> bool:
 # stim.PauliString.copy
 
 # (in class stim.PauliString)
-def copy(self) -> stim.PauliString:
+def copy(
+    self,
+) -> stim.PauliString:
     """Returns a copy of the pauli string. An independent pauli string with the same contents.
 
     Examples:
@@ -4789,7 +5346,10 @@ def copy(self) -> stim.PauliString:
 # stim.PauliString.extended_product
 
 # (in class stim.PauliString)
-def extended_product(self, other: stim.PauliString) -> Tuple[complex, stim.PauliString]:
+def extended_product(
+    self,
+    other: stim.PauliString,
+) -> Tuple[complex, stim.PauliString]:
     """[DEPRECATED] Use multiplication (__mul__ or *) instead.
     """
 ```
@@ -4800,7 +5360,11 @@ def extended_product(self, other: stim.PauliString) -> Tuple[complex, stim.Pauli
 
 # (in class stim.PauliString)
 @staticmethod
-def random(num_qubits: int, *, allow_imaginary: bool = False) -> stim.PauliString:
+def random(
+    num_qubits: int,
+    *,
+    allow_imaginary: bool = False,
+) -> stim.PauliString:
     """Samples a uniformly random Hermitian Pauli string over the given number of qubits.
 
     Args:
@@ -4834,7 +5398,9 @@ def random(num_qubits: int, *, allow_imaginary: bool = False) -> stim.PauliStrin
 
 # (in class stim.PauliString)
 @property
-def sign(self) -> complex:
+def sign(
+    self,
+) -> complex:
     """The sign of the Pauli string. Can be +1, -1, 1j, or -1j.
 
     Examples:
@@ -4898,7 +5464,10 @@ class Tableau:
 # stim.Tableau.__add__
 
 # (in class stim.Tableau)
-def __add__(self, rhs: stim.Tableau) -> stim.Tableau:
+def __add__(
+    self,
+    rhs: stim.Tableau,
+) -> stim.Tableau:
     """Returns the direct sum (diagonal concatenation) of two Tableaus.
 
     Args:
@@ -4926,7 +5495,10 @@ def __add__(self, rhs: stim.Tableau) -> stim.Tableau:
 # stim.Tableau.__call__
 
 # (in class stim.Tableau)
-def __call__(self, pauli_string: stim.PauliString) -> stim.PauliString:
+def __call__(
+    self,
+    pauli_string: stim.PauliString,
+) -> stim.PauliString:
     """Returns the result of conjugating the given PauliString by the Tableau's Clifford operation.
 
     Args:
@@ -4950,7 +5522,10 @@ def __call__(self, pauli_string: stim.PauliString) -> stim.PauliString:
 # stim.Tableau.__eq__
 
 # (in class stim.Tableau)
-def __eq__(self, arg0: stim.Tableau) -> bool:
+def __eq__(
+    self,
+    arg0: stim.Tableau,
+) -> bool:
     """Determines if two tableaus have identical contents.
     """
 ```
@@ -4960,7 +5535,10 @@ def __eq__(self, arg0: stim.Tableau) -> bool:
 # stim.Tableau.__iadd__
 
 # (in class stim.Tableau)
-def __iadd__(self, rhs: stim.Tableau) -> stim.Tableau:
+def __iadd__(
+    self,
+    rhs: stim.Tableau,
+) -> stim.Tableau:
     """Performs an inplace direct sum (diagonal concatenation).
 
     Args:
@@ -4992,7 +5570,10 @@ def __iadd__(self, rhs: stim.Tableau) -> stim.Tableau:
 # stim.Tableau.__init__
 
 # (in class stim.Tableau)
-def __init__(self, num_qubits: int) -> None:
+def __init__(
+    self,
+    num_qubits: int,
+) -> None:
     """Creates an identity tableau over the given number of qubits.
 
     Examples:
@@ -5015,7 +5596,9 @@ def __init__(self, num_qubits: int) -> None:
 # stim.Tableau.__len__
 
 # (in class stim.Tableau)
-def __len__(self) -> int:
+def __len__(
+    self,
+) -> int:
     """Returns the number of qubits operated on by the tableau.
     """
 ```
@@ -5025,7 +5608,10 @@ def __len__(self) -> int:
 # stim.Tableau.__mul__
 
 # (in class stim.Tableau)
-def __mul__(self, rhs: stim.Tableau) -> stim.Tableau:
+def __mul__(
+    self,
+    rhs: stim.Tableau,
+) -> stim.Tableau:
     """Returns the product of two tableaus.
 
     If the tableau T1 represents the Clifford operation with unitary C1,
@@ -5051,7 +5637,10 @@ def __mul__(self, rhs: stim.Tableau) -> stim.Tableau:
 # stim.Tableau.__ne__
 
 # (in class stim.Tableau)
-def __ne__(self, arg0: stim.Tableau) -> bool:
+def __ne__(
+    self,
+    arg0: stim.Tableau,
+) -> bool:
     """Determines if two tableaus have non-identical contents.
     """
 ```
@@ -5061,7 +5650,10 @@ def __ne__(self, arg0: stim.Tableau) -> bool:
 # stim.Tableau.__pow__
 
 # (in class stim.Tableau)
-def __pow__(self, exponent: int) -> stim.Tableau:
+def __pow__(
+    self,
+    exponent: int,
+) -> stim.Tableau:
     """Raises the tableau to an integer power.
 
     Large powers are reached efficiently using repeated squaring.
@@ -5095,7 +5687,9 @@ def __pow__(self, exponent: int) -> stim.Tableau:
 # stim.Tableau.__repr__
 
 # (in class stim.Tableau)
-def __repr__(self) -> str:
+def __repr__(
+    self,
+) -> str:
     """Returns text that is a valid python expression evaluating to an equivalent `stim.Tableau`.
     """
 ```
@@ -5105,7 +5699,9 @@ def __repr__(self) -> str:
 # stim.Tableau.__str__
 
 # (in class stim.Tableau)
-def __str__(self) -> str:
+def __str__(
+    self,
+) -> str:
     """Returns a text description.
     """
 ```
@@ -5115,7 +5711,11 @@ def __str__(self) -> str:
 # stim.Tableau.append
 
 # (in class stim.Tableau)
-def append(self, gate: stim.Tableau, targets: List[int]) -> None:
+def append(
+    self,
+    gate: stim.Tableau,
+    targets: List[int],
+) -> None:
     """Appends an operation's effect into this tableau, mutating this tableau.
 
     Time cost is O(n*m*m) where n=len(self) and m=len(gate).
@@ -5141,7 +5741,9 @@ def append(self, gate: stim.Tableau, targets: List[int]) -> None:
 # stim.Tableau.copy
 
 # (in class stim.Tableau)
-def copy(self) -> stim.Tableau:
+def copy(
+    self,
+) -> stim.Tableau:
     """Returns a copy of the tableau. An independent tableau with the same contents.
 
     Examples:
@@ -5161,7 +5763,13 @@ def copy(self) -> stim.Tableau:
 
 # (in class stim.Tableau)
 @staticmethod
-def from_circuit(circuit: stim.Circuit, *, ignore_noise: bool = False, ignore_measurement: bool = False, ignore_reset: bool = False) -> stim.Tableau:
+def from_circuit(
+    circuit: stim.Circuit,
+    *,
+    ignore_noise: bool = False,
+    ignore_measurement: bool = False,
+    ignore_reset: bool = False,
+) -> stim.Tableau:
 
     """Converts a circuit into an equivalent stabilizer tableau.
 
@@ -5213,7 +5821,11 @@ def from_circuit(circuit: stim.Circuit, *, ignore_noise: bool = False, ignore_me
 
 # (in class stim.Tableau)
 @staticmethod
-def from_conjugated_generators(*, xs: List[stim.PauliString], zs: List[stim.PauliString]) -> stim.Tableau:
+def from_conjugated_generators(
+    *,
+    xs: List[stim.PauliString],
+    zs: List[stim.PauliString],
+) -> stim.Tableau:
     """Creates a tableau from the given outputs for each generator.
 
     Verifies that the tableau is well formed.
@@ -5254,7 +5866,9 @@ def from_conjugated_generators(*, xs: List[stim.PauliString], zs: List[stim.Paul
 
 # (in class stim.Tableau)
 @staticmethod
-def from_named_gate(name: str) -> stim.Tableau:
+def from_named_gate(
+    name: str,
+) -> stim.Tableau:
     """Returns the tableau of a named Clifford gate.
 
     Args:
@@ -5287,7 +5901,11 @@ def from_named_gate(name: str) -> stim.Tableau:
 
 # (in class stim.Tableau)
 @staticmethod
-def from_unitary_matrix(matrix: Iterable[Iterable[float]], *, endian: str = 'little') -> stim.Tableau:
+def from_unitary_matrix(
+    matrix: Iterable[Iterable[float]],
+    *,
+    endian: str = 'little',
+) -> stim.Tableau:
 
     """Creates a tableau from the unitary matrix of a Clifford operation.
 
@@ -5344,7 +5962,11 @@ def from_unitary_matrix(matrix: Iterable[Iterable[float]], *, endian: str = 'lit
 # stim.Tableau.inverse
 
 # (in class stim.Tableau)
-def inverse(self, *, unsigned: bool = False) -> stim.Tableau:
+def inverse(
+    self,
+    *,
+    unsigned: bool = False,
+) -> stim.Tableau:
     """Computes the inverse of the tableau.
 
     The inverse T^-1 of a tableau T is the unique tableau with the property that T * T^-1 = T^-1 * T = I where
@@ -5403,7 +6025,12 @@ def inverse(self, *, unsigned: bool = False) -> stim.Tableau:
 # stim.Tableau.inverse_x_output
 
 # (in class stim.Tableau)
-def inverse_x_output(self, input_index: int, *, unsigned: bool = False) -> stim.PauliString:
+def inverse_x_output(
+    self,
+    input_index: int,
+    *,
+    unsigned: bool = False,
+) -> stim.PauliString:
     """Returns the result of conjugating an X Pauli generator by the inverse of the tableau.
 
     A faster version of `tableau.inverse(unsigned).x_output(input_index)`.
@@ -5436,7 +6063,11 @@ def inverse_x_output(self, input_index: int, *, unsigned: bool = False) -> stim.
 # stim.Tableau.inverse_x_output_pauli
 
 # (in class stim.Tableau)
-def inverse_x_output_pauli(self, input_index: int, output_index: int) -> int:
+def inverse_x_output_pauli(
+    self,
+    input_index: int,
+    output_index: int,
+) -> int:
     """Returns a Pauli term from the tableau's inverse's output pauli string for an input X generator.
 
     A constant-time equivalent for `tableau.inverse().x_output(input_index)[output_index]`.
@@ -5476,7 +6107,12 @@ def inverse_x_output_pauli(self, input_index: int, output_index: int) -> int:
 # stim.Tableau.inverse_y_output
 
 # (in class stim.Tableau)
-def inverse_y_output(self, input_index: int, *, unsigned: bool = False) -> stim.PauliString:
+def inverse_y_output(
+    self,
+    input_index: int,
+    *,
+    unsigned: bool = False,
+) -> stim.PauliString:
     """Returns the result of conjugating a Y Pauli generator by the inverse of the tableau.
 
     A faster version of `tableau.inverse(unsigned).y_output(input_index)`.
@@ -5509,7 +6145,11 @@ def inverse_y_output(self, input_index: int, *, unsigned: bool = False) -> stim.
 # stim.Tableau.inverse_y_output_pauli
 
 # (in class stim.Tableau)
-def inverse_y_output_pauli(self, input_index: int, output_index: int) -> int:
+def inverse_y_output_pauli(
+    self,
+    input_index: int,
+    output_index: int,
+) -> int:
     """Returns a Pauli term from the tableau's inverse's output pauli string for an input Y generator.
 
     A constant-time equivalent for `tableau.inverse().y_output(input_index)[output_index]`.
@@ -5549,7 +6189,12 @@ def inverse_y_output_pauli(self, input_index: int, output_index: int) -> int:
 # stim.Tableau.inverse_z_output
 
 # (in class stim.Tableau)
-def inverse_z_output(self, input_index: int, *, unsigned: bool = False) -> stim.PauliString:
+def inverse_z_output(
+    self,
+    input_index: int,
+    *,
+    unsigned: bool = False,
+) -> stim.PauliString:
     """Returns the result of conjugating a Z Pauli generator by the inverse of the tableau.
 
     A faster version of `tableau.inverse(unsigned).z_output(input_index)`.
@@ -5584,7 +6229,11 @@ def inverse_z_output(self, input_index: int, *, unsigned: bool = False) -> stim.
 # stim.Tableau.inverse_z_output_pauli
 
 # (in class stim.Tableau)
-def inverse_z_output_pauli(self, input_index: int, output_index: int) -> int:
+def inverse_z_output_pauli(
+    self,
+    input_index: int,
+    output_index: int,
+) -> int:
     """Returns a Pauli term from the tableau's inverse's output pauli string for an input Z generator.
 
     A constant-time equivalent for `tableau.inverse().z_output(input_index)[output_index]`.
@@ -5625,7 +6274,11 @@ def inverse_z_output_pauli(self, input_index: int, output_index: int) -> int:
 
 # (in class stim.Tableau)
 @staticmethod
-def iter_all(num_qubits: int, *, unsigned: bool = False) -> stim.TableauIterator:
+def iter_all(
+    num_qubits: int,
+    *,
+    unsigned: bool = False,
+) -> stim.TableauIterator:
     """Returns an iterator that iterates over all Tableaus of a given size.
 
     Args:
@@ -5659,7 +6312,11 @@ def iter_all(num_qubits: int, *, unsigned: bool = False) -> stim.TableauIterator
 # stim.Tableau.prepend
 
 # (in class stim.Tableau)
-def prepend(self, gate: stim.Tableau, targets: List[int]) -> None:
+def prepend(
+    self,
+    gate: stim.Tableau,
+    targets: List[int],
+) -> None:
     """Prepends an operation's effect into this tableau, mutating this tableau.
 
     Time cost is O(n*m*m) where n=len(self) and m=len(gate).
@@ -5685,7 +6342,9 @@ def prepend(self, gate: stim.Tableau, targets: List[int]) -> None:
 
 # (in class stim.Tableau)
 @staticmethod
-def random(num_qubits: int) -> stim.Tableau:
+def random(
+    num_qubits: int,
+) -> stim.Tableau:
     """Samples a uniformly random Clifford operation over the given number of qubits and returns its tableau.
 
     Args:
@@ -5710,7 +6369,10 @@ def random(num_qubits: int) -> stim.Tableau:
 # stim.Tableau.then
 
 # (in class stim.Tableau)
-def then(self, second: stim.Tableau) -> stim.Tableau:
+def then(
+    self,
+    second: stim.Tableau,
+) -> stim.Tableau:
     """Returns the result of composing two tableaus.
 
     If the tableau T1 represents the Clifford operation with unitary C1,
@@ -5737,7 +6399,11 @@ def then(self, second: stim.Tableau) -> stim.Tableau:
 # stim.Tableau.to_circuit
 
 # (in class stim.Tableau)
-def to_circuit(self, *, method: str) -> stim.Circuit:
+def to_circuit(
+    self,
+    *,
+    method: str,
+) -> stim.Circuit:
 
     """Synthesizes a circuit that implements the tableau's Clifford operation.
 
@@ -5797,7 +6463,11 @@ def to_circuit(self, *, method: str) -> stim.Circuit:
 # stim.Tableau.to_unitary_matrix
 
 # (in class stim.Tableau)
-def to_unitary_matrix(self, *, endian: str) -> np.ndarray[np.complex64]:
+def to_unitary_matrix(
+    self,
+    *,
+    endian: str,
+) -> np.ndarray[np.complex64]:
 
     """Converts the tableau into a unitary matrix.
 
@@ -5836,7 +6506,10 @@ def to_unitary_matrix(self, *, endian: str) -> np.ndarray[np.complex64]:
 # stim.Tableau.x_output
 
 # (in class stim.Tableau)
-def x_output(self, target: int) -> stim.PauliString:
+def x_output(
+    self,
+    target: int,
+) -> stim.PauliString:
     """Returns the result of conjugating a Pauli X by the tableau's Clifford operation.
 
     Args:
@@ -5861,7 +6534,11 @@ def x_output(self, target: int) -> stim.PauliString:
 # stim.Tableau.x_output_pauli
 
 # (in class stim.Tableau)
-def x_output_pauli(self, input_index: int, output_index: int) -> int:
+def x_output_pauli(
+    self,
+    input_index: int,
+    output_index: int,
+) -> int:
     """Returns a Pauli term from the tableau's output pauli string for an input X generator.
 
     A constant-time equivalent for `tableau.x_output(input_index)[output_index]`.
@@ -5901,7 +6578,10 @@ def x_output_pauli(self, input_index: int, output_index: int) -> int:
 # stim.Tableau.y_output
 
 # (in class stim.Tableau)
-def y_output(self, target: int) -> stim.PauliString:
+def y_output(
+    self,
+    target: int,
+) -> stim.PauliString:
     """Returns the result of conjugating a Pauli Y by the tableau's Clifford operation.
 
     Args:
@@ -5926,7 +6606,11 @@ def y_output(self, target: int) -> stim.PauliString:
 # stim.Tableau.y_output_pauli
 
 # (in class stim.Tableau)
-def y_output_pauli(self, input_index: int, output_index: int) -> int:
+def y_output_pauli(
+    self,
+    input_index: int,
+    output_index: int,
+) -> int:
     """Returns a Pauli term from the tableau's output pauli string for an input Y generator.
 
     A constant-time equivalent for `tableau.y_output(input_index)[output_index]`.
@@ -5966,7 +6650,10 @@ def y_output_pauli(self, input_index: int, output_index: int) -> int:
 # stim.Tableau.z_output
 
 # (in class stim.Tableau)
-def z_output(self, target: int) -> stim.PauliString:
+def z_output(
+    self,
+    target: int,
+) -> stim.PauliString:
     """Returns the result of conjugating a Pauli Z by the tableau's Clifford operation.
 
     Args:
@@ -5991,7 +6678,11 @@ def z_output(self, target: int) -> stim.PauliString:
 # stim.Tableau.z_output_pauli
 
 # (in class stim.Tableau)
-def z_output_pauli(self, input_index: int, output_index: int) -> int:
+def z_output_pauli(
+    self,
+    input_index: int,
+    output_index: int,
+) -> int:
     """Returns a Pauli term from the tableau's output pauli string for an input Z generator.
 
     A constant-time equivalent for `tableau.z_output(input_index)[output_index]`.
@@ -6050,7 +6741,9 @@ class TableauIterator:
 # stim.TableauIterator.__iter__
 
 # (in class stim.TableauIterator)
-def __iter__(self) -> stim.TableauIterator:
+def __iter__(
+    self,
+) -> stim.TableauIterator:
     """Returns an independent copy of the tableau iterator.
 
     Since for-loops and loop-comprehensions call `iter` on things they
@@ -6064,7 +6757,9 @@ def __iter__(self) -> stim.TableauIterator:
 # stim.TableauIterator.__next__
 
 # (in class stim.TableauIterator)
-def __next__(self) -> stim.Tableau:
+def __next__(
+    self,
+) -> stim.Tableau:
     """Returns the next iterated tableau.
     """
 ```
@@ -6111,7 +6806,10 @@ class TableauSimulator:
 # stim.TableauSimulator.c_xyz
 
 # (in class stim.TableauSimulator)
-def c_xyz(self, *targets) -> None:
+def c_xyz(
+    self,
+    *targets,
+) -> None:
     """Applies a C_XYZ gate to the simulator's state.
 
     Args:
@@ -6124,7 +6822,10 @@ def c_xyz(self, *targets) -> None:
 # stim.TableauSimulator.c_zyx
 
 # (in class stim.TableauSimulator)
-def c_zyx(self, *targets) -> None:
+def c_zyx(
+    self,
+    *targets,
+) -> None:
     """Applies a C_ZYX gate to the simulator's state.
 
     Args:
@@ -6137,7 +6838,9 @@ def c_zyx(self, *targets) -> None:
 # stim.TableauSimulator.canonical_stabilizers
 
 # (in class stim.TableauSimulator)
-def canonical_stabilizers(self) -> List[stim.PauliString]:
+def canonical_stabilizers(
+    self,
+) -> List[stim.PauliString]:
     """Returns a list of the stabilizers of the simulator's current state in a standard form.
 
     Two simulators have the same canonical stabilizers if and only if their current quantum state is equal
@@ -6180,7 +6883,10 @@ def canonical_stabilizers(self) -> List[stim.PauliString]:
 # stim.TableauSimulator.cnot
 
 # (in class stim.TableauSimulator)
-def cnot(self, *targets) -> None:
+def cnot(
+    self,
+    *targets,
+) -> None:
     """Applies a controlled X gate to the simulator's state.
 
     Args:
@@ -6195,7 +6901,9 @@ def cnot(self, *targets) -> None:
 # stim.TableauSimulator.copy
 
 # (in class stim.TableauSimulator)
-def copy(self) -> stim.TableauSimulator:
+def copy(
+    self,
+) -> stim.TableauSimulator:
     """Returns a copy of the simulator. A simulator with the same internal state.
 
     Examples:
@@ -6229,7 +6937,9 @@ def copy(self) -> stim.TableauSimulator:
 # stim.TableauSimulator.current_inverse_tableau
 
 # (in class stim.TableauSimulator)
-def current_inverse_tableau(self) -> stim.Tableau:
+def current_inverse_tableau(
+    self,
+) -> stim.Tableau:
     """Returns a copy of the internal state of the simulator as a stim.Tableau.
 
     Returns:
@@ -6268,7 +6978,9 @@ def current_inverse_tableau(self) -> stim.Tableau:
 # stim.TableauSimulator.current_measurement_record
 
 # (in class stim.TableauSimulator)
-def current_measurement_record(self) -> List[bool]:
+def current_measurement_record(
+    self,
+) -> List[bool]:
     """Returns a copy of the record of all measurements performed by the simulator.
 
     Examples:
@@ -6297,7 +7009,10 @@ def current_measurement_record(self) -> List[bool]:
 # stim.TableauSimulator.cx
 
 # (in class stim.TableauSimulator)
-def cx(self, *targets) -> None:
+def cx(
+    self,
+    *targets,
+) -> None:
     """Applies a controlled X gate to the simulator's state.
 
     Args:
@@ -6312,7 +7027,10 @@ def cx(self, *targets) -> None:
 # stim.TableauSimulator.cy
 
 # (in class stim.TableauSimulator)
-def cy(self, *targets) -> None:
+def cy(
+    self,
+    *targets,
+) -> None:
     """Applies a controlled Y gate to the simulator's state.
 
     Args:
@@ -6327,7 +7045,10 @@ def cy(self, *targets) -> None:
 # stim.TableauSimulator.cz
 
 # (in class stim.TableauSimulator)
-def cz(self, *targets) -> None:
+def cz(
+    self,
+    *targets,
+) -> None:
     """Applies a controlled Z gate to the simulator's state.
 
     Args:
@@ -6343,12 +7064,21 @@ def cz(self, *targets) -> None:
 
 # (in class stim.TableauSimulator)
 @overload
-def do(self, circuit_or_pauli_string: stim.Circuit) -> None:
+def do(
+    self,
+    circuit_or_pauli_string: stim.Circuit,
+) -> None:
     pass
 @overload
-def do(self, circuit_or_pauli_string: stim.PauliString) -> None:
+def do(
+    self,
+    circuit_or_pauli_string: stim.PauliString,
+) -> None:
     pass
-def do(self, circuit_or_pauli_string: object) -> None:
+def do(
+    self,
+    circuit_or_pauli_string: object,
+) -> None:
     """Applies a circuit or pauli string to the simulator's state.
 
     Args:
@@ -6376,7 +7106,10 @@ def do(self, circuit_or_pauli_string: object) -> None:
 # stim.TableauSimulator.do_circuit
 
 # (in class stim.TableauSimulator)
-def do_circuit(self, circuit: stim.Circuit) -> None:
+def do_circuit(
+    self,
+    circuit: stim.Circuit,
+) -> None:
     """Applies a circuit to the simulator's state.
 
     Args:
@@ -6399,7 +7132,10 @@ def do_circuit(self, circuit: stim.Circuit) -> None:
 # stim.TableauSimulator.do_pauli_string
 
 # (in class stim.TableauSimulator)
-def do_pauli_string(self, pauli_string: stim.PauliString) -> None:
+def do_pauli_string(
+    self,
+    pauli_string: stim.PauliString,
+) -> None:
     """Applies the paulis from a pauli string to the simulator's state.
 
     Args:
@@ -6419,7 +7155,11 @@ def do_pauli_string(self, pauli_string: stim.PauliString) -> None:
 # stim.TableauSimulator.do_tableau
 
 # (in class stim.TableauSimulator)
-def do_tableau(self, tableau: stim.Tableau, targets: List[int]) -> None:
+def do_tableau(
+    self,
+    tableau: stim.Tableau,
+    targets: List[int],
+) -> None:
     """Applies a custom tableau operation to qubits in the simulator.
 
     Note that this method has to compute the inverse of the tableau, because the
@@ -6464,7 +7204,10 @@ def do_tableau(self, tableau: stim.Tableau, targets: List[int]) -> None:
 # stim.TableauSimulator.h
 
 # (in class stim.TableauSimulator)
-def h(self, *targets) -> None:
+def h(
+    self,
+    *targets,
+) -> None:
     """Applies a Hadamard gate to the simulator's state.
 
     Args:
@@ -6477,7 +7220,10 @@ def h(self, *targets) -> None:
 # stim.TableauSimulator.h_xy
 
 # (in class stim.TableauSimulator)
-def h_xy(self, *targets) -> None:
+def h_xy(
+    self,
+    *targets,
+) -> None:
     """Applies a variant of the Hadamard gate that swaps the X and Y axes to the simulator's state.
 
     Args:
@@ -6490,7 +7236,10 @@ def h_xy(self, *targets) -> None:
 # stim.TableauSimulator.h_xz
 
 # (in class stim.TableauSimulator)
-def h_xz(self, *targets) -> None:
+def h_xz(
+    self,
+    *targets,
+) -> None:
     """Applies a Hadamard gate to the simulator's state.
 
     Args:
@@ -6503,7 +7252,10 @@ def h_xz(self, *targets) -> None:
 # stim.TableauSimulator.h_yz
 
 # (in class stim.TableauSimulator)
-def h_yz(self, *targets) -> None:
+def h_yz(
+    self,
+    *targets,
+) -> None:
     """Applies a variant of the Hadamard gate that swaps the Y and Z axes to the simulator's state.
 
     Args:
@@ -6516,7 +7268,10 @@ def h_yz(self, *targets) -> None:
 # stim.TableauSimulator.iswap
 
 # (in class stim.TableauSimulator)
-def iswap(self, *targets) -> None:
+def iswap(
+    self,
+    *targets,
+) -> None:
     """Applies an ISWAP gate to the simulator's state.
 
     Args:
@@ -6531,7 +7286,10 @@ def iswap(self, *targets) -> None:
 # stim.TableauSimulator.iswap_dag
 
 # (in class stim.TableauSimulator)
-def iswap_dag(self, *targets) -> None:
+def iswap_dag(
+    self,
+    *targets,
+) -> None:
     """Applies an ISWAP_DAG gate to the simulator's state.
 
     Args:
@@ -6546,7 +7304,10 @@ def iswap_dag(self, *targets) -> None:
 # stim.TableauSimulator.measure
 
 # (in class stim.TableauSimulator)
-def measure(self, target: int) -> bool:
+def measure(
+    self,
+    target: int,
+) -> bool:
     """Measures a single qubit.
 
     Unlike the other methods on TableauSimulator, this one does not broadcast
@@ -6568,7 +7329,10 @@ def measure(self, target: int) -> bool:
 # stim.TableauSimulator.measure_kickback
 
 # (in class stim.TableauSimulator)
-def measure_kickback(self, target: int) -> tuple:
+def measure_kickback(
+    self,
+    target: int,
+) -> tuple:
     """Measures a qubit and returns the result as well as its Pauli kickback (if any).
 
     The "Pauli kickback" of a stabilizer circuit measurement is a set of Pauli operations that
@@ -6626,7 +7390,10 @@ def measure_kickback(self, target: int) -> tuple:
 # stim.TableauSimulator.measure_many
 
 # (in class stim.TableauSimulator)
-def measure_many(self, *targets) -> List[bool]:
+def measure_many(
+    self,
+    *targets,
+) -> List[bool]:
     """Measures multiple qubits.
 
     Args:
@@ -6643,7 +7410,9 @@ def measure_many(self, *targets) -> List[bool]:
 
 # (in class stim.TableauSimulator)
 @property
-def num_qubits(self) -> int:
+def num_qubits(
+    self,
+) -> int:
     """Returns the number of qubits currently being tracked by the simulator's internal state.
 
     Note that the number of qubits being tracked will implicitly increase if qubits beyond
@@ -6665,7 +7434,10 @@ def num_qubits(self) -> int:
 # stim.TableauSimulator.peek_bloch
 
 # (in class stim.TableauSimulator)
-def peek_bloch(self, target: int) -> stim.PauliString:
+def peek_bloch(
+    self,
+    target: int,
+) -> stim.PauliString:
     """Returns the current bloch vector of the qubit, represented as a stim.PauliString.
 
     This is a non-physical operation. It reports information about the qubit without disturbing it.
@@ -6707,7 +7479,10 @@ def peek_bloch(self, target: int) -> stim.PauliString:
 # stim.TableauSimulator.peek_observable_expectation
 
 # (in class stim.TableauSimulator)
-def peek_observable_expectation(self, observable: stim.PauliString) -> int:
+def peek_observable_expectation(
+    self,
+    observable: stim.PauliString,
+) -> int:
     """Determines the expected value of an observable (which will always be -1, 0, or +1).
 
     This is a non-physical operation.
@@ -6754,7 +7529,10 @@ def peek_observable_expectation(self, observable: stim.PauliString) -> int:
 # stim.TableauSimulator.peek_x
 
 # (in class stim.TableauSimulator)
-def peek_x(self, target: int) -> int:
+def peek_x(
+    self,
+    target: int,
+) -> int:
     """Returns the expected value of a qubit's X observable (which will always be -1, 0, or +1).
 
     This is a non-physical operation.
@@ -6788,7 +7566,10 @@ def peek_x(self, target: int) -> int:
 # stim.TableauSimulator.peek_y
 
 # (in class stim.TableauSimulator)
-def peek_y(self, target: int) -> int:
+def peek_y(
+    self,
+    target: int,
+) -> int:
     """Returns the expected value of a qubit's Y observable (which will always be -1, 0, or +1).
 
     This is a non-physical operation.
@@ -6822,7 +7603,10 @@ def peek_y(self, target: int) -> int:
 # stim.TableauSimulator.peek_z
 
 # (in class stim.TableauSimulator)
-def peek_z(self, target: int) -> int:
+def peek_z(
+    self,
+    target: int,
+) -> int:
     """Returns the expected value of a qubit's Z observable (which will always be -1, 0, or +1).
 
     This is a non-physical operation.
@@ -6856,7 +7640,12 @@ def peek_z(self, target: int) -> int:
 # stim.TableauSimulator.postselect_x
 
 # (in class stim.TableauSimulator)
-def postselect_x(self, targets: Union[int, Iterable[int]], *, desired_value: bool) -> None:
+def postselect_x(
+    self,
+    targets: Union[int, Iterable[int]],
+    *,
+    desired_value: bool,
+) -> None:
 
     """Postselects qubits in the X basis, or raises an exception.
 
@@ -6883,7 +7672,12 @@ def postselect_x(self, targets: Union[int, Iterable[int]], *, desired_value: boo
 # stim.TableauSimulator.postselect_y
 
 # (in class stim.TableauSimulator)
-def postselect_y(self, targets: Union[int, Iterable[int]], *, desired_value: bool) -> None:
+def postselect_y(
+    self,
+    targets: Union[int, Iterable[int]],
+    *,
+    desired_value: bool,
+) -> None:
 
     """Postselects qubits in the Y basis, or raises an exception.
 
@@ -6910,7 +7704,12 @@ def postselect_y(self, targets: Union[int, Iterable[int]], *, desired_value: boo
 # stim.TableauSimulator.postselect_z
 
 # (in class stim.TableauSimulator)
-def postselect_z(self, targets: Union[int, Iterable[int]], *, desired_value: bool) -> None:
+def postselect_z(
+    self,
+    targets: Union[int, Iterable[int]],
+    *,
+    desired_value: bool,
+) -> None:
 
     """Postselects qubits in the Z basis, or raises an exception.
 
@@ -6937,7 +7736,10 @@ def postselect_z(self, targets: Union[int, Iterable[int]], *, desired_value: boo
 # stim.TableauSimulator.reset
 
 # (in class stim.TableauSimulator)
-def reset(self, *targets) -> None:
+def reset(
+    self,
+    *targets,
+) -> None:
     """Resets qubits to the |0> state.
 
     Args:
@@ -6958,7 +7760,10 @@ def reset(self, *targets) -> None:
 # stim.TableauSimulator.reset_x
 
 # (in class stim.TableauSimulator)
-def reset_x(self, *targets) -> None:
+def reset_x(
+    self,
+    *targets,
+) -> None:
     """Resets qubits to the |+> state.
 
     Args:
@@ -6978,7 +7783,10 @@ def reset_x(self, *targets) -> None:
 # stim.TableauSimulator.reset_y
 
 # (in class stim.TableauSimulator)
-def reset_y(self, *targets) -> None:
+def reset_y(
+    self,
+    *targets,
+) -> None:
     """Resets qubits to the |i> state.
 
     Args:
@@ -6998,7 +7806,10 @@ def reset_y(self, *targets) -> None:
 # stim.TableauSimulator.reset_z
 
 # (in class stim.TableauSimulator)
-def reset_z(self, *targets) -> None:
+def reset_z(
+    self,
+    *targets,
+) -> None:
     """Resets qubits to the |0> state.
 
     Args:
@@ -7019,7 +7830,10 @@ def reset_z(self, *targets) -> None:
 # stim.TableauSimulator.s
 
 # (in class stim.TableauSimulator)
-def s(self, *targets) -> None:
+def s(
+    self,
+    *targets,
+) -> None:
     """Applies a SQRT_Z gate to the simulator's state.
 
     Args:
@@ -7032,7 +7846,10 @@ def s(self, *targets) -> None:
 # stim.TableauSimulator.s_dag
 
 # (in class stim.TableauSimulator)
-def s_dag(self, *targets) -> None:
+def s_dag(
+    self,
+    *targets,
+) -> None:
     """Applies a SQRT_Z_DAG gate to the simulator's state.
 
     Args:
@@ -7045,7 +7862,10 @@ def s_dag(self, *targets) -> None:
 # stim.TableauSimulator.set_inverse_tableau
 
 # (in class stim.TableauSimulator)
-def set_inverse_tableau(self, new_inverse_tableau: stim.Tableau) -> None:
+def set_inverse_tableau(
+    self,
+    new_inverse_tableau: stim.Tableau,
+) -> None:
     """Overwrites the simulator's internal state with a copy of the given inverse tableau.
 
     The inverse tableau specifies how Pauli product observables of qubits at the current time transform
@@ -7075,7 +7895,10 @@ def set_inverse_tableau(self, new_inverse_tableau: stim.Tableau) -> None:
 # stim.TableauSimulator.set_num_qubits
 
 # (in class stim.TableauSimulator)
-def set_num_qubits(self, new_num_qubits: int) -> None:
+def set_num_qubits(
+    self,
+    new_num_qubits: int,
+) -> None:
     """Forces the simulator's internal state to track exactly the qubits whose indices are in range(new_num_qubits).
 
     Note that untracked qubits are always assumed to be in the |0> state. Therefore, calling this method
@@ -7110,7 +7933,13 @@ def set_num_qubits(self, new_num_qubits: int) -> None:
 # stim.TableauSimulator.set_state_from_stabilizers
 
 # (in class stim.TableauSimulator)
-def set_state_from_stabilizers(self, stabilizers: Iterable[stim.PauliString], *, bool allow_redundant = False, bool allow_underconstrained = False) -> None:
+def set_state_from_stabilizers(
+    self,
+    stabilizers: Iterable[stim.PauliString],
+    *,
+    bool allow_redundant = False,
+    bool allow_underconstrained = False,
+) -> None:
 
     """Sets the tableau simulator's state to a state satisfying the given stabilizers.
 
@@ -7197,7 +8026,12 @@ def set_state_from_stabilizers(self, stabilizers: Iterable[stim.PauliString], *,
 # stim.TableauSimulator.set_state_from_state_vector
 
 # (in class stim.TableauSimulator)
-def set_state_from_state_vector(self, state_vector: Iterable[float], *, endian: str) -> None:
+def set_state_from_state_vector(
+    self,
+    state_vector: Iterable[float],
+    *,
+    endian: str,
+) -> None:
 
     """Sets the tableau simulator's state to a superposition specified by a vector of amplitudes.
 
@@ -7262,7 +8096,10 @@ def set_state_from_state_vector(self, state_vector: Iterable[float], *, endian: 
 # stim.TableauSimulator.sqrt_x
 
 # (in class stim.TableauSimulator)
-def sqrt_x(self, *targets) -> None:
+def sqrt_x(
+    self,
+    *targets,
+) -> None:
     """Applies a SQRT_X gate to the simulator's state.
 
     Args:
@@ -7275,7 +8112,10 @@ def sqrt_x(self, *targets) -> None:
 # stim.TableauSimulator.sqrt_x_dag
 
 # (in class stim.TableauSimulator)
-def sqrt_x_dag(self, *targets) -> None:
+def sqrt_x_dag(
+    self,
+    *targets,
+) -> None:
     """Applies a SQRT_X_DAG gate to the simulator's state.
 
     Args:
@@ -7288,7 +8128,10 @@ def sqrt_x_dag(self, *targets) -> None:
 # stim.TableauSimulator.sqrt_y
 
 # (in class stim.TableauSimulator)
-def sqrt_y(self, *targets) -> None:
+def sqrt_y(
+    self,
+    *targets,
+) -> None:
     """Applies a SQRT_Y gate to the simulator's state.
 
     Args:
@@ -7301,7 +8144,10 @@ def sqrt_y(self, *targets) -> None:
 # stim.TableauSimulator.sqrt_y_dag
 
 # (in class stim.TableauSimulator)
-def sqrt_y_dag(self, *targets) -> None:
+def sqrt_y_dag(
+    self,
+    *targets,
+) -> None:
     """Applies a SQRT_Y_DAG gate to the simulator's state.
 
     Args:
@@ -7314,7 +8160,11 @@ def sqrt_y_dag(self, *targets) -> None:
 # stim.TableauSimulator.state_vector
 
 # (in class stim.TableauSimulator)
-def state_vector(self, *, endian: str = 'little') -> np.ndarray[np.complex64]:
+def state_vector(
+    self,
+    *,
+    endian: str = 'little',
+) -> np.ndarray[np.complex64]:
 
     """Returns a wavefunction that satisfies the stabilizers of the simulator's current state.
 
@@ -7363,7 +8213,10 @@ def state_vector(self, *, endian: str = 'little') -> np.ndarray[np.complex64]:
 # stim.TableauSimulator.swap
 
 # (in class stim.TableauSimulator)
-def swap(self, *targets) -> None:
+def swap(
+    self,
+    *targets,
+) -> None:
     """Applies a swap gate to the simulator's state.
 
     Args:
@@ -7378,7 +8231,10 @@ def swap(self, *targets) -> None:
 # stim.TableauSimulator.x
 
 # (in class stim.TableauSimulator)
-def x(self, *targets) -> None:
+def x(
+    self,
+    *targets,
+) -> None:
     """Applies a Pauli X gate to the simulator's state.
 
     Args:
@@ -7391,7 +8247,10 @@ def x(self, *targets) -> None:
 # stim.TableauSimulator.xcx
 
 # (in class stim.TableauSimulator)
-def xcx(self, *targets) -> None:
+def xcx(
+    self,
+    *targets,
+) -> None:
     """Applies an X-controlled X gate to the simulator's state.
 
     Args:
@@ -7406,7 +8265,10 @@ def xcx(self, *targets) -> None:
 # stim.TableauSimulator.xcy
 
 # (in class stim.TableauSimulator)
-def xcy(self, *targets) -> None:
+def xcy(
+    self,
+    *targets,
+) -> None:
     """Applies an X-controlled Y gate to the simulator's state.
 
     Args:
@@ -7421,7 +8283,10 @@ def xcy(self, *targets) -> None:
 # stim.TableauSimulator.xcz
 
 # (in class stim.TableauSimulator)
-def xcz(self, *targets) -> None:
+def xcz(
+    self,
+    *targets,
+) -> None:
     """Applies an X-controlled Z gate to the simulator's state.
 
     Args:
@@ -7436,7 +8301,10 @@ def xcz(self, *targets) -> None:
 # stim.TableauSimulator.y
 
 # (in class stim.TableauSimulator)
-def y(self, *targets) -> None:
+def y(
+    self,
+    *targets,
+) -> None:
     """Applies a Pauli Y gate to the simulator's state.
 
     Args:
@@ -7449,7 +8317,10 @@ def y(self, *targets) -> None:
 # stim.TableauSimulator.ycx
 
 # (in class stim.TableauSimulator)
-def ycx(self, *targets) -> None:
+def ycx(
+    self,
+    *targets,
+) -> None:
     """Applies a Y-controlled X gate to the simulator's state.
 
     Args:
@@ -7464,7 +8335,10 @@ def ycx(self, *targets) -> None:
 # stim.TableauSimulator.ycy
 
 # (in class stim.TableauSimulator)
-def ycy(self, *targets) -> None:
+def ycy(
+    self,
+    *targets,
+) -> None:
     """Applies a Y-controlled Y gate to the simulator's state.
 
     Args:
@@ -7479,7 +8353,10 @@ def ycy(self, *targets) -> None:
 # stim.TableauSimulator.ycz
 
 # (in class stim.TableauSimulator)
-def ycz(self, *targets) -> None:
+def ycz(
+    self,
+    *targets,
+) -> None:
     """Applies a Y-controlled Z gate to the simulator's state.
 
     Args:
@@ -7494,7 +8371,10 @@ def ycz(self, *targets) -> None:
 # stim.TableauSimulator.z
 
 # (in class stim.TableauSimulator)
-def z(self, *targets) -> None:
+def z(
+    self,
+    *targets,
+) -> None:
     """Applies a Pauli Z gate to the simulator's state.
 
     Args:
@@ -7507,7 +8387,10 @@ def z(self, *targets) -> None:
 # stim.TableauSimulator.zcx
 
 # (in class stim.TableauSimulator)
-def zcx(self, *targets) -> None:
+def zcx(
+    self,
+    *targets,
+) -> None:
     """Applies a controlled X gate to the simulator's state.
 
     Args:
@@ -7522,7 +8405,10 @@ def zcx(self, *targets) -> None:
 # stim.TableauSimulator.zcy
 
 # (in class stim.TableauSimulator)
-def zcy(self, *targets) -> None:
+def zcy(
+    self,
+    *targets,
+) -> None:
     """Applies a controlled Y gate to the simulator's state.
 
     Args:
@@ -7537,7 +8423,10 @@ def zcy(self, *targets) -> None:
 # stim.TableauSimulator.zcz
 
 # (in class stim.TableauSimulator)
-def zcz(self, *targets) -> None:
+def zcz(
+    self,
+    *targets,
+) -> None:
     """Applies a controlled Z gate to the simulator's state.
 
     Args:
@@ -7552,7 +8441,10 @@ def zcz(self, *targets) -> None:
 # stim.main
 
 # (at top-level in the stim module)
-def main(*, command_line_args: List[str]) -> int:
+def main(
+    *,
+    command_line_args: List[str],
+) -> int:
     """Runs the command line tool version of stim on the given arguments.
 
     Note that by default any input will be read from stdin, any output
@@ -7629,7 +8521,15 @@ def main(*, command_line_args: List[str]) -> int:
 # stim.read_shot_data_file
 
 # (at top-level in the stim module)
-def read_shot_data_file(*, path: str, format: str, num_measurements: int = 0, num_detectors: int = 0, num_observables: int = 0, bit_pack: bool = False) -> np.ndarray:
+def read_shot_data_file(
+    *,
+    path: str,
+    format: str,
+    num_measurements: int = 0,
+    num_detectors: int = 0,
+    num_observables: int = 0,
+    bit_pack: bool = False,
+) -> np.ndarray:
 
     """Reads shot data, such as measurement samples, from a file.
 
@@ -7682,7 +8582,8 @@ def read_shot_data_file(*, path: str, format: str, num_measurements: int = 0, nu
 # stim.target_combiner
 
 # (at top-level in the stim module)
-def target_combiner() -> stim.GateTarget:
+def target_combiner(
+) -> stim.GateTarget:
     """Returns a target combiner (`*` in circuit files) that can be used as an operation target.
     """
 ```
@@ -7692,7 +8593,9 @@ def target_combiner() -> stim.GateTarget:
 # stim.target_inv
 
 # (at top-level in the stim module)
-def target_inv(qubit_index: int) -> stim.GateTarget:
+def target_inv(
+    qubit_index: int,
+) -> stim.GateTarget:
     """Returns a target flagged as inverted that can be passed into Circuit.append_operation
     For example, the '!1' in 'M 0 !1 2' is qubit 1 flagged as inverted,
     meaning the measurement result from qubit 1 should be inverted when reported.
@@ -7704,7 +8607,9 @@ def target_inv(qubit_index: int) -> stim.GateTarget:
 # stim.target_logical_observable_id
 
 # (at top-level in the stim module)
-def target_logical_observable_id(index: int) -> stim.DemTarget:
+def target_logical_observable_id(
+    index: int,
+) -> stim.DemTarget:
     """Returns a logical observable id identifying a frame change (e.g. "L5" in a .dem file).
 
     Args:
@@ -7731,7 +8636,9 @@ def target_logical_observable_id(index: int) -> stim.DemTarget:
 # stim.target_rec
 
 # (at top-level in the stim module)
-def target_rec(lookback_index: int) -> stim.GateTarget:
+def target_rec(
+    lookback_index: int,
+) -> stim.GateTarget:
     """Returns a record target that can be passed into Circuit.append_operation.
     For example, the 'rec[-2]' in 'DETECTOR rec[-2]' is a record target.
     """
@@ -7742,7 +8649,9 @@ def target_rec(lookback_index: int) -> stim.GateTarget:
 # stim.target_relative_detector_id
 
 # (at top-level in the stim module)
-def target_relative_detector_id(index: int) -> stim.DemTarget:
+def target_relative_detector_id(
+    index: int,
+) -> stim.DemTarget:
     """Returns a relative detector id (e.g. "D5" in a .dem file).
 
     Args:
@@ -7769,7 +8678,8 @@ def target_relative_detector_id(index: int) -> stim.DemTarget:
 # stim.target_separator
 
 # (at top-level in the stim module)
-def target_separator() -> stim.DemTarget:
+def target_separator(
+) -> stim.DemTarget:
     """Returns a target separator (e.g. "^" in a .dem file).
 
     Examples:
@@ -7792,7 +8702,9 @@ def target_separator() -> stim.DemTarget:
 # stim.target_sweep_bit
 
 # (at top-level in the stim module)
-def target_sweep_bit(sweep_bit_index: int) -> stim.GateTarget:
+def target_sweep_bit(
+    sweep_bit_index: int,
+) -> stim.GateTarget:
     """Returns a sweep bit target that can be passed into Circuit.append_operation
     For example, the 'sweep[5]' in 'CNOT sweep[5] 7' is from `stim.target_sweep_bit(5)`.
     """
@@ -7803,7 +8715,10 @@ def target_sweep_bit(sweep_bit_index: int) -> stim.GateTarget:
 # stim.target_x
 
 # (at top-level in the stim module)
-def target_x(qubit_index: int, invert: bool = False) -> stim.GateTarget:
+def target_x(
+    qubit_index: int,
+    invert: bool = False,
+) -> stim.GateTarget:
     """Returns a target flagged as Pauli X that can be passed into Circuit.append_operation
     For example, the 'X1' in 'CORRELATED_ERROR(0.1) X1 Y2 Z3' is qubit 1 flagged as Pauli X.
     """
@@ -7814,7 +8729,10 @@ def target_x(qubit_index: int, invert: bool = False) -> stim.GateTarget:
 # stim.target_y
 
 # (at top-level in the stim module)
-def target_y(qubit_index: int, invert: bool = False) -> stim.GateTarget:
+def target_y(
+    qubit_index: int,
+    invert: bool = False,
+) -> stim.GateTarget:
     """Returns a target flagged as Pauli Y that can be passed into Circuit.append_operation
     For example, the 'Y2' in 'CORRELATED_ERROR(0.1) X1 Y2 Z3' is qubit 2 flagged as Pauli Y.
     """
@@ -7825,7 +8743,10 @@ def target_y(qubit_index: int, invert: bool = False) -> stim.GateTarget:
 # stim.target_z
 
 # (at top-level in the stim module)
-def target_z(qubit_index: int, invert: bool = False) -> stim.GateTarget:
+def target_z(
+    qubit_index: int,
+    invert: bool = False,
+) -> stim.GateTarget:
     """Returns a target flagged as Pauli Z that can be passed into Circuit.append_operation
     For example, the 'Z3' in 'CORRELATED_ERROR(0.1) X1 Y2 Z3' is qubit 3 flagged as Pauli Z.
     """
@@ -7836,7 +8757,15 @@ def target_z(qubit_index: int, invert: bool = False) -> stim.GateTarget:
 # stim.write_shot_data_file
 
 # (at top-level in the stim module)
-def write_shot_data_file(*, data: object, path: str, format: str, num_measurements: Any = None, num_detectors: Any = None, num_observables: Any = None) -> None:
+def write_shot_data_file(
+    *,
+    data: object,
+    path: str,
+    format: str,
+    num_measurements: Any = None,
+    num_detectors: Any = None,
+    num_observables: Any = None,
+) -> None:
     """Writes shot data, such as measurement samples, to a file.
 
     Args:

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -7346,7 +7346,7 @@ def measure_kickback(
     if in the previous example there was a third qubit in the |0> state, then both
     `stim.PauliString("XX_")` and `stim.PauliString("XXZ")` are valid kickbacks.
 
-    Measurements with determinist results don't have a Pauli kickback.
+    Measurements with deterministic results don't have a Pauli kickback.
 
     Args:
         target: The index of the qubit to measure.

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -3369,6 +3369,51 @@ class Tableau:
             True
         """
     @staticmethod
+    def from_circuit(circuit: stim.Circuit, *, ignore_noise: bool = False, ignore_measurement: bool = False, ignore_reset: bool = False) -> stim.Tableau:
+
+        """Converts a circuit into an equivalent stabilizer tableau.
+
+        Args:
+            circuit: The circuit to compile into a tableau.
+            ignore_noise: Defaults to False. When False, any noise operations in the circuit will cause
+                the conversion to fail with an exception. When True, noise operations are skipped over
+                as if they weren't even present in the circuit.
+            ignore_measurement: Defaults to False. When False, any measurement operations in the circuit
+                will cause the conversion to fail with an exception. When True, measurement operations are
+                skipped over as if they weren't even present in the circuit.
+            ignore_reset: Defaults to False. When False, any reset operations in the circuit will cause
+                the conversion to fail with an exception. When True, reset operations are skipped over
+                as if they weren't even present in the circuit.
+
+        Returns:
+            The tableau equivalent to the given circuit (up to global phase).
+
+        Raises:
+            ValueError:
+                The circuit contains noise operations but ignore_noise=False.
+                OR
+                The circuit contains measurement operations but ignore_measurement=False.
+                OR
+                The circuit contains reset operations but ignore_reset=False.
+
+        Examples:
+            >>> import stim
+            >>> stim.Tableau.from_circuit(stim.Circuit("""
+            ...     H 0
+            ...     CNOT 0 1
+            ... """))
+            stim.Tableau.from_conjugated_generators(
+                xs=[
+                    stim.PauliString("+Z_"),
+                    stim.PauliString("+_X"),
+                ],
+                zs=[
+                    stim.PauliString("+XX"),
+                    stim.PauliString("+ZZ"),
+                ],
+            )
+        """
+    @staticmethod
     def from_conjugated_generators(*, xs: List[stim.PauliString], zs: List[stim.PauliString]) -> stim.Tableau:
         """Creates a tableau from the given outputs for each generator.
 
@@ -3427,6 +3472,57 @@ class Tableau:
             +-xz-
             | ++
             | YZ
+        """
+    @staticmethod
+    def from_unitary_matrix(matrix: Iterable[Iterable[float]], *, endian: str = 'little') -> stim.Tableau:
+
+        """Creates a tableau from the unitary matrix of a Clifford operation.
+
+        Args:
+            matrix: A unitary matrix specified as an iterable of rows, with each row is an iterable of amplitudes.
+                The unitary matrix must correspond to a Clifford operation.
+            endian:
+                "little": matrix entries are in little endian order, where higher index qubits
+                    correspond to larger changes in row/col indices.
+                "big": matrix entries are in little endian order, where higher index qubits correspond to
+                    smaller changes in row/col indices.
+        Returns:
+            The tableau equivalent to the given unitary matrix (up to global phase).
+
+        Raises:
+            ValueError: The given matrix isn't the unitary matrix of a Clifford operation.
+
+        Examples:
+            >>> import stim
+            >>> stim.Tableau.from_unitary_matrix([
+            ...     [1, 0],
+            ...     [0, 1j],
+            ... ], endian='little')
+            stim.Tableau.from_conjugated_generators(
+                xs=[
+                    stim.PauliString("+Y"),
+                ],
+                zs=[
+                    stim.PauliString("+Z"),
+                ],
+            )
+
+            >>> stim.Tableau.from_unitary_matrix([
+            ...     [1, 0, 0, 0],
+            ...     [0, 1, 0, 0],
+            ...     [0, 0, 0, -1j],
+            ...     [0, 0, 1j, 0],
+            ... ], endian='little')
+            stim.Tableau.from_conjugated_generators(
+                xs=[
+                    stim.PauliString("+XZ"),
+                    stim.PauliString("+YX"),
+                ],
+                zs=[
+                    stim.PauliString("+ZZ"),
+                    stim.PauliString("+_Z"),
+                ],
+            )
         """
     def inverse(self, *, unsigned: bool = False) -> stim.Tableau:
         """Computes the inverse of the tableau.
@@ -3743,6 +3839,59 @@ class Tableau:
             >>> p = stim.PauliString.random(4)
             >>> t3(p) == t2(t1(p))
             True
+        """
+    def to_circuit(self, *, method: str) -> stim.Circuit:
+
+        """Synthesizes a circuit that implements the tableau's Clifford operation.
+
+        The circuits returned by this method are not guaranteed to be stable
+        from version to version, and may be produced using randomization.
+
+        Args:
+            method: The method to use when synthesizing the circuit. Available values are:
+                "elimination": Uses Gaussian elimination to cancel off-diagonal terms one by one.
+                    Gate set: H, S, CX
+                    Circuit qubit count: n
+                    Circuit operation count: O(n^2)
+                    Circuit depth: O(n^2)
+
+        Returns:
+            The synthesized circuit.
+
+        Example:
+            >>> import stim
+            >>> tableau = stim.Tableau.from_conjugated_generators(
+            ...     xs=[
+            ...         stim.PauliString("-_YZ"),
+            ...         stim.PauliString("-YY_"),
+            ...         stim.PauliString("-XZX"),
+            ...     ],
+            ...     zs=[
+            ...         stim.PauliString("+Y_Y"),
+            ...         stim.PauliString("-_XY"),
+            ...         stim.PauliString("-Y__"),
+            ...     ],
+            ... )
+            >>> tableau.to_circuit(method="elimination")
+            stim.Circuit('''
+                CX 2 0 0 2 2 0
+                S 0
+                H 0
+                S 0
+                H 1
+                CX 0 1 0 2
+                H 1 2
+                CX 1 0 2 0 2 1 1 2 2 1
+                H 1
+                S 1 2
+                H 2
+                CX 2 1
+                S 2
+                H 0 1 2
+                S 0 0 1 1 2 2
+                H 0 1 2
+                S 1 1 2 2
+            ''')
         """
     def to_unitary_matrix(self, *, endian: str) -> np.ndarray[np.complex64]:
 
@@ -4699,6 +4848,144 @@ class TableauSimulator:
             >>> s.set_num_qubits(2)
             >>> s.measure_many(0, 1, 2, 3)
             [True, True, False, False]
+        """
+    def set_state_from_stabilizers(self, stabilizers: Iterable[stim.PauliString], *, bool allow_redundant = False, bool allow_underconstrained = False) -> None:
+
+        """Sets the tableau simulator's state to a state satisfying the given stabilizers.
+
+        The old quantum state is completely overwritten, even if the new state is underconstrained
+        underconstrained by the given stabilizers. The number of qubits is changed to exactly match
+        the number of qubits in the longest given stabilizer.
+
+        Args:
+            stabilizers: A list of `stim.PauliString`s specifying the stabilizers that the new
+                state must have. It is permitted for stabilizers to have different lengths. All
+                stabilizers are padded up to the length of the longest stabilizer by appending
+                identity terms.
+            allow_redundant: Defaults to False. If set to False, then the given stabilizers must
+                all be independent. If any one of them is a product of the others (including the
+                empty product), an exception will be raised. If set to True, then redundant
+                stabilizers are simply ignored.
+            allow_underconstrained: Defaults to False. If set to False, then the given stabilizers
+                must form a complete set of generators. They must exactly specify the desired
+                stabilizer state, with no degrees of freedom left over. For an n-qubit state there
+                must be n independent stabilizers. If set to True, then there can be leftover
+                degrees of freedom which can be set arbitrarily.
+
+        Returns:
+            Nothing. Mutates the states of the simulator to match the desired stabilizers.
+            Guarantees that self.current_inverse_tableau().inverse_z_output(k) will be equal
+            to the k'th independent stabilizer from the `stabilizers` argument.
+
+        Raises:
+            ValueError:
+                A stabilizer is redundant but allow_redundant=True wasn't set.
+                OR
+                The given stabilizers are contradictory (e.g. "+Z" and "-Z" both specified).
+                OR
+                The given stabilizers anticommute (e.g. "+Z" and "+X" both specified).
+                OR
+                The stabilizers left behind a degree of freedom but allow_underconstrained=True wasn't set.
+                OR
+                A stabilizer has an imaginary sign (i or -i).
+
+        Examples:
+
+            >>> import stim
+            >>> tab_sim = stim.TableauSimulator()
+            >>> tab_sim.set_state_from_stabilizers([
+            ...     stim.PauliString("XX"),
+            ...     stim.PauliString("ZZ"),
+            ... ])
+            >>> tab_sim.current_inverse_tableau().inverse()
+            stim.Tableau.from_conjugated_generators(
+                xs=[
+                    stim.PauliString("+Z_"),
+                    stim.PauliString("+_X"),
+                ],
+                zs=[
+                    stim.PauliString("+XX"),
+                    stim.PauliString("+ZZ"),
+                ],
+            )
+
+            >>> tab_sim.set_state_from_stabilizers([
+            ...     stim.PauliString("XX_"),
+            ...     stim.PauliString("ZZ_"),
+            ...     stim.PauliString("-YY_"),
+            ...     stim.PauliString(""),
+            ... ], allow_underconstrained=True, allow_redundant=True)
+            >>> tab_sim.current_inverse_tableau().inverse()
+            stim.Tableau.from_conjugated_generators(
+                xs=[
+                    stim.PauliString("+Z__"),
+                    stim.PauliString("+_X_"),
+                    stim.PauliString("+__X"),
+                ],
+                zs=[
+                    stim.PauliString("+XX_"),
+                    stim.PauliString("+ZZ_"),
+                    stim.PauliString("+__Z"),
+                ],
+            )
+        """
+    def set_state_from_state_vector(self, state_vector: Iterable[float], *, endian: str) -> None:
+
+        """Sets the tableau simulator's state to a superposition specified by a vector of amplitudes.
+
+        Args:
+            state_vector: A list of complex amplitudes specifying a superposition. The vector
+                must correspond to a state that is reachable using Clifford operations, and must
+                be normalized (i.e. it must be a unit vector).
+            endian:
+                "little": state vector is in little endian order, where higher index qubits
+                    correspond to larger changes in the state index.
+                "big": state vector is in little endian order, where higher index qubits correspond to
+                    smaller changes in the state index.
+
+        Returns:
+            Nothing. Mutates the states of the simulator to match the desired state.
+
+        Raises:
+            ValueError:
+                The given state vector isn't a list of complex values specifying a stabilizer state.
+                OR
+                The given endian value isn't 'little' or 'big'.
+
+        Examples:
+
+            >>> import stim
+            >>> tab_sim = stim.TableauSimulator()
+            >>> tab_sim.set_state_from_state_vector([
+            ...     0.5**0.5,
+            ...     0.5**0.5 * 1j,
+            ... ], endian='little')
+            >>> tab_sim.current_inverse_tableau().inverse()
+            stim.Tableau.from_conjugated_generators(
+                xs=[
+                    stim.PauliString("+Z"),
+                ],
+                zs=[
+                    stim.PauliString("+Y"),
+                ],
+            )
+            >>> tab_sim.set_state_from_state_vector([
+            ...     0.5**0.5,
+            ...     0,
+            ...     0,
+            ...     0.5**0.5,
+            ... ], endian='little')
+            >>> tab_sim.current_inverse_tableau().inverse()
+            stim.Tableau.from_conjugated_generators(
+                xs=[
+                    stim.PauliString("+Z_"),
+                    stim.PauliString("+_X"),
+                ],
+                zs=[
+                    stim.PauliString("+XX"),
+                    stim.PauliString("+ZZ"),
+                ],
+            )
         """
     def sqrt_x(self, *targets) -> None:
         """Applies a SQRT_X gate to the simulator's state.

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -26,7 +26,10 @@ class Circuit:
         array([[False]])
 
     """
-    def __add__(self, second: stim.Circuit) -> stim.Circuit:
+    def __add__(
+        self,
+        second: stim.Circuit,
+    ) -> stim.Circuit:
         """Creates a circuit by appending two circuits.
 
         Examples:
@@ -45,16 +48,28 @@ class Circuit:
                 M 0 1 2
             ''')
         """
-    def __eq__(self, arg0: stim.Circuit) -> bool:
+    def __eq__(
+        self,
+        arg0: stim.Circuit,
+    ) -> bool:
         """Determines if two circuits have identical contents.
         """
     @overload
-    def __getitem__(self, index_or_slice: int) -> Union[stim.CircuitInstruction, stim.CircuitRepeatBlock]:
+    def __getitem__(
+        self,
+        index_or_slice: int,
+    ) -> Union[stim.CircuitInstruction, stim.CircuitRepeatBlock]:
         pass
     @overload
-    def __getitem__(self, index_or_slice: slice) -> stim.Circuit:
+    def __getitem__(
+        self,
+        index_or_slice: slice,
+    ) -> stim.Circuit:
         pass
-    def __getitem__(self, index_or_slice: object) -> object:
+    def __getitem__(
+        self,
+        index_or_slice: object,
+    ) -> object:
         """Returns copies of instructions from the circuit.
 
         Args:
@@ -92,7 +107,10 @@ class Circuit:
                 DETECTOR rec[-1]
             ''')
         """
-    def __iadd__(self, second: stim.Circuit) -> stim.Circuit:
+    def __iadd__(
+        self,
+        second: stim.Circuit,
+    ) -> stim.Circuit:
         """Appends a circuit into the receiving circuit (mutating it).
 
         Examples:
@@ -112,7 +130,10 @@ class Circuit:
                 M 0 1 2
             ''')
         """
-    def __imul__(self, repetitions: int) -> stim.Circuit:
+    def __imul__(
+        self,
+        repetitions: int,
+    ) -> stim.Circuit:
         """Mutates the circuit by putting its contents into a REPEAT block.
 
         Special case: if the repetition count is 0, the circuit is cleared.
@@ -136,7 +157,10 @@ class Circuit:
                 }
             ''')
         """
-    def __init__(self, stim_program_text: str = '') -> None:
+    def __init__(
+        self,
+        stim_program_text: str = '',
+    ) -> None:
         """Creates a stim.Circuit.
 
         Args:
@@ -151,7 +175,9 @@ class Circuit:
             ...    M 1
             ... ''')
         """
-    def __len__(self) -> int:
+    def __len__(
+        self,
+    ) -> int:
         """Returns the number of top-level instructions and blocks in the circuit.
 
         Instructions inside of blocks are not included in this count.
@@ -176,7 +202,10 @@ class Circuit:
             ... '''))
             1
         """
-    def __mul__(self, repetitions: int) -> stim.Circuit:
+    def __mul__(
+        self,
+        repetitions: int,
+    ) -> stim.Circuit:
         """Returns a circuit with a REPEAT block containing the current circuit's instructions.
 
         Special case: if the repetition count is 0, an empty circuit is returned.
@@ -199,13 +228,21 @@ class Circuit:
                 }
             ''')
         """
-    def __ne__(self, arg0: stim.Circuit) -> bool:
+    def __ne__(
+        self,
+        arg0: stim.Circuit,
+    ) -> bool:
         """Determines if two circuits have non-identical contents.
         """
-    def __repr__(self) -> str:
+    def __repr__(
+        self,
+    ) -> str:
         """Returns text that is a valid python expression evaluating to an equivalent `stim.Circuit`.
         """
-    def __rmul__(self, repetitions: int) -> stim.Circuit:
+    def __rmul__(
+        self,
+        repetitions: int,
+    ) -> stim.Circuit:
         """Returns a circuit with a REPEAT block containing the current circuit's instructions.
 
         Special case: if the repetition count is 0, an empty circuit is returned.
@@ -228,16 +265,31 @@ class Circuit:
                 }
             ''')
         """
-    def __str__(self) -> str:
+    def __str__(
+        self,
+    ) -> str:
         """Returns stim instructions (that can be saved to a file and parsed by stim) for the current circuit.
         """
     @overload
-    def append(self, name: str, targets: Union[int, stim.GateTarget, Iterable[Union[int, stim.GateTarget]]], arg: Union[float, Iterable[float]]) -> None:
+    def append(
+        self,
+        name: str,
+        targets: Union[int, stim.GateTarget, Iterable[Union[int, stim.GateTarget]]],
+        arg: Union[float, Iterable[float]],
+    ) -> None:
         pass
     @overload
-    def append(self, name: Union[stim.CircuitOperation, stim.CircuitRepeatBlock]) -> None:
+    def append(
+        self,
+        name: Union[stim.CircuitOperation, stim.CircuitRepeatBlock],
+    ) -> None:
         pass
-    def append(self, name: object, targets: object = (), arg: object = None) -> None:
+    def append(
+        self,
+        name: object,
+        targets: object = (),
+        arg: object = None,
+    ) -> None:
         """Appends an operation into the circuit.
 
         Note: `stim.Circuit.append_operation` is an alias of `stim.Circuit.append`.
@@ -282,7 +334,10 @@ class Circuit:
                 `cirq.append_operation` (but not `cirq.append`) will default to a single 0.0 argument for gates
                 that take exactly one argument.
         """
-    def append_from_stim_program_text(self, stim_program_text: str) -> None:
+    def append_from_stim_program_text(
+        self,
+        stim_program_text: str,
+    ) -> None:
         """Appends operations described by a STIM format program into the circuit.
 
         Examples:
@@ -304,10 +359,20 @@ class Circuit:
         Args:
             stim_program_text: The STIM program text containing the circuit operations to append.
         """
-    def append_operation(self, name: object, targets: object = (), arg: object = None) -> None:
+    def append_operation(
+        self,
+        name: object,
+        targets: object = (),
+        arg: object = None,
+    ) -> None:
         """[DEPRECATED] use stim.Circuit.append instead
         """
-    def approx_equals(self, other: object, *, atol: float) -> bool:
+    def approx_equals(
+        self,
+        other: object,
+        *,
+        atol: float,
+    ) -> bool:
         """Checks if a circuit is approximately equal to another circuit.
 
         Two circuits are approximately equal if they are equal up to slight perturbations of instruction arguments
@@ -357,7 +422,9 @@ class Circuit:
             ... '''), atol=9999)
             False
         """
-    def clear(self) -> None:
+    def clear(
+        self,
+    ) -> None:
         """Clears the contents of the circuit.
 
         Examples:
@@ -370,7 +437,11 @@ class Circuit:
             >>> c
             stim.Circuit()
         """
-    def compile_detector_sampler(self, *, seed: object = None) -> stim.CompiledDetectorSampler:
+    def compile_detector_sampler(
+        self,
+        *,
+        seed: object = None,
+    ) -> stim.CompiledDetectorSampler:
         """Returns a CompiledDetectorSampler, which can quickly batch sample detection events, for the circuit.
 
         Args:
@@ -406,7 +477,11 @@ class Circuit:
             >>> s.sample(shots=1)
             array([[False]])
         """
-    def compile_m2d_converter(self, *, skip_reference_sample: bool = False) -> stim.CompiledMeasurementsToDetectionEventsConverter:
+    def compile_m2d_converter(
+        self,
+        *,
+        skip_reference_sample: bool = False,
+    ) -> stim.CompiledMeasurementsToDetectionEventsConverter:
         """Returns an object that can efficiently convert measurements into detection events for the given circuit.
 
         The converter uses a noiseless reference sample, collected from the circuit using stim's Tableau simulator
@@ -441,7 +516,12 @@ class Circuit:
             array([[ True],
                    [False]])
         """
-    def compile_sampler(self, *, skip_reference_sample: bool = False, seed: object = None) -> stim.CompiledMeasurementSampler:
+    def compile_sampler(
+        self,
+        *,
+        skip_reference_sample: bool = False,
+        seed: object = None,
+    ) -> stim.CompiledMeasurementSampler:
         """Returns a CompiledMeasurementSampler, which can quickly batch sample measurements, for the circuit.
 
         Args:
@@ -487,7 +567,9 @@ class Circuit:
             >>> s.sample(shots=1)
             array([[False, False,  True]])
         """
-    def copy(self) -> stim.Circuit:
+    def copy(
+        self,
+    ) -> stim.Circuit:
         """Returns a copy of the circuit. An independent circuit with the same contents.
 
         Examples:
@@ -500,7 +582,16 @@ class Circuit:
             >>> c2 == c1
             True
         """
-    def detector_error_model(self, *, decompose_errors: bool = False, flatten_loops: bool = False, allow_gauge_detectors: bool = False, approximate_disjoint_errors: float = False, ignore_decomposition_failures: bool = False, block_decomposition_from_introducing_remnant_edges: bool = False) -> stim.DetectorErrorModel:
+    def detector_error_model(
+        self,
+        *,
+        decompose_errors: bool = False,
+        flatten_loops: bool = False,
+        allow_gauge_detectors: bool = False,
+        approximate_disjoint_errors: float = False,
+        ignore_decomposition_failures: bool = False,
+        block_decomposition_from_introducing_remnant_edges: bool = False,
+    ) -> stim.DetectorErrorModel:
         """Returns a stim.DetectorErrorModel describing the error processes in the circuit.
 
         Args:
@@ -572,7 +663,12 @@ class Circuit:
                 error(0.25) D1
             ''')
         """
-    def explain_detector_error_model_errors(self, *, dem_filter: object = None, reduce_to_one_representative_error: bool = False) -> List[stim.ExplainedError]:
+    def explain_detector_error_model_errors(
+        self,
+        *,
+        dem_filter: object = None,
+        reduce_to_one_representative_error: bool = False,
+    ) -> List[stim.ExplainedError]:
         """Explains how detector error model errors are produced by circuit errors.
 
         Args:
@@ -620,7 +716,9 @@ class Circuit:
                     resolving to DEPOLARIZE1(0.01) 0
             }
         """
-    def flattened(self) -> stim.Circuit:
+    def flattened(
+        self,
+    ) -> stim.Circuit:
         """Creates an equivalent circuit without REPEAT or SHIFT_COORDS.
 
         Returns:
@@ -656,7 +754,9 @@ class Circuit:
                 DETECTOR(1, 4) rec[-1]
             ''')
         """
-    def flattened_operations(self) -> list:
+    def flattened_operations(
+        self,
+    ) -> list:
         """[DEPRECATED]
 
         Returns a list of tuples encoding the contents of the circuit.
@@ -680,7 +780,9 @@ class Circuit:
             [('H', [6], 0), ('H', [6], 0)]
         """
     @staticmethod
-    def from_file(file: object) -> stim.Circuit:
+    def from_file(
+        file: object,
+    ) -> stim.Circuit:
         """Args:
             file: A file path or open file object to read from.
 
@@ -713,7 +815,16 @@ class Circuit:
             ''')
         """
     @staticmethod
-    def generated(code_task: str, *, distance: int, rounds: int, after_clifford_depolarization: float = 0.0, before_round_data_depolarization: float = 0.0, before_measure_flip_probability: float = 0.0, after_reset_flip_probability: float = 0.0) -> stim.Circuit:
+    def generated(
+        code_task: str,
+        *,
+        distance: int,
+        rounds: int,
+        after_clifford_depolarization: float = 0.0,
+        before_round_data_depolarization: float = 0.0,
+        before_measure_flip_probability: float = 0.0,
+        after_reset_flip_probability: float = 0.0,
+    ) -> stim.Circuit:
         """Generates common circuits.
 
         The generated circuits can include configurable noise.
@@ -795,7 +906,10 @@ class Circuit:
             DETECTOR(5, 1) rec[-1] rec[-2] rec[-5]
             OBSERVABLE_INCLUDE(0) rec[-1]
         """
-    def get_detector_coordinates(self, only: object = None) -> Dict[int, List[float]]:
+    def get_detector_coordinates(
+        self,
+        only: object = None,
+    ) -> Dict[int, List[float]]:
         """Returns the coordinate metadata of detectors in the circuit.
 
         Args:
@@ -824,7 +938,9 @@ class Circuit:
             >>> circuit.get_detector_coordinates(only=[1])
             {1: [1.0, 2.0, 3.0]}
         """
-    def get_final_qubit_coordinates(self) -> Dict[int, List[float]]:
+    def get_final_qubit_coordinates(
+        self,
+    ) -> Dict[int, List[float]]:
         """Returns the coordinate metadata of qubits in the circuit.
 
         If a qubit's coordinates are specified multiple times, only the last specified coordinates are returned.
@@ -842,7 +958,9 @@ class Circuit:
             {1: [1.0, 2.0, 3.0]}
         """
     @property
-    def num_detectors(self) -> int:
+    def num_detectors(
+        self,
+    ) -> int:
         """Counts the number of bits produced when sampling the circuit's detectors.
 
         Examples:
@@ -860,7 +978,9 @@ class Circuit:
             201
         """
     @property
-    def num_measurements(self) -> int:
+    def num_measurements(
+        self,
+    ) -> int:
         """Counts the number of bits produced when sampling the circuit's measurements.
 
         Examples:
@@ -875,7 +995,9 @@ class Circuit:
             201
         """
     @property
-    def num_observables(self) -> int:
+    def num_observables(
+        self,
+    ) -> int:
         """Counts the number of bits produced when sampling the circuit's logical observables.
 
         This is one more than the largest observable index given to OBSERVABLE_INCLUDE.
@@ -891,7 +1013,9 @@ class Circuit:
             6
         """
     @property
-    def num_qubits(self) -> int:
+    def num_qubits(
+        self,
+    ) -> int:
         """Counts the number of qubits used when simulating the circuit.
 
         This is always one more than the largest qubit index used by the circuit.
@@ -911,7 +1035,9 @@ class Circuit:
             101
         """
     @property
-    def num_sweep_bits(self) -> int:
+    def num_sweep_bits(
+        self,
+    ) -> int:
         """Returns the number of sweep bits needed to completely configure the circuit.
 
         This is always one more than the largest sweep bit index used by the circuit.
@@ -928,7 +1054,14 @@ class Circuit:
             ... ''').num_sweep_bits
             6
         """
-    def search_for_undetectable_logical_errors(self, *, dont_explore_detection_event_sets_with_size_above: int, dont_explore_edges_with_degree_above: int, dont_explore_edges_increasing_symptom_degree: bool, canonicalize_circuit_errors: bool = False) -> List[stim.ExplainedError]:
+    def search_for_undetectable_logical_errors(
+        self,
+        *,
+        dont_explore_detection_event_sets_with_size_above: int,
+        dont_explore_edges_with_degree_above: int,
+        dont_explore_edges_increasing_symptom_degree: bool,
+        canonicalize_circuit_errors: bool = False,
+    ) -> List[stim.ExplainedError]:
         """Searches for lists of errors from the model that form an undetectable logical error.
 
         THIS IS A HEURISTIC METHOD. It does not guarantee that it will find errors of particular
@@ -1000,7 +1133,12 @@ class Circuit:
             ... )))
             5
         """
-    def shortest_graphlike_error(self, *, ignore_ungraphlike_errors: bool = True, canonicalize_circuit_errors: bool = False) -> List[stim.ExplainedError]:
+    def shortest_graphlike_error(
+        self,
+        *,
+        ignore_ungraphlike_errors: bool = True,
+        canonicalize_circuit_errors: bool = False,
+    ) -> List[stim.ExplainedError]:
         """Finds a minimum sized set of graphlike errors that produce an undetected logical error.
 
         A "graphlike error" is an error that creates at most two detection events (causes a change in the parity of
@@ -1051,7 +1189,10 @@ class Circuit:
             >>> len(circuit.shortest_graphlike_error())
             7
         """
-    def to_file(self, file: Union[io.TextIOBase, str, pathlib.Path]) -> None:
+    def to_file(
+        self,
+        file: Union[io.TextIOBase, str, pathlib.Path],
+    ) -> None:
 
         """Writes the stim circuit to a file.
 
@@ -1080,7 +1221,9 @@ class Circuit:
             >>> contents
             'H 5\nX 0\n'
         """
-    def without_noise(self) -> stim.Circuit:
+    def without_noise(
+        self,
+    ) -> stim.Circuit:
         """Returns a copy of the circuit with all noise processes removed.
 
         Pure noise instructions, such as X_ERROR and DEPOLARIZE2, are not
@@ -1108,33 +1251,51 @@ class Circuit:
 class CircuitErrorLocation:
     """Describes the location of an error mechanism from a stim circuit.
     """
-    def __init__(self, *, tick_offset: int, flipped_pauli_product: List[stim.GateTargetWithCoords], flipped_measurement: object, instruction_targets: stim.CircuitTargetsInsideInstruction, stack_frames: List[stim.CircuitErrorLocationStackFrame]) -> None:
+    def __init__(
+        self,
+        *,
+        tick_offset: int,
+        flipped_pauli_product: List[stim.GateTargetWithCoords],
+        flipped_measurement: object,
+        instruction_targets: stim.CircuitTargetsInsideInstruction,
+        stack_frames: List[stim.CircuitErrorLocationStackFrame],
+    ) -> None:
         """Creates a stim.CircuitErrorLocation.
         """
     @property
-    def flipped_measurement(self) -> Optional[stim.FlippedMeasurement]:
+    def flipped_measurement(
+        self,
+    ) -> Optional[stim.FlippedMeasurement]:
 
         """The measurement that was flipped by the error mechanism.
         If the error isn't a measurement error, this will be None.
         """
     @property
-    def flipped_pauli_product(self) -> List[stim.GateTargetWithCoords]:
+    def flipped_pauli_product(
+        self,
+    ) -> List[stim.GateTargetWithCoords]:
         """The Pauli errors that the error mechanism applied to qubits.
         When the error is a measurement error, this will be an empty list.
         """
     @property
-    def instruction_targets(self) -> stim.CircuitTargetsInsideInstruction:
+    def instruction_targets(
+        self,
+    ) -> stim.CircuitTargetsInsideInstruction:
         """Within the error instruction, which may have hundreds of
         targets, which specific targets were being executed to
         produce the error.
         """
     @property
-    def stack_frames(self) -> List[stim.CircuitErrorLocationStackFrame]:
+    def stack_frames(
+        self,
+    ) -> List[stim.CircuitErrorLocationStackFrame]:
         """Where in the circuit's execution does the error mechanism occur,
         accounting for things like nested loops that iterate multiple times.
         """
     @property
-    def tick_offset(self) -> int:
+    def tick_offset(
+        self,
+    ) -> int:
         """The number of TICKs that executed before the error mechanism being discussed,
         including TICKs that occurred multiple times during loops.
         """
@@ -1146,11 +1307,19 @@ class CircuitErrorLocationStackFrame:
     drilling down from the top level circuit to the inner-most loop
     that the instruction is within.
     """
-    def __init__(self, *, instruction_offset: int, iteration_index: int, instruction_repetitions_arg: int) -> None:
+    def __init__(
+        self,
+        *,
+        instruction_offset: int,
+        iteration_index: int,
+        instruction_repetitions_arg: int,
+    ) -> None:
         """Creates a stim.CircuitErrorLocationStackFrame.
         """
     @property
-    def instruction_offset(self) -> int:
+    def instruction_offset(
+        self,
+    ) -> int:
         """The index of the instruction within the circuit, or within the
         instruction's parent REPEAT block. This is slightly different
         from the line number, because blank lines and commented lines
@@ -1158,13 +1327,17 @@ class CircuitErrorLocationStackFrame:
         is 0 instead of 1.
         """
     @property
-    def instruction_repetitions_arg(self) -> int:
+    def instruction_repetitions_arg(
+        self,
+    ) -> int:
         """If the instruction being referred to is a REPEAT block,
         this is the repetition count of that REPEAT block. Otherwise
         this field defaults to 0.
         """
     @property
-    def iteration_index(self) -> int:
+    def iteration_index(
+        self,
+    ) -> int:
         """Disambiguates which iteration of the loop containing this instruction
         is being referred to. If the instruction isn't in a REPEAT block, this
         field defaults to 0.
@@ -1186,10 +1359,18 @@ class CircuitInstruction:
         >>> circuit[2]
         stim.CircuitInstruction('X_ERROR', [stim.GateTarget(5), stim.GateTarget(3)], [0.125])
     """
-    def __eq__(self, arg0: stim.CircuitInstruction) -> bool:
+    def __eq__(
+        self,
+        arg0: stim.CircuitInstruction,
+    ) -> bool:
         """Determines if two `stim.CircuitInstruction`s are identical.
         """
-    def __init__(self, name: str, targets: List[object], gate_args: List[float] = ()) -> None:
+    def __init__(
+        self,
+        name: str,
+        targets: List[object],
+        gate_args: List[float] = (),
+    ) -> None:
         """Initializes a `stim.CircuitInstruction`.
 
         Args:
@@ -1199,26 +1380,39 @@ class CircuitInstruction:
             gate_args: The sequence of numeric arguments parameterizing a gate. For noise gates this is their
                 probabilities. For OBSERVABLE_INCLUDE it's the logical observable's index.
         """
-    def __ne__(self, arg0: stim.CircuitInstruction) -> bool:
+    def __ne__(
+        self,
+        arg0: stim.CircuitInstruction,
+    ) -> bool:
         """Determines if two `stim.CircuitInstruction`s are different.
         """
-    def __repr__(self) -> str:
+    def __repr__(
+        self,
+    ) -> str:
         """Returns text that is a valid python expression evaluating to an equivalent `stim.CircuitInstruction`.
         """
-    def __str__(self) -> str:
+    def __str__(
+        self,
+    ) -> str:
         """Returns a text description of the instruction as a stim circuit file line.
         """
-    def gate_args_copy(self) -> List[float]:
+    def gate_args_copy(
+        self,
+    ) -> List[float]:
         """Returns the gate's arguments (numbers parameterizing the instruction).
 
         For noisy gates this typically a list of probabilities.
         For OBSERVABLE_INCLUDE it's a singleton list containing the logical observable index.
         """
     @property
-    def name(self) -> str:
+    def name(
+        self,
+    ) -> str:
         """The name of the instruction (e.g. `H` or `X_ERROR` or `DETECTOR`).
         """
-    def targets_copy(self) -> List[stim.GateTarget]:
+    def targets_copy(
+        self,
+    ) -> List[stim.GateTarget]:
         """Returns a copy of the targets of the instruction.
         """
 class CircuitRepeatBlock:
@@ -1242,23 +1436,37 @@ class CircuitRepeatBlock:
             CZ 1 2
         ''')
     """
-    def __eq__(self, arg0: stim.CircuitRepeatBlock) -> bool:
+    def __eq__(
+        self,
+        arg0: stim.CircuitRepeatBlock,
+    ) -> bool:
         """Determines if two `stim.CircuitRepeatBlock`s are identical.
         """
-    def __init__(self, repeat_count: int, body: stim.Circuit) -> None:
+    def __init__(
+        self,
+        repeat_count: int,
+        body: stim.Circuit,
+    ) -> None:
         """Initializes a `stim.CircuitRepeatBlock`.
 
         Args:
             repeat_count: The number of times to repeat the block.
             body: The body of the block, as a circuit.
         """
-    def __ne__(self, arg0: stim.CircuitRepeatBlock) -> bool:
+    def __ne__(
+        self,
+        arg0: stim.CircuitRepeatBlock,
+    ) -> bool:
         """Determines if two `stim.CircuitRepeatBlock`s are different.
         """
-    def __repr__(self) -> str:
+    def __repr__(
+        self,
+    ) -> str:
         """Returns text that is a valid python expression evaluating to an equivalent `stim.CircuitRepeatBlock`.
         """
-    def body_copy(self) -> stim.Circuit:
+    def body_copy(
+        self,
+    ) -> stim.Circuit:
         """Returns a copy of the body of the repeat block.
 
         The copy is forced to ensure it's clear that editing the result will not change the circuit that the repeat
@@ -1281,7 +1489,9 @@ class CircuitRepeatBlock:
             ''')
         """
     @property
-    def repeat_count(self) -> int:
+    def repeat_count(
+        self,
+    ) -> int:
         """The repetition count of the repeat block.
 
         Examples:
@@ -1300,30 +1510,48 @@ class CircuitRepeatBlock:
 class CircuitTargetsInsideInstruction:
     """Describes a range of targets within a circuit instruction.
     """
-    def __init__(self, *, gate: str, args: List[float], target_range_start: int, target_range_end: int, targets_in_range: List[stim.GateTargetWithCoords]) -> None:
+    def __init__(
+        self,
+        *,
+        gate: str,
+        args: List[float],
+        target_range_start: int,
+        target_range_end: int,
+        targets_in_range: List[stim.GateTargetWithCoords],
+    ) -> None:
         """Creates a stim.CircuitTargetsInsideInstruction.
         """
     @property
-    def args(self) -> List[float]:
+    def args(
+        self,
+    ) -> List[float]:
         """Returns parens arguments of the gate / instruction that was being executed.
         """
     @property
-    def gate(self) -> Optional[str]:
+    def gate(
+        self,
+    ) -> Optional[str]:
 
         """Returns the name of the gate / instruction that was being executed.
         """
     @property
-    def target_range_end(self) -> int:
+    def target_range_end(
+        self,
+    ) -> int:
         """Returns the exclusive end of the range of targets that were executing
         within the gate / instruction.
         """
     @property
-    def target_range_start(self) -> int:
+    def target_range_start(
+        self,
+    ) -> int:
         """Returns the inclusive start of the range of targets that were executing
         within the gate / instruction.
         """
     @property
-    def targets_in_range(self) -> List[stim.GateTargetWithCoords]:
+    def targets_in_range(
+        self,
+    ) -> List[stim.GateTargetWithCoords]:
         """Returns the subset of targets of the gate / instruction that were being executed.
 
         Includes coordinate data with the targets.
@@ -1331,7 +1559,12 @@ class CircuitTargetsInsideInstruction:
 class CompiledDetectorSampler:
     """An analyzed stabilizer circuit whose detection events can be sampled quickly.
     """
-    def __init__(self, circuit: stim.Circuit, *, seed: object = None) -> None:
+    def __init__(
+        self,
+        circuit: stim.Circuit,
+        *,
+        seed: object = None,
+    ) -> None:
         """Creates a detector sampler, which can sample the detectors (and optionally observables) in a circuit.
 
         Args:
@@ -1372,10 +1605,18 @@ class CompiledDetectorSampler:
             >>> s.sample(shots=1)
             array([[ True]])
         """
-    def __repr__(self) -> str:
+    def __repr__(
+        self,
+    ) -> str:
         """Returns text that is a valid python expression evaluating to an equivalent `stim.CompiledDetectorSampler`.
         """
-    def sample(self, shots: int, *, prepend_observables: bool = False, append_observables: bool = False) -> np.ndarray[bool]:
+    def sample(
+        self,
+        shots: int,
+        *,
+        prepend_observables: bool = False,
+        append_observables: bool = False,
+    ) -> np.ndarray[bool]:
         """Returns a numpy array containing a batch of detector samples from the circuit.
 
         The circuit must define the detectors using DETECTOR instructions. Observables defined by OBSERVABLE_INCLUDE
@@ -1393,7 +1634,13 @@ class CompiledDetectorSampler:
             `n = num_detectors + num_observables*(append_observables + prepend_observables)`.
             The bit for detection event `m` in shot `s` is at `result[s, m]`.
         """
-    def sample_bit_packed(self, shots: int, *, prepend_observables: bool = False, append_observables: bool = False) -> np.ndarray[np.uint8]:
+    def sample_bit_packed(
+        self,
+        shots: int,
+        *,
+        prepend_observables: bool = False,
+        append_observables: bool = False,
+    ) -> np.ndarray[np.uint8]:
         """Returns a numpy array containing bit packed batch of detector samples from the circuit.
 
         The circuit must define the detectors using DETECTOR instructions. Observables defined by OBSERVABLE_INCLUDE
@@ -1411,7 +1658,17 @@ class CompiledDetectorSampler:
             `n = num_detectors + num_observables*(append_observables + prepend_observables)`.
             The bit for detection event `m` in shot `s` is at `result[s, (m // 8)] & 2**(m % 8)`.
         """
-    def sample_write(self, shots: int, *, filepath: str, format: str = '01', prepend_observables: bool = False, append_observables: bool = False, obs_out_filepath: str = None, obs_out_format: str = '01') -> None:
+    def sample_write(
+        self,
+        shots: int,
+        *,
+        filepath: str,
+        format: str = '01',
+        prepend_observables: bool = False,
+        append_observables: bool = False,
+        obs_out_filepath: str = None,
+        obs_out_format: str = '01',
+    ) -> None:
         """Samples detection events from the circuit and writes them to a file.
 
         Examples:
@@ -1454,7 +1711,13 @@ class CompiledDetectorSampler:
 class CompiledMeasurementSampler:
     """An analyzed stabilizer circuit whose measurements can be sampled quickly.
     """
-    def __init__(self, circuit: stim.Circuit, *, skip_reference_sample: bool = False, seed: object = None) -> None:
+    def __init__(
+        self,
+        circuit: stim.Circuit,
+        *,
+        skip_reference_sample: bool = False,
+        seed: object = None,
+    ) -> None:
         """Creates a measurement sampler for the given circuit.
 
         The sampler uses a noiseless reference sample, collected from the circuit using stim's Tableau simulator
@@ -1508,10 +1771,15 @@ class CompiledMeasurementSampler:
             >>> s.sample(shots=1)
             array([[ True, False,  True,  True]])
         """
-    def __repr__(self) -> str:
+    def __repr__(
+        self,
+    ) -> str:
         """Returns text that is a valid python expression evaluating to an equivalent `stim.CompiledMeasurementSampler`.
         """
-    def sample(self, shots: int) -> np.ndarray[bool]:
+    def sample(
+        self,
+        shots: int,
+    ) -> np.ndarray[bool]:
         """Returns a numpy array containing a batch of measurement samples from the circuit.
 
         Examples:
@@ -1531,7 +1799,10 @@ class CompiledMeasurementSampler:
             A numpy array with `dtype=uint8` and `shape=(shots, num_measurements)`.
             The bit for measurement `m` in shot `s` is at `result[s, m]`.
         """
-    def sample_bit_packed(self, shots: int) -> np.ndarray[np.uint8]:
+    def sample_bit_packed(
+        self,
+        shots: int,
+    ) -> np.ndarray[np.uint8]:
         """Returns a numpy array containing a bit packed batch of measurement samples from the circuit.
 
         Examples:
@@ -1551,7 +1822,13 @@ class CompiledMeasurementSampler:
             A numpy array with `dtype=uint8` and `shape=(shots, (num_measurements + 7) // 8)`.
             The bit for measurement `m` in shot `s` is at `result[s, (m // 8)] & 2**(m % 8)`.
         """
-    def sample_write(self, shots: int, *, filepath: str, format: str = '01') -> None:
+    def sample_write(
+        self,
+        shots: int,
+        *,
+        filepath: str,
+        format: str = '01',
+    ) -> None:
         """Samples measurements from the circuit and writes them to a file.
 
         Examples:
@@ -1585,7 +1862,12 @@ class CompiledMeasurementSampler:
 class CompiledMeasurementsToDetectionEventsConverter:
     """A tool for quickly converting measurements from an analyzed stabilizer circuit into detection events.
     """
-    def __init__(self, circuit: stim.Circuit, *, skip_reference_sample: bool = False) -> None:
+    def __init__(
+        self,
+        circuit: stim.Circuit,
+        *,
+        skip_reference_sample: bool = False,
+    ) -> None:
         """Creates a measurement-to-detection-events converter for the given circuit.
 
         The converter uses a noiseless reference sample, collected from the circuit using stim's Tableau simulator
@@ -1621,10 +1903,20 @@ class CompiledMeasurementsToDetectionEventsConverter:
             array([[ True],
                    [False]])
         """
-    def __repr__(self) -> str:
+    def __repr__(
+        self,
+    ) -> str:
         """Returns text that is a valid python expression evaluating to an equivalent `stim.CompiledMeasurementsToDetectionEventsConverter`.
         """
-    def convert(self, *, measurements: np.ndarray, sweep_bits: Optional[np.ndarray] = None, separate_observables: bool = False, append_observables: bool = False, bit_pack_result: bool = False) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
+    def convert(
+        self,
+        *,
+        measurements: np.ndarray,
+        sweep_bits: Optional[np.ndarray] = None,
+        separate_observables: bool = False,
+        append_observables: bool = False,
+        bit_pack_result: bool = False,
+    ) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
 
         """Converts measurement data into detection event data.
 
@@ -1690,7 +1982,19 @@ class CompiledMeasurementsToDetectionEventsConverter:
                    [ True],
                    [False]])
         """
-    def convert_file(self, *, measurements_filepath: str, measurements_format: str = '01', sweep_bits_filepath: str = None, sweep_bits_format: str = '01', detection_events_filepath: str, detection_events_format: str = '01', append_observables: bool = False, obs_out_filepath: str = None, obs_out_format: str = '01') -> None:
+    def convert_file(
+        self,
+        *,
+        measurements_filepath: str,
+        measurements_format: str = '01',
+        sweep_bits_filepath: str = None,
+        sweep_bits_format: str = '01',
+        detection_events_filepath: str,
+        detection_events_format: str = '01',
+        append_observables: bool = False,
+        obs_out_filepath: str = None,
+        obs_out_format: str = '01',
+    ) -> None:
         """Reads measurement data from a file, converts it, and writes the detection events to another file.
 
         Args:
@@ -1756,10 +2060,18 @@ class DemInstruction:
         >>> instruction
         stim.DemInstruction('error', [0.125], [stim.target_relative_detector_id(0)])
     """
-    def __eq__(self, arg0: stim.DemInstruction) -> bool:
+    def __eq__(
+        self,
+        arg0: stim.DemInstruction,
+    ) -> bool:
         """Determines if two instructions have identical contents.
         """
-    def __init__(self, type: str, args: List[float], targets: List[object]) -> None:
+    def __init__(
+        self,
+        type: str,
+        args: List[float],
+        targets: List[object],
+    ) -> None:
         """Creates a stim.DemInstruction.
 
         Args:
@@ -1773,24 +2085,37 @@ class DemInstruction:
             >>> print(instruction)
             error(0.125) D5
         """
-    def __ne__(self, arg0: stim.DemInstruction) -> bool:
+    def __ne__(
+        self,
+        arg0: stim.DemInstruction,
+    ) -> bool:
         """Determines if two instructions have non-identical contents.
         """
-    def __repr__(self) -> str:
+    def __repr__(
+        self,
+    ) -> str:
         """Returns text that is a valid python expression evaluating to an equivalent `stim.DetectorErrorModel`.
         """
-    def __str__(self) -> str:
+    def __str__(
+        self,
+    ) -> str:
         """Returns detector error model (.dem) instructions (that can be parsed by stim) for the model.
         """
-    def args_copy(self) -> List[float]:
+    def args_copy(
+        self,
+    ) -> List[float]:
         """Returns a copy of the list of numbers parameterizing the instruction (e.g. the probability of an error).
         """
-    def targets_copy(self) -> List[Union[int, stim.DemTarget]]:
+    def targets_copy(
+        self,
+    ) -> List[Union[int, stim.DemTarget]]:
 
         """Returns a copy of the list of objects the instruction applies to (e.g. affected detectors.
         """
     @property
-    def type(self) -> str:
+    def type(
+        self,
+    ) -> str:
         """The name of the instruction type (e.g. "error" or "shift_detectors").
         """
 class DemRepeatBlock:
@@ -1810,10 +2135,17 @@ class DemRepeatBlock:
             shift_detectors 1
         '''))
     """
-    def __eq__(self, arg0: stim.DemRepeatBlock) -> bool:
+    def __eq__(
+        self,
+        arg0: stim.DemRepeatBlock,
+    ) -> bool:
         """Determines if two repeat blocks are identical.
         """
-    def __init__(self, repeat_count: int, block: stim.DetectorErrorModel) -> None:
+    def __init__(
+        self,
+        repeat_count: int,
+        block: stim.DetectorErrorModel,
+    ) -> None:
         """Creates a stim.DemRepeatBlock.
 
         Args:
@@ -1827,45 +2159,72 @@ class DemRepeatBlock:
             ...     shift_detectors 1
             ... '''))
         """
-    def __ne__(self, arg0: stim.DemRepeatBlock) -> bool:
+    def __ne__(
+        self,
+        arg0: stim.DemRepeatBlock,
+    ) -> bool:
         """Determines if two repeat blocks are different.
         """
-    def __repr__(self) -> str:
+    def __repr__(
+        self,
+    ) -> str:
         """Returns text that is a valid python expression evaluating to an equivalent `stim.DemRepeatBlock`.
         """
-    def body_copy(self) -> stim.DetectorErrorModel:
+    def body_copy(
+        self,
+    ) -> stim.DetectorErrorModel:
         """Returns a copy of the block's body, as a stim.DetectorErrorModel.
         """
     @property
-    def repeat_count(self) -> int:
+    def repeat_count(
+        self,
+    ) -> int:
         """The number of times the repeat block's body is supposed to execute.
         """
 class DemTarget:
     """An instruction target from a detector error model (.dem) file.
     """
-    def __eq__(self, arg0: stim.DemTarget) -> bool:
+    def __eq__(
+        self,
+        arg0: stim.DemTarget,
+    ) -> bool:
         """Determines if two `stim.DemTarget`s are identical.
         """
-    def __ne__(self, arg0: stim.DemTarget) -> bool:
+    def __ne__(
+        self,
+        arg0: stim.DemTarget,
+    ) -> bool:
         """Determines if two `stim.DemTarget`s are different.
         """
-    def __repr__(self) -> str:
+    def __repr__(
+        self,
+    ) -> str:
         """Returns text that is a valid python expression evaluating to an equivalent `stim.DemTarget`.
         """
-    def __str__(self) -> str:
+    def __str__(
+        self,
+    ) -> str:
         """Returns a text description of the detector error model target.
         """
-    def is_logical_observable_id(self) -> bool:
+    def is_logical_observable_id(
+        self,
+    ) -> bool:
         """Determines if the detector error model target is a logical observable id target (like "L5" in a .dem file).
         """
-    def is_relative_detector_id(self) -> bool:
+    def is_relative_detector_id(
+        self,
+    ) -> bool:
         """Determines if the detector error model target is a relative detector id target (like "D4" in a .dem file).
         """
-    def is_separator(self) -> bool:
+    def is_separator(
+        self,
+    ) -> bool:
         """Determines if the detector error model target is a separator (like "^" in a .dem file).
         """
     @staticmethod
-    def logical_observable_id(index: int) -> stim.DemTarget:
+    def logical_observable_id(
+        index: int,
+    ) -> stim.DemTarget:
         """Returns a logical observable id identifying a frame change (e.g. "L5" in a .dem file).
 
         Args:
@@ -1886,7 +2245,9 @@ class DemTarget:
             ''')
         """
     @staticmethod
-    def relative_detector_id(index: int) -> stim.DemTarget:
+    def relative_detector_id(
+        index: int,
+    ) -> stim.DemTarget:
         """Returns a relative detector id (e.g. "D5" in a .dem file).
 
         Args:
@@ -1907,7 +2268,8 @@ class DemTarget:
             ''')
         """
     @staticmethod
-    def separator() -> stim.DemTarget:
+    def separator(
+    ) -> stim.DemTarget:
         """Returns a target separator (e.g. "^" in a .dem file).
 
         Examples:
@@ -1924,7 +2286,9 @@ class DemTarget:
             ''')
         """
     @property
-    def val(self) -> int:
+    def val(
+        self,
+    ) -> int:
         """Returns the target's integer value.
 
         Example:
@@ -1951,17 +2315,26 @@ class DemTargetWithCoords:
     look up the coordinates of a detector index in order to understand
     what is happening.
     """
-    def __init__(self, *, dem_target: stim.DemTarget, coords: List[float]) -> None:
+    def __init__(
+        self,
+        *,
+        dem_target: stim.DemTarget,
+        coords: List[float],
+    ) -> None:
         """Creates a stim.DemTargetWithCoords.
         """
     @property
-    def coords(self) -> List[float]:
+    def coords(
+        self,
+    ) -> List[float]:
         """Returns the associated coordinate information as a list of flaots.
 
         If there is no coordinate information, returns an empty list.
         """
     @property
-    def dem_target(self) -> stim.DemTarget:
+    def dem_target(
+        self,
+    ) -> stim.DemTarget:
         """Returns the actual DEM target as a `stim.DemTarget`.
         """
 class DetectorErrorModel:
@@ -1993,7 +2366,10 @@ class DetectorErrorModel:
             error(0.25) D1
         ''')
     """
-    def __add__(self, second: stim.DetectorErrorModel) -> stim.DetectorErrorModel:
+    def __add__(
+        self,
+        second: stim.DetectorErrorModel,
+    ) -> stim.DetectorErrorModel:
         """Creates a detector error model by appending two models.
 
         Examples:
@@ -2010,16 +2386,28 @@ class DetectorErrorModel:
                 error(0.25) D1
             ''')
         """
-    def __eq__(self, arg0: stim.DetectorErrorModel) -> bool:
+    def __eq__(
+        self,
+        arg0: stim.DetectorErrorModel,
+    ) -> bool:
         """Determines if two detector error models have identical contents.
         """
     @overload
-    def __getitem__(self, index_or_slice: int) -> Union[stim.DemInstruction, stim.DemRepeatBlock]:
+    def __getitem__(
+        self,
+        index_or_slice: int,
+    ) -> Union[stim.DemInstruction, stim.DemRepeatBlock]:
         pass
     @overload
-    def __getitem__(self, index_or_slice: slice) -> stim.DetectorErrorModel:
+    def __getitem__(
+        self,
+        index_or_slice: slice,
+    ) -> stim.DetectorErrorModel:
         pass
-    def __getitem__(self, index_or_slice: object) -> object:
+    def __getitem__(
+        self,
+        index_or_slice: object,
+    ) -> object:
         """Returns copies of instructions from the detector error model.
 
         Args:
@@ -2054,7 +2442,10 @@ class DetectorErrorModel:
                 detector D5
             ''')
         """
-    def __iadd__(self, second: stim.DetectorErrorModel) -> stim.DetectorErrorModel:
+    def __iadd__(
+        self,
+        second: stim.DetectorErrorModel,
+    ) -> stim.DetectorErrorModel:
         """Appends a detector error model into the receiving model (mutating it).
 
         Examples:
@@ -2072,7 +2463,10 @@ class DetectorErrorModel:
                 error(0.25) D1
             ''')
         """
-    def __imul__(self, repetitions: int) -> stim.DetectorErrorModel:
+    def __imul__(
+        self,
+        repetitions: int,
+    ) -> stim.DetectorErrorModel:
         """Mutates the detector error model by putting its contents into a repeat block.
 
         Special case: if the repetition count is 0, the model is cleared.
@@ -2094,7 +2488,10 @@ class DetectorErrorModel:
                 shift_detectors 1
             }
         """
-    def __init__(self, detector_error_model_text: str = '') -> None:
+    def __init__(
+        self,
+        detector_error_model_text: str = '',
+    ) -> None:
         """Creates a stim.DetectorErrorModel.
 
         Args:
@@ -2108,7 +2505,9 @@ class DetectorErrorModel:
             ...    error(0.125) D0 L0
             ... ''')
         """
-    def __len__(self) -> int:
+    def __len__(
+        self,
+    ) -> int:
         """Returns the number of top-level instructions and blocks in the detector error model.
 
         Instructions inside of blocks are not included in this count.
@@ -2131,7 +2530,10 @@ class DetectorErrorModel:
             ... '''))
             1
         """
-    def __mul__(self, repetitions: int) -> stim.DetectorErrorModel:
+    def __mul__(
+        self,
+        repetitions: int,
+    ) -> stim.DetectorErrorModel:
         """Returns a detector error model with a repeat block containing the current model's instructions.
 
         Special case: if the repetition count is 0, an empty model is returned.
@@ -2154,13 +2556,21 @@ class DetectorErrorModel:
                 }
             ''')
         """
-    def __ne__(self, arg0: stim.DetectorErrorModel) -> bool:
+    def __ne__(
+        self,
+        arg0: stim.DetectorErrorModel,
+    ) -> bool:
         """Determines if two detector error models have non-identical contents.
         """
-    def __repr__(self) -> str:
+    def __repr__(
+        self,
+    ) -> str:
         """"Returns text that is a valid python expression evaluating to an equivalent `stim.DetectorErrorModel`."
         """
-    def __rmul__(self, repetitions: int) -> stim.DetectorErrorModel:
+    def __rmul__(
+        self,
+        repetitions: int,
+    ) -> stim.DetectorErrorModel:
         """Returns a detector error model with a repeat block containing the current model's instructions.
 
         Special case: if the repetition count is 0, an empty model is returned.
@@ -2183,10 +2593,17 @@ class DetectorErrorModel:
                 }
             ''')
         """
-    def __str__(self) -> str:
+    def __str__(
+        self,
+    ) -> str:
         """"Returns detector error model (.dem) instructions (that can be parsed by stim) for the model.");
         """
-    def append(self, instruction: object, parens_arguments: object = None, targets: List[object] = ()) -> None:
+    def append(
+        self,
+        instruction: object,
+        parens_arguments: object = None,
+        targets: List[object] = (),
+    ) -> None:
         """Appends an instruction to the detector error model.
 
         Args:
@@ -2244,7 +2661,12 @@ class DetectorErrorModel:
                 }
             ''')
         """
-    def approx_equals(self, other: object, *, atol: float) -> bool:
+    def approx_equals(
+        self,
+        other: object,
+        *,
+        atol: float,
+    ) -> bool:
         """Checks if a detector error model is approximately equal to another detector error model.
 
         Two detector error model are approximately equal if they are equal up to slight perturbations of instruction
@@ -2289,7 +2711,9 @@ class DetectorErrorModel:
             ... '''), atol=9999)
             False
         """
-    def clear(self) -> None:
+    def clear(
+        self,
+    ) -> None:
         """Clears the contents of the detector error model.
 
         Examples:
@@ -2301,7 +2725,9 @@ class DetectorErrorModel:
             >>> model
             stim.DetectorErrorModel()
         """
-    def copy(self) -> stim.DetectorErrorModel:
+    def copy(
+        self,
+    ) -> stim.DetectorErrorModel:
         """Returns a copy of the detector error model. An independent model with the same contents.
 
         Examples:
@@ -2315,7 +2741,9 @@ class DetectorErrorModel:
             True
         """
     @staticmethod
-    def from_file(file: object) -> stim.DetectorErrorModel:
+    def from_file(
+        file: object,
+    ) -> stim.DetectorErrorModel:
         """Args:
             file: A file path or open file object to read from.
 
@@ -2347,7 +2775,10 @@ class DetectorErrorModel:
                 error(0.25) D2 D3
             ''')
         """
-    def get_detector_coordinates(self, only: object = None) -> Dict[int, List[float]]:
+    def get_detector_coordinates(
+        self,
+        only: object = None,
+    ) -> Dict[int, List[float]]:
         """Returns the coordinate metadata of detectors in the detector error model.
 
         Args:
@@ -2373,7 +2804,9 @@ class DetectorErrorModel:
             {1: [1.0, 2.0, 3.0]}
         """
     @property
-    def num_detectors(self) -> int:
+    def num_detectors(
+        self,
+    ) -> int:
         """Counts the number of detectors (e.g. `D2`) in the error model.
 
         Detector indices are assumed to be contiguous from 0 up to whatever the maximum detector id is.
@@ -2404,7 +2837,9 @@ class DetectorErrorModel:
             1200
         """
     @property
-    def num_errors(self) -> int:
+    def num_errors(
+        self,
+    ) -> int:
         """Counts the number of errors (e.g. `error(0.1) D0`) in the error model.
 
         Error instructions inside repeat blocks count once per repetition.
@@ -2424,7 +2859,9 @@ class DetectorErrorModel:
             501
         """
     @property
-    def num_observables(self) -> int:
+    def num_observables(
+        self,
+    ) -> int:
         """Counts the number of frame changes (e.g. `L2`) in the error model.
 
         Observable indices are assumed to be contiguous from 0 up to whatever the maximum observable id is.
@@ -2445,7 +2882,10 @@ class DetectorErrorModel:
             ... ''').num_observables
             400
         """
-    def shortest_graphlike_error(self, ignore_ungraphlike_errors: bool = False) -> stim.DetectorErrorModel:
+    def shortest_graphlike_error(
+        self,
+        ignore_ungraphlike_errors: bool = False,
+    ) -> stim.DetectorErrorModel:
         """Finds a minimum sized set of graphlike errors that produce an undetected logical error.
 
         Note that this method does not pay attention to error probabilities (other than ignoring errors with
@@ -2520,7 +2960,10 @@ class DetectorErrorModel:
             >>> len(model.shortest_graphlike_error())
             7
         """
-    def to_file(self, file: Union[io.TextIOBase, str, pathlib.Path]) -> None:
+    def to_file(
+        self,
+        file: Union[io.TextIOBase, str, pathlib.Path],
+    ) -> None:
 
         """Writes the stim circuit to a file.
 
@@ -2552,11 +2995,18 @@ class DetectorErrorModel:
 class ExplainedError:
     """Describes the location of an error mechanism from a stim circuit.
     """
-    def __init__(self, *, dem_error_terms: List[stim.DemTargetWithCoords], circuit_error_locations: List[stim.CircuitErrorLocation]) -> None:
+    def __init__(
+        self,
+        *,
+        dem_error_terms: List[stim.DemTargetWithCoords],
+        circuit_error_locations: List[stim.CircuitErrorLocation],
+    ) -> None:
         """Creates a stim.ExplainedError.
         """
     @property
-    def circuit_error_locations(self) -> List[stim.CircuitErrorLocation]:
+    def circuit_error_locations(
+        self,
+    ) -> List[stim.CircuitErrorLocation]:
         """The locations of circuit errors that produce the symptoms in dem_error_terms.
 
         Note: if this list contains a single entry, it may be because a result
@@ -2568,7 +3018,9 @@ class ExplainedError:
         circuit error.
         """
     @property
-    def dem_error_terms(self) -> List[stim.DemTargetWithCoords]:
+    def dem_error_terms(
+        self,
+    ) -> List[stim.DemTargetWithCoords]:
         """The detectors and observables flipped by this error mechanism.
         """
 class FlippedMeasurement:
@@ -2577,17 +3029,26 @@ class FlippedMeasurement:
     Gives the measurement's index in the measurement record, and also
     the observable of the measurement.
     """
-    def __init__(self, *, record_index: int, observable: object) -> None:
+    def __init__(
+        self,
+        *,
+        record_index: int,
+        observable: object,
+    ) -> None:
         """Creates a stim.FlippedMeasurement.
         """
     @property
-    def observable(self) -> List[stim.GateTargetWithCoords]:
+    def observable(
+        self,
+    ) -> List[stim.GateTargetWithCoords]:
         """Returns the observable of the flipped measurement.
 
         For example, an `MX 5` measurement will have the observable X5.
         """
     @property
-    def record_index(self) -> int:
+    def record_index(
+        self,
+    ) -> int:
         """The measurement record index of the flipped measurement.
         For example, the fifth measurement in a circuit has a measurement
         record index of 4.
@@ -2605,58 +3066,87 @@ class GateTarget:
         >>> circuit[0].targets_copy()[1]
         stim.GateTarget(stim.target_inv(1))
     """
-    def __eq__(self, arg0: stim.GateTarget) -> bool:
+    def __eq__(
+        self,
+        arg0: stim.GateTarget,
+    ) -> bool:
         """Determines if two `stim.GateTarget`s are identical.
         """
-    def __init__(self, value: object) -> None:
+    def __init__(
+        self,
+        value: object,
+    ) -> None:
         """Initializes a `stim.GateTarget`.
 
         Args:
             value: A target like `5` or `stim.target_rec(-1)`.
         """
-    def __ne__(self, arg0: stim.GateTarget) -> bool:
+    def __ne__(
+        self,
+        arg0: stim.GateTarget,
+    ) -> bool:
         """Determines if two `stim.GateTarget`s are different.
         """
-    def __repr__(self) -> str:
+    def __repr__(
+        self,
+    ) -> str:
         """Returns text that is a valid python expression evaluating to an equivalent `stim.GateTarget`.
         """
     @property
-    def is_combiner(self) -> bool:
+    def is_combiner(
+        self,
+    ) -> bool:
         """Returns whether or not this is a `stim.target_combiner()` (a `*` in a circuit file).
         """
     @property
-    def is_inverted_result_target(self) -> bool:
+    def is_inverted_result_target(
+        self,
+    ) -> bool:
         """Returns whether or not this is an inverted target.
 
         Inverted targets include inverted qubit targets `stim.target_inv(5)` (`!5` in a circuit file) and
         inverted Pauli targets like `stim.target_x(4, invert=True)` (`!X4` in a circuit file).
         """
     @property
-    def is_measurement_record_target(self) -> bool:
+    def is_measurement_record_target(
+        self,
+    ) -> bool:
         """Returns whether or not this is a `stim.target_rec` target (e.g. `rec[-5]` in a circuit file).
         """
     @property
-    def is_qubit_target(self) -> bool:
+    def is_qubit_target(
+        self,
+    ) -> bool:
         """Returns true if this is a qubit target (e.g. `5`) or an inverted qubit target (e.g. `stim.target_inv(4)`).
         """
     @property
-    def is_sweep_bit_target(self) -> bool:
+    def is_sweep_bit_target(
+        self,
+    ) -> bool:
         """Returns whether or not this is a `stim.target_sweep_bit` target (e.g. `sweep[5]` in a circuit file).
         """
     @property
-    def is_x_target(self) -> bool:
+    def is_x_target(
+        self,
+    ) -> bool:
         """Returns whether or not this is a `stim.target_x` target (e.g. `X5` in a circuit file).
         """
     @property
-    def is_y_target(self) -> bool:
+    def is_y_target(
+        self,
+    ) -> bool:
         """Returns whether or not this is a `stim.target_y` target (e.g. `Y5` in a circuit file).
         """
     @property
-    def is_z_target(self) -> bool:
+    def is_z_target(
+        self,
+    ) -> bool:
         """Returns whether or not this is a `stim.target_z` target (e.g. `Z5` in a circuit file).
         """
     @property
-    def value(self) -> int:
+    def value(
+        self,
+    ) -> int:
         """The numeric part of the target. Positive for qubit targets, negative for measurement record targets.
         """
 class GateTargetWithCoords:
@@ -2671,17 +3161,26 @@ class GateTargetWithCoords:
     look up the coordinates of a qubit index in order to understand
     what is happening.
     """
-    def __init__(self, *, gate_target: object, coords: List[float]) -> None:
+    def __init__(
+        self,
+        *,
+        gate_target: object,
+        coords: List[float],
+    ) -> None:
         """Creates a stim.GateTargetWithCoords.
         """
     @property
-    def coords(self) -> List[float]:
+    def coords(
+        self,
+    ) -> List[float]:
         """Returns the associated coordinate information as a list of flaots.
 
         If there is no coordinate information, returns an empty list.
         """
     @property
-    def gate_target(self) -> stim.GateTarget:
+    def gate_target(
+        self,
+    ) -> stim.GateTarget:
         """Returns the actual gate target as a `stim.GateTarget`.
         """
 class PauliString:
@@ -2696,7 +3195,10 @@ class PauliString:
         >>> print(stim.PauliString(5))
         +_____
     """
-    def __add__(self, rhs: stim.PauliString) -> stim.PauliString:
+    def __add__(
+        self,
+        rhs: stim.PauliString,
+    ) -> stim.PauliString:
         """Returns the tensor product of two Pauli strings.
 
         Concatenates the Pauli strings and multiplies their signs.
@@ -2716,16 +3218,28 @@ class PauliString:
         Returns:
             The tensor product.
         """
-    def __eq__(self, arg0: stim.PauliString) -> bool:
+    def __eq__(
+        self,
+        arg0: stim.PauliString,
+    ) -> bool:
         """Determines if two Pauli strings have identical contents.
         """
     @overload
-    def __getitem__(self, index_or_slice: int) -> int:
+    def __getitem__(
+        self,
+        index_or_slice: int,
+    ) -> int:
         pass
     @overload
-    def __getitem__(self, index_or_slice: slice) -> stim.PauliString:
+    def __getitem__(
+        self,
+        index_or_slice: slice,
+    ) -> stim.PauliString:
         pass
-    def __getitem__(self, index_or_slice: object) -> object:
+    def __getitem__(
+        self,
+        index_or_slice: object,
+    ) -> object:
         """Returns an individual Pauli or Pauli string slice from the pauli string.
 
         Individual Paulis are returned as an int using the encoding 0=I, 1=X, 2=Y, 3=Z.
@@ -2752,7 +3266,10 @@ class PauliString:
             2: Pauli Y.
             3: Pauli Z.
         """
-    def __iadd__(self, rhs: stim.PauliString) -> stim.PauliString:
+    def __iadd__(
+        self,
+        rhs: stim.PauliString,
+    ) -> stim.PauliString:
         """Performs an inplace tensor product.
 
         Concatenates the given Pauli string onto the receiving string and multiplies their signs.
@@ -2774,7 +3291,10 @@ class PauliString:
         Returns:
             The mutated pauli string.
         """
-    def __imul__(self, rhs: object) -> stim.PauliString:
+    def __imul__(
+        self,
+        rhs: object,
+    ) -> stim.PauliString:
         """Inplace right-multiplies the Pauli string by another Pauli string, a complex unit, or a tensor power.
 
         Args:
@@ -2811,7 +3331,10 @@ class PauliString:
             The mutated Pauli string.
         """
     @staticmethod
-    def __init__(*args, **kwargs):
+    def __init__(
+        *args,
+        **kwargs,
+    ):
         """Overloaded function.
 
         1. __init__(self: stim.PauliString, num_qubits: int) -> None
@@ -2886,7 +3409,10 @@ class PauliString:
         Args:
             pauli_indices: A sequence of integers from 0 to 3 (inclusive) indicating paulis.
         """
-    def __itruediv__(self, rhs: complex) -> stim.PauliString:
+    def __itruediv__(
+        self,
+        rhs: complex,
+    ) -> stim.PauliString:
         """Inplace divides the Pauli string by a complex unit.
 
         Args:
@@ -2906,10 +3432,15 @@ class PauliString:
         Raises:
             ValueError: The divisor isn't 1, -1, 1j, or -1j.
         """
-    def __len__(self) -> int:
+    def __len__(
+        self,
+    ) -> int:
         """Returns the length the pauli string; the number of qubits it operates on.
         """
-    def __mul__(self, rhs: object) -> stim.PauliString:
+    def __mul__(
+        self,
+        rhs: object,
+    ) -> stim.PauliString:
         """Right-multiplies the Pauli string by another Pauli string, a complex unit, or a tensor power.
 
         Args:
@@ -2952,10 +3483,15 @@ class PauliString:
         Raises:
             TypeError: The right hand side isn't a stim.PauliString, a non-negative integer, or a complex unit (1, -1, 1j, or -1j).
         """
-    def __ne__(self, arg0: stim.PauliString) -> bool:
+    def __ne__(
+        self,
+        arg0: stim.PauliString,
+    ) -> bool:
         """Determines if two Pauli strings have non-identical contents.
         """
-    def __neg__(self) -> stim.PauliString:
+    def __neg__(
+        self,
+    ) -> stim.PauliString:
         """Returns the negation of the pauli string.
 
         Examples:
@@ -2967,7 +3503,9 @@ class PauliString:
             >>> -stim.PauliString("iZZZ")
             stim.PauliString("-iZZZ")
         """
-    def __pos__(self) -> stim.PauliString:
+    def __pos__(
+        self,
+    ) -> stim.PauliString:
         """Returns a pauli string with the same contents.
 
         Examples:
@@ -2979,10 +3517,15 @@ class PauliString:
             >>> +stim.PauliString("iZZZ")
             stim.PauliString("+iZZZ")
         """
-    def __repr__(self) -> str:
+    def __repr__(
+        self,
+    ) -> str:
         """Returns text that is a valid python expression evaluating to an equivalent `stim.PauliString`.
         """
-    def __rmul__(self, lhs: object) -> stim.PauliString:
+    def __rmul__(
+        self,
+        lhs: object,
+    ) -> stim.PauliString:
         """Left-multiplies the Pauli string by another Pauli string, a complex unit, or a tensor power.
 
         Args:
@@ -3025,7 +3568,11 @@ class PauliString:
         Raises:
             ValueError: The scalar phase factor isn't 1, -1, 1j, or -1j.
         """
-    def __setitem__(self, index: int, new_pauli: object) -> None:
+    def __setitem__(
+        self,
+        index: int,
+        new_pauli: object,
+    ) -> None:
         """Mutates an entry in the pauli string using the encoding 0=I, 1=X, 2=Y, 3=Z.
 
         Args:
@@ -3053,10 +3600,15 @@ class PauliString:
             >>> print(p)
             +_XYY
         """
-    def __str__(self) -> str:
+    def __str__(
+        self,
+    ) -> str:
         """Returns a text description.
         """
-    def __truediv__(self, rhs: complex) -> stim.PauliString:
+    def __truediv__(
+        self,
+        rhs: complex,
+    ) -> stim.PauliString:
         """Divides the Pauli string by a complex unit.
 
         Args:
@@ -3074,7 +3626,10 @@ class PauliString:
         Raises:
             ValueError: The divisor isn't 1, -1, 1j, or -1j.
         """
-    def commutes(self, other: stim.PauliString) -> bool:
+    def commutes(
+        self,
+        other: stim.PauliString,
+    ) -> bool:
         """Determines if two Pauli strings commute or not.
 
         Two Pauli strings commute if they have an even number of matched
@@ -3104,7 +3659,9 @@ class PauliString:
         Returns:
             True if the Pauli strings commute, False if they anti-commute.
         """
-    def copy(self) -> stim.PauliString:
+    def copy(
+        self,
+    ) -> stim.PauliString:
         """Returns a copy of the pauli string. An independent pauli string with the same contents.
 
         Examples:
@@ -3116,11 +3673,18 @@ class PauliString:
             >>> p2 == p1
             True
         """
-    def extended_product(self, other: stim.PauliString) -> Tuple[complex, stim.PauliString]:
+    def extended_product(
+        self,
+        other: stim.PauliString,
+    ) -> Tuple[complex, stim.PauliString]:
         """[DEPRECATED] Use multiplication (__mul__ or *) instead.
         """
     @staticmethod
-    def random(num_qubits: int, *, allow_imaginary: bool = False) -> stim.PauliString:
+    def random(
+        num_qubits: int,
+        *,
+        allow_imaginary: bool = False,
+    ) -> stim.PauliString:
         """Samples a uniformly random Hermitian Pauli string over the given number of qubits.
 
         Args:
@@ -3147,7 +3711,9 @@ class PauliString:
             The sampled Pauli string.
         """
     @property
-    def sign(self) -> complex:
+    def sign(
+        self,
+    ) -> complex:
         """The sign of the Pauli string. Can be +1, -1, 1j, or -1j.
 
         Examples:
@@ -3197,7 +3763,10 @@ class Tableau:
         >>> t_inv(x2z3)
         stim.PauliString("+__XZ_")
     """
-    def __add__(self, rhs: stim.Tableau) -> stim.Tableau:
+    def __add__(
+        self,
+        rhs: stim.Tableau,
+    ) -> stim.Tableau:
         """Returns the direct sum (diagonal concatenation) of two Tableaus.
 
         Args:
@@ -3218,7 +3787,10 @@ class Tableau:
         Returns:
             The direct sum.
         """
-    def __call__(self, pauli_string: stim.PauliString) -> stim.PauliString:
+    def __call__(
+        self,
+        pauli_string: stim.PauliString,
+    ) -> stim.PauliString:
         """Returns the result of conjugating the given PauliString by the Tableau's Clifford operation.
 
         Args:
@@ -3235,10 +3807,16 @@ class Tableau:
             >>> print(result)
             +X_
         """
-    def __eq__(self, arg0: stim.Tableau) -> bool:
+    def __eq__(
+        self,
+        arg0: stim.Tableau,
+    ) -> bool:
         """Determines if two tableaus have identical contents.
         """
-    def __iadd__(self, rhs: stim.Tableau) -> stim.Tableau:
+    def __iadd__(
+        self,
+        rhs: stim.Tableau,
+    ) -> stim.Tableau:
         """Performs an inplace direct sum (diagonal concatenation).
 
         Args:
@@ -3263,7 +3841,10 @@ class Tableau:
         Returns:
             The mutated tableau.
         """
-    def __init__(self, num_qubits: int) -> None:
+    def __init__(
+        self,
+        num_qubits: int,
+    ) -> None:
         """Creates an identity tableau over the given number of qubits.
 
         Examples:
@@ -3279,10 +3860,15 @@ class Tableau:
         Args:
             num_qubits: The number of qubits the tableau's operation acts on.
         """
-    def __len__(self) -> int:
+    def __len__(
+        self,
+    ) -> int:
         """Returns the number of qubits operated on by the tableau.
         """
-    def __mul__(self, rhs: stim.Tableau) -> stim.Tableau:
+    def __mul__(
+        self,
+        rhs: stim.Tableau,
+    ) -> stim.Tableau:
         """Returns the product of two tableaus.
 
         If the tableau T1 represents the Clifford operation with unitary C1,
@@ -3301,10 +3887,16 @@ class Tableau:
             >>> t3(p) == t2(t1(p))
             True
         """
-    def __ne__(self, arg0: stim.Tableau) -> bool:
+    def __ne__(
+        self,
+        arg0: stim.Tableau,
+    ) -> bool:
         """Determines if two tableaus have non-identical contents.
         """
-    def __pow__(self, exponent: int) -> stim.Tableau:
+    def __pow__(
+        self,
+        exponent: int,
+    ) -> stim.Tableau:
         """Raises the tableau to an integer power.
 
         Large powers are reached efficiently using repeated squaring.
@@ -3331,13 +3923,21 @@ class Tableau:
             >>> s**(-400000000 + 1) == s
             True
         """
-    def __repr__(self) -> str:
+    def __repr__(
+        self,
+    ) -> str:
         """Returns text that is a valid python expression evaluating to an equivalent `stim.Tableau`.
         """
-    def __str__(self) -> str:
+    def __str__(
+        self,
+    ) -> str:
         """Returns a text description.
         """
-    def append(self, gate: stim.Tableau, targets: List[int]) -> None:
+    def append(
+        self,
+        gate: stim.Tableau,
+        targets: List[int],
+    ) -> None:
         """Appends an operation's effect into this tableau, mutating this tableau.
 
         Time cost is O(n*m*m) where n=len(self) and m=len(gate).
@@ -3356,7 +3956,9 @@ class Tableau:
             >>> t == stim.Tableau.from_named_gate("SWAP")
             True
         """
-    def copy(self) -> stim.Tableau:
+    def copy(
+        self,
+    ) -> stim.Tableau:
         """Returns a copy of the tableau. An independent tableau with the same contents.
 
         Examples:
@@ -3369,7 +3971,13 @@ class Tableau:
             True
         """
     @staticmethod
-    def from_circuit(circuit: stim.Circuit, *, ignore_noise: bool = False, ignore_measurement: bool = False, ignore_reset: bool = False) -> stim.Tableau:
+    def from_circuit(
+        circuit: stim.Circuit,
+        *,
+        ignore_noise: bool = False,
+        ignore_measurement: bool = False,
+        ignore_reset: bool = False,
+    ) -> stim.Tableau:
 
         """Converts a circuit into an equivalent stabilizer tableau.
 
@@ -3414,7 +4022,11 @@ class Tableau:
             )
         """
     @staticmethod
-    def from_conjugated_generators(*, xs: List[stim.PauliString], zs: List[stim.PauliString]) -> stim.Tableau:
+    def from_conjugated_generators(
+        *,
+        xs: List[stim.PauliString],
+        zs: List[stim.PauliString],
+    ) -> stim.Tableau:
         """Creates a tableau from the given outputs for each generator.
 
         Verifies that the tableau is well formed.
@@ -3448,7 +4060,9 @@ class Tableau:
             True
         """
     @staticmethod
-    def from_named_gate(name: str) -> stim.Tableau:
+    def from_named_gate(
+        name: str,
+    ) -> stim.Tableau:
         """Returns the tableau of a named Clifford gate.
 
         Args:
@@ -3474,7 +4088,11 @@ class Tableau:
             | YZ
         """
     @staticmethod
-    def from_unitary_matrix(matrix: Iterable[Iterable[float]], *, endian: str = 'little') -> stim.Tableau:
+    def from_unitary_matrix(
+        matrix: Iterable[Iterable[float]],
+        *,
+        endian: str = 'little',
+    ) -> stim.Tableau:
 
         """Creates a tableau from the unitary matrix of a Clifford operation.
 
@@ -3524,7 +4142,11 @@ class Tableau:
                 ],
             )
         """
-    def inverse(self, *, unsigned: bool = False) -> stim.Tableau:
+    def inverse(
+        self,
+        *,
+        unsigned: bool = False,
+    ) -> stim.Tableau:
         """Computes the inverse of the tableau.
 
         The inverse T^-1 of a tableau T is the unique tableau with the property that T * T^-1 = T^-1 * T = I where
@@ -3576,7 +4198,12 @@ class Tableau:
             | XZ Z_ X_
             | X_ YX Y_
         """
-    def inverse_x_output(self, input_index: int, *, unsigned: bool = False) -> stim.PauliString:
+    def inverse_x_output(
+        self,
+        input_index: int,
+        *,
+        unsigned: bool = False,
+    ) -> stim.PauliString:
         """Returns the result of conjugating an X Pauli generator by the inverse of the tableau.
 
         A faster version of `tableau.inverse(unsigned).x_output(input_index)`.
@@ -3602,7 +4229,11 @@ class Tableau:
             >>> t.inverse_x_output(0, unsigned=True) == expected
             True
         """
-    def inverse_x_output_pauli(self, input_index: int, output_index: int) -> int:
+    def inverse_x_output_pauli(
+        self,
+        input_index: int,
+        output_index: int,
+    ) -> int:
         """Returns a Pauli term from the tableau's inverse's output pauli string for an input X generator.
 
         A constant-time equivalent for `tableau.inverse().x_output(input_index)[output_index]`.
@@ -3635,7 +4266,12 @@ class Tableau:
             >>> t_inv.inverse_x_output_pauli(1, 1)
             3
         """
-    def inverse_y_output(self, input_index: int, *, unsigned: bool = False) -> stim.PauliString:
+    def inverse_y_output(
+        self,
+        input_index: int,
+        *,
+        unsigned: bool = False,
+    ) -> stim.PauliString:
         """Returns the result of conjugating a Y Pauli generator by the inverse of the tableau.
 
         A faster version of `tableau.inverse(unsigned).y_output(input_index)`.
@@ -3661,7 +4297,11 @@ class Tableau:
             >>> t.inverse_y_output(0, unsigned=True) == expected
             True
         """
-    def inverse_y_output_pauli(self, input_index: int, output_index: int) -> int:
+    def inverse_y_output_pauli(
+        self,
+        input_index: int,
+        output_index: int,
+    ) -> int:
         """Returns a Pauli term from the tableau's inverse's output pauli string for an input Y generator.
 
         A constant-time equivalent for `tableau.inverse().y_output(input_index)[output_index]`.
@@ -3694,7 +4334,12 @@ class Tableau:
             >>> t_inv.inverse_y_output_pauli(1, 1)
             2
         """
-    def inverse_z_output(self, input_index: int, *, unsigned: bool = False) -> stim.PauliString:
+    def inverse_z_output(
+        self,
+        input_index: int,
+        *,
+        unsigned: bool = False,
+    ) -> stim.PauliString:
         """Returns the result of conjugating a Z Pauli generator by the inverse of the tableau.
 
         A faster version of `tableau.inverse(unsigned).z_output(input_index)`.
@@ -3722,7 +4367,11 @@ class Tableau:
             >>> t.inverse_z_output(0, unsigned=True) == expected
             True
         """
-    def inverse_z_output_pauli(self, input_index: int, output_index: int) -> int:
+    def inverse_z_output_pauli(
+        self,
+        input_index: int,
+        output_index: int,
+    ) -> int:
         """Returns a Pauli term from the tableau's inverse's output pauli string for an input Z generator.
 
         A constant-time equivalent for `tableau.inverse().z_output(input_index)[output_index]`.
@@ -3756,7 +4405,11 @@ class Tableau:
             1
         """
     @staticmethod
-    def iter_all(num_qubits: int, *, unsigned: bool = False) -> stim.TableauIterator:
+    def iter_all(
+        num_qubits: int,
+        *,
+        unsigned: bool = False,
+    ) -> stim.TableauIterator:
         """Returns an iterator that iterates over all Tableaus of a given size.
 
         Args:
@@ -3783,7 +4436,11 @@ class Tableau:
             >>> num_2q_gates_mod_paulis
             720
         """
-    def prepend(self, gate: stim.Tableau, targets: List[int]) -> None:
+    def prepend(
+        self,
+        gate: stim.Tableau,
+        targets: List[int],
+    ) -> None:
         """Prepends an operation's effect into this tableau, mutating this tableau.
 
         Time cost is O(n*m*m) where n=len(self) and m=len(gate).
@@ -3802,7 +4459,9 @@ class Tableau:
             True
         """
     @staticmethod
-    def random(num_qubits: int) -> stim.Tableau:
+    def random(
+        num_qubits: int,
+    ) -> stim.Tableau:
         """Samples a uniformly random Clifford operation over the given number of qubits and returns its tableau.
 
         Args:
@@ -3820,7 +4479,10 @@ class Tableau:
             Sergey Bravyi, Dmitri Maslov
             https://arxiv.org/abs/2003.09412
         """
-    def then(self, second: stim.Tableau) -> stim.Tableau:
+    def then(
+        self,
+        second: stim.Tableau,
+    ) -> stim.Tableau:
         """Returns the result of composing two tableaus.
 
         If the tableau T1 represents the Clifford operation with unitary C1,
@@ -3840,7 +4502,11 @@ class Tableau:
             >>> t3(p) == t2(t1(p))
             True
         """
-    def to_circuit(self, *, method: str) -> stim.Circuit:
+    def to_circuit(
+        self,
+        *,
+        method: str,
+    ) -> stim.Circuit:
 
         """Synthesizes a circuit that implements the tableau's Clifford operation.
 
@@ -3893,7 +4559,11 @@ class Tableau:
                 S 1 1 2 2
             ''')
         """
-    def to_unitary_matrix(self, *, endian: str) -> np.ndarray[np.complex64]:
+    def to_unitary_matrix(
+        self,
+        *,
+        endian: str,
+    ) -> np.ndarray[np.complex64]:
 
         """Converts the tableau into a unitary matrix.
 
@@ -3925,7 +4595,10 @@ class Tableau:
                    [0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j],
                    [0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j]], dtype=complex64)
         """
-    def x_output(self, target: int) -> stim.PauliString:
+    def x_output(
+        self,
+        target: int,
+    ) -> stim.PauliString:
         """Returns the result of conjugating a Pauli X by the tableau's Clifford operation.
 
         Args:
@@ -3943,7 +4616,11 @@ class Tableau:
             >>> cnot.x_output(1)
             stim.PauliString("+_X")
         """
-    def x_output_pauli(self, input_index: int, output_index: int) -> int:
+    def x_output_pauli(
+        self,
+        input_index: int,
+        output_index: int,
+    ) -> int:
         """Returns a Pauli term from the tableau's output pauli string for an input X generator.
 
         A constant-time equivalent for `tableau.x_output(input_index)[output_index]`.
@@ -3976,7 +4653,10 @@ class Tableau:
             >>> t.x_output_pauli(1, 1)
             3
         """
-    def y_output(self, target: int) -> stim.PauliString:
+    def y_output(
+        self,
+        target: int,
+    ) -> stim.PauliString:
         """Returns the result of conjugating a Pauli Y by the tableau's Clifford operation.
 
         Args:
@@ -3994,7 +4674,11 @@ class Tableau:
             >>> cnot.y_output(1)
             stim.PauliString("+ZY")
         """
-    def y_output_pauli(self, input_index: int, output_index: int) -> int:
+    def y_output_pauli(
+        self,
+        input_index: int,
+        output_index: int,
+    ) -> int:
         """Returns a Pauli term from the tableau's output pauli string for an input Y generator.
 
         A constant-time equivalent for `tableau.y_output(input_index)[output_index]`.
@@ -4027,7 +4711,10 @@ class Tableau:
             >>> t.y_output_pauli(1, 1)
             2
         """
-    def z_output(self, target: int) -> stim.PauliString:
+    def z_output(
+        self,
+        target: int,
+    ) -> stim.PauliString:
         """Returns the result of conjugating a Pauli Z by the tableau's Clifford operation.
 
         Args:
@@ -4045,7 +4732,11 @@ class Tableau:
             >>> cnot.z_output(1)
             stim.PauliString("+ZZ")
         """
-    def z_output_pauli(self, input_index: int, output_index: int) -> int:
+    def z_output_pauli(
+        self,
+        input_index: int,
+        output_index: int,
+    ) -> int:
         """Returns a Pauli term from the tableau's output pauli string for an input Z generator.
 
         A constant-time equivalent for `tableau.z_output(input_index)[output_index]`.
@@ -4090,14 +4781,18 @@ class TableauIterator:
         >>> n
         24
     """
-    def __iter__(self) -> stim.TableauIterator:
+    def __iter__(
+        self,
+    ) -> stim.TableauIterator:
         """Returns an independent copy of the tableau iterator.
 
         Since for-loops and loop-comprehensions call `iter` on things they
         iterate, this effectively allows the iterator to be iterated
         multiple times.
         """
-    def __next__(self) -> stim.Tableau:
+    def __next__(
+        self,
+    ) -> stim.Tableau:
         """Returns the next iterated tableau.
         """
 class TableauSimulator:
@@ -4130,19 +4825,27 @@ class TableauSimulator:
             ],
         )
     """
-    def c_xyz(self, *targets) -> None:
+    def c_xyz(
+        self,
+        *targets,
+    ) -> None:
         """Applies a C_XYZ gate to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def c_zyx(self, *targets) -> None:
+    def c_zyx(
+        self,
+        *targets,
+    ) -> None:
         """Applies a C_ZYX gate to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def canonical_stabilizers(self) -> List[stim.PauliString]:
+    def canonical_stabilizers(
+        self,
+    ) -> List[stim.PauliString]:
         """Returns a list of the stabilizers of the simulator's current state in a standard form.
 
         Two simulators have the same canonical stabilizers if and only if their current quantum state is equal
@@ -4178,7 +4881,10 @@ class TableauSimulator:
             >>> s.canonical_stabilizers()
             [stim.PauliString("+XX_"), stim.PauliString("+ZZ_"), stim.PauliString("-__Z")]
         """
-    def cnot(self, *targets) -> None:
+    def cnot(
+        self,
+        *targets,
+    ) -> None:
         """Applies a controlled X gate to the simulator's state.
 
         Args:
@@ -4186,7 +4892,9 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def copy(self) -> stim.TableauSimulator:
+    def copy(
+        self,
+    ) -> stim.TableauSimulator:
         """Returns a copy of the simulator. A simulator with the same internal state.
 
         Examples:
@@ -4213,7 +4921,9 @@ class TableauSimulator:
             >>> s.measure(0)
             True
         """
-    def current_inverse_tableau(self) -> stim.Tableau:
+    def current_inverse_tableau(
+        self,
+    ) -> stim.Tableau:
         """Returns a copy of the internal state of the simulator as a stim.Tableau.
 
         Returns:
@@ -4245,7 +4955,9 @@ class TableauSimulator:
                 ],
             )
         """
-    def current_measurement_record(self) -> List[bool]:
+    def current_measurement_record(
+        self,
+    ) -> List[bool]:
         """Returns a copy of the record of all measurements performed by the simulator.
 
         Examples:
@@ -4267,7 +4979,10 @@ class TableauSimulator:
         Returns:
             A list of booleans containing the result of every measurement performed by the simulator so far.
         """
-    def cx(self, *targets) -> None:
+    def cx(
+        self,
+        *targets,
+    ) -> None:
         """Applies a controlled X gate to the simulator's state.
 
         Args:
@@ -4275,7 +4990,10 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def cy(self, *targets) -> None:
+    def cy(
+        self,
+        *targets,
+    ) -> None:
         """Applies a controlled Y gate to the simulator's state.
 
         Args:
@@ -4283,7 +5001,10 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def cz(self, *targets) -> None:
+    def cz(
+        self,
+        *targets,
+    ) -> None:
         """Applies a controlled Z gate to the simulator's state.
 
         Args:
@@ -4292,12 +5013,21 @@ class TableauSimulator:
                 There must be an even number of targets.
         """
     @overload
-    def do(self, circuit_or_pauli_string: stim.Circuit) -> None:
+    def do(
+        self,
+        circuit_or_pauli_string: stim.Circuit,
+    ) -> None:
         pass
     @overload
-    def do(self, circuit_or_pauli_string: stim.PauliString) -> None:
+    def do(
+        self,
+        circuit_or_pauli_string: stim.PauliString,
+    ) -> None:
         pass
-    def do(self, circuit_or_pauli_string: object) -> None:
+    def do(
+        self,
+        circuit_or_pauli_string: object,
+    ) -> None:
         """Applies a circuit or pauli string to the simulator's state.
 
         Args:
@@ -4318,7 +5048,10 @@ class TableauSimulator:
             >>> s.measure_many(0, 1, 2, 3)
             [False, True, True, False]
         """
-    def do_circuit(self, circuit: stim.Circuit) -> None:
+    def do_circuit(
+        self,
+        circuit: stim.Circuit,
+    ) -> None:
         """Applies a circuit to the simulator's state.
 
         Args:
@@ -4334,7 +5067,10 @@ class TableauSimulator:
             >>> s.current_measurement_record()
             [True]
         """
-    def do_pauli_string(self, pauli_string: stim.PauliString) -> None:
+    def do_pauli_string(
+        self,
+        pauli_string: stim.PauliString,
+    ) -> None:
         """Applies the paulis from a pauli string to the simulator's state.
 
         Args:
@@ -4347,7 +5083,11 @@ class TableauSimulator:
             >>> s.measure_many(0, 1, 2, 3)
             [False, True, True, False]
         """
-    def do_tableau(self, tableau: stim.Tableau, targets: List[int]) -> None:
+    def do_tableau(
+        self,
+        tableau: stim.Tableau,
+        targets: List[int],
+    ) -> None:
         """Applies a custom tableau operation to qubits in the simulator.
 
         Note that this method has to compute the inverse of the tableau, because the
@@ -4385,31 +5125,46 @@ class TableauSimulator:
             >>> [str(sim.peek_bloch(k)) for k in range(4)]
             ['+Z', '+Y', '+Z', '+X']
         """
-    def h(self, *targets) -> None:
+    def h(
+        self,
+        *targets,
+    ) -> None:
         """Applies a Hadamard gate to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def h_xy(self, *targets) -> None:
+    def h_xy(
+        self,
+        *targets,
+    ) -> None:
         """Applies a variant of the Hadamard gate that swaps the X and Y axes to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def h_xz(self, *targets) -> None:
+    def h_xz(
+        self,
+        *targets,
+    ) -> None:
         """Applies a Hadamard gate to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def h_yz(self, *targets) -> None:
+    def h_yz(
+        self,
+        *targets,
+    ) -> None:
         """Applies a variant of the Hadamard gate that swaps the Y and Z axes to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def iswap(self, *targets) -> None:
+    def iswap(
+        self,
+        *targets,
+    ) -> None:
         """Applies an ISWAP gate to the simulator's state.
 
         Args:
@@ -4417,7 +5172,10 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def iswap_dag(self, *targets) -> None:
+    def iswap_dag(
+        self,
+        *targets,
+    ) -> None:
         """Applies an ISWAP_DAG gate to the simulator's state.
 
         Args:
@@ -4425,7 +5183,10 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def measure(self, target: int) -> bool:
+    def measure(
+        self,
+        target: int,
+    ) -> bool:
         """Measures a single qubit.
 
         Unlike the other methods on TableauSimulator, this one does not broadcast
@@ -4440,7 +5201,10 @@ class TableauSimulator:
         Returns:
             The measurement result as a bool.
         """
-    def measure_kickback(self, target: int) -> tuple:
+    def measure_kickback(
+        self,
+        target: int,
+    ) -> tuple:
         """Measures a qubit and returns the result as well as its Pauli kickback (if any).
 
         The "Pauli kickback" of a stabilizer circuit measurement is a set of Pauli operations that
@@ -4491,7 +5255,10 @@ class TableauSimulator:
             >>> s.measure_many(0, 1, 2)
             [True, True, True]
         """
-    def measure_many(self, *targets) -> List[bool]:
+    def measure_many(
+        self,
+        *targets,
+    ) -> List[bool]:
         """Measures multiple qubits.
 
         Args:
@@ -4501,7 +5268,9 @@ class TableauSimulator:
             The measurement results as a list of bools.
         """
     @property
-    def num_qubits(self) -> int:
+    def num_qubits(
+        self,
+    ) -> int:
         """Returns the number of qubits currently being tracked by the simulator's internal state.
 
         Note that the number of qubits being tracked will implicitly increase if qubits beyond
@@ -4516,7 +5285,10 @@ class TableauSimulator:
             >>> s.num_qubits
             3
         """
-    def peek_bloch(self, target: int) -> stim.PauliString:
+    def peek_bloch(
+        self,
+        target: int,
+    ) -> stim.PauliString:
         """Returns the current bloch vector of the qubit, represented as a stim.PauliString.
 
         This is a non-physical operation. It reports information about the qubit without disturbing it.
@@ -4551,7 +5323,10 @@ class TableauSimulator:
             >>> s.peek_bloch(0)
             stim.PauliString("+_")
         """
-    def peek_observable_expectation(self, observable: stim.PauliString) -> int:
+    def peek_observable_expectation(
+        self,
+        observable: stim.PauliString,
+    ) -> int:
         """Determines the expected value of an observable (which will always be -1, 0, or +1).
 
         This is a non-physical operation.
@@ -4591,7 +5366,10 @@ class TableauSimulator:
             II 1
             IIZ 1
         """
-    def peek_x(self, target: int) -> int:
+    def peek_x(
+        self,
+        target: int,
+    ) -> int:
         """Returns the expected value of a qubit's X observable (which will always be -1, 0, or +1).
 
         This is a non-physical operation.
@@ -4618,7 +5396,10 @@ class TableauSimulator:
             >>> s.peek_x(0)
             -1
         """
-    def peek_y(self, target: int) -> int:
+    def peek_y(
+        self,
+        target: int,
+    ) -> int:
         """Returns the expected value of a qubit's Y observable (which will always be -1, 0, or +1).
 
         This is a non-physical operation.
@@ -4645,7 +5426,10 @@ class TableauSimulator:
             >>> s.peek_y(0)
             -1
         """
-    def peek_z(self, target: int) -> int:
+    def peek_z(
+        self,
+        target: int,
+    ) -> int:
         """Returns the expected value of a qubit's Z observable (which will always be -1, 0, or +1).
 
         This is a non-physical operation.
@@ -4672,7 +5456,12 @@ class TableauSimulator:
             >>> s.peek_z(0)
             -1
         """
-    def postselect_x(self, targets: Union[int, Iterable[int]], *, desired_value: bool) -> None:
+    def postselect_x(
+        self,
+        targets: Union[int, Iterable[int]],
+        *,
+        desired_value: bool,
+    ) -> None:
 
         """Postselects qubits in the X basis, or raises an exception.
 
@@ -4692,7 +5481,12 @@ class TableauSimulator:
                 impossible for a measurement of the qubit to return the
                 desired result.
         """
-    def postselect_y(self, targets: Union[int, Iterable[int]], *, desired_value: bool) -> None:
+    def postselect_y(
+        self,
+        targets: Union[int, Iterable[int]],
+        *,
+        desired_value: bool,
+    ) -> None:
 
         """Postselects qubits in the Y basis, or raises an exception.
 
@@ -4712,7 +5506,12 @@ class TableauSimulator:
                 impossible for a measurement of the qubit to return the
                 desired result.
         """
-    def postselect_z(self, targets: Union[int, Iterable[int]], *, desired_value: bool) -> None:
+    def postselect_z(
+        self,
+        targets: Union[int, Iterable[int]],
+        *,
+        desired_value: bool,
+    ) -> None:
 
         """Postselects qubits in the Z basis, or raises an exception.
 
@@ -4732,7 +5531,10 @@ class TableauSimulator:
                 impossible for a measurement of the qubit to return the
                 desired result.
         """
-    def reset(self, *targets) -> None:
+    def reset(
+        self,
+        *targets,
+    ) -> None:
         """Resets qubits to the |0> state.
 
         Args:
@@ -4746,7 +5548,10 @@ class TableauSimulator:
             >>> s.peek_bloch(0)
             stim.PauliString("+Z")
         """
-    def reset_x(self, *targets) -> None:
+    def reset_x(
+        self,
+        *targets,
+    ) -> None:
         """Resets qubits to the |+> state.
 
         Args:
@@ -4759,7 +5564,10 @@ class TableauSimulator:
             >>> s.peek_bloch(0)
             stim.PauliString("+X")
         """
-    def reset_y(self, *targets) -> None:
+    def reset_y(
+        self,
+        *targets,
+    ) -> None:
         """Resets qubits to the |i> state.
 
         Args:
@@ -4772,7 +5580,10 @@ class TableauSimulator:
             >>> s.peek_bloch(0)
             stim.PauliString("+Y")
         """
-    def reset_z(self, *targets) -> None:
+    def reset_z(
+        self,
+        *targets,
+    ) -> None:
         """Resets qubits to the |0> state.
 
         Args:
@@ -4786,19 +5597,28 @@ class TableauSimulator:
             >>> s.peek_bloch(0)
             stim.PauliString("+Z")
         """
-    def s(self, *targets) -> None:
+    def s(
+        self,
+        *targets,
+    ) -> None:
         """Applies a SQRT_Z gate to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def s_dag(self, *targets) -> None:
+    def s_dag(
+        self,
+        *targets,
+    ) -> None:
         """Applies a SQRT_Z_DAG gate to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def set_inverse_tableau(self, new_inverse_tableau: stim.Tableau) -> None:
+    def set_inverse_tableau(
+        self,
+        new_inverse_tableau: stim.Tableau,
+    ) -> None:
         """Overwrites the simulator's internal state with a copy of the given inverse tableau.
 
         The inverse tableau specifies how Pauli product observables of qubits at the current time transform
@@ -4821,7 +5641,10 @@ class TableauSimulator:
             >>> s.current_inverse_tableau() == t
             True
         """
-    def set_num_qubits(self, new_num_qubits: int) -> None:
+    def set_num_qubits(
+        self,
+        new_num_qubits: int,
+    ) -> None:
         """Forces the simulator's internal state to track exactly the qubits whose indices are in range(new_num_qubits).
 
         Note that untracked qubits are always assumed to be in the |0> state. Therefore, calling this method
@@ -4849,7 +5672,13 @@ class TableauSimulator:
             >>> s.measure_many(0, 1, 2, 3)
             [True, True, False, False]
         """
-    def set_state_from_stabilizers(self, stabilizers: Iterable[stim.PauliString], *, bool allow_redundant = False, bool allow_underconstrained = False) -> None:
+    def set_state_from_stabilizers(
+        self,
+        stabilizers: Iterable[stim.PauliString],
+        *,
+        bool allow_redundant = False,
+        bool allow_underconstrained = False,
+    ) -> None:
 
         """Sets the tableau simulator's state to a state satisfying the given stabilizers.
 
@@ -4929,7 +5758,12 @@ class TableauSimulator:
                 ],
             )
         """
-    def set_state_from_state_vector(self, state_vector: Iterable[float], *, endian: str) -> None:
+    def set_state_from_state_vector(
+        self,
+        state_vector: Iterable[float],
+        *,
+        endian: str,
+    ) -> None:
 
         """Sets the tableau simulator's state to a superposition specified by a vector of amplitudes.
 
@@ -4987,31 +5821,47 @@ class TableauSimulator:
                 ],
             )
         """
-    def sqrt_x(self, *targets) -> None:
+    def sqrt_x(
+        self,
+        *targets,
+    ) -> None:
         """Applies a SQRT_X gate to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def sqrt_x_dag(self, *targets) -> None:
+    def sqrt_x_dag(
+        self,
+        *targets,
+    ) -> None:
         """Applies a SQRT_X_DAG gate to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def sqrt_y(self, *targets) -> None:
+    def sqrt_y(
+        self,
+        *targets,
+    ) -> None:
         """Applies a SQRT_Y gate to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def sqrt_y_dag(self, *targets) -> None:
+    def sqrt_y_dag(
+        self,
+        *targets,
+    ) -> None:
         """Applies a SQRT_Y_DAG gate to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def state_vector(self, *, endian: str = 'little') -> np.ndarray[np.complex64]:
+    def state_vector(
+        self,
+        *,
+        endian: str = 'little',
+    ) -> np.ndarray[np.complex64]:
 
         """Returns a wavefunction that satisfies the stabilizers of the simulator's current state.
 
@@ -5053,7 +5903,10 @@ class TableauSimulator:
             >>> list(s.state_vector())
             [(0.5+0j), 0j, -0.5j, 0j, 0.5j, 0j, (0.5+0j), 0j]
         """
-    def swap(self, *targets) -> None:
+    def swap(
+        self,
+        *targets,
+    ) -> None:
         """Applies a swap gate to the simulator's state.
 
         Args:
@@ -5061,13 +5914,19 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def x(self, *targets) -> None:
+    def x(
+        self,
+        *targets,
+    ) -> None:
         """Applies a Pauli X gate to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def xcx(self, *targets) -> None:
+    def xcx(
+        self,
+        *targets,
+    ) -> None:
         """Applies an X-controlled X gate to the simulator's state.
 
         Args:
@@ -5075,7 +5934,10 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def xcy(self, *targets) -> None:
+    def xcy(
+        self,
+        *targets,
+    ) -> None:
         """Applies an X-controlled Y gate to the simulator's state.
 
         Args:
@@ -5083,7 +5945,10 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def xcz(self, *targets) -> None:
+    def xcz(
+        self,
+        *targets,
+    ) -> None:
         """Applies an X-controlled Z gate to the simulator's state.
 
         Args:
@@ -5091,13 +5956,19 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def y(self, *targets) -> None:
+    def y(
+        self,
+        *targets,
+    ) -> None:
         """Applies a Pauli Y gate to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def ycx(self, *targets) -> None:
+    def ycx(
+        self,
+        *targets,
+    ) -> None:
         """Applies a Y-controlled X gate to the simulator's state.
 
         Args:
@@ -5105,7 +5976,10 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def ycy(self, *targets) -> None:
+    def ycy(
+        self,
+        *targets,
+    ) -> None:
         """Applies a Y-controlled Y gate to the simulator's state.
 
         Args:
@@ -5113,7 +5987,10 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def ycz(self, *targets) -> None:
+    def ycz(
+        self,
+        *targets,
+    ) -> None:
         """Applies a Y-controlled Z gate to the simulator's state.
 
         Args:
@@ -5121,13 +5998,19 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def z(self, *targets) -> None:
+    def z(
+        self,
+        *targets,
+    ) -> None:
         """Applies a Pauli Z gate to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def zcx(self, *targets) -> None:
+    def zcx(
+        self,
+        *targets,
+    ) -> None:
         """Applies a controlled X gate to the simulator's state.
 
         Args:
@@ -5135,7 +6018,10 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def zcy(self, *targets) -> None:
+    def zcy(
+        self,
+        *targets,
+    ) -> None:
         """Applies a controlled Y gate to the simulator's state.
 
         Args:
@@ -5143,7 +6029,10 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def zcz(self, *targets) -> None:
+    def zcz(
+        self,
+        *targets,
+    ) -> None:
         """Applies a controlled Z gate to the simulator's state.
 
         Args:
@@ -5151,7 +6040,10 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-def main(*, command_line_args: List[str]) -> int:
+def main(
+    *,
+    command_line_args: List[str],
+) -> int:
     """Runs the command line tool version of stim on the given arguments.
 
     Note that by default any input will be read from stdin, any output
@@ -5221,7 +6113,15 @@ def main(*, command_line_args: List[str]) -> int:
         DETECTOR(1, 1) rec[-1] rec[-2] rec[-3]
         OBSERVABLE_INCLUDE(0) rec[-1]
     """
-def read_shot_data_file(*, path: str, format: str, num_measurements: int = 0, num_detectors: int = 0, num_observables: int = 0, bit_pack: bool = False) -> np.ndarray:
+def read_shot_data_file(
+    *,
+    path: str,
+    format: str,
+    num_measurements: int = 0,
+    num_detectors: int = 0,
+    num_observables: int = 0,
+    bit_pack: bool = False,
+) -> np.ndarray:
 
     """Reads shot data, such as measurement samples, from a file.
 
@@ -5267,15 +6167,20 @@ def read_shot_data_file(*, path: str, format: str, num_measurements: int = 0, nu
         array([[False, False, False, False],
                [False,  True, False,  True]])
     """
-def target_combiner() -> stim.GateTarget:
+def target_combiner(
+) -> stim.GateTarget:
     """Returns a target combiner (`*` in circuit files) that can be used as an operation target.
     """
-def target_inv(qubit_index: int) -> stim.GateTarget:
+def target_inv(
+    qubit_index: int,
+) -> stim.GateTarget:
     """Returns a target flagged as inverted that can be passed into Circuit.append_operation
     For example, the '!1' in 'M 0 !1 2' is qubit 1 flagged as inverted,
     meaning the measurement result from qubit 1 should be inverted when reported.
     """
-def target_logical_observable_id(index: int) -> stim.DemTarget:
+def target_logical_observable_id(
+    index: int,
+) -> stim.DemTarget:
     """Returns a logical observable id identifying a frame change (e.g. "L5" in a .dem file).
 
     Args:
@@ -5295,11 +6200,15 @@ def target_logical_observable_id(index: int) -> stim.DemTarget:
             error(0.25) L13
         ''')
     """
-def target_rec(lookback_index: int) -> stim.GateTarget:
+def target_rec(
+    lookback_index: int,
+) -> stim.GateTarget:
     """Returns a record target that can be passed into Circuit.append_operation.
     For example, the 'rec[-2]' in 'DETECTOR rec[-2]' is a record target.
     """
-def target_relative_detector_id(index: int) -> stim.DemTarget:
+def target_relative_detector_id(
+    index: int,
+) -> stim.DemTarget:
     """Returns a relative detector id (e.g. "D5" in a .dem file).
 
     Args:
@@ -5319,7 +6228,8 @@ def target_relative_detector_id(index: int) -> stim.DemTarget:
             error(0.25) D13
         ''')
     """
-def target_separator() -> stim.DemTarget:
+def target_separator(
+) -> stim.DemTarget:
     """Returns a target separator (e.g. "^" in a .dem file).
 
     Examples:
@@ -5335,23 +6245,42 @@ def target_separator() -> stim.DemTarget:
             error(0.25) D1 ^ D2
         ''')
     """
-def target_sweep_bit(sweep_bit_index: int) -> stim.GateTarget:
+def target_sweep_bit(
+    sweep_bit_index: int,
+) -> stim.GateTarget:
     """Returns a sweep bit target that can be passed into Circuit.append_operation
     For example, the 'sweep[5]' in 'CNOT sweep[5] 7' is from `stim.target_sweep_bit(5)`.
     """
-def target_x(qubit_index: int, invert: bool = False) -> stim.GateTarget:
+def target_x(
+    qubit_index: int,
+    invert: bool = False,
+) -> stim.GateTarget:
     """Returns a target flagged as Pauli X that can be passed into Circuit.append_operation
     For example, the 'X1' in 'CORRELATED_ERROR(0.1) X1 Y2 Z3' is qubit 1 flagged as Pauli X.
     """
-def target_y(qubit_index: int, invert: bool = False) -> stim.GateTarget:
+def target_y(
+    qubit_index: int,
+    invert: bool = False,
+) -> stim.GateTarget:
     """Returns a target flagged as Pauli Y that can be passed into Circuit.append_operation
     For example, the 'Y2' in 'CORRELATED_ERROR(0.1) X1 Y2 Z3' is qubit 2 flagged as Pauli Y.
     """
-def target_z(qubit_index: int, invert: bool = False) -> stim.GateTarget:
+def target_z(
+    qubit_index: int,
+    invert: bool = False,
+) -> stim.GateTarget:
     """Returns a target flagged as Pauli Z that can be passed into Circuit.append_operation
     For example, the 'Z3' in 'CORRELATED_ERROR(0.1) X1 Y2 Z3' is qubit 3 flagged as Pauli Z.
     """
-def write_shot_data_file(*, data: object, path: str, format: str, num_measurements: Any = None, num_detectors: Any = None, num_observables: Any = None) -> None:
+def write_shot_data_file(
+    *,
+    data: object,
+    path: str,
+    format: str,
+    num_measurements: Any = None,
+    num_detectors: Any = None,
+    num_observables: Any = None,
+) -> None:
     """Writes shot data, such as measurement samples, to a file.
 
     Args:

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -5218,7 +5218,7 @@ class TableauSimulator:
         if in the previous example there was a third qubit in the |0> state, then both
         `stim.PauliString("XX_")` and `stim.PauliString("XXZ")` are valid kickbacks.
 
-        Measurements with determinist results don't have a Pauli kickback.
+        Measurements with deterministic results don't have a Pauli kickback.
 
         Args:
             target: The index of the qubit to measure.

--- a/glue/python/generate_api_reference.py
+++ b/glue/python/generate_api_reference.py
@@ -70,12 +70,19 @@ def main():
     version = stim.__version__
     if "dev" in version or version == "VERSION_INFO" or "-dev" in sys.argv:
         version = "(Development Version)"
+        is_dev = True
     else:
         version = "v" + version
+        is_dev = False
     objects = list(generate_documentation(obj=stim, full_name="stim", level=0))
 
     print(f"# Stim {version} API Reference")
     print()
+    if is_dev:
+        print("*CAUTION*: this API reference is for the in-development version of Stim.")
+        print("Methods and arguments mentioned here may not be accessible in stable versions, yet.")
+        print("API references for stable versions are kept on the [stim github wiki](https://github.com/quantumlib/Stim/wiki)")
+        print()
     print("## Index")
     for obj in objects:
         level = obj.level

--- a/glue/python/generate_stub_file.py
+++ b/glue/python/generate_stub_file.py
@@ -117,10 +117,16 @@ def print_doc(*, full_name: str, parent: object, obj: object, level: int) -> Opt
             if '@overload ' in line:
                 _, sig = line.split('@overload ')
                 out_obj.lines.append("@overload")
+                is_static = '(self' not in sig and inspect.isclass(parent)
+                if is_static:
+                    out_obj.lines.append("@staticmethod")
                 out_obj.lines.append(sig)
                 out_obj.lines.append("    pass")
             elif '@signature ' in line:
                 _, sig = line.split('@signature ')
+                is_static = '(self' not in sig and inspect.isclass(parent)
+                if is_static:
+                    out_obj.lines.append("@staticmethod")
                 out_obj.lines.append(sig)
                 sig_handled = True
             else:
@@ -143,9 +149,10 @@ def print_doc(*, full_name: str, parent: object, obj: object, level: int) -> Opt
             if '->' in sig_name: k_high = sig_name.index('->', k_low, k_high)
             k_high = sig_name.index(", " if ", " in sig_name[k_low:k_high] else ")", k_low, k_high)
             sig_name = sig_name[:k_low] + sig_name[k_high:]
-        is_static = '(self' not in sig_name and inspect.isclass(parent)
-        if is_static:
-            out_obj.lines.append("@staticmethod")
+        if not sig_handled:
+            is_static = '(self' not in sig_name and inspect.isclass(parent)
+            if is_static:
+                out_obj.lines.append("@staticmethod")
         sig_name = sig_name.replace(': handle', ': Any')
         sig_name = sig_name.replace('numpy.', 'np.')
         if new_args_name is not None:

--- a/glue/python/generate_stub_file.py
+++ b/glue/python/generate_stub_file.py
@@ -4,7 +4,7 @@
 Produces a .pyi file for stim, describing the contained classes and functions.
 """
 
-from typing import Optional, Iterator
+from typing import Optional, Iterator, List
 
 import stim
 
@@ -89,6 +89,36 @@ class DescribedObject:
         self.lines = []
 
 
+def splay_signature(sig: str) -> List[str]:
+    assert sig.startswith('def')
+    out = []
+
+    level = 0
+
+    start = sig.index('(') + 1
+    mark = start
+    out.append(sig[:mark])
+    for k in range(mark, len(sig)):
+        c = sig[k]
+        if c in '([':
+            level += 1
+        if c in '])':
+            level -= 1
+        if (c == ',' and level == 0) or level < 0:
+            k2 = k + (0 if level < 0 else 1)
+            s = sig[mark:k2].lstrip()
+            if s:
+                if not s.endswith(','):
+                    s += ','
+                out.append('    ' + s)
+            mark = k2
+        if level < 0:
+            break
+    assert level == -1
+    out.append(sig[mark:])
+    return out
+
+
 def print_doc(*, full_name: str, parent: object, obj: object, level: int) -> Optional[DescribedObject]:
     out_obj = DescribedObject()
     out_obj.full_name = full_name
@@ -120,14 +150,14 @@ def print_doc(*, full_name: str, parent: object, obj: object, level: int) -> Opt
                 is_static = '(self' not in sig and inspect.isclass(parent)
                 if is_static:
                     out_obj.lines.append("@staticmethod")
-                out_obj.lines.append(sig)
+                out_obj.lines.extend(splay_signature(sig))
                 out_obj.lines.append("    pass")
             elif '@signature ' in line:
                 _, sig = line.split('@signature ')
                 is_static = '(self' not in sig and inspect.isclass(parent)
                 if is_static:
                     out_obj.lines.append("@staticmethod")
-                out_obj.lines.append(sig)
+                out_obj.lines.extend(splay_signature(sig))
                 sig_handled = True
             else:
                 doc_lines_left.append(line)
@@ -143,23 +173,23 @@ def print_doc(*, full_name: str, parent: object, obj: object, level: int) -> Opt
             sig_name = term_name + doc_lines_left[0][len(term_name):]
             doc_lines_left = doc_lines_left[1:]
         doc = "\n".join(doc_lines_left).lstrip()
-        if "(self: " in sig_name:
-            k_low = sig_name.index("(self: ") + len('(self')
-            k_high = len(sig_name)
-            if '->' in sig_name: k_high = sig_name.index('->', k_low, k_high)
-            k_high = sig_name.index(", " if ", " in sig_name[k_low:k_high] else ")", k_low, k_high)
-            sig_name = sig_name[:k_low] + sig_name[k_high:]
-        if not sig_handled:
-            is_static = '(self' not in sig_name and inspect.isclass(parent)
-            if is_static:
-                out_obj.lines.append("@staticmethod")
-        sig_name = sig_name.replace(': handle', ': Any')
-        sig_name = sig_name.replace('numpy.', 'np.')
-        if new_args_name is not None:
-            sig_name = sig_name.replace('*args', new_args_name)
         text = ""
         if not sig_handled:
-            text = f"def {sig_name}:"
+            if "(self: " in sig_name:
+                k_low = sig_name.index("(self: ") + len('(self')
+                k_high = len(sig_name)
+                if '->' in sig_name: k_high = sig_name.index('->', k_low, k_high)
+                k_high = sig_name.index(", " if ", " in sig_name[k_low:k_high] else ")", k_low, k_high)
+                sig_name = sig_name[:k_low] + sig_name[k_high:]
+            if not sig_handled:
+                is_static = '(self' not in sig_name and inspect.isclass(parent)
+                if is_static:
+                    out_obj.lines.append("@staticmethod")
+            sig_name = sig_name.replace(': handle', ': Any')
+            sig_name = sig_name.replace('numpy.', 'np.')
+            if new_args_name is not None:
+                sig_name = sig_name.replace('*args', new_args_name)
+            text = "\n".join(splay_signature(f"def {sig_name}:"))
     else:
         text = f"class {term_name}:"
     if doc:

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -3369,6 +3369,51 @@ class Tableau:
             True
         """
     @staticmethod
+    def from_circuit(circuit: stim.Circuit, *, ignore_noise: bool = False, ignore_measurement: bool = False, ignore_reset: bool = False) -> stim.Tableau:
+
+        """Converts a circuit into an equivalent stabilizer tableau.
+
+        Args:
+            circuit: The circuit to compile into a tableau.
+            ignore_noise: Defaults to False. When False, any noise operations in the circuit will cause
+                the conversion to fail with an exception. When True, noise operations are skipped over
+                as if they weren't even present in the circuit.
+            ignore_measurement: Defaults to False. When False, any measurement operations in the circuit
+                will cause the conversion to fail with an exception. When True, measurement operations are
+                skipped over as if they weren't even present in the circuit.
+            ignore_reset: Defaults to False. When False, any reset operations in the circuit will cause
+                the conversion to fail with an exception. When True, reset operations are skipped over
+                as if they weren't even present in the circuit.
+
+        Returns:
+            The tableau equivalent to the given circuit (up to global phase).
+
+        Raises:
+            ValueError:
+                The circuit contains noise operations but ignore_noise=False.
+                OR
+                The circuit contains measurement operations but ignore_measurement=False.
+                OR
+                The circuit contains reset operations but ignore_reset=False.
+
+        Examples:
+            >>> import stim
+            >>> stim.Tableau.from_circuit(stim.Circuit("""
+            ...     H 0
+            ...     CNOT 0 1
+            ... """))
+            stim.Tableau.from_conjugated_generators(
+                xs=[
+                    stim.PauliString("+Z_"),
+                    stim.PauliString("+_X"),
+                ],
+                zs=[
+                    stim.PauliString("+XX"),
+                    stim.PauliString("+ZZ"),
+                ],
+            )
+        """
+    @staticmethod
     def from_conjugated_generators(*, xs: List[stim.PauliString], zs: List[stim.PauliString]) -> stim.Tableau:
         """Creates a tableau from the given outputs for each generator.
 
@@ -3427,6 +3472,57 @@ class Tableau:
             +-xz-
             | ++
             | YZ
+        """
+    @staticmethod
+    def from_unitary_matrix(matrix: Iterable[Iterable[float]], *, endian: str = 'little') -> stim.Tableau:
+
+        """Creates a tableau from the unitary matrix of a Clifford operation.
+
+        Args:
+            matrix: A unitary matrix specified as an iterable of rows, with each row is an iterable of amplitudes.
+                The unitary matrix must correspond to a Clifford operation.
+            endian:
+                "little": matrix entries are in little endian order, where higher index qubits
+                    correspond to larger changes in row/col indices.
+                "big": matrix entries are in little endian order, where higher index qubits correspond to
+                    smaller changes in row/col indices.
+        Returns:
+            The tableau equivalent to the given unitary matrix (up to global phase).
+
+        Raises:
+            ValueError: The given matrix isn't the unitary matrix of a Clifford operation.
+
+        Examples:
+            >>> import stim
+            >>> stim.Tableau.from_unitary_matrix([
+            ...     [1, 0],
+            ...     [0, 1j],
+            ... ], endian='little')
+            stim.Tableau.from_conjugated_generators(
+                xs=[
+                    stim.PauliString("+Y"),
+                ],
+                zs=[
+                    stim.PauliString("+Z"),
+                ],
+            )
+
+            >>> stim.Tableau.from_unitary_matrix([
+            ...     [1, 0, 0, 0],
+            ...     [0, 1, 0, 0],
+            ...     [0, 0, 0, -1j],
+            ...     [0, 0, 1j, 0],
+            ... ], endian='little')
+            stim.Tableau.from_conjugated_generators(
+                xs=[
+                    stim.PauliString("+XZ"),
+                    stim.PauliString("+YX"),
+                ],
+                zs=[
+                    stim.PauliString("+ZZ"),
+                    stim.PauliString("+_Z"),
+                ],
+            )
         """
     def inverse(self, *, unsigned: bool = False) -> stim.Tableau:
         """Computes the inverse of the tableau.
@@ -3743,6 +3839,59 @@ class Tableau:
             >>> p = stim.PauliString.random(4)
             >>> t3(p) == t2(t1(p))
             True
+        """
+    def to_circuit(self, *, method: str) -> stim.Circuit:
+
+        """Synthesizes a circuit that implements the tableau's Clifford operation.
+
+        The circuits returned by this method are not guaranteed to be stable
+        from version to version, and may be produced using randomization.
+
+        Args:
+            method: The method to use when synthesizing the circuit. Available values are:
+                "elimination": Uses Gaussian elimination to cancel off-diagonal terms one by one.
+                    Gate set: H, S, CX
+                    Circuit qubit count: n
+                    Circuit operation count: O(n^2)
+                    Circuit depth: O(n^2)
+
+        Returns:
+            The synthesized circuit.
+
+        Example:
+            >>> import stim
+            >>> tableau = stim.Tableau.from_conjugated_generators(
+            ...     xs=[
+            ...         stim.PauliString("-_YZ"),
+            ...         stim.PauliString("-YY_"),
+            ...         stim.PauliString("-XZX"),
+            ...     ],
+            ...     zs=[
+            ...         stim.PauliString("+Y_Y"),
+            ...         stim.PauliString("-_XY"),
+            ...         stim.PauliString("-Y__"),
+            ...     ],
+            ... )
+            >>> tableau.to_circuit(method="elimination")
+            stim.Circuit('''
+                CX 2 0 0 2 2 0
+                S 0
+                H 0
+                S 0
+                H 1
+                CX 0 1 0 2
+                H 1 2
+                CX 1 0 2 0 2 1 1 2 2 1
+                H 1
+                S 1 2
+                H 2
+                CX 2 1
+                S 2
+                H 0 1 2
+                S 0 0 1 1 2 2
+                H 0 1 2
+                S 1 1 2 2
+            ''')
         """
     def to_unitary_matrix(self, *, endian: str) -> np.ndarray[np.complex64]:
 
@@ -4699,6 +4848,144 @@ class TableauSimulator:
             >>> s.set_num_qubits(2)
             >>> s.measure_many(0, 1, 2, 3)
             [True, True, False, False]
+        """
+    def set_state_from_stabilizers(self, stabilizers: Iterable[stim.PauliString], *, bool allow_redundant = False, bool allow_underconstrained = False) -> None:
+
+        """Sets the tableau simulator's state to a state satisfying the given stabilizers.
+
+        The old quantum state is completely overwritten, even if the new state is underconstrained
+        underconstrained by the given stabilizers. The number of qubits is changed to exactly match
+        the number of qubits in the longest given stabilizer.
+
+        Args:
+            stabilizers: A list of `stim.PauliString`s specifying the stabilizers that the new
+                state must have. It is permitted for stabilizers to have different lengths. All
+                stabilizers are padded up to the length of the longest stabilizer by appending
+                identity terms.
+            allow_redundant: Defaults to False. If set to False, then the given stabilizers must
+                all be independent. If any one of them is a product of the others (including the
+                empty product), an exception will be raised. If set to True, then redundant
+                stabilizers are simply ignored.
+            allow_underconstrained: Defaults to False. If set to False, then the given stabilizers
+                must form a complete set of generators. They must exactly specify the desired
+                stabilizer state, with no degrees of freedom left over. For an n-qubit state there
+                must be n independent stabilizers. If set to True, then there can be leftover
+                degrees of freedom which can be set arbitrarily.
+
+        Returns:
+            Nothing. Mutates the states of the simulator to match the desired stabilizers.
+            Guarantees that self.current_inverse_tableau().inverse_z_output(k) will be equal
+            to the k'th independent stabilizer from the `stabilizers` argument.
+
+        Raises:
+            ValueError:
+                A stabilizer is redundant but allow_redundant=True wasn't set.
+                OR
+                The given stabilizers are contradictory (e.g. "+Z" and "-Z" both specified).
+                OR
+                The given stabilizers anticommute (e.g. "+Z" and "+X" both specified).
+                OR
+                The stabilizers left behind a degree of freedom but allow_underconstrained=True wasn't set.
+                OR
+                A stabilizer has an imaginary sign (i or -i).
+
+        Examples:
+
+            >>> import stim
+            >>> tab_sim = stim.TableauSimulator()
+            >>> tab_sim.set_state_from_stabilizers([
+            ...     stim.PauliString("XX"),
+            ...     stim.PauliString("ZZ"),
+            ... ])
+            >>> tab_sim.current_inverse_tableau().inverse()
+            stim.Tableau.from_conjugated_generators(
+                xs=[
+                    stim.PauliString("+Z_"),
+                    stim.PauliString("+_X"),
+                ],
+                zs=[
+                    stim.PauliString("+XX"),
+                    stim.PauliString("+ZZ"),
+                ],
+            )
+
+            >>> tab_sim.set_state_from_stabilizers([
+            ...     stim.PauliString("XX_"),
+            ...     stim.PauliString("ZZ_"),
+            ...     stim.PauliString("-YY_"),
+            ...     stim.PauliString(""),
+            ... ], allow_underconstrained=True, allow_redundant=True)
+            >>> tab_sim.current_inverse_tableau().inverse()
+            stim.Tableau.from_conjugated_generators(
+                xs=[
+                    stim.PauliString("+Z__"),
+                    stim.PauliString("+_X_"),
+                    stim.PauliString("+__X"),
+                ],
+                zs=[
+                    stim.PauliString("+XX_"),
+                    stim.PauliString("+ZZ_"),
+                    stim.PauliString("+__Z"),
+                ],
+            )
+        """
+    def set_state_from_state_vector(self, state_vector: Iterable[float], *, endian: str) -> None:
+
+        """Sets the tableau simulator's state to a superposition specified by a vector of amplitudes.
+
+        Args:
+            state_vector: A list of complex amplitudes specifying a superposition. The vector
+                must correspond to a state that is reachable using Clifford operations, and must
+                be normalized (i.e. it must be a unit vector).
+            endian:
+                "little": state vector is in little endian order, where higher index qubits
+                    correspond to larger changes in the state index.
+                "big": state vector is in little endian order, where higher index qubits correspond to
+                    smaller changes in the state index.
+
+        Returns:
+            Nothing. Mutates the states of the simulator to match the desired state.
+
+        Raises:
+            ValueError:
+                The given state vector isn't a list of complex values specifying a stabilizer state.
+                OR
+                The given endian value isn't 'little' or 'big'.
+
+        Examples:
+
+            >>> import stim
+            >>> tab_sim = stim.TableauSimulator()
+            >>> tab_sim.set_state_from_state_vector([
+            ...     0.5**0.5,
+            ...     0.5**0.5 * 1j,
+            ... ], endian='little')
+            >>> tab_sim.current_inverse_tableau().inverse()
+            stim.Tableau.from_conjugated_generators(
+                xs=[
+                    stim.PauliString("+Z"),
+                ],
+                zs=[
+                    stim.PauliString("+Y"),
+                ],
+            )
+            >>> tab_sim.set_state_from_state_vector([
+            ...     0.5**0.5,
+            ...     0,
+            ...     0,
+            ...     0.5**0.5,
+            ... ], endian='little')
+            >>> tab_sim.current_inverse_tableau().inverse()
+            stim.Tableau.from_conjugated_generators(
+                xs=[
+                    stim.PauliString("+Z_"),
+                    stim.PauliString("+_X"),
+                ],
+                zs=[
+                    stim.PauliString("+XX"),
+                    stim.PauliString("+ZZ"),
+                ],
+            )
         """
     def sqrt_x(self, *targets) -> None:
         """Applies a SQRT_X gate to the simulator's state.

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -26,7 +26,10 @@ class Circuit:
         array([[False]])
 
     """
-    def __add__(self, second: stim.Circuit) -> stim.Circuit:
+    def __add__(
+        self,
+        second: stim.Circuit,
+    ) -> stim.Circuit:
         """Creates a circuit by appending two circuits.
 
         Examples:
@@ -45,16 +48,28 @@ class Circuit:
                 M 0 1 2
             ''')
         """
-    def __eq__(self, arg0: stim.Circuit) -> bool:
+    def __eq__(
+        self,
+        arg0: stim.Circuit,
+    ) -> bool:
         """Determines if two circuits have identical contents.
         """
     @overload
-    def __getitem__(self, index_or_slice: int) -> Union[stim.CircuitInstruction, stim.CircuitRepeatBlock]:
+    def __getitem__(
+        self,
+        index_or_slice: int,
+    ) -> Union[stim.CircuitInstruction, stim.CircuitRepeatBlock]:
         pass
     @overload
-    def __getitem__(self, index_or_slice: slice) -> stim.Circuit:
+    def __getitem__(
+        self,
+        index_or_slice: slice,
+    ) -> stim.Circuit:
         pass
-    def __getitem__(self, index_or_slice: object) -> object:
+    def __getitem__(
+        self,
+        index_or_slice: object,
+    ) -> object:
         """Returns copies of instructions from the circuit.
 
         Args:
@@ -92,7 +107,10 @@ class Circuit:
                 DETECTOR rec[-1]
             ''')
         """
-    def __iadd__(self, second: stim.Circuit) -> stim.Circuit:
+    def __iadd__(
+        self,
+        second: stim.Circuit,
+    ) -> stim.Circuit:
         """Appends a circuit into the receiving circuit (mutating it).
 
         Examples:
@@ -112,7 +130,10 @@ class Circuit:
                 M 0 1 2
             ''')
         """
-    def __imul__(self, repetitions: int) -> stim.Circuit:
+    def __imul__(
+        self,
+        repetitions: int,
+    ) -> stim.Circuit:
         """Mutates the circuit by putting its contents into a REPEAT block.
 
         Special case: if the repetition count is 0, the circuit is cleared.
@@ -136,7 +157,10 @@ class Circuit:
                 }
             ''')
         """
-    def __init__(self, stim_program_text: str = '') -> None:
+    def __init__(
+        self,
+        stim_program_text: str = '',
+    ) -> None:
         """Creates a stim.Circuit.
 
         Args:
@@ -151,7 +175,9 @@ class Circuit:
             ...    M 1
             ... ''')
         """
-    def __len__(self) -> int:
+    def __len__(
+        self,
+    ) -> int:
         """Returns the number of top-level instructions and blocks in the circuit.
 
         Instructions inside of blocks are not included in this count.
@@ -176,7 +202,10 @@ class Circuit:
             ... '''))
             1
         """
-    def __mul__(self, repetitions: int) -> stim.Circuit:
+    def __mul__(
+        self,
+        repetitions: int,
+    ) -> stim.Circuit:
         """Returns a circuit with a REPEAT block containing the current circuit's instructions.
 
         Special case: if the repetition count is 0, an empty circuit is returned.
@@ -199,13 +228,21 @@ class Circuit:
                 }
             ''')
         """
-    def __ne__(self, arg0: stim.Circuit) -> bool:
+    def __ne__(
+        self,
+        arg0: stim.Circuit,
+    ) -> bool:
         """Determines if two circuits have non-identical contents.
         """
-    def __repr__(self) -> str:
+    def __repr__(
+        self,
+    ) -> str:
         """Returns text that is a valid python expression evaluating to an equivalent `stim.Circuit`.
         """
-    def __rmul__(self, repetitions: int) -> stim.Circuit:
+    def __rmul__(
+        self,
+        repetitions: int,
+    ) -> stim.Circuit:
         """Returns a circuit with a REPEAT block containing the current circuit's instructions.
 
         Special case: if the repetition count is 0, an empty circuit is returned.
@@ -228,16 +265,31 @@ class Circuit:
                 }
             ''')
         """
-    def __str__(self) -> str:
+    def __str__(
+        self,
+    ) -> str:
         """Returns stim instructions (that can be saved to a file and parsed by stim) for the current circuit.
         """
     @overload
-    def append(self, name: str, targets: Union[int, stim.GateTarget, Iterable[Union[int, stim.GateTarget]]], arg: Union[float, Iterable[float]]) -> None:
+    def append(
+        self,
+        name: str,
+        targets: Union[int, stim.GateTarget, Iterable[Union[int, stim.GateTarget]]],
+        arg: Union[float, Iterable[float]],
+    ) -> None:
         pass
     @overload
-    def append(self, name: Union[stim.CircuitOperation, stim.CircuitRepeatBlock]) -> None:
+    def append(
+        self,
+        name: Union[stim.CircuitOperation, stim.CircuitRepeatBlock],
+    ) -> None:
         pass
-    def append(self, name: object, targets: object = (), arg: object = None) -> None:
+    def append(
+        self,
+        name: object,
+        targets: object = (),
+        arg: object = None,
+    ) -> None:
         """Appends an operation into the circuit.
 
         Note: `stim.Circuit.append_operation` is an alias of `stim.Circuit.append`.
@@ -282,7 +334,10 @@ class Circuit:
                 `cirq.append_operation` (but not `cirq.append`) will default to a single 0.0 argument for gates
                 that take exactly one argument.
         """
-    def append_from_stim_program_text(self, stim_program_text: str) -> None:
+    def append_from_stim_program_text(
+        self,
+        stim_program_text: str,
+    ) -> None:
         """Appends operations described by a STIM format program into the circuit.
 
         Examples:
@@ -304,10 +359,20 @@ class Circuit:
         Args:
             stim_program_text: The STIM program text containing the circuit operations to append.
         """
-    def append_operation(self, name: object, targets: object = (), arg: object = None) -> None:
+    def append_operation(
+        self,
+        name: object,
+        targets: object = (),
+        arg: object = None,
+    ) -> None:
         """[DEPRECATED] use stim.Circuit.append instead
         """
-    def approx_equals(self, other: object, *, atol: float) -> bool:
+    def approx_equals(
+        self,
+        other: object,
+        *,
+        atol: float,
+    ) -> bool:
         """Checks if a circuit is approximately equal to another circuit.
 
         Two circuits are approximately equal if they are equal up to slight perturbations of instruction arguments
@@ -357,7 +422,9 @@ class Circuit:
             ... '''), atol=9999)
             False
         """
-    def clear(self) -> None:
+    def clear(
+        self,
+    ) -> None:
         """Clears the contents of the circuit.
 
         Examples:
@@ -370,7 +437,11 @@ class Circuit:
             >>> c
             stim.Circuit()
         """
-    def compile_detector_sampler(self, *, seed: object = None) -> stim.CompiledDetectorSampler:
+    def compile_detector_sampler(
+        self,
+        *,
+        seed: object = None,
+    ) -> stim.CompiledDetectorSampler:
         """Returns a CompiledDetectorSampler, which can quickly batch sample detection events, for the circuit.
 
         Args:
@@ -406,7 +477,11 @@ class Circuit:
             >>> s.sample(shots=1)
             array([[False]])
         """
-    def compile_m2d_converter(self, *, skip_reference_sample: bool = False) -> stim.CompiledMeasurementsToDetectionEventsConverter:
+    def compile_m2d_converter(
+        self,
+        *,
+        skip_reference_sample: bool = False,
+    ) -> stim.CompiledMeasurementsToDetectionEventsConverter:
         """Returns an object that can efficiently convert measurements into detection events for the given circuit.
 
         The converter uses a noiseless reference sample, collected from the circuit using stim's Tableau simulator
@@ -441,7 +516,12 @@ class Circuit:
             array([[ True],
                    [False]])
         """
-    def compile_sampler(self, *, skip_reference_sample: bool = False, seed: object = None) -> stim.CompiledMeasurementSampler:
+    def compile_sampler(
+        self,
+        *,
+        skip_reference_sample: bool = False,
+        seed: object = None,
+    ) -> stim.CompiledMeasurementSampler:
         """Returns a CompiledMeasurementSampler, which can quickly batch sample measurements, for the circuit.
 
         Args:
@@ -487,7 +567,9 @@ class Circuit:
             >>> s.sample(shots=1)
             array([[False, False,  True]])
         """
-    def copy(self) -> stim.Circuit:
+    def copy(
+        self,
+    ) -> stim.Circuit:
         """Returns a copy of the circuit. An independent circuit with the same contents.
 
         Examples:
@@ -500,7 +582,16 @@ class Circuit:
             >>> c2 == c1
             True
         """
-    def detector_error_model(self, *, decompose_errors: bool = False, flatten_loops: bool = False, allow_gauge_detectors: bool = False, approximate_disjoint_errors: float = False, ignore_decomposition_failures: bool = False, block_decomposition_from_introducing_remnant_edges: bool = False) -> stim.DetectorErrorModel:
+    def detector_error_model(
+        self,
+        *,
+        decompose_errors: bool = False,
+        flatten_loops: bool = False,
+        allow_gauge_detectors: bool = False,
+        approximate_disjoint_errors: float = False,
+        ignore_decomposition_failures: bool = False,
+        block_decomposition_from_introducing_remnant_edges: bool = False,
+    ) -> stim.DetectorErrorModel:
         """Returns a stim.DetectorErrorModel describing the error processes in the circuit.
 
         Args:
@@ -572,7 +663,12 @@ class Circuit:
                 error(0.25) D1
             ''')
         """
-    def explain_detector_error_model_errors(self, *, dem_filter: object = None, reduce_to_one_representative_error: bool = False) -> List[stim.ExplainedError]:
+    def explain_detector_error_model_errors(
+        self,
+        *,
+        dem_filter: object = None,
+        reduce_to_one_representative_error: bool = False,
+    ) -> List[stim.ExplainedError]:
         """Explains how detector error model errors are produced by circuit errors.
 
         Args:
@@ -620,7 +716,9 @@ class Circuit:
                     resolving to DEPOLARIZE1(0.01) 0
             }
         """
-    def flattened(self) -> stim.Circuit:
+    def flattened(
+        self,
+    ) -> stim.Circuit:
         """Creates an equivalent circuit without REPEAT or SHIFT_COORDS.
 
         Returns:
@@ -656,7 +754,9 @@ class Circuit:
                 DETECTOR(1, 4) rec[-1]
             ''')
         """
-    def flattened_operations(self) -> list:
+    def flattened_operations(
+        self,
+    ) -> list:
         """[DEPRECATED]
 
         Returns a list of tuples encoding the contents of the circuit.
@@ -680,7 +780,9 @@ class Circuit:
             [('H', [6], 0), ('H', [6], 0)]
         """
     @staticmethod
-    def from_file(file: object) -> stim.Circuit:
+    def from_file(
+        file: object,
+    ) -> stim.Circuit:
         """Args:
             file: A file path or open file object to read from.
 
@@ -713,7 +815,16 @@ class Circuit:
             ''')
         """
     @staticmethod
-    def generated(code_task: str, *, distance: int, rounds: int, after_clifford_depolarization: float = 0.0, before_round_data_depolarization: float = 0.0, before_measure_flip_probability: float = 0.0, after_reset_flip_probability: float = 0.0) -> stim.Circuit:
+    def generated(
+        code_task: str,
+        *,
+        distance: int,
+        rounds: int,
+        after_clifford_depolarization: float = 0.0,
+        before_round_data_depolarization: float = 0.0,
+        before_measure_flip_probability: float = 0.0,
+        after_reset_flip_probability: float = 0.0,
+    ) -> stim.Circuit:
         """Generates common circuits.
 
         The generated circuits can include configurable noise.
@@ -795,7 +906,10 @@ class Circuit:
             DETECTOR(5, 1) rec[-1] rec[-2] rec[-5]
             OBSERVABLE_INCLUDE(0) rec[-1]
         """
-    def get_detector_coordinates(self, only: object = None) -> Dict[int, List[float]]:
+    def get_detector_coordinates(
+        self,
+        only: object = None,
+    ) -> Dict[int, List[float]]:
         """Returns the coordinate metadata of detectors in the circuit.
 
         Args:
@@ -824,7 +938,9 @@ class Circuit:
             >>> circuit.get_detector_coordinates(only=[1])
             {1: [1.0, 2.0, 3.0]}
         """
-    def get_final_qubit_coordinates(self) -> Dict[int, List[float]]:
+    def get_final_qubit_coordinates(
+        self,
+    ) -> Dict[int, List[float]]:
         """Returns the coordinate metadata of qubits in the circuit.
 
         If a qubit's coordinates are specified multiple times, only the last specified coordinates are returned.
@@ -842,7 +958,9 @@ class Circuit:
             {1: [1.0, 2.0, 3.0]}
         """
     @property
-    def num_detectors(self) -> int:
+    def num_detectors(
+        self,
+    ) -> int:
         """Counts the number of bits produced when sampling the circuit's detectors.
 
         Examples:
@@ -860,7 +978,9 @@ class Circuit:
             201
         """
     @property
-    def num_measurements(self) -> int:
+    def num_measurements(
+        self,
+    ) -> int:
         """Counts the number of bits produced when sampling the circuit's measurements.
 
         Examples:
@@ -875,7 +995,9 @@ class Circuit:
             201
         """
     @property
-    def num_observables(self) -> int:
+    def num_observables(
+        self,
+    ) -> int:
         """Counts the number of bits produced when sampling the circuit's logical observables.
 
         This is one more than the largest observable index given to OBSERVABLE_INCLUDE.
@@ -891,7 +1013,9 @@ class Circuit:
             6
         """
     @property
-    def num_qubits(self) -> int:
+    def num_qubits(
+        self,
+    ) -> int:
         """Counts the number of qubits used when simulating the circuit.
 
         This is always one more than the largest qubit index used by the circuit.
@@ -911,7 +1035,9 @@ class Circuit:
             101
         """
     @property
-    def num_sweep_bits(self) -> int:
+    def num_sweep_bits(
+        self,
+    ) -> int:
         """Returns the number of sweep bits needed to completely configure the circuit.
 
         This is always one more than the largest sweep bit index used by the circuit.
@@ -928,7 +1054,14 @@ class Circuit:
             ... ''').num_sweep_bits
             6
         """
-    def search_for_undetectable_logical_errors(self, *, dont_explore_detection_event_sets_with_size_above: int, dont_explore_edges_with_degree_above: int, dont_explore_edges_increasing_symptom_degree: bool, canonicalize_circuit_errors: bool = False) -> List[stim.ExplainedError]:
+    def search_for_undetectable_logical_errors(
+        self,
+        *,
+        dont_explore_detection_event_sets_with_size_above: int,
+        dont_explore_edges_with_degree_above: int,
+        dont_explore_edges_increasing_symptom_degree: bool,
+        canonicalize_circuit_errors: bool = False,
+    ) -> List[stim.ExplainedError]:
         """Searches for lists of errors from the model that form an undetectable logical error.
 
         THIS IS A HEURISTIC METHOD. It does not guarantee that it will find errors of particular
@@ -1000,7 +1133,12 @@ class Circuit:
             ... )))
             5
         """
-    def shortest_graphlike_error(self, *, ignore_ungraphlike_errors: bool = True, canonicalize_circuit_errors: bool = False) -> List[stim.ExplainedError]:
+    def shortest_graphlike_error(
+        self,
+        *,
+        ignore_ungraphlike_errors: bool = True,
+        canonicalize_circuit_errors: bool = False,
+    ) -> List[stim.ExplainedError]:
         """Finds a minimum sized set of graphlike errors that produce an undetected logical error.
 
         A "graphlike error" is an error that creates at most two detection events (causes a change in the parity of
@@ -1051,7 +1189,10 @@ class Circuit:
             >>> len(circuit.shortest_graphlike_error())
             7
         """
-    def to_file(self, file: Union[io.TextIOBase, str, pathlib.Path]) -> None:
+    def to_file(
+        self,
+        file: Union[io.TextIOBase, str, pathlib.Path],
+    ) -> None:
 
         """Writes the stim circuit to a file.
 
@@ -1080,7 +1221,9 @@ class Circuit:
             >>> contents
             'H 5\nX 0\n'
         """
-    def without_noise(self) -> stim.Circuit:
+    def without_noise(
+        self,
+    ) -> stim.Circuit:
         """Returns a copy of the circuit with all noise processes removed.
 
         Pure noise instructions, such as X_ERROR and DEPOLARIZE2, are not
@@ -1108,33 +1251,51 @@ class Circuit:
 class CircuitErrorLocation:
     """Describes the location of an error mechanism from a stim circuit.
     """
-    def __init__(self, *, tick_offset: int, flipped_pauli_product: List[stim.GateTargetWithCoords], flipped_measurement: object, instruction_targets: stim.CircuitTargetsInsideInstruction, stack_frames: List[stim.CircuitErrorLocationStackFrame]) -> None:
+    def __init__(
+        self,
+        *,
+        tick_offset: int,
+        flipped_pauli_product: List[stim.GateTargetWithCoords],
+        flipped_measurement: object,
+        instruction_targets: stim.CircuitTargetsInsideInstruction,
+        stack_frames: List[stim.CircuitErrorLocationStackFrame],
+    ) -> None:
         """Creates a stim.CircuitErrorLocation.
         """
     @property
-    def flipped_measurement(self) -> Optional[stim.FlippedMeasurement]:
+    def flipped_measurement(
+        self,
+    ) -> Optional[stim.FlippedMeasurement]:
 
         """The measurement that was flipped by the error mechanism.
         If the error isn't a measurement error, this will be None.
         """
     @property
-    def flipped_pauli_product(self) -> List[stim.GateTargetWithCoords]:
+    def flipped_pauli_product(
+        self,
+    ) -> List[stim.GateTargetWithCoords]:
         """The Pauli errors that the error mechanism applied to qubits.
         When the error is a measurement error, this will be an empty list.
         """
     @property
-    def instruction_targets(self) -> stim.CircuitTargetsInsideInstruction:
+    def instruction_targets(
+        self,
+    ) -> stim.CircuitTargetsInsideInstruction:
         """Within the error instruction, which may have hundreds of
         targets, which specific targets were being executed to
         produce the error.
         """
     @property
-    def stack_frames(self) -> List[stim.CircuitErrorLocationStackFrame]:
+    def stack_frames(
+        self,
+    ) -> List[stim.CircuitErrorLocationStackFrame]:
         """Where in the circuit's execution does the error mechanism occur,
         accounting for things like nested loops that iterate multiple times.
         """
     @property
-    def tick_offset(self) -> int:
+    def tick_offset(
+        self,
+    ) -> int:
         """The number of TICKs that executed before the error mechanism being discussed,
         including TICKs that occurred multiple times during loops.
         """
@@ -1146,11 +1307,19 @@ class CircuitErrorLocationStackFrame:
     drilling down from the top level circuit to the inner-most loop
     that the instruction is within.
     """
-    def __init__(self, *, instruction_offset: int, iteration_index: int, instruction_repetitions_arg: int) -> None:
+    def __init__(
+        self,
+        *,
+        instruction_offset: int,
+        iteration_index: int,
+        instruction_repetitions_arg: int,
+    ) -> None:
         """Creates a stim.CircuitErrorLocationStackFrame.
         """
     @property
-    def instruction_offset(self) -> int:
+    def instruction_offset(
+        self,
+    ) -> int:
         """The index of the instruction within the circuit, or within the
         instruction's parent REPEAT block. This is slightly different
         from the line number, because blank lines and commented lines
@@ -1158,13 +1327,17 @@ class CircuitErrorLocationStackFrame:
         is 0 instead of 1.
         """
     @property
-    def instruction_repetitions_arg(self) -> int:
+    def instruction_repetitions_arg(
+        self,
+    ) -> int:
         """If the instruction being referred to is a REPEAT block,
         this is the repetition count of that REPEAT block. Otherwise
         this field defaults to 0.
         """
     @property
-    def iteration_index(self) -> int:
+    def iteration_index(
+        self,
+    ) -> int:
         """Disambiguates which iteration of the loop containing this instruction
         is being referred to. If the instruction isn't in a REPEAT block, this
         field defaults to 0.
@@ -1186,10 +1359,18 @@ class CircuitInstruction:
         >>> circuit[2]
         stim.CircuitInstruction('X_ERROR', [stim.GateTarget(5), stim.GateTarget(3)], [0.125])
     """
-    def __eq__(self, arg0: stim.CircuitInstruction) -> bool:
+    def __eq__(
+        self,
+        arg0: stim.CircuitInstruction,
+    ) -> bool:
         """Determines if two `stim.CircuitInstruction`s are identical.
         """
-    def __init__(self, name: str, targets: List[object], gate_args: List[float] = ()) -> None:
+    def __init__(
+        self,
+        name: str,
+        targets: List[object],
+        gate_args: List[float] = (),
+    ) -> None:
         """Initializes a `stim.CircuitInstruction`.
 
         Args:
@@ -1199,26 +1380,39 @@ class CircuitInstruction:
             gate_args: The sequence of numeric arguments parameterizing a gate. For noise gates this is their
                 probabilities. For OBSERVABLE_INCLUDE it's the logical observable's index.
         """
-    def __ne__(self, arg0: stim.CircuitInstruction) -> bool:
+    def __ne__(
+        self,
+        arg0: stim.CircuitInstruction,
+    ) -> bool:
         """Determines if two `stim.CircuitInstruction`s are different.
         """
-    def __repr__(self) -> str:
+    def __repr__(
+        self,
+    ) -> str:
         """Returns text that is a valid python expression evaluating to an equivalent `stim.CircuitInstruction`.
         """
-    def __str__(self) -> str:
+    def __str__(
+        self,
+    ) -> str:
         """Returns a text description of the instruction as a stim circuit file line.
         """
-    def gate_args_copy(self) -> List[float]:
+    def gate_args_copy(
+        self,
+    ) -> List[float]:
         """Returns the gate's arguments (numbers parameterizing the instruction).
 
         For noisy gates this typically a list of probabilities.
         For OBSERVABLE_INCLUDE it's a singleton list containing the logical observable index.
         """
     @property
-    def name(self) -> str:
+    def name(
+        self,
+    ) -> str:
         """The name of the instruction (e.g. `H` or `X_ERROR` or `DETECTOR`).
         """
-    def targets_copy(self) -> List[stim.GateTarget]:
+    def targets_copy(
+        self,
+    ) -> List[stim.GateTarget]:
         """Returns a copy of the targets of the instruction.
         """
 class CircuitRepeatBlock:
@@ -1242,23 +1436,37 @@ class CircuitRepeatBlock:
             CZ 1 2
         ''')
     """
-    def __eq__(self, arg0: stim.CircuitRepeatBlock) -> bool:
+    def __eq__(
+        self,
+        arg0: stim.CircuitRepeatBlock,
+    ) -> bool:
         """Determines if two `stim.CircuitRepeatBlock`s are identical.
         """
-    def __init__(self, repeat_count: int, body: stim.Circuit) -> None:
+    def __init__(
+        self,
+        repeat_count: int,
+        body: stim.Circuit,
+    ) -> None:
         """Initializes a `stim.CircuitRepeatBlock`.
 
         Args:
             repeat_count: The number of times to repeat the block.
             body: The body of the block, as a circuit.
         """
-    def __ne__(self, arg0: stim.CircuitRepeatBlock) -> bool:
+    def __ne__(
+        self,
+        arg0: stim.CircuitRepeatBlock,
+    ) -> bool:
         """Determines if two `stim.CircuitRepeatBlock`s are different.
         """
-    def __repr__(self) -> str:
+    def __repr__(
+        self,
+    ) -> str:
         """Returns text that is a valid python expression evaluating to an equivalent `stim.CircuitRepeatBlock`.
         """
-    def body_copy(self) -> stim.Circuit:
+    def body_copy(
+        self,
+    ) -> stim.Circuit:
         """Returns a copy of the body of the repeat block.
 
         The copy is forced to ensure it's clear that editing the result will not change the circuit that the repeat
@@ -1281,7 +1489,9 @@ class CircuitRepeatBlock:
             ''')
         """
     @property
-    def repeat_count(self) -> int:
+    def repeat_count(
+        self,
+    ) -> int:
         """The repetition count of the repeat block.
 
         Examples:
@@ -1300,30 +1510,48 @@ class CircuitRepeatBlock:
 class CircuitTargetsInsideInstruction:
     """Describes a range of targets within a circuit instruction.
     """
-    def __init__(self, *, gate: str, args: List[float], target_range_start: int, target_range_end: int, targets_in_range: List[stim.GateTargetWithCoords]) -> None:
+    def __init__(
+        self,
+        *,
+        gate: str,
+        args: List[float],
+        target_range_start: int,
+        target_range_end: int,
+        targets_in_range: List[stim.GateTargetWithCoords],
+    ) -> None:
         """Creates a stim.CircuitTargetsInsideInstruction.
         """
     @property
-    def args(self) -> List[float]:
+    def args(
+        self,
+    ) -> List[float]:
         """Returns parens arguments of the gate / instruction that was being executed.
         """
     @property
-    def gate(self) -> Optional[str]:
+    def gate(
+        self,
+    ) -> Optional[str]:
 
         """Returns the name of the gate / instruction that was being executed.
         """
     @property
-    def target_range_end(self) -> int:
+    def target_range_end(
+        self,
+    ) -> int:
         """Returns the exclusive end of the range of targets that were executing
         within the gate / instruction.
         """
     @property
-    def target_range_start(self) -> int:
+    def target_range_start(
+        self,
+    ) -> int:
         """Returns the inclusive start of the range of targets that were executing
         within the gate / instruction.
         """
     @property
-    def targets_in_range(self) -> List[stim.GateTargetWithCoords]:
+    def targets_in_range(
+        self,
+    ) -> List[stim.GateTargetWithCoords]:
         """Returns the subset of targets of the gate / instruction that were being executed.
 
         Includes coordinate data with the targets.
@@ -1331,7 +1559,12 @@ class CircuitTargetsInsideInstruction:
 class CompiledDetectorSampler:
     """An analyzed stabilizer circuit whose detection events can be sampled quickly.
     """
-    def __init__(self, circuit: stim.Circuit, *, seed: object = None) -> None:
+    def __init__(
+        self,
+        circuit: stim.Circuit,
+        *,
+        seed: object = None,
+    ) -> None:
         """Creates a detector sampler, which can sample the detectors (and optionally observables) in a circuit.
 
         Args:
@@ -1372,10 +1605,18 @@ class CompiledDetectorSampler:
             >>> s.sample(shots=1)
             array([[ True]])
         """
-    def __repr__(self) -> str:
+    def __repr__(
+        self,
+    ) -> str:
         """Returns text that is a valid python expression evaluating to an equivalent `stim.CompiledDetectorSampler`.
         """
-    def sample(self, shots: int, *, prepend_observables: bool = False, append_observables: bool = False) -> np.ndarray[bool]:
+    def sample(
+        self,
+        shots: int,
+        *,
+        prepend_observables: bool = False,
+        append_observables: bool = False,
+    ) -> np.ndarray[bool]:
         """Returns a numpy array containing a batch of detector samples from the circuit.
 
         The circuit must define the detectors using DETECTOR instructions. Observables defined by OBSERVABLE_INCLUDE
@@ -1393,7 +1634,13 @@ class CompiledDetectorSampler:
             `n = num_detectors + num_observables*(append_observables + prepend_observables)`.
             The bit for detection event `m` in shot `s` is at `result[s, m]`.
         """
-    def sample_bit_packed(self, shots: int, *, prepend_observables: bool = False, append_observables: bool = False) -> np.ndarray[np.uint8]:
+    def sample_bit_packed(
+        self,
+        shots: int,
+        *,
+        prepend_observables: bool = False,
+        append_observables: bool = False,
+    ) -> np.ndarray[np.uint8]:
         """Returns a numpy array containing bit packed batch of detector samples from the circuit.
 
         The circuit must define the detectors using DETECTOR instructions. Observables defined by OBSERVABLE_INCLUDE
@@ -1411,7 +1658,17 @@ class CompiledDetectorSampler:
             `n = num_detectors + num_observables*(append_observables + prepend_observables)`.
             The bit for detection event `m` in shot `s` is at `result[s, (m // 8)] & 2**(m % 8)`.
         """
-    def sample_write(self, shots: int, *, filepath: str, format: str = '01', prepend_observables: bool = False, append_observables: bool = False, obs_out_filepath: str = None, obs_out_format: str = '01') -> None:
+    def sample_write(
+        self,
+        shots: int,
+        *,
+        filepath: str,
+        format: str = '01',
+        prepend_observables: bool = False,
+        append_observables: bool = False,
+        obs_out_filepath: str = None,
+        obs_out_format: str = '01',
+    ) -> None:
         """Samples detection events from the circuit and writes them to a file.
 
         Examples:
@@ -1454,7 +1711,13 @@ class CompiledDetectorSampler:
 class CompiledMeasurementSampler:
     """An analyzed stabilizer circuit whose measurements can be sampled quickly.
     """
-    def __init__(self, circuit: stim.Circuit, *, skip_reference_sample: bool = False, seed: object = None) -> None:
+    def __init__(
+        self,
+        circuit: stim.Circuit,
+        *,
+        skip_reference_sample: bool = False,
+        seed: object = None,
+    ) -> None:
         """Creates a measurement sampler for the given circuit.
 
         The sampler uses a noiseless reference sample, collected from the circuit using stim's Tableau simulator
@@ -1508,10 +1771,15 @@ class CompiledMeasurementSampler:
             >>> s.sample(shots=1)
             array([[ True, False,  True,  True]])
         """
-    def __repr__(self) -> str:
+    def __repr__(
+        self,
+    ) -> str:
         """Returns text that is a valid python expression evaluating to an equivalent `stim.CompiledMeasurementSampler`.
         """
-    def sample(self, shots: int) -> np.ndarray[bool]:
+    def sample(
+        self,
+        shots: int,
+    ) -> np.ndarray[bool]:
         """Returns a numpy array containing a batch of measurement samples from the circuit.
 
         Examples:
@@ -1531,7 +1799,10 @@ class CompiledMeasurementSampler:
             A numpy array with `dtype=uint8` and `shape=(shots, num_measurements)`.
             The bit for measurement `m` in shot `s` is at `result[s, m]`.
         """
-    def sample_bit_packed(self, shots: int) -> np.ndarray[np.uint8]:
+    def sample_bit_packed(
+        self,
+        shots: int,
+    ) -> np.ndarray[np.uint8]:
         """Returns a numpy array containing a bit packed batch of measurement samples from the circuit.
 
         Examples:
@@ -1551,7 +1822,13 @@ class CompiledMeasurementSampler:
             A numpy array with `dtype=uint8` and `shape=(shots, (num_measurements + 7) // 8)`.
             The bit for measurement `m` in shot `s` is at `result[s, (m // 8)] & 2**(m % 8)`.
         """
-    def sample_write(self, shots: int, *, filepath: str, format: str = '01') -> None:
+    def sample_write(
+        self,
+        shots: int,
+        *,
+        filepath: str,
+        format: str = '01',
+    ) -> None:
         """Samples measurements from the circuit and writes them to a file.
 
         Examples:
@@ -1585,7 +1862,12 @@ class CompiledMeasurementSampler:
 class CompiledMeasurementsToDetectionEventsConverter:
     """A tool for quickly converting measurements from an analyzed stabilizer circuit into detection events.
     """
-    def __init__(self, circuit: stim.Circuit, *, skip_reference_sample: bool = False) -> None:
+    def __init__(
+        self,
+        circuit: stim.Circuit,
+        *,
+        skip_reference_sample: bool = False,
+    ) -> None:
         """Creates a measurement-to-detection-events converter for the given circuit.
 
         The converter uses a noiseless reference sample, collected from the circuit using stim's Tableau simulator
@@ -1621,10 +1903,20 @@ class CompiledMeasurementsToDetectionEventsConverter:
             array([[ True],
                    [False]])
         """
-    def __repr__(self) -> str:
+    def __repr__(
+        self,
+    ) -> str:
         """Returns text that is a valid python expression evaluating to an equivalent `stim.CompiledMeasurementsToDetectionEventsConverter`.
         """
-    def convert(self, *, measurements: np.ndarray, sweep_bits: Optional[np.ndarray] = None, separate_observables: bool = False, append_observables: bool = False, bit_pack_result: bool = False) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
+    def convert(
+        self,
+        *,
+        measurements: np.ndarray,
+        sweep_bits: Optional[np.ndarray] = None,
+        separate_observables: bool = False,
+        append_observables: bool = False,
+        bit_pack_result: bool = False,
+    ) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
 
         """Converts measurement data into detection event data.
 
@@ -1690,7 +1982,19 @@ class CompiledMeasurementsToDetectionEventsConverter:
                    [ True],
                    [False]])
         """
-    def convert_file(self, *, measurements_filepath: str, measurements_format: str = '01', sweep_bits_filepath: str = None, sweep_bits_format: str = '01', detection_events_filepath: str, detection_events_format: str = '01', append_observables: bool = False, obs_out_filepath: str = None, obs_out_format: str = '01') -> None:
+    def convert_file(
+        self,
+        *,
+        measurements_filepath: str,
+        measurements_format: str = '01',
+        sweep_bits_filepath: str = None,
+        sweep_bits_format: str = '01',
+        detection_events_filepath: str,
+        detection_events_format: str = '01',
+        append_observables: bool = False,
+        obs_out_filepath: str = None,
+        obs_out_format: str = '01',
+    ) -> None:
         """Reads measurement data from a file, converts it, and writes the detection events to another file.
 
         Args:
@@ -1756,10 +2060,18 @@ class DemInstruction:
         >>> instruction
         stim.DemInstruction('error', [0.125], [stim.target_relative_detector_id(0)])
     """
-    def __eq__(self, arg0: stim.DemInstruction) -> bool:
+    def __eq__(
+        self,
+        arg0: stim.DemInstruction,
+    ) -> bool:
         """Determines if two instructions have identical contents.
         """
-    def __init__(self, type: str, args: List[float], targets: List[object]) -> None:
+    def __init__(
+        self,
+        type: str,
+        args: List[float],
+        targets: List[object],
+    ) -> None:
         """Creates a stim.DemInstruction.
 
         Args:
@@ -1773,24 +2085,37 @@ class DemInstruction:
             >>> print(instruction)
             error(0.125) D5
         """
-    def __ne__(self, arg0: stim.DemInstruction) -> bool:
+    def __ne__(
+        self,
+        arg0: stim.DemInstruction,
+    ) -> bool:
         """Determines if two instructions have non-identical contents.
         """
-    def __repr__(self) -> str:
+    def __repr__(
+        self,
+    ) -> str:
         """Returns text that is a valid python expression evaluating to an equivalent `stim.DetectorErrorModel`.
         """
-    def __str__(self) -> str:
+    def __str__(
+        self,
+    ) -> str:
         """Returns detector error model (.dem) instructions (that can be parsed by stim) for the model.
         """
-    def args_copy(self) -> List[float]:
+    def args_copy(
+        self,
+    ) -> List[float]:
         """Returns a copy of the list of numbers parameterizing the instruction (e.g. the probability of an error).
         """
-    def targets_copy(self) -> List[Union[int, stim.DemTarget]]:
+    def targets_copy(
+        self,
+    ) -> List[Union[int, stim.DemTarget]]:
 
         """Returns a copy of the list of objects the instruction applies to (e.g. affected detectors.
         """
     @property
-    def type(self) -> str:
+    def type(
+        self,
+    ) -> str:
         """The name of the instruction type (e.g. "error" or "shift_detectors").
         """
 class DemRepeatBlock:
@@ -1810,10 +2135,17 @@ class DemRepeatBlock:
             shift_detectors 1
         '''))
     """
-    def __eq__(self, arg0: stim.DemRepeatBlock) -> bool:
+    def __eq__(
+        self,
+        arg0: stim.DemRepeatBlock,
+    ) -> bool:
         """Determines if two repeat blocks are identical.
         """
-    def __init__(self, repeat_count: int, block: stim.DetectorErrorModel) -> None:
+    def __init__(
+        self,
+        repeat_count: int,
+        block: stim.DetectorErrorModel,
+    ) -> None:
         """Creates a stim.DemRepeatBlock.
 
         Args:
@@ -1827,45 +2159,72 @@ class DemRepeatBlock:
             ...     shift_detectors 1
             ... '''))
         """
-    def __ne__(self, arg0: stim.DemRepeatBlock) -> bool:
+    def __ne__(
+        self,
+        arg0: stim.DemRepeatBlock,
+    ) -> bool:
         """Determines if two repeat blocks are different.
         """
-    def __repr__(self) -> str:
+    def __repr__(
+        self,
+    ) -> str:
         """Returns text that is a valid python expression evaluating to an equivalent `stim.DemRepeatBlock`.
         """
-    def body_copy(self) -> stim.DetectorErrorModel:
+    def body_copy(
+        self,
+    ) -> stim.DetectorErrorModel:
         """Returns a copy of the block's body, as a stim.DetectorErrorModel.
         """
     @property
-    def repeat_count(self) -> int:
+    def repeat_count(
+        self,
+    ) -> int:
         """The number of times the repeat block's body is supposed to execute.
         """
 class DemTarget:
     """An instruction target from a detector error model (.dem) file.
     """
-    def __eq__(self, arg0: stim.DemTarget) -> bool:
+    def __eq__(
+        self,
+        arg0: stim.DemTarget,
+    ) -> bool:
         """Determines if two `stim.DemTarget`s are identical.
         """
-    def __ne__(self, arg0: stim.DemTarget) -> bool:
+    def __ne__(
+        self,
+        arg0: stim.DemTarget,
+    ) -> bool:
         """Determines if two `stim.DemTarget`s are different.
         """
-    def __repr__(self) -> str:
+    def __repr__(
+        self,
+    ) -> str:
         """Returns text that is a valid python expression evaluating to an equivalent `stim.DemTarget`.
         """
-    def __str__(self) -> str:
+    def __str__(
+        self,
+    ) -> str:
         """Returns a text description of the detector error model target.
         """
-    def is_logical_observable_id(self) -> bool:
+    def is_logical_observable_id(
+        self,
+    ) -> bool:
         """Determines if the detector error model target is a logical observable id target (like "L5" in a .dem file).
         """
-    def is_relative_detector_id(self) -> bool:
+    def is_relative_detector_id(
+        self,
+    ) -> bool:
         """Determines if the detector error model target is a relative detector id target (like "D4" in a .dem file).
         """
-    def is_separator(self) -> bool:
+    def is_separator(
+        self,
+    ) -> bool:
         """Determines if the detector error model target is a separator (like "^" in a .dem file).
         """
     @staticmethod
-    def logical_observable_id(index: int) -> stim.DemTarget:
+    def logical_observable_id(
+        index: int,
+    ) -> stim.DemTarget:
         """Returns a logical observable id identifying a frame change (e.g. "L5" in a .dem file).
 
         Args:
@@ -1886,7 +2245,9 @@ class DemTarget:
             ''')
         """
     @staticmethod
-    def relative_detector_id(index: int) -> stim.DemTarget:
+    def relative_detector_id(
+        index: int,
+    ) -> stim.DemTarget:
         """Returns a relative detector id (e.g. "D5" in a .dem file).
 
         Args:
@@ -1907,7 +2268,8 @@ class DemTarget:
             ''')
         """
     @staticmethod
-    def separator() -> stim.DemTarget:
+    def separator(
+    ) -> stim.DemTarget:
         """Returns a target separator (e.g. "^" in a .dem file).
 
         Examples:
@@ -1924,7 +2286,9 @@ class DemTarget:
             ''')
         """
     @property
-    def val(self) -> int:
+    def val(
+        self,
+    ) -> int:
         """Returns the target's integer value.
 
         Example:
@@ -1951,17 +2315,26 @@ class DemTargetWithCoords:
     look up the coordinates of a detector index in order to understand
     what is happening.
     """
-    def __init__(self, *, dem_target: stim.DemTarget, coords: List[float]) -> None:
+    def __init__(
+        self,
+        *,
+        dem_target: stim.DemTarget,
+        coords: List[float],
+    ) -> None:
         """Creates a stim.DemTargetWithCoords.
         """
     @property
-    def coords(self) -> List[float]:
+    def coords(
+        self,
+    ) -> List[float]:
         """Returns the associated coordinate information as a list of flaots.
 
         If there is no coordinate information, returns an empty list.
         """
     @property
-    def dem_target(self) -> stim.DemTarget:
+    def dem_target(
+        self,
+    ) -> stim.DemTarget:
         """Returns the actual DEM target as a `stim.DemTarget`.
         """
 class DetectorErrorModel:
@@ -1993,7 +2366,10 @@ class DetectorErrorModel:
             error(0.25) D1
         ''')
     """
-    def __add__(self, second: stim.DetectorErrorModel) -> stim.DetectorErrorModel:
+    def __add__(
+        self,
+        second: stim.DetectorErrorModel,
+    ) -> stim.DetectorErrorModel:
         """Creates a detector error model by appending two models.
 
         Examples:
@@ -2010,16 +2386,28 @@ class DetectorErrorModel:
                 error(0.25) D1
             ''')
         """
-    def __eq__(self, arg0: stim.DetectorErrorModel) -> bool:
+    def __eq__(
+        self,
+        arg0: stim.DetectorErrorModel,
+    ) -> bool:
         """Determines if two detector error models have identical contents.
         """
     @overload
-    def __getitem__(self, index_or_slice: int) -> Union[stim.DemInstruction, stim.DemRepeatBlock]:
+    def __getitem__(
+        self,
+        index_or_slice: int,
+    ) -> Union[stim.DemInstruction, stim.DemRepeatBlock]:
         pass
     @overload
-    def __getitem__(self, index_or_slice: slice) -> stim.DetectorErrorModel:
+    def __getitem__(
+        self,
+        index_or_slice: slice,
+    ) -> stim.DetectorErrorModel:
         pass
-    def __getitem__(self, index_or_slice: object) -> object:
+    def __getitem__(
+        self,
+        index_or_slice: object,
+    ) -> object:
         """Returns copies of instructions from the detector error model.
 
         Args:
@@ -2054,7 +2442,10 @@ class DetectorErrorModel:
                 detector D5
             ''')
         """
-    def __iadd__(self, second: stim.DetectorErrorModel) -> stim.DetectorErrorModel:
+    def __iadd__(
+        self,
+        second: stim.DetectorErrorModel,
+    ) -> stim.DetectorErrorModel:
         """Appends a detector error model into the receiving model (mutating it).
 
         Examples:
@@ -2072,7 +2463,10 @@ class DetectorErrorModel:
                 error(0.25) D1
             ''')
         """
-    def __imul__(self, repetitions: int) -> stim.DetectorErrorModel:
+    def __imul__(
+        self,
+        repetitions: int,
+    ) -> stim.DetectorErrorModel:
         """Mutates the detector error model by putting its contents into a repeat block.
 
         Special case: if the repetition count is 0, the model is cleared.
@@ -2094,7 +2488,10 @@ class DetectorErrorModel:
                 shift_detectors 1
             }
         """
-    def __init__(self, detector_error_model_text: str = '') -> None:
+    def __init__(
+        self,
+        detector_error_model_text: str = '',
+    ) -> None:
         """Creates a stim.DetectorErrorModel.
 
         Args:
@@ -2108,7 +2505,9 @@ class DetectorErrorModel:
             ...    error(0.125) D0 L0
             ... ''')
         """
-    def __len__(self) -> int:
+    def __len__(
+        self,
+    ) -> int:
         """Returns the number of top-level instructions and blocks in the detector error model.
 
         Instructions inside of blocks are not included in this count.
@@ -2131,7 +2530,10 @@ class DetectorErrorModel:
             ... '''))
             1
         """
-    def __mul__(self, repetitions: int) -> stim.DetectorErrorModel:
+    def __mul__(
+        self,
+        repetitions: int,
+    ) -> stim.DetectorErrorModel:
         """Returns a detector error model with a repeat block containing the current model's instructions.
 
         Special case: if the repetition count is 0, an empty model is returned.
@@ -2154,13 +2556,21 @@ class DetectorErrorModel:
                 }
             ''')
         """
-    def __ne__(self, arg0: stim.DetectorErrorModel) -> bool:
+    def __ne__(
+        self,
+        arg0: stim.DetectorErrorModel,
+    ) -> bool:
         """Determines if two detector error models have non-identical contents.
         """
-    def __repr__(self) -> str:
+    def __repr__(
+        self,
+    ) -> str:
         """"Returns text that is a valid python expression evaluating to an equivalent `stim.DetectorErrorModel`."
         """
-    def __rmul__(self, repetitions: int) -> stim.DetectorErrorModel:
+    def __rmul__(
+        self,
+        repetitions: int,
+    ) -> stim.DetectorErrorModel:
         """Returns a detector error model with a repeat block containing the current model's instructions.
 
         Special case: if the repetition count is 0, an empty model is returned.
@@ -2183,10 +2593,17 @@ class DetectorErrorModel:
                 }
             ''')
         """
-    def __str__(self) -> str:
+    def __str__(
+        self,
+    ) -> str:
         """"Returns detector error model (.dem) instructions (that can be parsed by stim) for the model.");
         """
-    def append(self, instruction: object, parens_arguments: object = None, targets: List[object] = ()) -> None:
+    def append(
+        self,
+        instruction: object,
+        parens_arguments: object = None,
+        targets: List[object] = (),
+    ) -> None:
         """Appends an instruction to the detector error model.
 
         Args:
@@ -2244,7 +2661,12 @@ class DetectorErrorModel:
                 }
             ''')
         """
-    def approx_equals(self, other: object, *, atol: float) -> bool:
+    def approx_equals(
+        self,
+        other: object,
+        *,
+        atol: float,
+    ) -> bool:
         """Checks if a detector error model is approximately equal to another detector error model.
 
         Two detector error model are approximately equal if they are equal up to slight perturbations of instruction
@@ -2289,7 +2711,9 @@ class DetectorErrorModel:
             ... '''), atol=9999)
             False
         """
-    def clear(self) -> None:
+    def clear(
+        self,
+    ) -> None:
         """Clears the contents of the detector error model.
 
         Examples:
@@ -2301,7 +2725,9 @@ class DetectorErrorModel:
             >>> model
             stim.DetectorErrorModel()
         """
-    def copy(self) -> stim.DetectorErrorModel:
+    def copy(
+        self,
+    ) -> stim.DetectorErrorModel:
         """Returns a copy of the detector error model. An independent model with the same contents.
 
         Examples:
@@ -2315,7 +2741,9 @@ class DetectorErrorModel:
             True
         """
     @staticmethod
-    def from_file(file: object) -> stim.DetectorErrorModel:
+    def from_file(
+        file: object,
+    ) -> stim.DetectorErrorModel:
         """Args:
             file: A file path or open file object to read from.
 
@@ -2347,7 +2775,10 @@ class DetectorErrorModel:
                 error(0.25) D2 D3
             ''')
         """
-    def get_detector_coordinates(self, only: object = None) -> Dict[int, List[float]]:
+    def get_detector_coordinates(
+        self,
+        only: object = None,
+    ) -> Dict[int, List[float]]:
         """Returns the coordinate metadata of detectors in the detector error model.
 
         Args:
@@ -2373,7 +2804,9 @@ class DetectorErrorModel:
             {1: [1.0, 2.0, 3.0]}
         """
     @property
-    def num_detectors(self) -> int:
+    def num_detectors(
+        self,
+    ) -> int:
         """Counts the number of detectors (e.g. `D2`) in the error model.
 
         Detector indices are assumed to be contiguous from 0 up to whatever the maximum detector id is.
@@ -2404,7 +2837,9 @@ class DetectorErrorModel:
             1200
         """
     @property
-    def num_errors(self) -> int:
+    def num_errors(
+        self,
+    ) -> int:
         """Counts the number of errors (e.g. `error(0.1) D0`) in the error model.
 
         Error instructions inside repeat blocks count once per repetition.
@@ -2424,7 +2859,9 @@ class DetectorErrorModel:
             501
         """
     @property
-    def num_observables(self) -> int:
+    def num_observables(
+        self,
+    ) -> int:
         """Counts the number of frame changes (e.g. `L2`) in the error model.
 
         Observable indices are assumed to be contiguous from 0 up to whatever the maximum observable id is.
@@ -2445,7 +2882,10 @@ class DetectorErrorModel:
             ... ''').num_observables
             400
         """
-    def shortest_graphlike_error(self, ignore_ungraphlike_errors: bool = False) -> stim.DetectorErrorModel:
+    def shortest_graphlike_error(
+        self,
+        ignore_ungraphlike_errors: bool = False,
+    ) -> stim.DetectorErrorModel:
         """Finds a minimum sized set of graphlike errors that produce an undetected logical error.
 
         Note that this method does not pay attention to error probabilities (other than ignoring errors with
@@ -2520,7 +2960,10 @@ class DetectorErrorModel:
             >>> len(model.shortest_graphlike_error())
             7
         """
-    def to_file(self, file: Union[io.TextIOBase, str, pathlib.Path]) -> None:
+    def to_file(
+        self,
+        file: Union[io.TextIOBase, str, pathlib.Path],
+    ) -> None:
 
         """Writes the stim circuit to a file.
 
@@ -2552,11 +2995,18 @@ class DetectorErrorModel:
 class ExplainedError:
     """Describes the location of an error mechanism from a stim circuit.
     """
-    def __init__(self, *, dem_error_terms: List[stim.DemTargetWithCoords], circuit_error_locations: List[stim.CircuitErrorLocation]) -> None:
+    def __init__(
+        self,
+        *,
+        dem_error_terms: List[stim.DemTargetWithCoords],
+        circuit_error_locations: List[stim.CircuitErrorLocation],
+    ) -> None:
         """Creates a stim.ExplainedError.
         """
     @property
-    def circuit_error_locations(self) -> List[stim.CircuitErrorLocation]:
+    def circuit_error_locations(
+        self,
+    ) -> List[stim.CircuitErrorLocation]:
         """The locations of circuit errors that produce the symptoms in dem_error_terms.
 
         Note: if this list contains a single entry, it may be because a result
@@ -2568,7 +3018,9 @@ class ExplainedError:
         circuit error.
         """
     @property
-    def dem_error_terms(self) -> List[stim.DemTargetWithCoords]:
+    def dem_error_terms(
+        self,
+    ) -> List[stim.DemTargetWithCoords]:
         """The detectors and observables flipped by this error mechanism.
         """
 class FlippedMeasurement:
@@ -2577,17 +3029,26 @@ class FlippedMeasurement:
     Gives the measurement's index in the measurement record, and also
     the observable of the measurement.
     """
-    def __init__(self, *, record_index: int, observable: object) -> None:
+    def __init__(
+        self,
+        *,
+        record_index: int,
+        observable: object,
+    ) -> None:
         """Creates a stim.FlippedMeasurement.
         """
     @property
-    def observable(self) -> List[stim.GateTargetWithCoords]:
+    def observable(
+        self,
+    ) -> List[stim.GateTargetWithCoords]:
         """Returns the observable of the flipped measurement.
 
         For example, an `MX 5` measurement will have the observable X5.
         """
     @property
-    def record_index(self) -> int:
+    def record_index(
+        self,
+    ) -> int:
         """The measurement record index of the flipped measurement.
         For example, the fifth measurement in a circuit has a measurement
         record index of 4.
@@ -2605,58 +3066,87 @@ class GateTarget:
         >>> circuit[0].targets_copy()[1]
         stim.GateTarget(stim.target_inv(1))
     """
-    def __eq__(self, arg0: stim.GateTarget) -> bool:
+    def __eq__(
+        self,
+        arg0: stim.GateTarget,
+    ) -> bool:
         """Determines if two `stim.GateTarget`s are identical.
         """
-    def __init__(self, value: object) -> None:
+    def __init__(
+        self,
+        value: object,
+    ) -> None:
         """Initializes a `stim.GateTarget`.
 
         Args:
             value: A target like `5` or `stim.target_rec(-1)`.
         """
-    def __ne__(self, arg0: stim.GateTarget) -> bool:
+    def __ne__(
+        self,
+        arg0: stim.GateTarget,
+    ) -> bool:
         """Determines if two `stim.GateTarget`s are different.
         """
-    def __repr__(self) -> str:
+    def __repr__(
+        self,
+    ) -> str:
         """Returns text that is a valid python expression evaluating to an equivalent `stim.GateTarget`.
         """
     @property
-    def is_combiner(self) -> bool:
+    def is_combiner(
+        self,
+    ) -> bool:
         """Returns whether or not this is a `stim.target_combiner()` (a `*` in a circuit file).
         """
     @property
-    def is_inverted_result_target(self) -> bool:
+    def is_inverted_result_target(
+        self,
+    ) -> bool:
         """Returns whether or not this is an inverted target.
 
         Inverted targets include inverted qubit targets `stim.target_inv(5)` (`!5` in a circuit file) and
         inverted Pauli targets like `stim.target_x(4, invert=True)` (`!X4` in a circuit file).
         """
     @property
-    def is_measurement_record_target(self) -> bool:
+    def is_measurement_record_target(
+        self,
+    ) -> bool:
         """Returns whether or not this is a `stim.target_rec` target (e.g. `rec[-5]` in a circuit file).
         """
     @property
-    def is_qubit_target(self) -> bool:
+    def is_qubit_target(
+        self,
+    ) -> bool:
         """Returns true if this is a qubit target (e.g. `5`) or an inverted qubit target (e.g. `stim.target_inv(4)`).
         """
     @property
-    def is_sweep_bit_target(self) -> bool:
+    def is_sweep_bit_target(
+        self,
+    ) -> bool:
         """Returns whether or not this is a `stim.target_sweep_bit` target (e.g. `sweep[5]` in a circuit file).
         """
     @property
-    def is_x_target(self) -> bool:
+    def is_x_target(
+        self,
+    ) -> bool:
         """Returns whether or not this is a `stim.target_x` target (e.g. `X5` in a circuit file).
         """
     @property
-    def is_y_target(self) -> bool:
+    def is_y_target(
+        self,
+    ) -> bool:
         """Returns whether or not this is a `stim.target_y` target (e.g. `Y5` in a circuit file).
         """
     @property
-    def is_z_target(self) -> bool:
+    def is_z_target(
+        self,
+    ) -> bool:
         """Returns whether or not this is a `stim.target_z` target (e.g. `Z5` in a circuit file).
         """
     @property
-    def value(self) -> int:
+    def value(
+        self,
+    ) -> int:
         """The numeric part of the target. Positive for qubit targets, negative for measurement record targets.
         """
 class GateTargetWithCoords:
@@ -2671,17 +3161,26 @@ class GateTargetWithCoords:
     look up the coordinates of a qubit index in order to understand
     what is happening.
     """
-    def __init__(self, *, gate_target: object, coords: List[float]) -> None:
+    def __init__(
+        self,
+        *,
+        gate_target: object,
+        coords: List[float],
+    ) -> None:
         """Creates a stim.GateTargetWithCoords.
         """
     @property
-    def coords(self) -> List[float]:
+    def coords(
+        self,
+    ) -> List[float]:
         """Returns the associated coordinate information as a list of flaots.
 
         If there is no coordinate information, returns an empty list.
         """
     @property
-    def gate_target(self) -> stim.GateTarget:
+    def gate_target(
+        self,
+    ) -> stim.GateTarget:
         """Returns the actual gate target as a `stim.GateTarget`.
         """
 class PauliString:
@@ -2696,7 +3195,10 @@ class PauliString:
         >>> print(stim.PauliString(5))
         +_____
     """
-    def __add__(self, rhs: stim.PauliString) -> stim.PauliString:
+    def __add__(
+        self,
+        rhs: stim.PauliString,
+    ) -> stim.PauliString:
         """Returns the tensor product of two Pauli strings.
 
         Concatenates the Pauli strings and multiplies their signs.
@@ -2716,16 +3218,28 @@ class PauliString:
         Returns:
             The tensor product.
         """
-    def __eq__(self, arg0: stim.PauliString) -> bool:
+    def __eq__(
+        self,
+        arg0: stim.PauliString,
+    ) -> bool:
         """Determines if two Pauli strings have identical contents.
         """
     @overload
-    def __getitem__(self, index_or_slice: int) -> int:
+    def __getitem__(
+        self,
+        index_or_slice: int,
+    ) -> int:
         pass
     @overload
-    def __getitem__(self, index_or_slice: slice) -> stim.PauliString:
+    def __getitem__(
+        self,
+        index_or_slice: slice,
+    ) -> stim.PauliString:
         pass
-    def __getitem__(self, index_or_slice: object) -> object:
+    def __getitem__(
+        self,
+        index_or_slice: object,
+    ) -> object:
         """Returns an individual Pauli or Pauli string slice from the pauli string.
 
         Individual Paulis are returned as an int using the encoding 0=I, 1=X, 2=Y, 3=Z.
@@ -2752,7 +3266,10 @@ class PauliString:
             2: Pauli Y.
             3: Pauli Z.
         """
-    def __iadd__(self, rhs: stim.PauliString) -> stim.PauliString:
+    def __iadd__(
+        self,
+        rhs: stim.PauliString,
+    ) -> stim.PauliString:
         """Performs an inplace tensor product.
 
         Concatenates the given Pauli string onto the receiving string and multiplies their signs.
@@ -2774,7 +3291,10 @@ class PauliString:
         Returns:
             The mutated pauli string.
         """
-    def __imul__(self, rhs: object) -> stim.PauliString:
+    def __imul__(
+        self,
+        rhs: object,
+    ) -> stim.PauliString:
         """Inplace right-multiplies the Pauli string by another Pauli string, a complex unit, or a tensor power.
 
         Args:
@@ -2811,7 +3331,10 @@ class PauliString:
             The mutated Pauli string.
         """
     @staticmethod
-    def __init__(*args, **kwargs):
+    def __init__(
+        *args,
+        **kwargs,
+    ):
         """Overloaded function.
 
         1. __init__(self: stim.PauliString, num_qubits: int) -> None
@@ -2886,7 +3409,10 @@ class PauliString:
         Args:
             pauli_indices: A sequence of integers from 0 to 3 (inclusive) indicating paulis.
         """
-    def __itruediv__(self, rhs: complex) -> stim.PauliString:
+    def __itruediv__(
+        self,
+        rhs: complex,
+    ) -> stim.PauliString:
         """Inplace divides the Pauli string by a complex unit.
 
         Args:
@@ -2906,10 +3432,15 @@ class PauliString:
         Raises:
             ValueError: The divisor isn't 1, -1, 1j, or -1j.
         """
-    def __len__(self) -> int:
+    def __len__(
+        self,
+    ) -> int:
         """Returns the length the pauli string; the number of qubits it operates on.
         """
-    def __mul__(self, rhs: object) -> stim.PauliString:
+    def __mul__(
+        self,
+        rhs: object,
+    ) -> stim.PauliString:
         """Right-multiplies the Pauli string by another Pauli string, a complex unit, or a tensor power.
 
         Args:
@@ -2952,10 +3483,15 @@ class PauliString:
         Raises:
             TypeError: The right hand side isn't a stim.PauliString, a non-negative integer, or a complex unit (1, -1, 1j, or -1j).
         """
-    def __ne__(self, arg0: stim.PauliString) -> bool:
+    def __ne__(
+        self,
+        arg0: stim.PauliString,
+    ) -> bool:
         """Determines if two Pauli strings have non-identical contents.
         """
-    def __neg__(self) -> stim.PauliString:
+    def __neg__(
+        self,
+    ) -> stim.PauliString:
         """Returns the negation of the pauli string.
 
         Examples:
@@ -2967,7 +3503,9 @@ class PauliString:
             >>> -stim.PauliString("iZZZ")
             stim.PauliString("-iZZZ")
         """
-    def __pos__(self) -> stim.PauliString:
+    def __pos__(
+        self,
+    ) -> stim.PauliString:
         """Returns a pauli string with the same contents.
 
         Examples:
@@ -2979,10 +3517,15 @@ class PauliString:
             >>> +stim.PauliString("iZZZ")
             stim.PauliString("+iZZZ")
         """
-    def __repr__(self) -> str:
+    def __repr__(
+        self,
+    ) -> str:
         """Returns text that is a valid python expression evaluating to an equivalent `stim.PauliString`.
         """
-    def __rmul__(self, lhs: object) -> stim.PauliString:
+    def __rmul__(
+        self,
+        lhs: object,
+    ) -> stim.PauliString:
         """Left-multiplies the Pauli string by another Pauli string, a complex unit, or a tensor power.
 
         Args:
@@ -3025,7 +3568,11 @@ class PauliString:
         Raises:
             ValueError: The scalar phase factor isn't 1, -1, 1j, or -1j.
         """
-    def __setitem__(self, index: int, new_pauli: object) -> None:
+    def __setitem__(
+        self,
+        index: int,
+        new_pauli: object,
+    ) -> None:
         """Mutates an entry in the pauli string using the encoding 0=I, 1=X, 2=Y, 3=Z.
 
         Args:
@@ -3053,10 +3600,15 @@ class PauliString:
             >>> print(p)
             +_XYY
         """
-    def __str__(self) -> str:
+    def __str__(
+        self,
+    ) -> str:
         """Returns a text description.
         """
-    def __truediv__(self, rhs: complex) -> stim.PauliString:
+    def __truediv__(
+        self,
+        rhs: complex,
+    ) -> stim.PauliString:
         """Divides the Pauli string by a complex unit.
 
         Args:
@@ -3074,7 +3626,10 @@ class PauliString:
         Raises:
             ValueError: The divisor isn't 1, -1, 1j, or -1j.
         """
-    def commutes(self, other: stim.PauliString) -> bool:
+    def commutes(
+        self,
+        other: stim.PauliString,
+    ) -> bool:
         """Determines if two Pauli strings commute or not.
 
         Two Pauli strings commute if they have an even number of matched
@@ -3104,7 +3659,9 @@ class PauliString:
         Returns:
             True if the Pauli strings commute, False if they anti-commute.
         """
-    def copy(self) -> stim.PauliString:
+    def copy(
+        self,
+    ) -> stim.PauliString:
         """Returns a copy of the pauli string. An independent pauli string with the same contents.
 
         Examples:
@@ -3116,11 +3673,18 @@ class PauliString:
             >>> p2 == p1
             True
         """
-    def extended_product(self, other: stim.PauliString) -> Tuple[complex, stim.PauliString]:
+    def extended_product(
+        self,
+        other: stim.PauliString,
+    ) -> Tuple[complex, stim.PauliString]:
         """[DEPRECATED] Use multiplication (__mul__ or *) instead.
         """
     @staticmethod
-    def random(num_qubits: int, *, allow_imaginary: bool = False) -> stim.PauliString:
+    def random(
+        num_qubits: int,
+        *,
+        allow_imaginary: bool = False,
+    ) -> stim.PauliString:
         """Samples a uniformly random Hermitian Pauli string over the given number of qubits.
 
         Args:
@@ -3147,7 +3711,9 @@ class PauliString:
             The sampled Pauli string.
         """
     @property
-    def sign(self) -> complex:
+    def sign(
+        self,
+    ) -> complex:
         """The sign of the Pauli string. Can be +1, -1, 1j, or -1j.
 
         Examples:
@@ -3197,7 +3763,10 @@ class Tableau:
         >>> t_inv(x2z3)
         stim.PauliString("+__XZ_")
     """
-    def __add__(self, rhs: stim.Tableau) -> stim.Tableau:
+    def __add__(
+        self,
+        rhs: stim.Tableau,
+    ) -> stim.Tableau:
         """Returns the direct sum (diagonal concatenation) of two Tableaus.
 
         Args:
@@ -3218,7 +3787,10 @@ class Tableau:
         Returns:
             The direct sum.
         """
-    def __call__(self, pauli_string: stim.PauliString) -> stim.PauliString:
+    def __call__(
+        self,
+        pauli_string: stim.PauliString,
+    ) -> stim.PauliString:
         """Returns the result of conjugating the given PauliString by the Tableau's Clifford operation.
 
         Args:
@@ -3235,10 +3807,16 @@ class Tableau:
             >>> print(result)
             +X_
         """
-    def __eq__(self, arg0: stim.Tableau) -> bool:
+    def __eq__(
+        self,
+        arg0: stim.Tableau,
+    ) -> bool:
         """Determines if two tableaus have identical contents.
         """
-    def __iadd__(self, rhs: stim.Tableau) -> stim.Tableau:
+    def __iadd__(
+        self,
+        rhs: stim.Tableau,
+    ) -> stim.Tableau:
         """Performs an inplace direct sum (diagonal concatenation).
 
         Args:
@@ -3263,7 +3841,10 @@ class Tableau:
         Returns:
             The mutated tableau.
         """
-    def __init__(self, num_qubits: int) -> None:
+    def __init__(
+        self,
+        num_qubits: int,
+    ) -> None:
         """Creates an identity tableau over the given number of qubits.
 
         Examples:
@@ -3279,10 +3860,15 @@ class Tableau:
         Args:
             num_qubits: The number of qubits the tableau's operation acts on.
         """
-    def __len__(self) -> int:
+    def __len__(
+        self,
+    ) -> int:
         """Returns the number of qubits operated on by the tableau.
         """
-    def __mul__(self, rhs: stim.Tableau) -> stim.Tableau:
+    def __mul__(
+        self,
+        rhs: stim.Tableau,
+    ) -> stim.Tableau:
         """Returns the product of two tableaus.
 
         If the tableau T1 represents the Clifford operation with unitary C1,
@@ -3301,10 +3887,16 @@ class Tableau:
             >>> t3(p) == t2(t1(p))
             True
         """
-    def __ne__(self, arg0: stim.Tableau) -> bool:
+    def __ne__(
+        self,
+        arg0: stim.Tableau,
+    ) -> bool:
         """Determines if two tableaus have non-identical contents.
         """
-    def __pow__(self, exponent: int) -> stim.Tableau:
+    def __pow__(
+        self,
+        exponent: int,
+    ) -> stim.Tableau:
         """Raises the tableau to an integer power.
 
         Large powers are reached efficiently using repeated squaring.
@@ -3331,13 +3923,21 @@ class Tableau:
             >>> s**(-400000000 + 1) == s
             True
         """
-    def __repr__(self) -> str:
+    def __repr__(
+        self,
+    ) -> str:
         """Returns text that is a valid python expression evaluating to an equivalent `stim.Tableau`.
         """
-    def __str__(self) -> str:
+    def __str__(
+        self,
+    ) -> str:
         """Returns a text description.
         """
-    def append(self, gate: stim.Tableau, targets: List[int]) -> None:
+    def append(
+        self,
+        gate: stim.Tableau,
+        targets: List[int],
+    ) -> None:
         """Appends an operation's effect into this tableau, mutating this tableau.
 
         Time cost is O(n*m*m) where n=len(self) and m=len(gate).
@@ -3356,7 +3956,9 @@ class Tableau:
             >>> t == stim.Tableau.from_named_gate("SWAP")
             True
         """
-    def copy(self) -> stim.Tableau:
+    def copy(
+        self,
+    ) -> stim.Tableau:
         """Returns a copy of the tableau. An independent tableau with the same contents.
 
         Examples:
@@ -3369,7 +3971,13 @@ class Tableau:
             True
         """
     @staticmethod
-    def from_circuit(circuit: stim.Circuit, *, ignore_noise: bool = False, ignore_measurement: bool = False, ignore_reset: bool = False) -> stim.Tableau:
+    def from_circuit(
+        circuit: stim.Circuit,
+        *,
+        ignore_noise: bool = False,
+        ignore_measurement: bool = False,
+        ignore_reset: bool = False,
+    ) -> stim.Tableau:
 
         """Converts a circuit into an equivalent stabilizer tableau.
 
@@ -3414,7 +4022,11 @@ class Tableau:
             )
         """
     @staticmethod
-    def from_conjugated_generators(*, xs: List[stim.PauliString], zs: List[stim.PauliString]) -> stim.Tableau:
+    def from_conjugated_generators(
+        *,
+        xs: List[stim.PauliString],
+        zs: List[stim.PauliString],
+    ) -> stim.Tableau:
         """Creates a tableau from the given outputs for each generator.
 
         Verifies that the tableau is well formed.
@@ -3448,7 +4060,9 @@ class Tableau:
             True
         """
     @staticmethod
-    def from_named_gate(name: str) -> stim.Tableau:
+    def from_named_gate(
+        name: str,
+    ) -> stim.Tableau:
         """Returns the tableau of a named Clifford gate.
 
         Args:
@@ -3474,7 +4088,11 @@ class Tableau:
             | YZ
         """
     @staticmethod
-    def from_unitary_matrix(matrix: Iterable[Iterable[float]], *, endian: str = 'little') -> stim.Tableau:
+    def from_unitary_matrix(
+        matrix: Iterable[Iterable[float]],
+        *,
+        endian: str = 'little',
+    ) -> stim.Tableau:
 
         """Creates a tableau from the unitary matrix of a Clifford operation.
 
@@ -3524,7 +4142,11 @@ class Tableau:
                 ],
             )
         """
-    def inverse(self, *, unsigned: bool = False) -> stim.Tableau:
+    def inverse(
+        self,
+        *,
+        unsigned: bool = False,
+    ) -> stim.Tableau:
         """Computes the inverse of the tableau.
 
         The inverse T^-1 of a tableau T is the unique tableau with the property that T * T^-1 = T^-1 * T = I where
@@ -3576,7 +4198,12 @@ class Tableau:
             | XZ Z_ X_
             | X_ YX Y_
         """
-    def inverse_x_output(self, input_index: int, *, unsigned: bool = False) -> stim.PauliString:
+    def inverse_x_output(
+        self,
+        input_index: int,
+        *,
+        unsigned: bool = False,
+    ) -> stim.PauliString:
         """Returns the result of conjugating an X Pauli generator by the inverse of the tableau.
 
         A faster version of `tableau.inverse(unsigned).x_output(input_index)`.
@@ -3602,7 +4229,11 @@ class Tableau:
             >>> t.inverse_x_output(0, unsigned=True) == expected
             True
         """
-    def inverse_x_output_pauli(self, input_index: int, output_index: int) -> int:
+    def inverse_x_output_pauli(
+        self,
+        input_index: int,
+        output_index: int,
+    ) -> int:
         """Returns a Pauli term from the tableau's inverse's output pauli string for an input X generator.
 
         A constant-time equivalent for `tableau.inverse().x_output(input_index)[output_index]`.
@@ -3635,7 +4266,12 @@ class Tableau:
             >>> t_inv.inverse_x_output_pauli(1, 1)
             3
         """
-    def inverse_y_output(self, input_index: int, *, unsigned: bool = False) -> stim.PauliString:
+    def inverse_y_output(
+        self,
+        input_index: int,
+        *,
+        unsigned: bool = False,
+    ) -> stim.PauliString:
         """Returns the result of conjugating a Y Pauli generator by the inverse of the tableau.
 
         A faster version of `tableau.inverse(unsigned).y_output(input_index)`.
@@ -3661,7 +4297,11 @@ class Tableau:
             >>> t.inverse_y_output(0, unsigned=True) == expected
             True
         """
-    def inverse_y_output_pauli(self, input_index: int, output_index: int) -> int:
+    def inverse_y_output_pauli(
+        self,
+        input_index: int,
+        output_index: int,
+    ) -> int:
         """Returns a Pauli term from the tableau's inverse's output pauli string for an input Y generator.
 
         A constant-time equivalent for `tableau.inverse().y_output(input_index)[output_index]`.
@@ -3694,7 +4334,12 @@ class Tableau:
             >>> t_inv.inverse_y_output_pauli(1, 1)
             2
         """
-    def inverse_z_output(self, input_index: int, *, unsigned: bool = False) -> stim.PauliString:
+    def inverse_z_output(
+        self,
+        input_index: int,
+        *,
+        unsigned: bool = False,
+    ) -> stim.PauliString:
         """Returns the result of conjugating a Z Pauli generator by the inverse of the tableau.
 
         A faster version of `tableau.inverse(unsigned).z_output(input_index)`.
@@ -3722,7 +4367,11 @@ class Tableau:
             >>> t.inverse_z_output(0, unsigned=True) == expected
             True
         """
-    def inverse_z_output_pauli(self, input_index: int, output_index: int) -> int:
+    def inverse_z_output_pauli(
+        self,
+        input_index: int,
+        output_index: int,
+    ) -> int:
         """Returns a Pauli term from the tableau's inverse's output pauli string for an input Z generator.
 
         A constant-time equivalent for `tableau.inverse().z_output(input_index)[output_index]`.
@@ -3756,7 +4405,11 @@ class Tableau:
             1
         """
     @staticmethod
-    def iter_all(num_qubits: int, *, unsigned: bool = False) -> stim.TableauIterator:
+    def iter_all(
+        num_qubits: int,
+        *,
+        unsigned: bool = False,
+    ) -> stim.TableauIterator:
         """Returns an iterator that iterates over all Tableaus of a given size.
 
         Args:
@@ -3783,7 +4436,11 @@ class Tableau:
             >>> num_2q_gates_mod_paulis
             720
         """
-    def prepend(self, gate: stim.Tableau, targets: List[int]) -> None:
+    def prepend(
+        self,
+        gate: stim.Tableau,
+        targets: List[int],
+    ) -> None:
         """Prepends an operation's effect into this tableau, mutating this tableau.
 
         Time cost is O(n*m*m) where n=len(self) and m=len(gate).
@@ -3802,7 +4459,9 @@ class Tableau:
             True
         """
     @staticmethod
-    def random(num_qubits: int) -> stim.Tableau:
+    def random(
+        num_qubits: int,
+    ) -> stim.Tableau:
         """Samples a uniformly random Clifford operation over the given number of qubits and returns its tableau.
 
         Args:
@@ -3820,7 +4479,10 @@ class Tableau:
             Sergey Bravyi, Dmitri Maslov
             https://arxiv.org/abs/2003.09412
         """
-    def then(self, second: stim.Tableau) -> stim.Tableau:
+    def then(
+        self,
+        second: stim.Tableau,
+    ) -> stim.Tableau:
         """Returns the result of composing two tableaus.
 
         If the tableau T1 represents the Clifford operation with unitary C1,
@@ -3840,7 +4502,11 @@ class Tableau:
             >>> t3(p) == t2(t1(p))
             True
         """
-    def to_circuit(self, *, method: str) -> stim.Circuit:
+    def to_circuit(
+        self,
+        *,
+        method: str,
+    ) -> stim.Circuit:
 
         """Synthesizes a circuit that implements the tableau's Clifford operation.
 
@@ -3893,7 +4559,11 @@ class Tableau:
                 S 1 1 2 2
             ''')
         """
-    def to_unitary_matrix(self, *, endian: str) -> np.ndarray[np.complex64]:
+    def to_unitary_matrix(
+        self,
+        *,
+        endian: str,
+    ) -> np.ndarray[np.complex64]:
 
         """Converts the tableau into a unitary matrix.
 
@@ -3925,7 +4595,10 @@ class Tableau:
                    [0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j],
                    [0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j]], dtype=complex64)
         """
-    def x_output(self, target: int) -> stim.PauliString:
+    def x_output(
+        self,
+        target: int,
+    ) -> stim.PauliString:
         """Returns the result of conjugating a Pauli X by the tableau's Clifford operation.
 
         Args:
@@ -3943,7 +4616,11 @@ class Tableau:
             >>> cnot.x_output(1)
             stim.PauliString("+_X")
         """
-    def x_output_pauli(self, input_index: int, output_index: int) -> int:
+    def x_output_pauli(
+        self,
+        input_index: int,
+        output_index: int,
+    ) -> int:
         """Returns a Pauli term from the tableau's output pauli string for an input X generator.
 
         A constant-time equivalent for `tableau.x_output(input_index)[output_index]`.
@@ -3976,7 +4653,10 @@ class Tableau:
             >>> t.x_output_pauli(1, 1)
             3
         """
-    def y_output(self, target: int) -> stim.PauliString:
+    def y_output(
+        self,
+        target: int,
+    ) -> stim.PauliString:
         """Returns the result of conjugating a Pauli Y by the tableau's Clifford operation.
 
         Args:
@@ -3994,7 +4674,11 @@ class Tableau:
             >>> cnot.y_output(1)
             stim.PauliString("+ZY")
         """
-    def y_output_pauli(self, input_index: int, output_index: int) -> int:
+    def y_output_pauli(
+        self,
+        input_index: int,
+        output_index: int,
+    ) -> int:
         """Returns a Pauli term from the tableau's output pauli string for an input Y generator.
 
         A constant-time equivalent for `tableau.y_output(input_index)[output_index]`.
@@ -4027,7 +4711,10 @@ class Tableau:
             >>> t.y_output_pauli(1, 1)
             2
         """
-    def z_output(self, target: int) -> stim.PauliString:
+    def z_output(
+        self,
+        target: int,
+    ) -> stim.PauliString:
         """Returns the result of conjugating a Pauli Z by the tableau's Clifford operation.
 
         Args:
@@ -4045,7 +4732,11 @@ class Tableau:
             >>> cnot.z_output(1)
             stim.PauliString("+ZZ")
         """
-    def z_output_pauli(self, input_index: int, output_index: int) -> int:
+    def z_output_pauli(
+        self,
+        input_index: int,
+        output_index: int,
+    ) -> int:
         """Returns a Pauli term from the tableau's output pauli string for an input Z generator.
 
         A constant-time equivalent for `tableau.z_output(input_index)[output_index]`.
@@ -4090,14 +4781,18 @@ class TableauIterator:
         >>> n
         24
     """
-    def __iter__(self) -> stim.TableauIterator:
+    def __iter__(
+        self,
+    ) -> stim.TableauIterator:
         """Returns an independent copy of the tableau iterator.
 
         Since for-loops and loop-comprehensions call `iter` on things they
         iterate, this effectively allows the iterator to be iterated
         multiple times.
         """
-    def __next__(self) -> stim.Tableau:
+    def __next__(
+        self,
+    ) -> stim.Tableau:
         """Returns the next iterated tableau.
         """
 class TableauSimulator:
@@ -4130,19 +4825,27 @@ class TableauSimulator:
             ],
         )
     """
-    def c_xyz(self, *targets) -> None:
+    def c_xyz(
+        self,
+        *targets,
+    ) -> None:
         """Applies a C_XYZ gate to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def c_zyx(self, *targets) -> None:
+    def c_zyx(
+        self,
+        *targets,
+    ) -> None:
         """Applies a C_ZYX gate to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def canonical_stabilizers(self) -> List[stim.PauliString]:
+    def canonical_stabilizers(
+        self,
+    ) -> List[stim.PauliString]:
         """Returns a list of the stabilizers of the simulator's current state in a standard form.
 
         Two simulators have the same canonical stabilizers if and only if their current quantum state is equal
@@ -4178,7 +4881,10 @@ class TableauSimulator:
             >>> s.canonical_stabilizers()
             [stim.PauliString("+XX_"), stim.PauliString("+ZZ_"), stim.PauliString("-__Z")]
         """
-    def cnot(self, *targets) -> None:
+    def cnot(
+        self,
+        *targets,
+    ) -> None:
         """Applies a controlled X gate to the simulator's state.
 
         Args:
@@ -4186,7 +4892,9 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def copy(self) -> stim.TableauSimulator:
+    def copy(
+        self,
+    ) -> stim.TableauSimulator:
         """Returns a copy of the simulator. A simulator with the same internal state.
 
         Examples:
@@ -4213,7 +4921,9 @@ class TableauSimulator:
             >>> s.measure(0)
             True
         """
-    def current_inverse_tableau(self) -> stim.Tableau:
+    def current_inverse_tableau(
+        self,
+    ) -> stim.Tableau:
         """Returns a copy of the internal state of the simulator as a stim.Tableau.
 
         Returns:
@@ -4245,7 +4955,9 @@ class TableauSimulator:
                 ],
             )
         """
-    def current_measurement_record(self) -> List[bool]:
+    def current_measurement_record(
+        self,
+    ) -> List[bool]:
         """Returns a copy of the record of all measurements performed by the simulator.
 
         Examples:
@@ -4267,7 +4979,10 @@ class TableauSimulator:
         Returns:
             A list of booleans containing the result of every measurement performed by the simulator so far.
         """
-    def cx(self, *targets) -> None:
+    def cx(
+        self,
+        *targets,
+    ) -> None:
         """Applies a controlled X gate to the simulator's state.
 
         Args:
@@ -4275,7 +4990,10 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def cy(self, *targets) -> None:
+    def cy(
+        self,
+        *targets,
+    ) -> None:
         """Applies a controlled Y gate to the simulator's state.
 
         Args:
@@ -4283,7 +5001,10 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def cz(self, *targets) -> None:
+    def cz(
+        self,
+        *targets,
+    ) -> None:
         """Applies a controlled Z gate to the simulator's state.
 
         Args:
@@ -4292,12 +5013,21 @@ class TableauSimulator:
                 There must be an even number of targets.
         """
     @overload
-    def do(self, circuit_or_pauli_string: stim.Circuit) -> None:
+    def do(
+        self,
+        circuit_or_pauli_string: stim.Circuit,
+    ) -> None:
         pass
     @overload
-    def do(self, circuit_or_pauli_string: stim.PauliString) -> None:
+    def do(
+        self,
+        circuit_or_pauli_string: stim.PauliString,
+    ) -> None:
         pass
-    def do(self, circuit_or_pauli_string: object) -> None:
+    def do(
+        self,
+        circuit_or_pauli_string: object,
+    ) -> None:
         """Applies a circuit or pauli string to the simulator's state.
 
         Args:
@@ -4318,7 +5048,10 @@ class TableauSimulator:
             >>> s.measure_many(0, 1, 2, 3)
             [False, True, True, False]
         """
-    def do_circuit(self, circuit: stim.Circuit) -> None:
+    def do_circuit(
+        self,
+        circuit: stim.Circuit,
+    ) -> None:
         """Applies a circuit to the simulator's state.
 
         Args:
@@ -4334,7 +5067,10 @@ class TableauSimulator:
             >>> s.current_measurement_record()
             [True]
         """
-    def do_pauli_string(self, pauli_string: stim.PauliString) -> None:
+    def do_pauli_string(
+        self,
+        pauli_string: stim.PauliString,
+    ) -> None:
         """Applies the paulis from a pauli string to the simulator's state.
 
         Args:
@@ -4347,7 +5083,11 @@ class TableauSimulator:
             >>> s.measure_many(0, 1, 2, 3)
             [False, True, True, False]
         """
-    def do_tableau(self, tableau: stim.Tableau, targets: List[int]) -> None:
+    def do_tableau(
+        self,
+        tableau: stim.Tableau,
+        targets: List[int],
+    ) -> None:
         """Applies a custom tableau operation to qubits in the simulator.
 
         Note that this method has to compute the inverse of the tableau, because the
@@ -4385,31 +5125,46 @@ class TableauSimulator:
             >>> [str(sim.peek_bloch(k)) for k in range(4)]
             ['+Z', '+Y', '+Z', '+X']
         """
-    def h(self, *targets) -> None:
+    def h(
+        self,
+        *targets,
+    ) -> None:
         """Applies a Hadamard gate to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def h_xy(self, *targets) -> None:
+    def h_xy(
+        self,
+        *targets,
+    ) -> None:
         """Applies a variant of the Hadamard gate that swaps the X and Y axes to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def h_xz(self, *targets) -> None:
+    def h_xz(
+        self,
+        *targets,
+    ) -> None:
         """Applies a Hadamard gate to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def h_yz(self, *targets) -> None:
+    def h_yz(
+        self,
+        *targets,
+    ) -> None:
         """Applies a variant of the Hadamard gate that swaps the Y and Z axes to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def iswap(self, *targets) -> None:
+    def iswap(
+        self,
+        *targets,
+    ) -> None:
         """Applies an ISWAP gate to the simulator's state.
 
         Args:
@@ -4417,7 +5172,10 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def iswap_dag(self, *targets) -> None:
+    def iswap_dag(
+        self,
+        *targets,
+    ) -> None:
         """Applies an ISWAP_DAG gate to the simulator's state.
 
         Args:
@@ -4425,7 +5183,10 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def measure(self, target: int) -> bool:
+    def measure(
+        self,
+        target: int,
+    ) -> bool:
         """Measures a single qubit.
 
         Unlike the other methods on TableauSimulator, this one does not broadcast
@@ -4440,7 +5201,10 @@ class TableauSimulator:
         Returns:
             The measurement result as a bool.
         """
-    def measure_kickback(self, target: int) -> tuple:
+    def measure_kickback(
+        self,
+        target: int,
+    ) -> tuple:
         """Measures a qubit and returns the result as well as its Pauli kickback (if any).
 
         The "Pauli kickback" of a stabilizer circuit measurement is a set of Pauli operations that
@@ -4491,7 +5255,10 @@ class TableauSimulator:
             >>> s.measure_many(0, 1, 2)
             [True, True, True]
         """
-    def measure_many(self, *targets) -> List[bool]:
+    def measure_many(
+        self,
+        *targets,
+    ) -> List[bool]:
         """Measures multiple qubits.
 
         Args:
@@ -4501,7 +5268,9 @@ class TableauSimulator:
             The measurement results as a list of bools.
         """
     @property
-    def num_qubits(self) -> int:
+    def num_qubits(
+        self,
+    ) -> int:
         """Returns the number of qubits currently being tracked by the simulator's internal state.
 
         Note that the number of qubits being tracked will implicitly increase if qubits beyond
@@ -4516,7 +5285,10 @@ class TableauSimulator:
             >>> s.num_qubits
             3
         """
-    def peek_bloch(self, target: int) -> stim.PauliString:
+    def peek_bloch(
+        self,
+        target: int,
+    ) -> stim.PauliString:
         """Returns the current bloch vector of the qubit, represented as a stim.PauliString.
 
         This is a non-physical operation. It reports information about the qubit without disturbing it.
@@ -4551,7 +5323,10 @@ class TableauSimulator:
             >>> s.peek_bloch(0)
             stim.PauliString("+_")
         """
-    def peek_observable_expectation(self, observable: stim.PauliString) -> int:
+    def peek_observable_expectation(
+        self,
+        observable: stim.PauliString,
+    ) -> int:
         """Determines the expected value of an observable (which will always be -1, 0, or +1).
 
         This is a non-physical operation.
@@ -4591,7 +5366,10 @@ class TableauSimulator:
             II 1
             IIZ 1
         """
-    def peek_x(self, target: int) -> int:
+    def peek_x(
+        self,
+        target: int,
+    ) -> int:
         """Returns the expected value of a qubit's X observable (which will always be -1, 0, or +1).
 
         This is a non-physical operation.
@@ -4618,7 +5396,10 @@ class TableauSimulator:
             >>> s.peek_x(0)
             -1
         """
-    def peek_y(self, target: int) -> int:
+    def peek_y(
+        self,
+        target: int,
+    ) -> int:
         """Returns the expected value of a qubit's Y observable (which will always be -1, 0, or +1).
 
         This is a non-physical operation.
@@ -4645,7 +5426,10 @@ class TableauSimulator:
             >>> s.peek_y(0)
             -1
         """
-    def peek_z(self, target: int) -> int:
+    def peek_z(
+        self,
+        target: int,
+    ) -> int:
         """Returns the expected value of a qubit's Z observable (which will always be -1, 0, or +1).
 
         This is a non-physical operation.
@@ -4672,7 +5456,12 @@ class TableauSimulator:
             >>> s.peek_z(0)
             -1
         """
-    def postselect_x(self, targets: Union[int, Iterable[int]], *, desired_value: bool) -> None:
+    def postselect_x(
+        self,
+        targets: Union[int, Iterable[int]],
+        *,
+        desired_value: bool,
+    ) -> None:
 
         """Postselects qubits in the X basis, or raises an exception.
 
@@ -4692,7 +5481,12 @@ class TableauSimulator:
                 impossible for a measurement of the qubit to return the
                 desired result.
         """
-    def postselect_y(self, targets: Union[int, Iterable[int]], *, desired_value: bool) -> None:
+    def postselect_y(
+        self,
+        targets: Union[int, Iterable[int]],
+        *,
+        desired_value: bool,
+    ) -> None:
 
         """Postselects qubits in the Y basis, or raises an exception.
 
@@ -4712,7 +5506,12 @@ class TableauSimulator:
                 impossible for a measurement of the qubit to return the
                 desired result.
         """
-    def postselect_z(self, targets: Union[int, Iterable[int]], *, desired_value: bool) -> None:
+    def postselect_z(
+        self,
+        targets: Union[int, Iterable[int]],
+        *,
+        desired_value: bool,
+    ) -> None:
 
         """Postselects qubits in the Z basis, or raises an exception.
 
@@ -4732,7 +5531,10 @@ class TableauSimulator:
                 impossible for a measurement of the qubit to return the
                 desired result.
         """
-    def reset(self, *targets) -> None:
+    def reset(
+        self,
+        *targets,
+    ) -> None:
         """Resets qubits to the |0> state.
 
         Args:
@@ -4746,7 +5548,10 @@ class TableauSimulator:
             >>> s.peek_bloch(0)
             stim.PauliString("+Z")
         """
-    def reset_x(self, *targets) -> None:
+    def reset_x(
+        self,
+        *targets,
+    ) -> None:
         """Resets qubits to the |+> state.
 
         Args:
@@ -4759,7 +5564,10 @@ class TableauSimulator:
             >>> s.peek_bloch(0)
             stim.PauliString("+X")
         """
-    def reset_y(self, *targets) -> None:
+    def reset_y(
+        self,
+        *targets,
+    ) -> None:
         """Resets qubits to the |i> state.
 
         Args:
@@ -4772,7 +5580,10 @@ class TableauSimulator:
             >>> s.peek_bloch(0)
             stim.PauliString("+Y")
         """
-    def reset_z(self, *targets) -> None:
+    def reset_z(
+        self,
+        *targets,
+    ) -> None:
         """Resets qubits to the |0> state.
 
         Args:
@@ -4786,19 +5597,28 @@ class TableauSimulator:
             >>> s.peek_bloch(0)
             stim.PauliString("+Z")
         """
-    def s(self, *targets) -> None:
+    def s(
+        self,
+        *targets,
+    ) -> None:
         """Applies a SQRT_Z gate to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def s_dag(self, *targets) -> None:
+    def s_dag(
+        self,
+        *targets,
+    ) -> None:
         """Applies a SQRT_Z_DAG gate to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def set_inverse_tableau(self, new_inverse_tableau: stim.Tableau) -> None:
+    def set_inverse_tableau(
+        self,
+        new_inverse_tableau: stim.Tableau,
+    ) -> None:
         """Overwrites the simulator's internal state with a copy of the given inverse tableau.
 
         The inverse tableau specifies how Pauli product observables of qubits at the current time transform
@@ -4821,7 +5641,10 @@ class TableauSimulator:
             >>> s.current_inverse_tableau() == t
             True
         """
-    def set_num_qubits(self, new_num_qubits: int) -> None:
+    def set_num_qubits(
+        self,
+        new_num_qubits: int,
+    ) -> None:
         """Forces the simulator's internal state to track exactly the qubits whose indices are in range(new_num_qubits).
 
         Note that untracked qubits are always assumed to be in the |0> state. Therefore, calling this method
@@ -4849,7 +5672,13 @@ class TableauSimulator:
             >>> s.measure_many(0, 1, 2, 3)
             [True, True, False, False]
         """
-    def set_state_from_stabilizers(self, stabilizers: Iterable[stim.PauliString], *, bool allow_redundant = False, bool allow_underconstrained = False) -> None:
+    def set_state_from_stabilizers(
+        self,
+        stabilizers: Iterable[stim.PauliString],
+        *,
+        bool allow_redundant = False,
+        bool allow_underconstrained = False,
+    ) -> None:
 
         """Sets the tableau simulator's state to a state satisfying the given stabilizers.
 
@@ -4929,7 +5758,12 @@ class TableauSimulator:
                 ],
             )
         """
-    def set_state_from_state_vector(self, state_vector: Iterable[float], *, endian: str) -> None:
+    def set_state_from_state_vector(
+        self,
+        state_vector: Iterable[float],
+        *,
+        endian: str,
+    ) -> None:
 
         """Sets the tableau simulator's state to a superposition specified by a vector of amplitudes.
 
@@ -4987,31 +5821,47 @@ class TableauSimulator:
                 ],
             )
         """
-    def sqrt_x(self, *targets) -> None:
+    def sqrt_x(
+        self,
+        *targets,
+    ) -> None:
         """Applies a SQRT_X gate to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def sqrt_x_dag(self, *targets) -> None:
+    def sqrt_x_dag(
+        self,
+        *targets,
+    ) -> None:
         """Applies a SQRT_X_DAG gate to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def sqrt_y(self, *targets) -> None:
+    def sqrt_y(
+        self,
+        *targets,
+    ) -> None:
         """Applies a SQRT_Y gate to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def sqrt_y_dag(self, *targets) -> None:
+    def sqrt_y_dag(
+        self,
+        *targets,
+    ) -> None:
         """Applies a SQRT_Y_DAG gate to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def state_vector(self, *, endian: str = 'little') -> np.ndarray[np.complex64]:
+    def state_vector(
+        self,
+        *,
+        endian: str = 'little',
+    ) -> np.ndarray[np.complex64]:
 
         """Returns a wavefunction that satisfies the stabilizers of the simulator's current state.
 
@@ -5053,7 +5903,10 @@ class TableauSimulator:
             >>> list(s.state_vector())
             [(0.5+0j), 0j, -0.5j, 0j, 0.5j, 0j, (0.5+0j), 0j]
         """
-    def swap(self, *targets) -> None:
+    def swap(
+        self,
+        *targets,
+    ) -> None:
         """Applies a swap gate to the simulator's state.
 
         Args:
@@ -5061,13 +5914,19 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def x(self, *targets) -> None:
+    def x(
+        self,
+        *targets,
+    ) -> None:
         """Applies a Pauli X gate to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def xcx(self, *targets) -> None:
+    def xcx(
+        self,
+        *targets,
+    ) -> None:
         """Applies an X-controlled X gate to the simulator's state.
 
         Args:
@@ -5075,7 +5934,10 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def xcy(self, *targets) -> None:
+    def xcy(
+        self,
+        *targets,
+    ) -> None:
         """Applies an X-controlled Y gate to the simulator's state.
 
         Args:
@@ -5083,7 +5945,10 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def xcz(self, *targets) -> None:
+    def xcz(
+        self,
+        *targets,
+    ) -> None:
         """Applies an X-controlled Z gate to the simulator's state.
 
         Args:
@@ -5091,13 +5956,19 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def y(self, *targets) -> None:
+    def y(
+        self,
+        *targets,
+    ) -> None:
         """Applies a Pauli Y gate to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def ycx(self, *targets) -> None:
+    def ycx(
+        self,
+        *targets,
+    ) -> None:
         """Applies a Y-controlled X gate to the simulator's state.
 
         Args:
@@ -5105,7 +5976,10 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def ycy(self, *targets) -> None:
+    def ycy(
+        self,
+        *targets,
+    ) -> None:
         """Applies a Y-controlled Y gate to the simulator's state.
 
         Args:
@@ -5113,7 +5987,10 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def ycz(self, *targets) -> None:
+    def ycz(
+        self,
+        *targets,
+    ) -> None:
         """Applies a Y-controlled Z gate to the simulator's state.
 
         Args:
@@ -5121,13 +5998,19 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def z(self, *targets) -> None:
+    def z(
+        self,
+        *targets,
+    ) -> None:
         """Applies a Pauli Z gate to the simulator's state.
 
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
-    def zcx(self, *targets) -> None:
+    def zcx(
+        self,
+        *targets,
+    ) -> None:
         """Applies a controlled X gate to the simulator's state.
 
         Args:
@@ -5135,7 +6018,10 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def zcy(self, *targets) -> None:
+    def zcy(
+        self,
+        *targets,
+    ) -> None:
         """Applies a controlled Y gate to the simulator's state.
 
         Args:
@@ -5143,7 +6029,10 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-    def zcz(self, *targets) -> None:
+    def zcz(
+        self,
+        *targets,
+    ) -> None:
         """Applies a controlled Z gate to the simulator's state.
 
         Args:
@@ -5151,7 +6040,10 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets, and so forth.
                 There must be an even number of targets.
         """
-def main(*, command_line_args: List[str]) -> int:
+def main(
+    *,
+    command_line_args: List[str],
+) -> int:
     """Runs the command line tool version of stim on the given arguments.
 
     Note that by default any input will be read from stdin, any output
@@ -5221,7 +6113,15 @@ def main(*, command_line_args: List[str]) -> int:
         DETECTOR(1, 1) rec[-1] rec[-2] rec[-3]
         OBSERVABLE_INCLUDE(0) rec[-1]
     """
-def read_shot_data_file(*, path: str, format: str, num_measurements: int = 0, num_detectors: int = 0, num_observables: int = 0, bit_pack: bool = False) -> np.ndarray:
+def read_shot_data_file(
+    *,
+    path: str,
+    format: str,
+    num_measurements: int = 0,
+    num_detectors: int = 0,
+    num_observables: int = 0,
+    bit_pack: bool = False,
+) -> np.ndarray:
 
     """Reads shot data, such as measurement samples, from a file.
 
@@ -5267,15 +6167,20 @@ def read_shot_data_file(*, path: str, format: str, num_measurements: int = 0, nu
         array([[False, False, False, False],
                [False,  True, False,  True]])
     """
-def target_combiner() -> stim.GateTarget:
+def target_combiner(
+) -> stim.GateTarget:
     """Returns a target combiner (`*` in circuit files) that can be used as an operation target.
     """
-def target_inv(qubit_index: int) -> stim.GateTarget:
+def target_inv(
+    qubit_index: int,
+) -> stim.GateTarget:
     """Returns a target flagged as inverted that can be passed into Circuit.append_operation
     For example, the '!1' in 'M 0 !1 2' is qubit 1 flagged as inverted,
     meaning the measurement result from qubit 1 should be inverted when reported.
     """
-def target_logical_observable_id(index: int) -> stim.DemTarget:
+def target_logical_observable_id(
+    index: int,
+) -> stim.DemTarget:
     """Returns a logical observable id identifying a frame change (e.g. "L5" in a .dem file).
 
     Args:
@@ -5295,11 +6200,15 @@ def target_logical_observable_id(index: int) -> stim.DemTarget:
             error(0.25) L13
         ''')
     """
-def target_rec(lookback_index: int) -> stim.GateTarget:
+def target_rec(
+    lookback_index: int,
+) -> stim.GateTarget:
     """Returns a record target that can be passed into Circuit.append_operation.
     For example, the 'rec[-2]' in 'DETECTOR rec[-2]' is a record target.
     """
-def target_relative_detector_id(index: int) -> stim.DemTarget:
+def target_relative_detector_id(
+    index: int,
+) -> stim.DemTarget:
     """Returns a relative detector id (e.g. "D5" in a .dem file).
 
     Args:
@@ -5319,7 +6228,8 @@ def target_relative_detector_id(index: int) -> stim.DemTarget:
             error(0.25) D13
         ''')
     """
-def target_separator() -> stim.DemTarget:
+def target_separator(
+) -> stim.DemTarget:
     """Returns a target separator (e.g. "^" in a .dem file).
 
     Examples:
@@ -5335,23 +6245,42 @@ def target_separator() -> stim.DemTarget:
             error(0.25) D1 ^ D2
         ''')
     """
-def target_sweep_bit(sweep_bit_index: int) -> stim.GateTarget:
+def target_sweep_bit(
+    sweep_bit_index: int,
+) -> stim.GateTarget:
     """Returns a sweep bit target that can be passed into Circuit.append_operation
     For example, the 'sweep[5]' in 'CNOT sweep[5] 7' is from `stim.target_sweep_bit(5)`.
     """
-def target_x(qubit_index: int, invert: bool = False) -> stim.GateTarget:
+def target_x(
+    qubit_index: int,
+    invert: bool = False,
+) -> stim.GateTarget:
     """Returns a target flagged as Pauli X that can be passed into Circuit.append_operation
     For example, the 'X1' in 'CORRELATED_ERROR(0.1) X1 Y2 Z3' is qubit 1 flagged as Pauli X.
     """
-def target_y(qubit_index: int, invert: bool = False) -> stim.GateTarget:
+def target_y(
+    qubit_index: int,
+    invert: bool = False,
+) -> stim.GateTarget:
     """Returns a target flagged as Pauli Y that can be passed into Circuit.append_operation
     For example, the 'Y2' in 'CORRELATED_ERROR(0.1) X1 Y2 Z3' is qubit 2 flagged as Pauli Y.
     """
-def target_z(qubit_index: int, invert: bool = False) -> stim.GateTarget:
+def target_z(
+    qubit_index: int,
+    invert: bool = False,
+) -> stim.GateTarget:
     """Returns a target flagged as Pauli Z that can be passed into Circuit.append_operation
     For example, the 'Z3' in 'CORRELATED_ERROR(0.1) X1 Y2 Z3' is qubit 3 flagged as Pauli Z.
     """
-def write_shot_data_file(*, data: object, path: str, format: str, num_measurements: Any = None, num_detectors: Any = None, num_observables: Any = None) -> None:
+def write_shot_data_file(
+    *,
+    data: object,
+    path: str,
+    format: str,
+    num_measurements: Any = None,
+    num_detectors: Any = None,
+    num_observables: Any = None,
+) -> None:
     """Writes shot data, such as measurement samples, to a file.
 
     Args:

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -5218,7 +5218,7 @@ class TableauSimulator:
         if in the previous example there was a third qubit in the |0> state, then both
         `stim.PauliString("XX_")` and `stim.PauliString("XXZ")` are valid kickbacks.
 
-        Measurements with determinist results don't have a Pauli kickback.
+        Measurements with deterministic results don't have a Pauli kickback.
 
         Args:
             target: The index of the qubit to measure.

--- a/glue/sample/requirements.txt
+++ b/glue/sample/requirements.txt
@@ -4,4 +4,4 @@ numpy ~= 1.22
 pymatching ~= 0.7.0
 pytest ~= 7.0
 pandas ~= 1.4
-stim ~= 1.9.dev
+stim ~= 1.9

--- a/src/stim/circuit/circuit.cc
+++ b/src/stim/circuit/circuit.cc
@@ -279,6 +279,7 @@ Circuit::Circuit(Circuit &&circuit) noexcept
 Circuit &Circuit::operator=(const Circuit &circuit) {
     if (&circuit != this) {
         blocks = circuit.blocks;
+        operations = circuit.operations;
 
         // Keep local copy of operation data.
         target_buf = MonotonicBuffer<GateTarget>(circuit.target_buf.total_allocated());

--- a/src/stim/circuit/circuit.h
+++ b/src/stim/circuit/circuit.h
@@ -191,6 +191,7 @@ struct Circuit {
     /// Returns an equivalent circuit without REPEAT or SHIFT_COORDS instructions.
     Circuit flattened() const;
 
+    /// Helper method for executing the circuit, e.g. repeating REPEAT blocks.
     template <typename CALLBACK>
     void for_each_operation(const CALLBACK &callback) const {
         for (const auto &op : operations) {
@@ -210,6 +211,7 @@ struct Circuit {
         }
     }
 
+    /// Helper method for reverse-executing the circuit, e.g. repeating REPEAT blocks.
     template <typename CALLBACK>
     void for_each_operation_reverse(const CALLBACK &callback) const {
         for (size_t p = operations.size(); p-- > 0;) {
@@ -230,6 +232,7 @@ struct Circuit {
         }
     }
 
+    /// Helper method for counting measurements, detectors, etc.
     template <typename COUNT>
     uint64_t flat_count_operations(const COUNT &count) const {
         uint64_t n = 0;
@@ -248,6 +251,7 @@ struct Circuit {
         return n;
     }
 
+    /// Helper method for finding the largest observable, etc.
     template <typename MAP>
     uint64_t max_operation_property(const MAP &map) const {
         uint64_t n = 0;
@@ -270,10 +274,39 @@ struct Circuit {
     /// file, not time proportional to the amount of data produced by the circuit.
     std::map<uint64_t, std::vector<double>> get_final_qubit_coords() const;
 
+    /// Looks up the coordinate data of a detector.
+    ///
+    /// Args:
+    ///     detector_index: The index of the detector to get coordinate data for.
+    ///         Detectors are indexed by the order they appear in the circuit (accounting for repeat blocks).
+    ///
+    /// Returns:
+    ///     The coordinate data for the detector.
+    ///     If the detector has no coordinate data, an empty vector is returned.
+    ///
+    /// Throws:
+    ///     std::invalid_argument: The detector index is greater than or equal to circuit.count_detectors().
     std::vector<double> coords_of_detector(uint64_t detector_index) const;
+
+    /// Looks up the coordinate data of a given set of detectors.
+    ///
+    /// Args:
+    ///     included_detector_indices: An ordered set of the indices of detectors to get coordinate data for.
+    ///
+    /// Returns:
+    ///     A map from detector index to coordinate data.
+    ///     Every index from included_detector_indices will be in this map as a key.
+    ///     Detectors with no coordinate data are mapped to an empty vector.
+    ///
+    /// Throws:
+    ///     std::invalid_argument: A detector index is greater than or equal to circuit.count_detectors().
     std::map<uint64_t, std::vector<double>> get_detector_coordinates(
         const std::set<uint64_t> &included_detector_indices) const;
+
+    /// Returns the total coordinate shift accumulated over the entire circuit, accounting for REPEAT blocks.
     std::vector<double> final_coord_shift() const;
+
+    /// Helper method for building up human readable descriptions of circuit locations.
     std::string describe_instruction_location(size_t instruction_offset) const;
 };
 

--- a/src/stim/circuit/circuit.test.cc
+++ b/src/stim/circuit/circuit.test.cc
@@ -1293,3 +1293,13 @@ TEST(circuit, concat_self_fuse) {
     ASSERT_EQ(c.operations.size(), 1);
     ASSERT_EQ(c, Circuit("H 0 0"));
 }
+
+TEST(circuit, assignment_copies_operations) {
+    Circuit c1("H 0 1\nS 0");
+    Circuit c2("TICK");
+    ASSERT_EQ(c1.operations.size(), 2);
+    ASSERT_EQ(c2.operations.size(), 1);
+    c2 = c1;
+    ASSERT_EQ(c2.operations.size(), 2);
+    ASSERT_EQ(c1, c2);
+}

--- a/src/stim/circuit/gate_data.h
+++ b/src/stim/circuit/gate_data.h
@@ -108,6 +108,8 @@ enum GateFlags : uint16_t {
     GATE_ARGS_ARE_UNSIGNED_INTEGERS = 1 << 11,
     // Controls instructions like MPP taking Pauli product combiners ("X1*Y2 Z3").
     GATE_TARGETS_COMBINERS = 1 << 12,
+    // Measurements and resets are dissipative operations.
+    GATE_IS_RESET = 1 << 13,
 };
 
 struct ExtraGateData {

--- a/src/stim/circuit/gate_data_annotations.cc
+++ b/src/stim/circuit/gate_data_annotations.cc
@@ -71,9 +71,8 @@ Targets:
 
     The measurement records to XOR together to get the deterministic-under-noiseless-execution parity.
 
-- Example:
+Example:
 
-    ```
     R 0
     X_ERROR(0.1) 0
     M 0  # This measurement is always False under noiseless execution.
@@ -102,7 +101,6 @@ Targets:
         SHIFT_COORDS(1, 2)
         DETECTOR(0, 3) rec[-1]
     }
-    ```
 )MARKDOWN",
                     {},
                     {},
@@ -161,9 +159,8 @@ Targets:
 
     The measurement records to add to the specified observable.
 
-- Example:
+Example:
 
-    ```
     R 0 1
     H 0
     CNOT 0 1
@@ -179,7 +176,6 @@ Targets:
     OBSERVABLE_INCLUDE(1) rec[-1]
     # ...and the one before that.
     OBSERVABLE_INCLUDE(1) rec[-2]
-    ```
 )MARKDOWN",
                     {},
                     {},
@@ -218,9 +214,8 @@ Targets:
 
     This instruction takes no targets.
 
-- Example:
+Example:
 
-    ```
     # First time step.
     H 0
     CZ 1 2
@@ -232,7 +227,6 @@ Targets:
 
     # Empty time step.
     TICK
-    ```
 )MARKDOWN",
                     {},
                     {},
@@ -276,15 +270,13 @@ Targets:
 
     The qubit or qubits the coordinates apply to.
 
-- Example:
+Example:
 
-    ```
     # Annotate that qubits 0 to 3 are at the corners of a square.
     QUBIT_COORDS(0, 0) 0
     QUBIT_COORDS(0, 1) 1
     QUBIT_COORDS(1, 0) 2
     QUBIT_COORDS(1, 1) 3
-    ```
 )MARKDOWN",
                     {},
                     {},
@@ -323,9 +315,8 @@ Targets:
 
     This instruction takes no targets.
 
-- Example:
+Example:
 
-    ```
     SHIFT_COORDS(500.5)
     QUBIT_COORDS(1510) 0  # Actually at 2010.5
     SHIFT_COORDS(1500)
@@ -340,7 +331,6 @@ Targets:
         DETECTOR(10.5, 0) rec[-1] rec[-2]  # Actually at (2011.0, iteration_count).
         SHIFT_COORDS(0, 1)  # Advance 2nd coordinate to track loop iterations.
     }
-    ```
 )MARKDOWN",
                     {},
                     {},

--- a/src/stim/circuit/gate_data_blocks.cc
+++ b/src/stim/circuit/gate_data_blocks.cc
@@ -47,9 +47,8 @@ Targets:
 
     A positive integer in [1, 10^18] specifying the number of repetitions.
 
-- Example:
+Example:
 
-    ```
     REPEAT 2 {
         CNOT 0 1
         CNOT 2 1
@@ -61,7 +60,6 @@ Targets:
         M 1
         DETECTOR rec[-1] rec[-3]
     }
-    ```
 )MARKDOWN",
                     {},
                     {},

--- a/src/stim/circuit/gate_data_collapsing.cc
+++ b/src/stim/circuit/gate_data_collapsing.cc
@@ -199,7 +199,7 @@ M 0
             &TableauSimulator::measure_reset_x,
             &FrameSimulator::measure_reset_x,
             &ErrorAnalyzer::MRX,
-            (GateFlags)(GATE_PRODUCES_NOISY_RESULTS | GATE_ARGS_ARE_DISJOINT_PROBABILITIES| GATE_IS_RESET),
+            (GateFlags)(GATE_PRODUCES_NOISY_RESULTS | GATE_ARGS_ARE_DISJOINT_PROBABILITIES | GATE_IS_RESET),
             []() -> ExtraGateData {
                 return {
                     "L_Collapsing Gates",
@@ -255,7 +255,7 @@ H 0
             &TableauSimulator::measure_reset_y,
             &FrameSimulator::measure_reset_y,
             &ErrorAnalyzer::MRY,
-            (GateFlags)(GATE_PRODUCES_NOISY_RESULTS | GATE_ARGS_ARE_DISJOINT_PROBABILITIES| GATE_IS_RESET),
+            (GateFlags)(GATE_PRODUCES_NOISY_RESULTS | GATE_ARGS_ARE_DISJOINT_PROBABILITIES | GATE_IS_RESET),
             []() -> ExtraGateData {
                 return {
                     "L_Collapsing Gates",
@@ -315,7 +315,7 @@ S 0
             &TableauSimulator::measure_reset_z,
             &FrameSimulator::measure_reset_z,
             &ErrorAnalyzer::MRZ,
-            (GateFlags)(GATE_PRODUCES_NOISY_RESULTS | GATE_ARGS_ARE_DISJOINT_PROBABILITIES| GATE_IS_RESET),
+            (GateFlags)(GATE_PRODUCES_NOISY_RESULTS | GATE_ARGS_ARE_DISJOINT_PROBABILITIES | GATE_IS_RESET),
             []() -> ExtraGateData {
                 return {
                     "L_Collapsing Gates",
@@ -375,7 +375,7 @@ R 0
             &TableauSimulator::reset_x,
             &FrameSimulator::reset_x,
             &ErrorAnalyzer::RX,
-             GATE_IS_RESET,
+            GATE_IS_RESET,
             []() -> ExtraGateData {
                 return {
                     "L_Collapsing Gates",
@@ -417,7 +417,7 @@ H 0
             &TableauSimulator::reset_y,
             &FrameSimulator::reset_y,
             &ErrorAnalyzer::RY,
-             GATE_IS_RESET,
+            GATE_IS_RESET,
             []() -> ExtraGateData {
                 return {
                     "L_Collapsing Gates",
@@ -463,7 +463,7 @@ S 0
             &TableauSimulator::reset_z,
             &FrameSimulator::reset_z,
             &ErrorAnalyzer::RZ,
-             GATE_IS_RESET,
+            GATE_IS_RESET,
             []() -> ExtraGateData {
                 return {
                     "L_Collapsing Gates",

--- a/src/stim/circuit/gate_data_collapsing.cc
+++ b/src/stim/circuit/gate_data_collapsing.cc
@@ -34,18 +34,36 @@ void GateDataMap::add_gate_data_collapsing(bool &failed) {
                 return {
                     "L_Collapsing Gates",
                     R"MARKDOWN(
-X-basis measurement (optionally noisy).
+X-basis measurement.
 Projects each target qubit into `|+>` or `|->` and reports its value (false=`|+>`, true=`|->`).
 
 Parens Arguments:
 
-    Optional.
-    A single float specifying A single float specifying the probability of flipping each reported measurement result.
+    If no parens argument is given, the measurement is perfect.
+    If one parens argument is given, the measurement result is noisy.
+    The argument is the probability of returning the wrong result.
 
 Targets:
 
     The qubits to measure in the X basis.
     Prefixing a qubit target with `!` flips its reported measurement result.
+
+Examples:
+
+    # Measure qubit 5 in the X basis, and append the result into the measurement record.
+    MX 5
+
+    # Measure qubit 5 in the X basis, and append the INVERSE of its result into the measurement record.
+    MX !5
+
+    # Do a noisy measurement where the result put into the measurement record is wrong 1% of the time.
+    MX(0.01) 5
+
+    # Measure multiple qubits in the X basis, putting 3 bits into the measurement record.
+    MX 2 3 5
+
+    # Perform multiple noisy measurements. Each measurement fails independently with 2% probability.
+    MX(0.02) 2 3 5
 )MARKDOWN",
                     {},
                     {"X -> +m xor chance(p)", "X -> +X"},
@@ -70,18 +88,36 @@ H 0
                 return {
                     "L_Collapsing Gates",
                     R"MARKDOWN(
-Y-basis measurement (optionally noisy).
+Y-basis measurement.
 Projects each target qubit into `|i>` or `|-i>` and reports its value (false=`|i>`, true=`|-i>`).
 
 Parens Arguments:
 
-    Optional.
-    A single float specifying the probability of flipping each reported measurement result.
+    If no parens argument is given, the measurement is perfect.
+    If one parens argument is given, the measurement result is noisy.
+    The argument is the probability of returning the wrong result.
 
 Targets:
 
     The qubits to measure in the Y basis.
     Prefixing a qubit target with `!` flips its reported measurement result.
+
+Examples:
+
+    # Measure qubit 5 in the Y basis, and append the result into the measurement record.
+    MY 5
+
+    # Measure qubit 5 in the Y basis, and append the INVERSE of its result into the measurement record.
+    MY !5
+
+    # Do a noisy measurement where the result put into the measurement record is wrong 1% of the time.
+    MY(0.01) 5
+
+    # Measure multiple qubits in the X basis, putting 3 bits into the measurement record.
+    MY 2 3 5
+
+    # Perform multiple noisy measurements. Each measurement fails independently with 2% probability.
+    MY(0.02) 2 3 5
 )MARKDOWN",
                     {},
                     {"Y -> m xor chance(p)", "Y -> +Y"},
@@ -110,18 +146,39 @@ S 0
                 return {
                     "L_Collapsing Gates",
                     R"MARKDOWN(
-Z-basis measurement (optionally noisy).
+Z-basis measurement.
 Projects each target qubit into `|0>` or `|1>` and reports its value (false=`|0>`, true=`|1>`).
 
 Parens Arguments:
 
-    Optional.
-    A single float specifying the probability of flipping each reported measurement result.
+    If no parens argument is given, the measurement is perfect.
+    If one parens argument is given, the measurement result is noisy.
+    The argument is the probability of returning the wrong result.
 
 Targets:
 
     The qubits to measure in the Z basis.
     Prefixing a qubit target with `!` flips its reported measurement result.
+
+Examples:
+
+    # Measure qubit 5 in the Z basis, and append the result into the measurement record.
+    M 5
+
+    # 'MZ' is the same as 'M'. This also measures qubit 5 in the Z basis.
+    MZ 5
+
+    # Measure qubit 5 in the Z basis, and append the INVERSE of its result into the measurement record.
+    MZ !5
+
+    # Do a noisy measurement where the result put into the measurement record is wrong 1% of the time.
+    MZ(0.01) 5
+
+    # Measure multiple qubits in the Z basis, putting 3 bits into the measurement record.
+    MZ 2 3 5
+
+    # Perform multiple noisy measurements. Each measurement fails independently with 2% probability.
+    MZ(0.02) 2 3 5
 )MARKDOWN",
                     {},
                     {"Z -> m xor chance(p)", "Z -> +Z"},
@@ -142,7 +199,7 @@ M 0
             &TableauSimulator::measure_reset_x,
             &FrameSimulator::measure_reset_x,
             &ErrorAnalyzer::MRX,
-            (GateFlags)(GATE_PRODUCES_NOISY_RESULTS | GATE_ARGS_ARE_DISJOINT_PROBABILITIES),
+            (GateFlags)(GATE_PRODUCES_NOISY_RESULTS | GATE_ARGS_ARE_DISJOINT_PROBABILITIES| GATE_IS_RESET),
             []() -> ExtraGateData {
                 return {
                     "L_Collapsing Gates",
@@ -152,13 +209,32 @@ Projects each target qubit into `|+>` or `|->`, reports its value (false=`|+>`, 
 
 Parens Arguments:
 
-    Optional.
-    A single float specifying the probability of flipping each reported measurement result.
+    If no parens argument is given, the demolition measurement is perfect.
+    If one parens argument is given, the demolition measurement's result is noisy.
+    The argument is the probability of returning the wrong result.
+    The argument does not affect the fidelity of the reset.
 
 Targets:
 
     The qubits to measure and reset in the X basis.
     Prefixing a qubit target with `!` flips its reported measurement result.
+
+Examples:
+
+    # Measure qubit 5 in the X basis, reset it to the |+> state, append the measurement result into the measurement record.
+    MRX 5
+
+    # Demolition measure qubit 5 in the X basis, but append the INVERSE of its result into the measurement record.
+    MRX !5
+
+    # Do a noisy demolition measurement where the result put into the measurement record is wrong 1% of the time.
+    MRX(0.01) 5
+
+    # Demolition measure multiple qubits in the X basis, putting 3 bits into the measurement record.
+    MRX 2 3 5
+
+    # Perform multiple noisy demolition measurements. Each measurement result is flipped independently with 2% probability.
+    MRX(0.02) 2 3 5
 )MARKDOWN",
                     {},
                     {"X -> m xor chance(p)", "1 -> +X"},
@@ -179,7 +255,7 @@ H 0
             &TableauSimulator::measure_reset_y,
             &FrameSimulator::measure_reset_y,
             &ErrorAnalyzer::MRY,
-            (GateFlags)(GATE_PRODUCES_NOISY_RESULTS | GATE_ARGS_ARE_DISJOINT_PROBABILITIES),
+            (GateFlags)(GATE_PRODUCES_NOISY_RESULTS | GATE_ARGS_ARE_DISJOINT_PROBABILITIES| GATE_IS_RESET),
             []() -> ExtraGateData {
                 return {
                     "L_Collapsing Gates",
@@ -189,13 +265,32 @@ Projects each target qubit into `|i>` or `|-i>`, reports its value (false=`|i>`,
 
 Parens Arguments:
 
-    Optional.
-    A single float specifying the probability of flipping each reported measurement result.
+    If no parens argument is given, the demolition measurement is perfect.
+    If one parens argument is given, the demolition measurement's result is noisy.
+    The argument is the probability of returning the wrong result.
+    The argument does not affect the fidelity of the reset.
 
 Targets:
 
     The qubits to measure and reset in the Y basis.
     Prefixing a qubit target with `!` flips its reported measurement result.
+
+Examples:
+
+    # Measure qubit 5 in the Y basis, reset it to the |i> state, append the measurement result into the measurement record.
+    MRY 5
+
+    # Demolition measure qubit 5 in the Y basis, but append the INVERSE of its result into the measurement record.
+    MRY !5
+
+    # Do a noisy demolition measurement where the result put into the measurement record is wrong 1% of the time.
+    MRY(0.01) 5
+
+    # Demolition measure multiple qubits in the Y basis, putting 3 bits into the measurement record.
+    MRY 2 3 5
+
+    # Perform multiple noisy demolition measurements. Each measurement result is flipped independently with 2% probability.
+    MRY(0.02) 2 3 5
 )MARKDOWN",
                     {},
                     {"Y -> m xor chance(p)", "1 -> +Y"},
@@ -220,7 +315,7 @@ S 0
             &TableauSimulator::measure_reset_z,
             &FrameSimulator::measure_reset_z,
             &ErrorAnalyzer::MRZ,
-            (GateFlags)(GATE_PRODUCES_NOISY_RESULTS | GATE_ARGS_ARE_DISJOINT_PROBABILITIES),
+            (GateFlags)(GATE_PRODUCES_NOISY_RESULTS | GATE_ARGS_ARE_DISJOINT_PROBABILITIES| GATE_IS_RESET),
             []() -> ExtraGateData {
                 return {
                     "L_Collapsing Gates",
@@ -230,13 +325,35 @@ Projects each target qubit into `|0>` or `|1>`, reports its value (false=`|0>`, 
 
 Parens Arguments:
 
-    Optional.
-    A single float specifying the probability of flipping each reported measurement result.
+    If no parens argument is given, the demolition measurement is perfect.
+    If one parens argument is given, the demolition measurement's result is noisy.
+    The argument is the probability of returning the wrong result.
+    The argument does not affect the fidelity of the reset.
 
 Targets:
 
     The qubits to measure and reset in the Z basis.
     Prefixing a qubit target with `!` flips its reported measurement result.
+
+Examples:
+
+    # Measure qubit 5 in the Z basis, reset it to the |0> state, append the measurement result into the measurement record.
+    MRZ 5
+
+    # MR is also a Z-basis demolition measurement.
+    MR 5
+
+    # Demolition measure qubit 5 in the Z basis, but append the INVERSE of its result into the measurement record.
+    MRZ !5
+
+    # Do a noisy demolition measurement where the result put into the measurement record is wrong 1% of the time.
+    MRZ(0.01) 5
+
+    # Demolition measure multiple qubits in the Z basis, putting 3 bits into the measurement record.
+    MRZ 2 3 5
+
+    # Perform multiple noisy demolition measurements. Each measurement result is flipped independently with 2% probability.
+    MRZ(0.02) 2 3 5
 )MARKDOWN",
                     {},
                     {"Z -> m xor chance(p)", "1 -> +Z"},
@@ -258,7 +375,7 @@ R 0
             &TableauSimulator::reset_x,
             &FrameSimulator::reset_x,
             &ErrorAnalyzer::RX,
-            GATE_NO_FLAGS,
+             GATE_IS_RESET,
             []() -> ExtraGateData {
                 return {
                     "L_Collapsing Gates",
@@ -273,6 +390,14 @@ Parens Arguments:
 Targets:
 
     The qubits to reset in the X basis.
+
+Examples:
+
+    # Reset qubit 5 into the |+> state.
+    RX 5
+
+    # Result multiple qubits into the |+> state.
+    RX 2 3 5
 )MARKDOWN",
                     {},
                     {"1 -> +X"},
@@ -292,7 +417,7 @@ H 0
             &TableauSimulator::reset_y,
             &FrameSimulator::reset_y,
             &ErrorAnalyzer::RY,
-            GATE_NO_FLAGS,
+             GATE_IS_RESET,
             []() -> ExtraGateData {
                 return {
                     "L_Collapsing Gates",
@@ -307,6 +432,14 @@ Parens Arguments:
 Targets:
 
     The qubits to reset in the Y basis.
+
+Examples:
+
+    # Reset qubit 5 into the |i> state.
+    RY 5
+
+    # Result multiple qubits into the |i> state.
+    RY 2 3 5
 )MARKDOWN",
                     {},
                     {"1 -> +Y"},
@@ -330,7 +463,7 @@ S 0
             &TableauSimulator::reset_z,
             &FrameSimulator::reset_z,
             &ErrorAnalyzer::RZ,
-            GATE_NO_FLAGS,
+             GATE_IS_RESET,
             []() -> ExtraGateData {
                 return {
                     "L_Collapsing Gates",
@@ -345,6 +478,17 @@ Parens Arguments:
 Targets:
 
     The qubits to reset in the Z basis.
+
+Examples:
+
+    # Reset qubit 5 into the |0> state.
+    RZ 5
+
+    # R means the same thing as RZ.
+    R 5
+
+    # Reset multiple qubits into the |0> state.
+    RZ 2 3 5
 )MARKDOWN",
                     {},
                     {"1 -> +Z"},
@@ -383,9 +527,8 @@ Targets:
     Each Pauli product is a series of Pauli targets (`[XYZ]#`) separated by combiners (`*`).
     Products can be negated by prefixing a Pauli target in the product with an inverter (`!`)
 
-- Example:
+Examples:
 
-    ```
     # Measure the two-body +X1*Y2 observable.
     MPP X1*Y2
 
@@ -397,7 +540,6 @@ Targets:
 
     # Noisily measure +Z1+Z2 and +X1*X2 (independently flip each reported result 0.1% of the time).
     MPP(0.001) Z1*Z2 X1*X2
-    ```
 
 )MARKDOWN",
                     {},

--- a/src/stim/circuit/gate_data_noisy.cc
+++ b/src/stim/circuit/gate_data_noisy.cc
@@ -47,12 +47,10 @@ Targets:
 
 Pauli Mixture:
 
-    ```
     1-p: I
     p/3: X
     p/3: Y
     p/3: Z
-    ```
 )MARKDOWN",
                     {},
                     {},
@@ -88,7 +86,6 @@ Targets:
 
 Pauli Mixture:
 
-    ```
      1-p: II
     p/15: IX
     p/15: IY
@@ -105,7 +102,6 @@ Pauli Mixture:
     p/15: ZX
     p/15: ZY
     p/15: ZZ
-    ```
 )MARKDOWN",
                     {},
                     {},
@@ -139,10 +135,8 @@ Targets:
 
 Pauli Mixture:
 
-    ```
     1-p: I
      p : X
-    ```
 )MARKDOWN",
                     {},
                     {},
@@ -176,10 +170,8 @@ Targets:
 
 Pauli Mixture:
 
-    ```
     1-p: I
      p : Y
-    ```
 )MARKDOWN",
                     {},
                     {},
@@ -213,10 +205,8 @@ Targets:
 
 Pauli Mixture:
 
-    ```
     1-p: I
      p : Z
-    ```
 )MARKDOWN",
                     {},
                     {},
@@ -251,22 +241,18 @@ Targets:
 
     Qubits to apply the custom noise channel to.
 
-- Example:
+Example:
 
-    ```
     # Sample errors from the distribution 10% X, 15% Y, 20% Z, 55% I.
     # Apply independently to qubits 1, 2, 4.
     PAULI_CHANNEL_1(0.1, 0.15, 0.2) 1 2 4
-    ```
 
 Pauli Mixture:
 
-    ```
     1-px-py-pz: I
     px: X
     py: Y
     pz: Z
-    ```
 )MARKDOWN",
                     {},
                     {},
@@ -317,17 +303,14 @@ Targets:
     Pairs of qubits to apply the custom noise channel to.
     There must be an even number of targets.
 
-- Example:
+Example:
 
-    ```
     # Sample errors from the distribution 10% XX, 20% YZ, 70% II.
     # Apply independently to qubit pairs (1,2), (5,6), and (8,3)
     PAULI_CHANNEL_2(0,0,0, 0.1,0,0,0, 0,0,0,0.2, 0,0,0,0) 1 2 5 6 8 3
-    ```
 
 Pauli Mixture:
 
-    ```
     1-pix-piy-piz-pxi-pxx-pxy-pxz-pyi-pyx-pyy-pyz-pzi-pzx-pzy-pzz: II
     pix: IX
     piy: IY
@@ -344,7 +327,6 @@ Pauli Mixture:
     pzx: ZX
     pzy: ZY
     pzz: ZZ
-    ```
 )MARKDOWN",
                     {},
                     {},
@@ -384,12 +366,10 @@ Targets:
 
 - Example:
 
-    ```
     # With 60% probability, uniformly pick X1*Y2 or Z2*Z3 or X1*Y2*Z3.
     CORRELATED_ERROR(0.2) X1 Y2
     ELSE_CORRELATED_ERROR(0.25) Z2 Z3
     ELSE_CORRELATED_ERROR(0.33333333333) X1 Y2 Z3
-    ```
 )MARKDOWN",
                     {},
                     {},
@@ -432,14 +412,12 @@ Targets:
     Note that, for backwards compatibility reasons, the targets are not combined using combiners (`*`).
     They are implicitly all combined.
 
-- Example:
+Example:
 
-    ```
     # With 60% probability, uniformly pick X1*Y2 or Z2*Z3 or X1*Y2*Z3.
     CORRELATED_ERROR(0.2) X1 Y2
     ELSE_CORRELATED_ERROR(0.25) Z2 Z3
     ELSE_CORRELATED_ERROR(0.33333333333) X1 Y2 Z3
-    ```
 )MARKDOWN",
                     {},
                     {},

--- a/src/stim/help.cc
+++ b/src/stim/help.cc
@@ -765,7 +765,7 @@ void print_fixed_width_float(Acc &out, float f, char u) {
 }
 
 void print_example(Acc &out, const char *name, const Gate &gate) {
-    out << "\n- Example:\n";
+    out << "\nExample:\n";
     out.change_indent(+4);
     for (size_t k = 0; k < 3; k++) {
         out << name;

--- a/src/stim/help.cc
+++ b/src/stim/help.cc
@@ -767,7 +767,6 @@ void print_fixed_width_float(Acc &out, float f, char u) {
 void print_example(Acc &out, const char *name, const Gate &gate) {
     out << "\n- Example:\n";
     out.change_indent(+4);
-    out << "```\n";
     for (size_t k = 0; k < 3; k++) {
         out << name;
         if ((gate.flags & GATE_IS_NOISE) || (k == 2 && (gate.flags & GATE_PRODUCES_NOISY_RESULTS))) {
@@ -799,7 +798,6 @@ void print_example(Acc &out, const char *name, const Gate &gate) {
             out << gate.name << " 111 rec[-1]\n";
         }
     }
-    out << "```\n";
     out.change_indent(-4);
 }
 
@@ -814,14 +812,12 @@ void print_decomposition(Acc &out, const Gate &gate) {
 
         out << "Decomposition (into H, S, CX, M, R):\n";
         out.change_indent(+4);
-        out << "```\n";
         out << "# The following circuit is equivalent (up to global phase) to `";
         out << undecomposed.str() << "`";
         out << decomposition;
         if (Circuit(decomposition) == Circuit(undecomposed.str().data())) {
             out << "\n# (The decomposition is trivial because this gate is in the target gate set.)\n";
         }
-        out << "```\n";
         out.change_indent(-4);
     }
 }
@@ -830,7 +826,6 @@ void print_stabilizer_generators(Acc &out, const Gate &gate) {
     if (gate.flags & GATE_IS_UNITARY) {
         out << "Stabilizer Generators:\n";
         out.change_indent(+4);
-        out << "```\n";
         auto tableau = gate.tableau();
         if (gate.flags & GATE_TARGETS_PAIRS) {
             out << "X_ -> " << tableau.xs[0] << "\n";
@@ -841,18 +836,15 @@ void print_stabilizer_generators(Acc &out, const Gate &gate) {
             out << "X -> " << tableau.xs[0] << "\n";
             out << "Z -> " << tableau.zs[0] << "\n";
         }
-        out << "```\n";
         out.change_indent(-4);
     } else {
         auto data = gate.extra_data_func();
         if (data.tableau_data.size()) {
             out << "Stabilizer Generators:\n";
             out.change_indent(+4);
-            out << "```\n";
             for (const auto &e : data.tableau_data) {
                 out << e << "\n";
             }
-            out << "```\n";
             out.change_indent(-4);
         }
     }
@@ -865,7 +857,6 @@ void print_bloch_vector(Acc &out, const Gate &gate) {
 
     out << "Bloch Rotation:\n";
     out.change_indent(+4);
-    out << "```\n";
     auto matrix = gate.unitary();
     auto a = matrix[0][0];
     auto b = matrix[0][1];
@@ -920,7 +911,6 @@ void print_bloch_vector(Acc &out, const Gate &gate) {
     }
     out << "\n";
     out << "Angle: " << angle << " degrees\n";
-    out << "```\n";
     out.change_indent(-4);
 }
 
@@ -929,7 +919,11 @@ void print_unitary_matrix(Acc &out, const Gate &gate) {
         return;
     }
     auto matrix = gate.unitary();
-    out << "Unitary Matrix:\n";
+    out << "Unitary Matrix";
+    if (gate.flags & GATE_TARGETS_PAIRS) {
+        out << " (little endian)";
+    }
+    out << ":\n";
     out.change_indent(+4);
     bool all_halves = true;
     bool all_sqrt_halves = true;
@@ -942,7 +936,6 @@ void print_unitary_matrix(Acc &out, const Gate &gate) {
             all_sqrt_halves &= fabs(fabs(cell.imag()) - s) < 0.001 || cell.imag() == 0;
         }
     }
-    out << "```\n";
     double factor = all_halves ? 2 : all_sqrt_halves ? 1 / s : 1;
     bool first_row = true;
     for (const auto &row : matrix) {
@@ -970,7 +963,7 @@ void print_unitary_matrix(Acc &out, const Gate &gate) {
     if (all_sqrt_halves) {
         out << " / sqrt(2)";
     }
-    out << "\n```\n";
+    out << "\n";
     out.change_indent(-4);
 }
 

--- a/src/stim/mem/simd_compat.test.cc
+++ b/src/stim/mem/simd_compat.test.cc
@@ -47,12 +47,6 @@ TEST(simd_compat, popcount) {
             for (size_t i = 0; i < n; i++) {
                 v.p[i >> 6] |= bits[i] << (i & 63);
             }
-            if (v.w.popcount() != expected) {
-                std::cerr << v.p[0] << "\n";
-                std::cerr << v.p[1] << "\n";
-                std::cerr << v.p[2] << "\n";
-                std::cerr << v.p[3] << "\n";
-            }
             ASSERT_EQ(v.w.popcount(), expected);
         }
     }

--- a/src/stim/simulators/tableau_simulator.cc
+++ b/src/stim/simulators/tableau_simulator.cc
@@ -782,7 +782,7 @@ void TableauSimulator::apply_tableau(const Tableau &tableau, const std::vector<s
 
 std::vector<std::complex<float>> TableauSimulator::to_state_vector(bool little_endian) const {
     auto sim = to_vector_sim();
-    if (!little_endian) {
+    if (!little_endian && inv_state.num_qubits > 0) {
         for (size_t q = 0; q < inv_state.num_qubits - q - 1; q++) {
             sim.apply("SWAP", q, inv_state.num_qubits - q - 1);
         }

--- a/src/stim/simulators/tableau_simulator.pybind.cc
+++ b/src/stim/simulators/tableau_simulator.pybind.cc
@@ -1487,7 +1487,7 @@ void pybind_tableau_simulator(pybind11::module &m) {
             if in the previous example there was a third qubit in the |0> state, then both
             `stim.PauliString("XX_")` and `stim.PauliString("XXZ")` are valid kickbacks.
 
-            Measurements with determinist results don't have a Pauli kickback.
+            Measurements with deterministic results don't have a Pauli kickback.
 
             Args:
                 target: The index of the qubit to measure.

--- a/src/stim/simulators/tableau_simulator.pybind.cc
+++ b/src/stim/simulators/tableau_simulator.pybind.cc
@@ -1646,9 +1646,9 @@ void pybind_tableau_simulator(pybind11::module &m) {
         },
         pybind11::arg("state_vector"),
         pybind11::kw_only(),
-        pybind11::arg("endian") = "little",
+        pybind11::arg("endian"),
         clean_doc_string(u8R"DOC(
-            @signature def set_state_from_state_vector(self, state_vector: Iterable[float], *, endian: str = 'little') -> None:
+            @signature def set_state_from_state_vector(self, state_vector: Iterable[float], *, endian: str) -> None:
             Sets the tableau simulator's state to a superposition specified by a vector of amplitudes.
 
             Args:
@@ -1656,7 +1656,7 @@ void pybind_tableau_simulator(pybind11::module &m) {
                     must correspond to a state that is reachable using Clifford operations, and must
                     be normalized (i.e. it must be a unit vector).
                 endian:
-                    "little" (default): state vector is in little endian order, where higher index qubits
+                    "little": state vector is in little endian order, where higher index qubits
                         correspond to larger changes in the state index.
                     "big": state vector is in little endian order, where higher index qubits correspond to
                         smaller changes in the state index.
@@ -1677,7 +1677,7 @@ void pybind_tableau_simulator(pybind11::module &m) {
                 >>> tab_sim.set_state_from_state_vector([
                 ...     0.5**0.5,
                 ...     0.5**0.5 * 1j,
-                ... ])
+                ... ], endian='little')
                 >>> tab_sim.current_inverse_tableau().inverse()
                 stim.Tableau.from_conjugated_generators(
                     xs=[
@@ -1692,7 +1692,7 @@ void pybind_tableau_simulator(pybind11::module &m) {
                 ...     0,
                 ...     0,
                 ...     0.5**0.5,
-                ... ])
+                ... ], endian='little')
                 >>> tab_sim.current_inverse_tableau().inverse()
                 stim.Tableau.from_conjugated_generators(
                     xs=[

--- a/src/stim/simulators/tableau_simulator.pybind.cc
+++ b/src/stim/simulators/tableau_simulator.pybind.cc
@@ -1537,7 +1537,8 @@ void pybind_tableau_simulator(pybind11::module &m) {
                 }
                 converted_stabilizers.push_back(p.value);
             }
-            self.inv_state = stabilizers_to_tableau(converted_stabilizers, allow_redundant, allow_underconstrained, true);
+            self.inv_state =
+                stabilizers_to_tableau(converted_stabilizers, allow_redundant, allow_underconstrained, true);
         },
         pybind11::arg("stabilizers"),
         pybind11::kw_only(),
@@ -1642,7 +1643,8 @@ void pybind_tableau_simulator(pybind11::module &m) {
                 v.push_back(pybind11::cast<std::complex<float>>(obj));
             }
 
-            self.inv_state = circuit_to_tableau(stabilizer_state_vector_to_circuit(v, little_endian), false, false, false).inverse();
+            self.inv_state =
+                circuit_to_tableau(stabilizer_state_vector_to_circuit(v, little_endian), false, false, false).inverse();
         },
         pybind11::arg("state_vector"),
         pybind11::kw_only(),

--- a/src/stim/simulators/tableau_simulator_pybind_test.py
+++ b/src/stim/simulators/tableau_simulator_pybind_test.py
@@ -516,7 +516,7 @@ def test_num_qubits():
 def test_set_state_from_state_vector():
     s = stim.TableauSimulator()
     expected = [0.5, 0.5, 0, 0, -0.5, 0.5, 0, 0]
-    s.set_state_from_state_vector(expected)
+    s.set_state_from_state_vector(expected, endian='little')
     np.testing.assert_allclose(s.state_vector(), expected, atol=1e-6)
 
 

--- a/src/stim/simulators/tableau_simulator_pybind_test.py
+++ b/src/stim/simulators/tableau_simulator_pybind_test.py
@@ -511,3 +511,18 @@ def test_num_qubits():
     assert s.num_qubits == 0
     s.cx(3, 1)
     assert s.num_qubits == 4
+
+
+def test_set_state_from_state_vector():
+    s = stim.TableauSimulator()
+    expected = [0.5, 0.5, 0, 0, -0.5, 0.5, 0, 0]
+    s.set_state_from_state_vector(expected)
+    np.testing.assert_allclose(s.state_vector(), expected, atol=1e-6)
+
+
+def test_set_state_from_stabilizers():
+    s = stim.TableauSimulator()
+    s.set_state_from_stabilizers([])
+    assert s.current_inverse_tableau() == stim.Tableau(0)
+    s.set_state_from_stabilizers([stim.PauliString("XXX"), stim.PauliString("_ZZ"), stim.PauliString("ZZ_")])
+    np.testing.assert_allclose(s.state_vector(), [0.5**0.5, 0, 0, 0, 0, 0, 0, 0.5**0.5], atol=1e-6)

--- a/src/stim/simulators/vector_simulator.cc
+++ b/src/stim/simulators/vector_simulator.cc
@@ -181,6 +181,29 @@ float VectorSimulator::project(const PauliStringRef &observable) {
     return mag2;
 }
 
+void VectorSimulator::smooth_stabilizer_state(std::complex<float> base_value) {
+    std::vector<std::complex<float>> ratio_values{
+        {0, 0},
+        {1, 0},
+        {-1, 0},
+        {0, 1},
+        {0, -1},
+    };
+    for (size_t k = 0; k < state.size(); k++) {
+        auto ratio = state[k] / base_value;
+        bool solved = false;
+        for (const auto &r : ratio_values) {
+            if (std::norm(ratio - r) < 0.125) {
+                state[k] = r;
+                solved = true;
+            }
+        }
+        if (!solved) {
+            throw std::invalid_argument("The state vector wasn't a stabilizer state.");
+        }
+    }
+}
+
 bool VectorSimulator::approximate_equals(const VectorSimulator &other, bool up_to_global_phase) const {
     if (state.size() != other.state.size()) {
         return false;

--- a/src/stim/simulators/vector_simulator.cc
+++ b/src/stim/simulators/vector_simulator.cc
@@ -282,3 +282,34 @@ void VectorSimulator::canonicalize_assuming_stabilizer_state(double norm2) {
         v *= scale;
     }
 }
+void VectorSimulator::do_unitary_circuit(const Circuit &circuit) {
+    std::vector<size_t> targets1{1};
+    std::vector<size_t> targets2{1, 2};
+    circuit.for_each_operation([&](const Operation &op) {
+        if (!(op.gate->flags & GATE_IS_UNITARY)) {
+            std::stringstream ss;
+            ss << "Not a unitary gate: " << op.gate->name;
+            throw std::invalid_argument(ss.str());
+        }
+        auto unitary = op.gate->unitary();
+        for (auto t : op.target_data.targets) {
+            if (!t.is_qubit_target() || (size_t{1} << t.data) >= state.size()) {
+                std::stringstream ss;
+                ss << "Targets out of range: " << op;
+                throw std::invalid_argument(ss.str());
+            }
+        }
+        if (op.gate->flags & stim::GATE_TARGETS_PAIRS) {
+            for (size_t k = 0; k < op.target_data.targets.size(); k += 2) {
+                targets2[0] = (size_t)op.target_data.targets[k].data;
+                targets2[1] = (size_t)op.target_data.targets[k + 1].data;
+                apply(unitary, targets2);
+            }
+        } else {
+            for (auto t : op.target_data.targets) {
+                targets1[0] = (size_t)t.data;
+                apply(unitary, targets1);
+            }
+        }
+    });
+}

--- a/src/stim/simulators/vector_simulator.h
+++ b/src/stim/simulators/vector_simulator.h
@@ -23,6 +23,7 @@
 #include <unordered_map>
 
 #include "stim/stabilizers/pauli_string.h"
+#include "stim/circuit/circuit.h"
 
 namespace stim {
 
@@ -53,6 +54,9 @@ struct VectorSimulator {
     void apply(const std::string &gate, size_t qubit1, size_t qubit2);
     /// Helper method for applying the gates in a Pauli string.
     void apply(const PauliStringRef &gate, size_t qubit_offset);
+
+    /// Applies the unitary operations within a circuit to the simulator's state.
+    void do_unitary_circuit(const Circuit &circuit);
 
     /// Modifies the state vector to be EXACTLY entries of 0, 1, -1, i, or -i.
     ///

--- a/src/stim/simulators/vector_simulator.h
+++ b/src/stim/simulators/vector_simulator.h
@@ -22,8 +22,8 @@
 #include <random>
 #include <unordered_map>
 
-#include "stim/stabilizers/pauli_string.h"
 #include "stim/circuit/circuit.h"
+#include "stim/stabilizers/pauli_string.h"
 
 namespace stim {
 

--- a/src/stim/simulators/vector_simulator.h
+++ b/src/stim/simulators/vector_simulator.h
@@ -54,6 +54,12 @@ struct VectorSimulator {
     /// Helper method for applying the gates in a Pauli string.
     void apply(const PauliStringRef &gate, size_t qubit_offset);
 
+    /// Modifies the state vector to be EXACTLY entries of 0, 1, -1, i, or -i.
+    ///
+    /// Each entry is a ratio relative to the given base value.
+    /// If any entry has a ratio not near the desired set, an exception is raised.
+    void smooth_stabilizer_state(std::complex<float> base_value);
+
     /// Projects the state vector into the +1 eigenstate of the given observable, and renormalizes.
     ///
     /// Returns:

--- a/src/stim/simulators/vector_simulator.test.cc
+++ b/src/stim/simulators/vector_simulator.test.cc
@@ -293,3 +293,28 @@ TEST(VectorSim, smooth_stabilizer_state) {
     sim.smooth_stabilizer_state({-0.25, -0.25});
     ASSERT_EQ(sim.state, (std::vector<std::complex<float>>{{-1, 0}, {0,-1}}));
 }
+
+TEST(VectorSim, do_unitary_circuit) {
+    VectorSimulator sim(3);
+    sim.do_unitary_circuit(Circuit(R"CIRCUIT(
+        H 0 1
+        S 0
+    )CIRCUIT"));
+    sim.smooth_stabilizer_state(0.5);
+    ASSERT_EQ(sim.state, (std::vector<std::complex<float>>({1, {0, 1}, 1, {0, 1}, 0, 0, 0, 0})));
+
+    sim.do_unitary_circuit(Circuit(R"CIRCUIT(
+        CNOT 0 2 2 0 0 2
+    )CIRCUIT"));
+    ASSERT_EQ(sim.state, (std::vector<std::complex<float>>({1, 0, 1, 0, {0, 1}, 0, {0, 1}, 0})));
+
+    ASSERT_THROW({
+        sim.do_unitary_circuit(Circuit("H 3"));
+    }, std::invalid_argument);
+    ASSERT_THROW({
+        sim.do_unitary_circuit(Circuit("CX rec[-1] 0"));
+    }, std::invalid_argument);
+    ASSERT_THROW({
+        sim.do_unitary_circuit(Circuit("X_ERROR(0.1) 0"));
+    }, std::invalid_argument);
+}

--- a/src/stim/simulators/vector_simulator.test.cc
+++ b/src/stim/simulators/vector_simulator.test.cc
@@ -271,3 +271,25 @@ TEST(VectorSim, from_stabilizers) {
     ref.state = {0, sqrtf(0.5), 0, 0, 0, 0, {0, -sqrtf(0.5)}, 0};
     ASSERT_TRUE(sim.approximate_equals(ref, true));
 }
+
+TEST(VectorSim, smooth_stabilizer_state) {
+    VectorSimulator sim(0);
+    sim.state = {
+        {1, 0},
+        {1, 1}
+    };
+    ASSERT_THROW({ sim.smooth_stabilizer_state(1); }, std::invalid_argument);
+
+    sim.state = {
+        {0.25, 0.25},
+        {-0.25, 0.25}
+    };
+    ASSERT_THROW({ sim.smooth_stabilizer_state(1); }, std::invalid_argument);
+
+    sim.state = {
+        {0.25, 0.25},
+        {-0.25, 0.25}
+    };
+    sim.smooth_stabilizer_state({-0.25, -0.25});
+    ASSERT_EQ(sim.state, (std::vector<std::complex<float>>{{-1, 0}, {0,-1}}));
+}

--- a/src/stim/simulators/vector_simulator.test.cc
+++ b/src/stim/simulators/vector_simulator.test.cc
@@ -274,24 +274,15 @@ TEST(VectorSim, from_stabilizers) {
 
 TEST(VectorSim, smooth_stabilizer_state) {
     VectorSimulator sim(0);
-    sim.state = {
-        {1, 0},
-        {1, 1}
-    };
+    sim.state = {{1, 0}, {1, 1}};
     ASSERT_THROW({ sim.smooth_stabilizer_state(1); }, std::invalid_argument);
 
-    sim.state = {
-        {0.25, 0.25},
-        {-0.25, 0.25}
-    };
+    sim.state = {{0.25, 0.25}, {-0.25, 0.25}};
     ASSERT_THROW({ sim.smooth_stabilizer_state(1); }, std::invalid_argument);
 
-    sim.state = {
-        {0.25, 0.25},
-        {-0.25, 0.25}
-    };
+    sim.state = {{0.25, 0.25}, {-0.25, 0.25}};
     sim.smooth_stabilizer_state({-0.25, -0.25});
-    ASSERT_EQ(sim.state, (std::vector<std::complex<float>>{{-1, 0}, {0,-1}}));
+    ASSERT_EQ(sim.state, (std::vector<std::complex<float>>{{-1, 0}, {0, -1}}));
 }
 
 TEST(VectorSim, do_unitary_circuit) {
@@ -308,13 +299,7 @@ TEST(VectorSim, do_unitary_circuit) {
     )CIRCUIT"));
     ASSERT_EQ(sim.state, (std::vector<std::complex<float>>({1, 0, 1, 0, {0, 1}, 0, {0, 1}, 0})));
 
-    ASSERT_THROW({
-        sim.do_unitary_circuit(Circuit("H 3"));
-    }, std::invalid_argument);
-    ASSERT_THROW({
-        sim.do_unitary_circuit(Circuit("CX rec[-1] 0"));
-    }, std::invalid_argument);
-    ASSERT_THROW({
-        sim.do_unitary_circuit(Circuit("X_ERROR(0.1) 0"));
-    }, std::invalid_argument);
+    ASSERT_THROW({ sim.do_unitary_circuit(Circuit("H 3")); }, std::invalid_argument);
+    ASSERT_THROW({ sim.do_unitary_circuit(Circuit("CX rec[-1] 0")); }, std::invalid_argument);
+    ASSERT_THROW({ sim.do_unitary_circuit(Circuit("X_ERROR(0.1) 0")); }, std::invalid_argument);
 }

--- a/src/stim/stabilizers/conversions.cc
+++ b/src/stim/stabilizers/conversions.cc
@@ -1,0 +1,198 @@
+#include "stim/stabilizers/conversions.h"
+#include "stim/simulators/vector_simulator.h"
+#include "stim/simulators/tableau_simulator.h"
+
+using namespace stim;
+
+uint8_t stim::floor_lg2(size_t value) {
+    uint8_t result = 0;
+    while (value > 1) {
+        result += 1;
+        value >>= 1;
+    }
+    return result;
+}
+
+uint8_t stim::is_power_of_2(size_t value) {
+    return value != 0 && (value & (value - 1)) == 0;
+}
+
+size_t biggest_index(const std::vector<std::complex<float>> &state_vector) {
+    size_t best_index = 0;
+    float best_size = std::norm(state_vector[0]);
+    for (size_t k = 1; k < state_vector.size(); k++) {
+        float size = std::norm(state_vector[k]);
+        if (size > best_size) {
+            best_size = size;
+            best_index = k;
+        }
+    }
+    return best_index;
+}
+
+size_t compute_occupation(const std::vector<std::complex<float>> &state_vector) {
+    size_t c = 0;
+    for (const auto &v : state_vector) {
+        if (v != std::complex<float>{0, 0}) {
+            c++;
+        }
+    }
+    return c;
+}
+
+Circuit stim::stabilizer_state_vector_to_circuit(const std::vector<std::complex<float>> &state_vector, bool little_endian) {
+    if (!is_power_of_2(state_vector.size())) {
+        std::stringstream ss;
+        ss << "Expected number of amplitudes to be a power of 2.";
+        ss << " The given state vector had " << state_vector.size() << " amplitudes.";
+        throw std::invalid_argument(ss.str());
+    }
+
+    uint8_t num_qubits = floor_lg2(state_vector.size());
+    double weight = 0;
+    for (const auto &c : state_vector) {
+        weight += std::norm(c);
+    }
+    if (abs(weight - 1) > 0.125) {
+        throw std::invalid_argument("The given state vector wasn't a unit vector. It had a length of " + std::to_string(weight) + ".");
+    }
+
+    VectorSimulator sim(num_qubits);
+    sim.state = state_vector;
+
+    Circuit recorded;
+    auto apply = [&](const std::string &name, uint32_t target) {
+        sim.apply(name, target);
+        recorded.append_op(name, {little_endian ? target : (num_qubits - target - 1)});
+    };
+    auto apply2 = [&](const std::string &name, uint32_t target, uint32_t target2) {
+        sim.apply(name, target, target2);
+        recorded.append_op(name, {
+            little_endian ? target : (num_qubits - target - 1),
+            little_endian ? target2 : (num_qubits - target2 - 1),
+        });
+    };
+
+    // Move biggest amplitude to start of state vector..
+    size_t pivot = biggest_index(state_vector);
+    for (size_t q = 0; q < num_qubits; q++) {
+        if ((pivot >> q) & 1) {
+            apply("X", q);
+        }
+    }
+    sim.smooth_stabilizer_state(sim.state[0]);
+    size_t occupation = compute_occupation(sim.state);
+    if (!is_power_of_2(occupation)) {
+        throw std::invalid_argument("State vector isn't a stabilizer state.");
+    }
+
+    // Repeatedly cancel amplitudes
+    while (occupation > 1) {
+        size_t k = 1;
+        for (; k < state_vector.size(); k++) {
+            if (sim.state[k].real() || sim.state[k].imag()) {
+                break;
+            }
+        }
+        if (k == state_vector.size()) {
+            break;
+        }
+
+        size_t base_qubit = SIZE_MAX;
+        for (size_t q = 0; q < num_qubits; q++) {
+            if ((k >> q) & 1) {
+                if (base_qubit == SIZE_MAX) {
+                    base_qubit = q;
+                } else {
+                    apply2("CNOT", base_qubit, q);
+                }
+            }
+        }
+
+        auto s = sim.state[1 << base_qubit];
+        assert(s != (std::complex<float>{0, 0}));
+        if (s == std::complex<float>{-1, 0}) {
+            apply("Z", base_qubit);
+        } else if (s == std::complex<float>{0, 1}) {
+            apply("S_DAG", base_qubit);
+        } else if (s == std::complex<float>{0, -1}) {
+            apply("S", base_qubit);
+        }
+        apply("H", base_qubit);
+
+        sim.smooth_stabilizer_state(sim.state[0]);
+        if (compute_occupation(sim.state) * 2 != occupation) {
+            throw std::invalid_argument("State vector isn't a stabilizer state.");
+        }
+        occupation >>= 1;
+    }
+
+    // Note: requires all targets within an individual CNOT to commute.
+    // This is guaranteed by the code above.
+    Circuit inverted;
+    recorded.for_each_operation_reverse([&](const Operation &op) {
+        inverted.append_operation(op.gate->inverse(), op.target_data.targets, op.target_data.args);
+    });
+
+    if (inverted.count_qubits() < num_qubits) {
+        inverted.append_op("I", {(uint32_t)(num_qubits - 1)});
+    }
+
+    return inverted;
+}
+
+Tableau stim::circuit_to_tableau(const Circuit &circuit, bool ignore_noise, bool ignore_measurement, bool ignore_reset) {
+    Tableau result(circuit.count_qubits());
+    std::mt19937_64 unused_rng(0);
+    TableauSimulator sim(unused_rng, circuit.count_qubits());
+
+    circuit.for_each_operation([&](const Operation &op){
+        if (op.gate->flags & GATE_IS_UNITARY) {
+            (sim.*op.gate->tableau_simulator_function)(op.target_data);
+        } else if (op.gate->flags & GATE_IS_NOISE) {
+            if (!ignore_noise) {
+                throw std::invalid_argument(
+                    "The circuit has no well-defined tableau because it contains noisy operations.\n"
+                    "To ignore noisy operations, pass the argument ignore_noise=True.\n"
+                    "The first noisy operation is: " + op.str());
+            }
+        } else if (op.gate->flags & (GATE_IS_RESET | GATE_PRODUCES_NOISY_RESULTS)) {
+            if (!ignore_measurement && (op.gate->flags & GATE_PRODUCES_NOISY_RESULTS)) {
+                throw std::invalid_argument(
+                    "The circuit has no well-defined tableau because it contains measurement operations.\n"
+                    "To ignore measurement operations, pass the argument ignore_measurement=True.\n"
+                    "The first measurement operation is: " + op.str());
+            }
+            if (!ignore_reset && (op.gate->flags & GATE_IS_RESET)) {
+                throw std::invalid_argument(
+                    "The circuit has no well-defined tableau because it contains reset operations.\n"
+                    "To ignore reset operations, pass the argument ignore_reset=True.\n"
+                    "The first reset operation is: " + op.str());
+            }
+        } else {
+            // Operation should be an annotation like TICK or DETECTOR.
+        }
+    });
+
+    return sim.inv_state.inverse();
+}
+
+std::vector<std::complex<float>> stim::circuit_to_output_state_vector(const Circuit &circuit, bool little_endian) {
+    Tableau result(circuit.count_qubits());
+    std::mt19937_64 unused_rng(0);
+    TableauSimulator sim(unused_rng, circuit.count_qubits());
+
+    circuit.for_each_operation([&](const Operation &op){
+        if (op.gate->flags & GATE_IS_UNITARY) {
+            (sim.*op.gate->tableau_simulator_function)(op.target_data);
+        } else if (op.gate->flags & (GATE_IS_NOISE | GATE_IS_RESET | GATE_PRODUCES_NOISY_RESULTS)) {
+            throw std::invalid_argument(
+                "The circuit has no well-defined tableau because it contains noisy or dissipative operations.\n"
+                "The first such operation is: " + op.str());
+        } else {
+            // Operation should be an annotation like TICK or DETECTOR.
+        }
+    });
+
+    return sim.to_state_vector(little_endian);
+}

--- a/src/stim/stabilizers/conversions.h
+++ b/src/stim/stabilizers/conversions.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _STIM_STABILIZERS_CONVERSIONS_H
+#define _STIM_STABILIZERS_CONVERSIONS_H
+
+#include "stim/stabilizers/tableau.h"
+#include "stim/circuit/circuit.h"
+
+namespace stim {
+
+uint8_t floor_lg2(size_t value);
+
+uint8_t is_power_of_2(size_t value);
+
+/// Synthesizes a circuit to generate the given state vector.
+///
+/// Args:
+///     stabilizer_state_vector: The vector of amplitudes to produce using a circuit.
+///     little_endian: Whether the vector is using little endian or big endian ordering.
+///
+/// Returns:
+///     A circuit that outputs the given state vector (up to global phase).
+///
+/// Throws:
+///     std::invalid_argument: The given state vector cannot be produced by a stabilizer circuit.
+Circuit stabilizer_state_vector_to_circuit(const std::vector<std::complex<float>> &stabilizer_state_vector, bool little_endian);
+
+/// Compiles the given circuit into a tableau.
+///
+/// Args:
+///     circuit: The circuit to compile. Should only contain unitary operations.
+///     ignore_noise: If the circuit contains noise channels, ignore them instead of raising an exception.
+///     ignore_measurement: If the circuit contains measurements, ignore them instead of raising an exception.
+///     ignore_reset: If the circuit contains resets, ignore them instead of raising an exception.
+///
+/// Returns:
+///     A tableau encoding the given circuit's Clifford operation.
+Tableau circuit_to_tableau(const Circuit &circuit, bool ignore_noise, bool ignore_measurement, bool ignore_reset);
+
+/// Simulates the given circuit and outputs a state vector.
+///
+/// Args:
+///     circuit: The circuit to simulate. Cannot contain noisy or dissipative operations.
+///     little_endian: Whether the returned vector uses little endian or big endian qubit order.
+///
+/// Returns:
+///     The state vector, using the requested endianness.
+std::vector<std::complex<float>> circuit_to_output_state_vector(const Circuit &circuit, bool little_endian);
+
+}  // namespace stim
+
+#endif

--- a/src/stim/stabilizers/conversions.h
+++ b/src/stim/stabilizers/conversions.h
@@ -104,15 +104,16 @@ Tableau unitary_to_tableau(const std::vector<std::vector<std::complex<float>>> &
 ///
 /// Args:
 ///     stabilizers: The desired stabilizers for the tableau. Every stabilizer must have the same number of qubits.
-///     ignore_redundant: If false, including a redundant stabilizer will result in an error.
+///     allow_redundant: If false, including a redundant stabilizer will result in an error.
 ///         If true, redundant stabilizers are quietly dropped.
-///     ignore_underconstrained: If false, the number of independent stabilizers must equal the number of qubits in each
+///     allow_underconstrained: If false, the number of independent stabilizers must equal the number of qubits in each
 ///         stabilizer. If true, the returned result will arbitrarily fill in missing stabilizers.
+///     invert: Return the inverse tableau instead of the tableau with the stabilizers as its Z outputs.
 ///
 /// Returns:
 ///     A tableau containing the given stabilizers, but extended to also include matching stabilizers.
 ///     The Z outputs of the tableau will be the given stabilizers (skipping any redundant ones).
-Tableau stabilizers_to_tableau(const std::vector<stim::PauliString> &stabilizers, bool ignore_redundant, bool ignore_underconstrained);
+Tableau stabilizers_to_tableau(const std::vector<stim::PauliString> &stabilizers, bool allow_redundant, bool allow_underconstrained, bool invert);
 
 }  // namespace stim
 

--- a/src/stim/stabilizers/conversions.h
+++ b/src/stim/stabilizers/conversions.h
@@ -100,6 +100,20 @@ Circuit tableau_to_circuit(const Tableau &tableau, const std::string &method);
 ///     std::invalid_argument: The given unitary matrix isn't a Clifford operation.
 Tableau unitary_to_tableau(const std::vector<std::vector<std::complex<float>>> &matrix, bool little_endian);
 
+/// Computes destabilizers for the given stabilizers, and packages into a tableau.
+///
+/// Args:
+///     stabilizers: The desired stabilizers for the tableau. Every stabilizer must have the same number of qubits.
+///     ignore_redundant: If false, including a redundant stabilizer will result in an error.
+///         If true, redundant stabilizers are quietly dropped.
+///     ignore_underconstrained: If false, the number of independent stabilizers must equal the number of qubits in each
+///         stabilizer. If true, the returned result will arbitrarily fill in missing stabilizers.
+///
+/// Returns:
+///     A tableau containing the given stabilizers, but extended to also include matching stabilizers.
+///     The Z outputs of the tableau will be the given stabilizers (skipping any redundant ones).
+Tableau stabilizers_to_tableau(const std::vector<stim::PauliString> &stabilizers, bool ignore_redundant, bool ignore_underconstrained);
+
 }  // namespace stim
 
 #endif

--- a/src/stim/stabilizers/conversions.h
+++ b/src/stim/stabilizers/conversions.h
@@ -61,6 +61,24 @@ Tableau circuit_to_tableau(const Circuit &circuit, bool ignore_noise, bool ignor
 ///     The state vector, using the requested endianness.
 std::vector<std::complex<float>> circuit_to_output_state_vector(const Circuit &circuit, bool little_endian);
 
+/// Synthesizes a circuit that implements the given tableau's Clifford operation.
+///
+/// This method is allowed to output different circuits, from call to call or version
+/// to version, for the same input tableau.
+///
+/// Args:
+///     tableau: The tableau to synthesize into a circuit.
+///     method: The method to use when synthesizing the circuit. Available values are:
+///         "elimination": Uses Gaussian elimination to cancel off-diagonal terms one by one.
+///             Gate set: H, S, CX
+///             Circuit qubit count: n
+///             Circuit operation count: O(n^2)
+///             Circuit depth: O(n^2)
+///
+/// Returns:
+///     The synthesized circuit.
+Circuit tableau_to_circuit(const Tableau &tableau, const std::string &method);
+
 }  // namespace stim
 
 #endif

--- a/src/stim/stabilizers/conversions.h
+++ b/src/stim/stabilizers/conversions.h
@@ -17,8 +17,8 @@
 #ifndef _STIM_STABILIZERS_CONVERSIONS_H
 #define _STIM_STABILIZERS_CONVERSIONS_H
 
-#include "stim/stabilizers/tableau.h"
 #include "stim/circuit/circuit.h"
+#include "stim/stabilizers/tableau.h"
 
 namespace stim {
 
@@ -45,7 +45,8 @@ Circuit unitary_circuit_inverse(const Circuit &unitary_circuit);
 ///
 /// Throws:
 ///     std::invalid_argument: The given state vector cannot be produced by a stabilizer circuit.
-Circuit stabilizer_state_vector_to_circuit(const std::vector<std::complex<float>> &stabilizer_state_vector, bool little_endian);
+Circuit stabilizer_state_vector_to_circuit(
+    const std::vector<std::complex<float>> &stabilizer_state_vector, bool little_endian);
 
 /// Compiles the given circuit into a tableau.
 ///
@@ -113,7 +114,8 @@ Tableau unitary_to_tableau(const std::vector<std::vector<std::complex<float>>> &
 /// Returns:
 ///     A tableau containing the given stabilizers, but extended to also include matching stabilizers.
 ///     The Z outputs of the tableau will be the given stabilizers (skipping any redundant ones).
-Tableau stabilizers_to_tableau(const std::vector<stim::PauliString> &stabilizers, bool allow_redundant, bool allow_underconstrained, bool invert);
+Tableau stabilizers_to_tableau(
+    const std::vector<stim::PauliString> &stabilizers, bool allow_redundant, bool allow_underconstrained, bool invert);
 
 }  // namespace stim
 

--- a/src/stim/stabilizers/conversions.h
+++ b/src/stim/stabilizers/conversions.h
@@ -26,11 +26,19 @@ uint8_t floor_lg2(size_t value);
 
 uint8_t is_power_of_2(size_t value);
 
+/// Converts a tableau into a unitary matrix.
+std::vector<std::vector<std::complex<float>>> tableau_to_unitary(const Tableau &tableau, bool little_endian);
+
+/// Inverts the given circuit, as long as it only contains unitary operations.
+Circuit unitary_circuit_inverse(const Circuit &unitary_circuit);
+
 /// Synthesizes a circuit to generate the given state vector.
 ///
 /// Args:
 ///     stabilizer_state_vector: The vector of amplitudes to produce using a circuit.
 ///     little_endian: Whether the vector is using little endian or big endian ordering.
+///     inverted_circuit: If false, returns a circuit that sends |000...0> to the state vector.
+///         If true, returns a circuit that sends the state vector to |000...0> instead of a cir.
 ///
 /// Returns:
 ///     A circuit that outputs the given state vector (up to global phase).
@@ -78,6 +86,19 @@ std::vector<std::complex<float>> circuit_to_output_state_vector(const Circuit &c
 /// Returns:
 ///     The synthesized circuit.
 Circuit tableau_to_circuit(const Tableau &tableau, const std::string &method);
+
+/// Converts a unitary matrix into a stabilizer tableau.
+///
+/// Args:
+///     matrix: The unitary matrix to convert. Must correspond to a Clifford.
+//      little_endian: Whether the amplitude ordering is little endian or big endian.
+///
+/// Returns:
+///     A tableau implementing the same operation as the unitary matrix (up to global phase).
+///
+/// Throws:
+///     std::invalid_argument: The given unitary matrix isn't a Clifford operation.
+Tableau unitary_to_tableau(const std::vector<std::vector<std::complex<float>>> &matrix, bool little_endian);
 
 }  // namespace stim
 

--- a/src/stim/stabilizers/conversions.test.cc
+++ b/src/stim/stabilizers/conversions.test.cc
@@ -1,0 +1,340 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "stim/stabilizers/conversions.h"
+
+#include "gtest/gtest.h"
+#include "stim/test_util.test.h"
+#include "stim/simulators/tableau_simulator.h"
+
+using namespace stim;
+
+TEST(conversions, is_power_of_2) {
+    ASSERT_FALSE(is_power_of_2(0));
+    ASSERT_TRUE(is_power_of_2(1));
+    ASSERT_TRUE(is_power_of_2(2));
+    ASSERT_FALSE(is_power_of_2(3));
+    ASSERT_TRUE(is_power_of_2(4));
+    ASSERT_FALSE(is_power_of_2(5));
+    ASSERT_FALSE(is_power_of_2(6));
+    ASSERT_FALSE(is_power_of_2(7));
+    ASSERT_TRUE(is_power_of_2(8));
+    ASSERT_FALSE(is_power_of_2(9));
+}
+
+TEST(conversions, floor_lg2) {
+    ASSERT_EQ(floor_lg2(1), 0);
+    ASSERT_EQ(floor_lg2(2), 1);
+    ASSERT_EQ(floor_lg2(3), 1);
+    ASSERT_EQ(floor_lg2(4), 2);
+    ASSERT_EQ(floor_lg2(5), 2);
+    ASSERT_EQ(floor_lg2(6), 2);
+    ASSERT_EQ(floor_lg2(7), 2);
+    ASSERT_EQ(floor_lg2(8), 3);
+    ASSERT_EQ(floor_lg2(9), 3);
+}
+
+TEST(conversions, stabilizer_state_vector_to_circuit_basic) {
+    ASSERT_THROW(stabilizer_state_vector_to_circuit({
+        {0.5},
+    }, false), std::invalid_argument);
+
+    ASSERT_EQ(stabilizer_state_vector_to_circuit({
+        {1},
+    }, false), stim::Circuit(R"CIRCUIT(
+    )CIRCUIT"));
+
+    ASSERT_EQ(stabilizer_state_vector_to_circuit({
+        {-1},
+    }, false), stim::Circuit(R"CIRCUIT(
+    )CIRCUIT"));
+
+    ASSERT_EQ(stabilizer_state_vector_to_circuit({
+        {0, 1},
+        {0},
+    }, false), stim::Circuit(R"CIRCUIT(
+        I 0
+    )CIRCUIT"));
+
+    ASSERT_EQ(stabilizer_state_vector_to_circuit({
+        {0},
+        {1},
+    }, false), stim::Circuit(R"CIRCUIT(
+        X 0
+    )CIRCUIT"));
+
+    ASSERT_EQ(stabilizer_state_vector_to_circuit({
+        {sqrtf(0.5)},
+        {sqrtf(0.5)},
+    }, false), stim::Circuit(R"CIRCUIT(
+        H 0
+    )CIRCUIT"));
+
+    ASSERT_EQ(stabilizer_state_vector_to_circuit({
+        {0},
+        {1},
+        {0},
+        {0},
+    }, false), stim::Circuit(R"CIRCUIT(
+        X 1
+    )CIRCUIT"));
+
+    ASSERT_EQ(stabilizer_state_vector_to_circuit({
+        {0},
+        {0},
+        {1},
+        {0},
+    }, false), stim::Circuit(R"CIRCUIT(
+        X 0
+        I 1
+    )CIRCUIT"));
+
+    ASSERT_EQ(stabilizer_state_vector_to_circuit({
+        {0},
+        {1},
+        {0},
+        {0},
+    }, true), stim::Circuit(R"CIRCUIT(
+        X 0
+        I 1
+    )CIRCUIT"));
+
+    ASSERT_EQ(stabilizer_state_vector_to_circuit({
+        {0},
+        {0},
+        {1},
+        {0},
+    }, true), stim::Circuit(R"CIRCUIT(
+        X 1
+    )CIRCUIT"));
+
+    ASSERT_EQ(stabilizer_state_vector_to_circuit({
+        {sqrtf(0.5)},
+        {0, sqrtf(0.5)},
+    }, true), stim::Circuit(R"CIRCUIT(
+        H 0
+        S 0
+    )CIRCUIT"));
+
+    ASSERT_EQ(stabilizer_state_vector_to_circuit({
+        {sqrtf(0.5)},
+        {0, -sqrtf(0.5)},
+    }, true), stim::Circuit(R"CIRCUIT(
+        H 0
+        S_DAG 0
+    )CIRCUIT"));
+
+    ASSERT_EQ(stabilizer_state_vector_to_circuit({
+        {sqrtf(0.5)},
+        {-sqrtf(0.5)},
+    }, true), stim::Circuit(R"CIRCUIT(
+        H 0
+        Z 0
+    )CIRCUIT"));
+}
+
+TEST(conversions, stabilizer_state_vector_to_circuit_fuzz_round_trip) {
+    for (const auto &little_endian : std::vector<bool>{false, true}) {
+        for (size_t n = 0; n < 10; n++) {
+            // Pick a random stabilizer state.
+            TableauSimulator sim(SHARED_TEST_RNG(), n);
+            sim.inv_state = Tableau::random(n, SHARED_TEST_RNG());
+            auto desired_vec = sim.to_state_vector(little_endian);
+
+            // Round trip through a circuit.
+            auto circuit = stabilizer_state_vector_to_circuit(desired_vec, little_endian);
+            auto actual_vec = circuit_to_output_state_vector(circuit, little_endian);
+            ASSERT_EQ(actual_vec, desired_vec) << "little_endian=" << little_endian << ", n=" << n;
+        }
+    }
+}
+
+TEST(conversions, circuit_to_tableau_ignoring_gates) {
+    Circuit unitary(R"CIRCUIT(
+        I 0
+        X 0
+        Y 0
+        Z 0
+        C_XYZ 0
+        C_ZYX 0
+        H 0
+        H_XY 0
+        H_XZ 0
+        H_YZ 0
+        S 0
+        SQRT_X 0
+        SQRT_X_DAG 0
+        SQRT_Y 0
+        SQRT_Y_DAG 0
+        SQRT_Z 0
+        SQRT_Z_DAG 0
+        S_DAG 0
+        CNOT 0 1
+        CX 0 1
+        CY 0 1
+        CZ 0 1
+        ISWAP 0 1
+        ISWAP_DAG 0 1
+        SQRT_XX 0 1
+        SQRT_XX_DAG 0 1
+        SQRT_YY 0 1
+        SQRT_YY_DAG 0 1
+        SQRT_ZZ 0 1
+        SQRT_ZZ_DAG 0 1
+        SWAP 0 1
+        XCX 0 1
+        XCY 0 1
+        XCZ 0 1
+        YCX 0 1
+        YCY 0 1
+        YCZ 0 1
+        ZCX 0 1
+        ZCY 0 1
+        ZCZ 0 1
+    )CIRCUIT");
+    Circuit noise(R"CIRCUIT(
+        CORRELATED_ERROR(0.1) X0
+        DEPOLARIZE1(0.1) 0
+        DEPOLARIZE2(0.1) 0 1
+        E(0.1) X0
+        ELSE_CORRELATED_ERROR(0.1) Y1
+        PAULI_CHANNEL_1(0.1,0.2,0.3) 0
+        PAULI_CHANNEL_2(0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01) 0 1
+        X_ERROR(0.1) 0
+        Y_ERROR(0.1) 0
+        Z_ERROR(0.1) 0
+    )CIRCUIT");
+    Circuit measure(R"CIRCUIT(
+        M 0
+        MPP X0
+        MX 0
+        MY 0
+        MZ 0
+    )CIRCUIT");
+    Circuit reset(R"CIRCUIT(
+        R 0
+        RX 0
+        RY 0
+        RZ 0
+    )CIRCUIT");
+    Circuit measure_reset(R"CIRCUIT(
+        MR 0
+        MRX 0
+        MRY 0
+        MRZ 0
+    )CIRCUIT");
+    Circuit annotations(R"CIRCUIT(
+        REPEAT 10 {
+            I 0
+        }
+        DETECTOR(1, 2)
+        OBSERVABLE_INCLUDE(1)
+        QUBIT_COORDS(0,1,2) 0
+        SHIFT_COORDS(2, 3, 4)
+        TICK
+    )CIRCUIT");
+
+    ASSERT_EQ(circuit_to_tableau(unitary, false, false, false).num_qubits, 2);
+
+    ASSERT_THROW({ circuit_to_tableau(noise, false, false, false); }, std::invalid_argument);
+    ASSERT_THROW({ circuit_to_tableau(noise, false, true, true); }, std::invalid_argument);
+    ASSERT_EQ(circuit_to_tableau(noise, true, false, false), Tableau(2));
+
+    ASSERT_THROW({ circuit_to_tableau(measure, false, false, false); }, std::invalid_argument);
+    ASSERT_THROW({ circuit_to_tableau(measure, true, false, true); }, std::invalid_argument);
+    ASSERT_EQ(circuit_to_tableau(measure, false, true, false), Tableau(1));
+
+    ASSERT_THROW({ circuit_to_tableau(reset, false, false, false); }, std::invalid_argument);
+    ASSERT_THROW({ circuit_to_tableau(reset, true, true, false); }, std::invalid_argument);
+    ASSERT_EQ(circuit_to_tableau(reset, false, false, true), Tableau(1));
+
+    ASSERT_THROW({ circuit_to_tableau(measure_reset, false, false, false); }, std::invalid_argument);
+    ASSERT_THROW({ circuit_to_tableau(measure_reset, true, false, true); }, std::invalid_argument);
+    ASSERT_THROW({ circuit_to_tableau(measure_reset, true, true, false); }, std::invalid_argument);
+    ASSERT_EQ(circuit_to_tableau(measure_reset, false, true, true), Tableau(1));
+
+    ASSERT_EQ(circuit_to_tableau(annotations, false, false, false), Tableau(1));
+
+    ASSERT_EQ(circuit_to_tableau(annotations + measure_reset + measure + reset + unitary + noise, true, true, true).num_qubits, 2);
+}
+
+TEST(conversions, circuit_to_tableau) {
+    ASSERT_EQ(
+        circuit_to_tableau(Circuit(R"CIRCUIT(
+        )CIRCUIT"), false, false, false),
+        Tableau(0));
+
+    ASSERT_EQ(
+        circuit_to_tableau(Circuit(R"CIRCUIT(
+            REPEAT 10 {
+                X 0
+                TICK
+            }
+        )CIRCUIT"), false, false, false),
+        Tableau(1));
+
+    ASSERT_EQ(
+        circuit_to_tableau(Circuit(R"CIRCUIT(
+            REPEAT 11 {
+                X 0
+                TICK
+            }
+        )CIRCUIT"), false, false, false),
+        GATE_DATA.at("X").tableau());
+
+    ASSERT_EQ(
+        circuit_to_tableau(Circuit(R"CIRCUIT(
+            S 0
+        )CIRCUIT"), false, false, false),
+        GATE_DATA.at("S").tableau());
+
+    ASSERT_EQ(
+        circuit_to_tableau(Circuit(R"CIRCUIT(
+            SQRT_Y_DAG 1
+            CZ 0 1
+            SQRT_Y 1
+        )CIRCUIT"), false, false, false),
+        GATE_DATA.at("CX").tableau());
+
+
+    ASSERT_EQ(
+        circuit_to_tableau(Circuit(R"CIRCUIT(
+            R 0
+            X_ERROR(0.1) 0
+            SQRT_Y_DAG 1
+            CZ 0 1
+            SQRT_Y 1
+            M 0
+        )CIRCUIT"), true, true, true),
+        GATE_DATA.at("CX").tableau());
+}
+
+TEST(conversions, circuit_to_output_state_vector) {
+    ASSERT_EQ(
+        circuit_to_output_state_vector(Circuit(""), false),
+        (std::vector<std::complex<float>>{{1}})
+    );
+    ASSERT_EQ(
+        circuit_to_output_state_vector(Circuit("H 0 1"), false),
+        (std::vector<std::complex<float>>{{0.5}, {0.5}, {0.5}, {0.5}})
+    );
+    ASSERT_EQ(
+        circuit_to_output_state_vector(Circuit("X 1"), false),
+        (std::vector<std::complex<float>>{{0}, {1}, {0}, {0}})
+    );
+    ASSERT_EQ(
+        circuit_to_output_state_vector(Circuit("X 1"), true),
+        (std::vector<std::complex<float>>{{0}, {0}, {1}, {0}})
+    );
+}

--- a/src/stim/stabilizers/conversions.test.cc
+++ b/src/stim/stabilizers/conversions.test.cc
@@ -15,8 +15,9 @@
 #include "stim/stabilizers/conversions.h"
 
 #include "gtest/gtest.h"
-#include "stim/test_util.test.h"
+
 #include "stim/simulators/tableau_simulator.h"
+#include "stim/test_util.test.h"
 
 using namespace stim;
 
@@ -46,11 +47,13 @@ TEST(conversions, floor_lg2) {
 }
 
 TEST(conversions, unitary_circuit_inverse) {
-    ASSERT_EQ(unitary_circuit_inverse(Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        unitary_circuit_inverse(Circuit(R"CIRCUIT(
         H 0
         ISWAP 0 1 1 2 3 2
         S 0 3 4
-    )CIRCUIT")), Circuit(R"CIRCUIT(
+    )CIRCUIT")),
+        Circuit(R"CIRCUIT(
         S_DAG 4 3 0
         ISWAP_DAG 3 2 1 2 0 1
         H 0
@@ -60,99 +63,151 @@ TEST(conversions, unitary_circuit_inverse) {
 }
 
 TEST(conversions, stabilizer_state_vector_to_circuit_basic) {
-    ASSERT_THROW(stabilizer_state_vector_to_circuit({
-        {0.5},
-    }, false), std::invalid_argument);
+    ASSERT_THROW(
+        stabilizer_state_vector_to_circuit(
+            {
+                {0.5},
+            },
+            false),
+        std::invalid_argument);
 
-    ASSERT_EQ(stabilizer_state_vector_to_circuit({
-        {1},
-    }, false), stim::Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        stabilizer_state_vector_to_circuit(
+            {
+                {1},
+            },
+            false),
+        stim::Circuit(R"CIRCUIT(
     )CIRCUIT"));
 
-    ASSERT_EQ(stabilizer_state_vector_to_circuit({
-        {-1},
-    }, false), stim::Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        stabilizer_state_vector_to_circuit(
+            {
+                {-1},
+            },
+            false),
+        stim::Circuit(R"CIRCUIT(
     )CIRCUIT"));
 
-    ASSERT_EQ(stabilizer_state_vector_to_circuit({
-        {0, 1},
-        {0},
-    }, false), stim::Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        stabilizer_state_vector_to_circuit(
+            {
+                {0, 1},
+                {0},
+            },
+            false),
+        stim::Circuit(R"CIRCUIT(
         I 0
     )CIRCUIT"));
 
-    ASSERT_EQ(stabilizer_state_vector_to_circuit({
-        {0},
-        {1},
-    }, false), stim::Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        stabilizer_state_vector_to_circuit(
+            {
+                {0},
+                {1},
+            },
+            false),
+        stim::Circuit(R"CIRCUIT(
         X 0
     )CIRCUIT"));
 
-    ASSERT_EQ(stabilizer_state_vector_to_circuit({
-        {sqrtf(0.5)},
-        {sqrtf(0.5)},
-    }, false), stim::Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        stabilizer_state_vector_to_circuit(
+            {
+                {sqrtf(0.5)},
+                {sqrtf(0.5)},
+            },
+            false),
+        stim::Circuit(R"CIRCUIT(
         H 0
     )CIRCUIT"));
 
-    ASSERT_EQ(stabilizer_state_vector_to_circuit({
-        {0},
-        {1},
-        {0},
-        {0},
-    }, false), stim::Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        stabilizer_state_vector_to_circuit(
+            {
+                {0},
+                {1},
+                {0},
+                {0},
+            },
+            false),
+        stim::Circuit(R"CIRCUIT(
         X 1
     )CIRCUIT"));
 
-    ASSERT_EQ(stabilizer_state_vector_to_circuit({
-        {0},
-        {0},
-        {1},
-        {0},
-    }, false), stim::Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        stabilizer_state_vector_to_circuit(
+            {
+                {0},
+                {0},
+                {1},
+                {0},
+            },
+            false),
+        stim::Circuit(R"CIRCUIT(
         X 0
         I 1
     )CIRCUIT"));
 
-    ASSERT_EQ(stabilizer_state_vector_to_circuit({
-        {0},
-        {1},
-        {0},
-        {0},
-    }, true), stim::Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        stabilizer_state_vector_to_circuit(
+            {
+                {0},
+                {1},
+                {0},
+                {0},
+            },
+            true),
+        stim::Circuit(R"CIRCUIT(
         X 0
         I 1
     )CIRCUIT"));
 
-    ASSERT_EQ(stabilizer_state_vector_to_circuit({
-        {0},
-        {0},
-        {1},
-        {0},
-    }, true), stim::Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        stabilizer_state_vector_to_circuit(
+            {
+                {0},
+                {0},
+                {1},
+                {0},
+            },
+            true),
+        stim::Circuit(R"CIRCUIT(
         X 1
     )CIRCUIT"));
 
-    ASSERT_EQ(stabilizer_state_vector_to_circuit({
-        {sqrtf(0.5)},
-        {0, sqrtf(0.5)},
-    }, true), stim::Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        stabilizer_state_vector_to_circuit(
+            {
+                {sqrtf(0.5)},
+                {0, sqrtf(0.5)},
+            },
+            true),
+        stim::Circuit(R"CIRCUIT(
         H 0
         S 0
     )CIRCUIT"));
 
-    ASSERT_EQ(stabilizer_state_vector_to_circuit({
-        {sqrtf(0.5)},
-        {0, -sqrtf(0.5)},
-    }, true), stim::Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        stabilizer_state_vector_to_circuit(
+            {
+                {sqrtf(0.5)},
+                {0, -sqrtf(0.5)},
+            },
+            true),
+        stim::Circuit(R"CIRCUIT(
         H 0
         S_DAG 0
     )CIRCUIT"));
 
-    ASSERT_EQ(stabilizer_state_vector_to_circuit({
-        {sqrtf(0.5)},
-        {-sqrtf(0.5)},
-    }, true), stim::Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        stabilizer_state_vector_to_circuit(
+            {
+                {sqrtf(0.5)},
+                {-sqrtf(0.5)},
+            },
+            true),
+        stim::Circuit(R"CIRCUIT(
         H 0
         Z 0
     )CIRCUIT"));
@@ -280,77 +335,95 @@ TEST(conversions, circuit_to_tableau_ignoring_gates) {
 
     ASSERT_EQ(circuit_to_tableau(annotations, false, false, false), Tableau(1));
 
-    ASSERT_EQ(circuit_to_tableau(annotations + measure_reset + measure + reset + unitary + noise, true, true, true).num_qubits, 2);
+    ASSERT_EQ(
+        circuit_to_tableau(annotations + measure_reset + measure + reset + unitary + noise, true, true, true)
+            .num_qubits,
+        2);
 }
 
 TEST(conversions, circuit_to_tableau) {
     ASSERT_EQ(
-        circuit_to_tableau(Circuit(R"CIRCUIT(
-        )CIRCUIT"), false, false, false),
+        circuit_to_tableau(
+            Circuit(R"CIRCUIT(
+        )CIRCUIT"),
+            false,
+            false,
+            false),
         Tableau(0));
 
     ASSERT_EQ(
-        circuit_to_tableau(Circuit(R"CIRCUIT(
+        circuit_to_tableau(
+            Circuit(R"CIRCUIT(
             REPEAT 10 {
                 X 0
                 TICK
             }
-        )CIRCUIT"), false, false, false),
+        )CIRCUIT"),
+            false,
+            false,
+            false),
         Tableau(1));
 
     ASSERT_EQ(
-        circuit_to_tableau(Circuit(R"CIRCUIT(
+        circuit_to_tableau(
+            Circuit(R"CIRCUIT(
             REPEAT 11 {
                 X 0
                 TICK
             }
-        )CIRCUIT"), false, false, false),
+        )CIRCUIT"),
+            false,
+            false,
+            false),
         GATE_DATA.at("X").tableau());
 
     ASSERT_EQ(
-        circuit_to_tableau(Circuit(R"CIRCUIT(
+        circuit_to_tableau(
+            Circuit(R"CIRCUIT(
             S 0
-        )CIRCUIT"), false, false, false),
+        )CIRCUIT"),
+            false,
+            false,
+            false),
         GATE_DATA.at("S").tableau());
 
     ASSERT_EQ(
-        circuit_to_tableau(Circuit(R"CIRCUIT(
+        circuit_to_tableau(
+            Circuit(R"CIRCUIT(
             SQRT_Y_DAG 1
             CZ 0 1
             SQRT_Y 1
-        )CIRCUIT"), false, false, false),
+        )CIRCUIT"),
+            false,
+            false,
+            false),
         GATE_DATA.at("CX").tableau());
 
-
     ASSERT_EQ(
-        circuit_to_tableau(Circuit(R"CIRCUIT(
+        circuit_to_tableau(
+            Circuit(R"CIRCUIT(
             R 0
             X_ERROR(0.1) 0
             SQRT_Y_DAG 1
             CZ 0 1
             SQRT_Y 1
             M 0
-        )CIRCUIT"), true, true, true),
+        )CIRCUIT"),
+            true,
+            true,
+            true),
         GATE_DATA.at("CX").tableau());
 }
 
 TEST(conversions, circuit_to_output_state_vector) {
-    ASSERT_EQ(
-        circuit_to_output_state_vector(Circuit(""), false),
-        (std::vector<std::complex<float>>{{1}})
-    );
+    ASSERT_EQ(circuit_to_output_state_vector(Circuit(""), false), (std::vector<std::complex<float>>{{1}}));
     ASSERT_EQ(
         circuit_to_output_state_vector(Circuit("H 0 1"), false),
-        (std::vector<std::complex<float>>{{0.5}, {0.5}, {0.5}, {0.5}})
-    );
+        (std::vector<std::complex<float>>{{0.5}, {0.5}, {0.5}, {0.5}}));
     ASSERT_EQ(
-        circuit_to_output_state_vector(Circuit("X 1"), false),
-        (std::vector<std::complex<float>>{{0}, {1}, {0}, {0}})
-    );
+        circuit_to_output_state_vector(Circuit("X 1"), false), (std::vector<std::complex<float>>{{0}, {1}, {0}, {0}}));
     ASSERT_EQ(
-        circuit_to_output_state_vector(Circuit("X 1"), true),
-        (std::vector<std::complex<float>>{{0}, {0}, {1}, {0}})
-    );
+        circuit_to_output_state_vector(Circuit("X 1"), true), (std::vector<std::complex<float>>{{0}, {0}, {1}, {0}}));
 }
 
 TEST(conversions, tableau_to_circuit_fuzz_vs_circuit_to_tableau) {
@@ -361,39 +434,31 @@ TEST(conversions, tableau_to_circuit_fuzz_vs_circuit_to_tableau) {
         ASSERT_EQ(actual, desired);
 
         for (const auto &op : circuit.operations) {
-            ASSERT_TRUE(op.gate == &GATE_DATA.at("S")
-                        || op.gate == &GATE_DATA.at("H")
-                        || op.gate == &GATE_DATA.at("CX")) << op;
+            ASSERT_TRUE(
+                op.gate == &GATE_DATA.at("S") || op.gate == &GATE_DATA.at("H") || op.gate == &GATE_DATA.at("CX"))
+                << op;
         }
     }
 }
 
 TEST(conversions, tableau_to_circuit) {
-    ASSERT_EQ(
-        tableau_to_circuit(GATE_DATA.at("I").tableau(), "elimination"),
-        Circuit(R"CIRCUIT(
+    ASSERT_EQ(tableau_to_circuit(GATE_DATA.at("I").tableau(), "elimination"), Circuit(R"CIRCUIT(
             H 0
             H 0
         )CIRCUIT"));
 
-    ASSERT_EQ(
-        tableau_to_circuit(GATE_DATA.at("X").tableau(), "elimination"),
-        Circuit(R"CIRCUIT(
+    ASSERT_EQ(tableau_to_circuit(GATE_DATA.at("X").tableau(), "elimination"), Circuit(R"CIRCUIT(
             H 0
             S 0
             S 0
             H 0
         )CIRCUIT"));
 
-    ASSERT_EQ(
-        tableau_to_circuit(GATE_DATA.at("S").tableau(), "elimination"),
-        Circuit(R"CIRCUIT(
+    ASSERT_EQ(tableau_to_circuit(GATE_DATA.at("S").tableau(), "elimination"), Circuit(R"CIRCUIT(
             S 0
         )CIRCUIT"));
 
-    ASSERT_EQ(
-        tableau_to_circuit(GATE_DATA.at("ISWAP").tableau(), "elimination"),
-        Circuit(R"CIRCUIT(
+    ASSERT_EQ(tableau_to_circuit(GATE_DATA.at("ISWAP").tableau(), "elimination"), Circuit(R"CIRCUIT(
             CX 1 0 0 1 1 0
             S 0
             H 1
@@ -461,29 +526,35 @@ TEST(conversions, unitary_to_tableau_fuzz_vs_tableau_to_unitary) {
 }
 
 TEST(conversions, unitary_to_tableau_fail) {
-    ASSERT_THROW({
-        unitary_to_tableau({{{1}, {0}}, {{0}, {sqrtf(0.5), sqrtf(0.5)}}}, false);
-    }, std::invalid_argument);
-    ASSERT_THROW({
-        unitary_to_tableau({
-            {1, 0, 0, 0},
-            {0, 1, 0, 0},
-            {0, 0, 1, 0},
-            {0, 0, 0, {0, 1}},
-        }, false);
-    }, std::invalid_argument);
-    ASSERT_THROW({
-        unitary_to_tableau({
-            {1, 0, 0, 0, 0, 0, 0, 0},
-            {0, 1, 0, 0, 0, 0, 0, 0},
-            {0, 0, 1, 0, 0, 0, 0, 0},
-            {0, 0, 0, 1, 0, 0, 0, 0},
-            {0, 0, 0, 0, 1, 0, 0, 0},
-            {0, 0, 0, 0, 0, 1, 0, 0},
-            {0, 0, 0, 0, 0, 0, 0, 1},
-            {0, 0, 0, 0, 0, 0, 1, 0},
-        }, false);
-    }, std::invalid_argument);
+    ASSERT_THROW({ unitary_to_tableau({{{1}, {0}}, {{0}, {sqrtf(0.5), sqrtf(0.5)}}}, false); }, std::invalid_argument);
+    ASSERT_THROW(
+        {
+            unitary_to_tableau(
+                {
+                    {1, 0, 0, 0},
+                    {0, 1, 0, 0},
+                    {0, 0, 1, 0},
+                    {0, 0, 0, {0, 1}},
+                },
+                false);
+        },
+        std::invalid_argument);
+    ASSERT_THROW(
+        {
+            unitary_to_tableau(
+                {
+                    {1, 0, 0, 0, 0, 0, 0, 0},
+                    {0, 1, 0, 0, 0, 0, 0, 0},
+                    {0, 0, 1, 0, 0, 0, 0, 0},
+                    {0, 0, 0, 1, 0, 0, 0, 0},
+                    {0, 0, 0, 0, 1, 0, 0, 0},
+                    {0, 0, 0, 0, 0, 1, 0, 0},
+                    {0, 0, 0, 0, 0, 0, 0, 1},
+                    {0, 0, 0, 0, 0, 0, 1, 0},
+                },
+                false);
+        },
+        std::invalid_argument);
 }
 
 TEST(conversions, stabilizers_to_tableau_fuzz) {
@@ -510,9 +581,7 @@ TEST(conversions, stabilizers_to_tableau_partial_fuzz) {
             for (size_t k = 0; k < n - skipped; k++) {
                 expected_stabilizers.push_back(t.zs[k]);
             }
-            ASSERT_THROW({
-                stabilizers_to_tableau(expected_stabilizers, false, false, false);
-            }, std::invalid_argument);
+            ASSERT_THROW({ stabilizers_to_tableau(expected_stabilizers, false, false, false); }, std::invalid_argument);
             auto actual = stabilizers_to_tableau(expected_stabilizers, false, true, false);
             for (size_t k = 0; k < n - skipped; k++) {
                 ASSERT_EQ(actual.zs[k], expected_stabilizers[k]);
@@ -541,9 +610,7 @@ TEST(conversions, stabilizers_to_tableau_overconstrained) {
         for (size_t k = 0; k < n; k++) {
             expected_stabilizers.push_back(t.zs[k]);
         }
-        ASSERT_THROW({
-            stabilizers_to_tableau(expected_stabilizers, false, false, false);
-        }, std::invalid_argument);
+        ASSERT_THROW({ stabilizers_to_tableau(expected_stabilizers, false, false, false); }, std::invalid_argument);
         auto actual = stabilizers_to_tableau(expected_stabilizers, true, false, false);
         for (size_t k = 0; k < n; k++) {
             ASSERT_EQ(actual.zs[k], expected_stabilizers[k + 1 + (k > 3)]);

--- a/src/stim/stabilizers/tableau.pybind.cc
+++ b/src/stim/stabilizers/tableau.pybind.cc
@@ -1166,6 +1166,62 @@ void pybind_tableau(pybind11::module &m) {
         )DOC")
             .data());
 
+    c.def_static(
+        "from_circuit",
+        [](const Circuit &circuit, bool ignore_noise, bool ignore_measurement, bool ignore_reset) {
+            return circuit_to_tableau(circuit, ignore_noise, ignore_measurement, ignore_reset);
+        },
+        pybind11::arg("circuit"),
+        pybind11::kw_only(),
+        pybind11::arg("ignore_noise") = false,
+        pybind11::arg("ignore_measurement") = false,
+        pybind11::arg("ignore_reset") = false,
+        clean_doc_string(u8R"DOC(
+            @signature def from_circuit(circuit: stim.Circuit, *, ignore_noise: bool = False, ignore_measurement: bool = False, ignore_reset: bool = False) -> stim.Tableau:
+            Converts a circuit into an equivalent stabilizer tableau.
+
+            Args:
+                circuit: The circuit to compile into a tableau.
+                ignore_noise: Defaults to False. When False, any noise operations in the circuit will cause
+                    the conversion to fail with an exception. When True, noise operations are skipped over
+                    as if they weren't even present in the circuit.
+                ignore_measurement: Defaults to False. When False, any measurement operations in the circuit
+                    will cause the conversion to fail with an exception. When True, measurement operations are
+                    skipped over as if they weren't even present in the circuit.
+                ignore_reset: Defaults to False. When False, any reset operations in the circuit will cause
+                    the conversion to fail with an exception. When True, reset operations are skipped over
+                    as if they weren't even present in the circuit.
+
+            Returns:
+                The tableau equivalent to the given circuit (up to global phase).
+
+            Raises:
+                ValueError:
+                    The circuit contains noise operations but ignore_noise=False.
+                    OR
+                    The circuit contains measurement operations but ignore_measurement=False.
+                    OR
+                    The circuit contains reset operations but ignore_reset=False.
+
+            Examples:
+                >>> import stim
+                >>> stim.Tableau.from_circuit(stim.Circuit("""
+                ...     H 0
+                ...     CNOT 0 1
+                ... """))
+                stim.Tableau.from_conjugated_generators(
+                    xs=[
+                        stim.PauliString("+Z_"),
+                        stim.PauliString("+_X"),
+                    ],
+                    zs=[
+                        stim.PauliString("+XX"),
+                        stim.PauliString("+ZZ"),
+                    ],
+                )
+        )DOC")
+            .data());
+
     c.def(
         "__repr__",
         [](const Tableau &self) {

--- a/src/stim/stabilizers/tableau_pybind_test.py
+++ b/src/stim/stabilizers/tableau_pybind_test.py
@@ -713,3 +713,26 @@ def test_iter_3q():
     for _ in stim.Tableau.iter_all(3, unsigned=True):
         n += 1
     assert n == 1451520
+
+
+def test_from_unitary_matrix():
+    s = 0.5**0.5
+    t = stim.Tableau.from_unitary_matrix([
+        [s, s],
+        [s, -s]
+    ], endian='little')
+    assert t == stim.Tableau.from_named_gate("H")
+
+    with pytest.raises(ValueError, match="Clifford operation"):
+        stim.Tableau.from_unitary_matrix([
+            [1, 0],
+            [0, 0],
+        ], endian='little')
+
+
+def test_to_circuit():
+    t = stim.Tableau.random(4)
+    c = t.to_circuit(method="elimination")
+    sim = stim.TableauSimulator()
+    sim.do_circuit(c)
+    assert sim.current_inverse_tableau().inverse() == t

--- a/src/stim/stabilizers/tableau_pybind_test.py
+++ b/src/stim/stabilizers/tableau_pybind_test.py
@@ -730,9 +730,10 @@ def test_from_unitary_matrix():
         ], endian='little')
 
 
-def test_to_circuit():
+def test_to_circuit_vs_from_circuit():
     t = stim.Tableau.random(4)
     c = t.to_circuit(method="elimination")
     sim = stim.TableauSimulator()
     sim.do_circuit(c)
     assert sim.current_inverse_tableau().inverse() == t
+    assert stim.Tableau.from_circuit(c) == t


### PR DESCRIPTION
Python changes:

- Add `stim.Tableau.from_unitary_matrix`
- Add `stim.Tableau.from_circuit`
- Add `stim.Tableau.to_circuit`
- Add `stim.TableauSimulator.set_state_from_stabilizers`
- Add `stim.TableauSimulator.set_state_from_state_vector`

Doc changes:

- Polish R,MR,M gate docs
- Remove some redundant ticks in gate docs
- Mention that two qubit gate unitaries are little endian in gate docs
- Update API generation to spread signatures over multiple lines

C++ changes:

- Add `stim::GATE_IS_RESET` data flag
- Add `stim::VectorSimulator::smooth_stabilizer_state`
- Add `stim::stabilizer_state_vector_to_circuit`
- Add `stim::circuit_to_tableau`
- Add `stim::circuit_to_output_state_vector`
- Add `stim::floor_lg2`
- Add `stim::is_power_of_2`
- Add `stim::stabilizers_to_tableau`
- Add `stim::unitary_circuit_inverse`
- Add `stim::tableau_to_unitary`
- Add `stim::unitary_to_tableau`
- Add `stim::tableau_to_circuit`
- Add `src/stim/stabilizers/conversions.{cc,h,test.cc}`
- Add `stim::VectorSimulator::do_unitary_circuit`
- Fix an out of bounds read in `TableauSimulator::to_state_vector` on zero-sized tableaus
- Fix a bug in `stim::Circuit`'s copy constructor where it didn't copy over operations (HOW??? How did this only get caught NOW???)
- Fix an aarch64 build failure caused by leftover test debug printing

Fixes https://github.com/quantumlib/Stim/issues/279
Fixes https://github.com/quantumlib/Stim/issues/292
Fixes https://github.com/quantumlib/Stim/issues/293
Fixes https://github.com/quantumlib/Stim/issues/295
Fixes https://github.com/quantumlib/Stim/issues/296
