### PR TITLE
Pybind refactor

### DIFF
--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -143,7 +143,7 @@ void circuit_append_strict(
     circuit_append(self, obj, targets, arg, false);
 }
 
-pybind11::class_<Circuit> pybind_circuit(pybind11::module &m) {
+pybind11::class_<Circuit> stim_pybind::pybind_circuit(pybind11::module &m) {
     auto c = pybind11::class_<Circuit>(
         m,
         "Circuit",
@@ -219,7 +219,7 @@ std::set<uint64_t> obj_to_abs_detector_id_set(
     return filter;
 }
 
-void pybind_circuit_after_types_all_defined(pybind11::class_<Circuit> &c) {
+void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Circuit> &c) {
     c.def(
         pybind11::init([](const char *stim_program_text) {
             Circuit self;

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -170,7 +170,6 @@ pybind11::class_<Circuit> stim_pybind::pybind_circuit(pybind11::module &m) {
             .data());
 
     pybind_circuit_repeat_block(m);
-    pybind_circuit_gate_target(m);
     pybind_circuit_instruction(m);
 
     return c;

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -170,7 +170,6 @@ pybind11::class_<Circuit> stim_pybind::pybind_circuit(pybind11::module &m) {
             .data());
 
     pybind_circuit_repeat_block(m);
-    pybind_circuit_instruction(m);
 
     return c;
 }

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -169,8 +169,6 @@ pybind11::class_<Circuit> stim_pybind::pybind_circuit(pybind11::module &m) {
         )DOC")
             .data());
 
-    pybind_circuit_repeat_block(m);
-
     return c;
 }
 

--- a/src/stim/circuit/circuit.pybind.h
+++ b/src/stim/circuit/circuit.pybind.h
@@ -19,8 +19,13 @@
 
 #include "stim/circuit/circuit.h"
 
+namespace stim_pybind {
+
 pybind11::class_<stim::Circuit> pybind_circuit(pybind11::module &m);
-void pybind_circuit_after_types_all_defined(pybind11::class_<stim::Circuit> &c);
+void pybind_circuit_methods(pybind11::module &m, pybind11::class_<stim::Circuit> &c);
+
+}
+
 std::set<uint64_t> obj_to_abs_detector_id_set(
     const pybind11::object &obj, const std::function<size_t(void)> &get_num_detectors);
 std::string circuit_repr(const stim::Circuit &self);

--- a/src/stim/circuit/circuit_gate_target.pybind.cc
+++ b/src/stim/circuit/circuit_gate_target.pybind.cc
@@ -37,8 +37,8 @@ GateTarget obj_to_gate_target(const pybind11::object &obj) {
     return handle_to_gate_target(obj);
 }
 
-void pybind_circuit_gate_target(pybind11::module &m) {
-    auto c = pybind11::class_<GateTarget>(
+pybind11::class_<stim::GateTarget> stim_pybind::pybind_circuit_gate_target(pybind11::module &m) {
+    return pybind11::class_<GateTarget>(
         m,
         "GateTarget",
         clean_doc_string(u8R"DOC(
@@ -55,6 +55,9 @@ void pybind_circuit_gate_target(pybind11::module &m) {
                 stim.GateTarget(stim.target_inv(1))
         )DOC")
             .data());
+}
+
+void stim_pybind::pybind_circuit_gate_target_methods(pybind11::module &m, pybind11::class_<stim::GateTarget> &c) {
     c.def(
         pybind11::init(&obj_to_gate_target),
         pybind11::arg("value"),

--- a/src/stim/circuit/circuit_gate_target.pybind.h
+++ b/src/stim/circuit/circuit_gate_target.pybind.h
@@ -21,7 +21,13 @@
 
 #include "stim/circuit/gate_target.h"
 
-void pybind_circuit_gate_target(pybind11::module &m);
+namespace stim_pybind {
+
+pybind11::class_<stim::GateTarget> pybind_circuit_gate_target(pybind11::module &m);
+void pybind_circuit_gate_target_methods(pybind11::module &m, pybind11::class_<stim::GateTarget> &c);
+
+}
+
 stim::GateTarget obj_to_gate_target(const pybind11::object &obj);
 stim::GateTarget handle_to_gate_target(const pybind11::handle &obj);
 

--- a/src/stim/circuit/circuit_instruction.pybind.cc
+++ b/src/stim/circuit/circuit_instruction.pybind.cc
@@ -80,8 +80,8 @@ std::vector<double> CircuitInstruction::gate_args_copy() const {
     return gate_args;
 }
 
-void pybind_circuit_instruction(pybind11::module &m) {
-    auto c = pybind11::class_<CircuitInstruction>(
+pybind11::class_<CircuitInstruction> stim_pybind::pybind_circuit_instruction(pybind11::module &m) {
+    return pybind11::class_<CircuitInstruction>(
         m,
         "CircuitInstruction",
         clean_doc_string(u8R"DOC(
@@ -102,7 +102,8 @@ void pybind_circuit_instruction(pybind11::module &m) {
                 stim.CircuitInstruction('X_ERROR', [stim.GateTarget(5)], [0.125])
         )DOC")
             .data());
-
+}
+void stim_pybind::pybind_circuit_instruction_methods(pybind11::module &m, pybind11::class_<CircuitInstruction> &c) {
     c.def(
         pybind11::init<const char *, std::vector<pybind11::object>, std::vector<double>>(),
         pybind11::arg("name"),

--- a/src/stim/circuit/circuit_instruction.pybind.h
+++ b/src/stim/circuit/circuit_instruction.pybind.h
@@ -17,11 +17,8 @@
 
 #include <pybind11/pybind11.h>
 
-#include "stim/circuit/circuit_gate_target.pybind.h"
 #include "stim/circuit/gate_data.h"
 #include "stim/circuit/gate_target.h"
-
-void pybind_circuit_instruction(pybind11::module &m);
 
 struct CircuitInstruction {
     const stim::Gate &gate;
@@ -42,5 +39,12 @@ struct CircuitInstruction {
     std::string repr() const;
     std::string str() const;
 };
+
+namespace stim_pybind {
+
+pybind11::class_<CircuitInstruction> pybind_circuit_instruction(pybind11::module &m);
+void pybind_circuit_instruction_methods(pybind11::module &m, pybind11::class_<CircuitInstruction> &c);
+
+}
 
 #endif

--- a/src/stim/circuit/circuit_repeat_block.pybind.cc
+++ b/src/stim/circuit/circuit_repeat_block.pybind.cc
@@ -42,8 +42,8 @@ std::string CircuitRepeatBlock::repr() const {
     return "stim.CircuitRepeatBlock(" + std::to_string(repeat_count) + ", " + circuit_repr(body) + ")";
 }
 
-void pybind_circuit_repeat_block(pybind11::module &m) {
-    auto c = pybind11::class_<CircuitRepeatBlock>(
+pybind11::class_<CircuitRepeatBlock> stim_pybind::pybind_circuit_repeat_block(pybind11::module &m) {
+    return pybind11::class_<CircuitRepeatBlock>(
         m,
         "CircuitRepeatBlock",
         clean_doc_string(u8R"DOC(
@@ -68,6 +68,9 @@ void pybind_circuit_repeat_block(pybind11::module &m) {
                 ''')
         )DOC")
             .data());
+}
+
+void stim_pybind::pybind_circuit_repeat_block_methods(pybind11::module &m, pybind11::class_<CircuitRepeatBlock> &c) {
 
     c.def(
         pybind11::init<uint64_t, Circuit>(),

--- a/src/stim/circuit/circuit_repeat_block.pybind.h
+++ b/src/stim/circuit/circuit_repeat_block.pybind.h
@@ -19,8 +19,6 @@
 
 #include "stim/circuit/circuit.h"
 
-void pybind_circuit_repeat_block(pybind11::module &m);
-
 struct CircuitRepeatBlock {
     uint64_t repeat_count;
     stim::Circuit body;
@@ -30,5 +28,12 @@ struct CircuitRepeatBlock {
     bool operator!=(const CircuitRepeatBlock &other) const;
     std::string repr() const;
 };
+
+namespace stim_pybind {
+
+pybind11::class_<CircuitRepeatBlock> pybind_circuit_repeat_block(pybind11::module &m);
+void pybind_circuit_repeat_block_methods(pybind11::module &m, pybind11::class_<CircuitRepeatBlock> &c);
+
+}
 
 #endif

--- a/src/stim/dem/detector_error_model.pybind.cc
+++ b/src/stim/dem/detector_error_model.pybind.cc
@@ -26,9 +26,8 @@
 #include "stim/simulators/dem_sampler.h"
 
 using namespace stim;
-using namespace stim_pybind;
 
-std::string stim_pybind::detector_error_model_repr(const DetectorErrorModel &self) {
+std::string detector_error_model_repr(const DetectorErrorModel &self) {
     if (self.instructions.empty()) {
         return "stim.DetectorErrorModel()";
     }
@@ -118,7 +117,7 @@ pybind11::class_<stim::DetectorErrorModel> stim_pybind::pybind_detector_error_mo
     return c;
 }
 
-void stim_pybind::pybind_detector_error_model_after_types_all_defined(pybind11::module &m, pybind11::class_<stim::DetectorErrorModel> &c) {
+void stim_pybind::pybind_detector_error_model_methods(pybind11::module &m, pybind11::class_<stim::DetectorErrorModel> &c) {
     c.def(
         pybind11::init([](const char *detector_error_model_text) {
             DetectorErrorModel self;

--- a/src/stim/dem/detector_error_model.pybind.cc
+++ b/src/stim/dem/detector_error_model.pybind.cc
@@ -111,9 +111,6 @@ pybind11::class_<stim::DetectorErrorModel> stim_pybind::pybind_detector_error_mo
         )DOC")
             .data());
 
-    pybind_detector_error_model_instruction(m);
-    pybind_detector_error_model_target(m);
-    pybind_detector_error_model_repeat_block(m);
     return c;
 }
 

--- a/src/stim/dem/detector_error_model.pybind.h
+++ b/src/stim/dem/detector_error_model.pybind.h
@@ -22,9 +22,10 @@
 namespace stim_pybind {
 
 pybind11::class_<stim::DetectorErrorModel> pybind_detector_error_model(pybind11::module &m);
-void pybind_detector_error_model_after_types_all_defined(pybind11::module &m, pybind11::class_<stim::DetectorErrorModel> &c);
-std::string detector_error_model_repr(const stim::DetectorErrorModel &self);
+void pybind_detector_error_model_methods(pybind11::module &m, pybind11::class_<stim::DetectorErrorModel> &c);
 
 }
+
+std::string detector_error_model_repr(const stim::DetectorErrorModel &self);
 
 #endif

--- a/src/stim/dem/detector_error_model_instruction.pybind.cc
+++ b/src/stim/dem/detector_error_model_instruction.pybind.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "stim/dem/detector_error_model_instruction.pybind.h"
-
+#include "stim/dem/detector_error_model_target.pybind.h"
 #include "stim/dem/detector_error_model.pybind.h"
 #include "stim/py/base.pybind.h"
 
@@ -83,8 +83,8 @@ std::vector<double> ExposedDemInstruction::args_copy() const {
     return arguments;
 }
 
-void pybind_detector_error_model_instruction(pybind11::module &m) {
-    auto c = pybind11::class_<ExposedDemInstruction>(
+pybind11::class_<ExposedDemInstruction> stim_pybind::pybind_detector_error_model_instruction(pybind11::module &m) {
+    return pybind11::class_<ExposedDemInstruction>(
         m,
         "DemInstruction",
         clean_doc_string(u8R"DOC(
@@ -104,6 +104,10 @@ void pybind_detector_error_model_instruction(pybind11::module &m) {
                 stim.DemInstruction('error', [0.125], [stim.target_relative_detector_id(0)])
         )DOC")
             .data());
+}
+void stim_pybind::pybind_detector_error_model_instruction_methods(
+    pybind11::module &m,
+    pybind11::class_<ExposedDemInstruction> &c) {
 
     c.def(
         pybind11::init(

--- a/src/stim/dem/detector_error_model_instruction.pybind.h
+++ b/src/stim/dem/detector_error_model_instruction.pybind.h
@@ -18,7 +18,6 @@
 #include <pybind11/pybind11.h>
 
 #include "stim/dem/detector_error_model.h"
-#include "stim/dem/detector_error_model_target.pybind.h"
 
 struct ExposedDemInstruction {
     std::vector<double> arguments;
@@ -35,6 +34,10 @@ struct ExposedDemInstruction {
     bool operator!=(const ExposedDemInstruction &other) const;
 };
 
-void pybind_detector_error_model_instruction(pybind11::module &m);
+namespace stim_pybind {
 
+pybind11::class_<ExposedDemInstruction> pybind_detector_error_model_instruction(pybind11::module &m);
+void pybind_detector_error_model_instruction_methods(pybind11::module &m, pybind11::class_<ExposedDemInstruction> &c);
+
+}
 #endif

--- a/src/stim/dem/detector_error_model_instruction.pybind.h
+++ b/src/stim/dem/detector_error_model_instruction.pybind.h
@@ -19,6 +19,9 @@
 
 #include "stim/dem/detector_error_model.h"
 
+
+namespace stim_pybind {
+
 struct ExposedDemInstruction {
     std::vector<double> arguments;
     std::vector<stim::DemTarget> targets;
@@ -33,8 +36,6 @@ struct ExposedDemInstruction {
     bool operator==(const ExposedDemInstruction &other) const;
     bool operator!=(const ExposedDemInstruction &other) const;
 };
-
-namespace stim_pybind {
 
 pybind11::class_<ExposedDemInstruction> pybind_detector_error_model_instruction(pybind11::module &m);
 void pybind_detector_error_model_instruction_methods(pybind11::module &m, pybind11::class_<ExposedDemInstruction> &c);

--- a/src/stim/dem/detector_error_model_repeat_block.pybind.cc
+++ b/src/stim/dem/detector_error_model_repeat_block.pybind.cc
@@ -19,10 +19,9 @@
 #include "stim/py/base.pybind.h"
 
 using namespace stim;
-using namespace stim_pybind;
 
-void pybind_detector_error_model_repeat_block(pybind11::module &m) {
-    auto c = pybind11::class_<ExposedDemRepeatBlock>(
+pybind11::class_<ExposedDemRepeatBlock> stim_pybind::pybind_detector_error_model_repeat_block(pybind11::module &m) {
+    return pybind11::class_<ExposedDemRepeatBlock>(
         m,
         "DemRepeatBlock",
         clean_doc_string(u8R"DOC(
@@ -43,6 +42,11 @@ void pybind_detector_error_model_repeat_block(pybind11::module &m) {
                 '''))
         )DOC")
             .data());
+}
+
+void stim_pybind::pybind_detector_error_model_repeat_block_methods(
+    pybind11::module &m,
+    pybind11::class_<ExposedDemRepeatBlock> c) {
 
     c.def(
         pybind11::init<uint64_t, DetectorErrorModel>(),

--- a/src/stim/dem/detector_error_model_repeat_block.pybind.cc
+++ b/src/stim/dem/detector_error_model_repeat_block.pybind.cc
@@ -19,6 +19,7 @@
 #include "stim/py/base.pybind.h"
 
 using namespace stim;
+using namespace stim_pybind;
 
 pybind11::class_<ExposedDemRepeatBlock> stim_pybind::pybind_detector_error_model_repeat_block(pybind11::module &m) {
     return pybind11::class_<ExposedDemRepeatBlock>(
@@ -46,7 +47,7 @@ pybind11::class_<ExposedDemRepeatBlock> stim_pybind::pybind_detector_error_model
 
 void stim_pybind::pybind_detector_error_model_repeat_block_methods(
     pybind11::module &m,
-    pybind11::class_<ExposedDemRepeatBlock> c) {
+    pybind11::class_<ExposedDemRepeatBlock> &c) {
 
     c.def(
         pybind11::init<uint64_t, DetectorErrorModel>(),

--- a/src/stim/dem/detector_error_model_repeat_block.pybind.h
+++ b/src/stim/dem/detector_error_model_repeat_block.pybind.h
@@ -19,6 +19,10 @@
 
 #include "stim/dem/detector_error_model.h"
 
+
+
+namespace stim_pybind {
+
 struct ExposedDemRepeatBlock {
     uint64_t repeat_count;
     stim::DetectorErrorModel body;
@@ -29,10 +33,8 @@ struct ExposedDemRepeatBlock {
     bool operator!=(const ExposedDemRepeatBlock &other) const;
 };
 
-namespace stim_pybind {
-
 pybind11::class_<ExposedDemRepeatBlock> pybind_detector_error_model_repeat_block(pybind11::module &m);
-void pybind_detector_error_model_repeat_block_methods(pybind11::module &m, pybind11::class_<ExposedDemRepeatBlock> c);
+void pybind_detector_error_model_repeat_block_methods(pybind11::module &m, pybind11::class_<ExposedDemRepeatBlock> &c);
 
 }
 

--- a/src/stim/dem/detector_error_model_repeat_block.pybind.h
+++ b/src/stim/dem/detector_error_model_repeat_block.pybind.h
@@ -29,6 +29,11 @@ struct ExposedDemRepeatBlock {
     bool operator!=(const ExposedDemRepeatBlock &other) const;
 };
 
-void pybind_detector_error_model_repeat_block(pybind11::module &m);
+namespace stim_pybind {
+
+pybind11::class_<ExposedDemRepeatBlock> pybind_detector_error_model_repeat_block(pybind11::module &m);
+void pybind_detector_error_model_repeat_block_methods(pybind11::module &m, pybind11::class_<ExposedDemRepeatBlock> c);
+
+}
 
 #endif

--- a/src/stim/dem/detector_error_model_target.pybind.cc
+++ b/src/stim/dem/detector_error_model_target.pybind.cc
@@ -20,10 +20,14 @@
 using namespace stim;
 using namespace stim_pybind;
 
-void stim_pybind::pybind_detector_error_model_target(pybind11::module &m) {
-    auto c = pybind11::class_<ExposedDemTarget>(
+pybind11::class_<ExposedDemTarget> stim_pybind::pybind_detector_error_model_target(pybind11::module &m) {
+    return pybind11::class_<ExposedDemTarget>(
         m, "DemTarget", "An instruction target from a detector error model (.dem) file.");
+}
 
+void stim_pybind::pybind_detector_error_model_target_methods(
+    pybind11::module &m,
+    pybind11::class_<ExposedDemTarget> &c) {
     m.def(
         "target_relative_detector_id",
         &ExposedDemTarget::relative_detector_id,
@@ -49,7 +53,6 @@ void stim_pybind::pybind_detector_error_model_target(pybind11::module &m) {
                 ''')
         )DOC")
             .data());
-
     m.def(
         "target_logical_observable_id",
         &ExposedDemTarget::observable_id,

--- a/src/stim/dem/detector_error_model_target.pybind.h
+++ b/src/stim/dem/detector_error_model_target.pybind.h
@@ -30,7 +30,8 @@ struct ExposedDemTarget : stim::DemTarget {
     static ExposedDemTarget separator();
 };
 
-void pybind_detector_error_model_target(pybind11::module &m);
+pybind11::class_<ExposedDemTarget> pybind_detector_error_model_target(pybind11::module &m);
+void pybind_detector_error_model_target_methods(pybind11::module &m, pybind11::class_<ExposedDemTarget> &c);
 
 }  // namespace stim_pybind
 

--- a/src/stim/py/compiled_detector_sampler.pybind.cc
+++ b/src/stim/py/compiled_detector_sampler.pybind.cc
@@ -113,7 +113,9 @@ pybind11::class_<CompiledDetectorSampler> stim_pybind::pybind_compiled_detector_
         m, "CompiledDetectorSampler", "An analyzed stabilizer circuit whose detection events can be sampled quickly.");
 }
 
-void stim_pybind::pybind_compiled_detector_sampler_methods(pybind11::class_<CompiledDetectorSampler> &c) {
+void stim_pybind::pybind_compiled_detector_sampler_methods(
+    pybind11::module &,
+    pybind11::class_<CompiledDetectorSampler> &c) {
     c.def(
         pybind11::init(&py_init_compiled_detector_sampler),
         pybind11::arg("circuit"),

--- a/src/stim/py/compiled_detector_sampler.pybind.h
+++ b/src/stim/py/compiled_detector_sampler.pybind.h
@@ -46,7 +46,7 @@ struct CompiledDetectorSampler {
 };
 
 pybind11::class_<CompiledDetectorSampler> pybind_compiled_detector_sampler_class(pybind11::module &m);
-void pybind_compiled_detector_sampler_methods(pybind11::class_<CompiledDetectorSampler> &c);
+void pybind_compiled_detector_sampler_methods(pybind11::module &m, pybind11::class_<CompiledDetectorSampler> &c);
 CompiledDetectorSampler py_init_compiled_detector_sampler(const stim::Circuit &circuit, const pybind11::object &seed);
 
 }  // namespace stim_pybind

--- a/src/stim/py/compiled_measurement_sampler.pybind.cc
+++ b/src/stim/py/compiled_measurement_sampler.pybind.cc
@@ -100,7 +100,9 @@ CompiledMeasurementSampler stim_pybind::py_init_compiled_sampler(
     return CompiledMeasurementSampler(ref_sample, circuit, skip_reference_sample, make_py_seeded_rng(seed));
 }
 
-void stim_pybind::pybind_compiled_measurement_sampler_methods(pybind11::class_<CompiledMeasurementSampler> &c) {
+void stim_pybind::pybind_compiled_measurement_sampler_methods(
+    pybind11::module &m,
+    pybind11::class_<CompiledMeasurementSampler> &c) {
     c.def(
         pybind11::init(&py_init_compiled_sampler),
         pybind11::arg("circuit"),

--- a/src/stim/py/compiled_measurement_sampler.pybind.h
+++ b/src/stim/py/compiled_measurement_sampler.pybind.h
@@ -44,7 +44,7 @@ struct CompiledMeasurementSampler {
 };
 
 pybind11::class_<CompiledMeasurementSampler> pybind_compiled_measurement_sampler_class(pybind11::module &m);
-void pybind_compiled_measurement_sampler_methods(pybind11::class_<CompiledMeasurementSampler> &c);
+    void pybind_compiled_measurement_sampler_methods(pybind11::module &m, pybind11::class_<CompiledMeasurementSampler> &c);
 CompiledMeasurementSampler py_init_compiled_sampler(
     const stim::Circuit &circuit, bool skip_reference_sample, const pybind11::object &seed);
 

--- a/src/stim/py/stim.pybind.cc
+++ b/src/stim/py/stim.pybind.cc
@@ -148,7 +148,7 @@ PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
     auto c_circuit = pybind_circuit(m);
 
     auto c_detector_error_model_instruction = pybind_detector_error_model_instruction(m);
-    pybind_detector_error_model_target(m);
+    auto c_detector_error_model_target = pybind_detector_error_model_target(m);
     auto c_detector_error_model_repeat_block = pybind_detector_error_model_repeat_block(m);
     auto c_detector_error_model = pybind_detector_error_model(m);
 
@@ -441,6 +441,7 @@ PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
 
     pybind_detector_error_model_instruction_methods(m, c_detector_error_model_instruction);
     pybind_detector_error_model_repeat_block_methods(m, c_detector_error_model_repeat_block);
+    pybind_detector_error_model_target_methods(m, c_detector_error_model_target);
     pybind_detector_error_model_methods(m, c_detector_error_model);
 
     pybind_tableau_methods(m, c_tableau);

--- a/src/stim/py/stim.pybind.cc
+++ b/src/stim/py/stim.pybind.cc
@@ -18,6 +18,7 @@
 
 #include "stim/circuit/circuit_instruction.pybind.h"
 #include "stim/circuit/circuit_gate_target.pybind.h"
+#include "stim/circuit/circuit_repeat_block.pybind.h"
 #include "stim/circuit/circuit.pybind.h"
 #include "stim/dem/detector_error_model.pybind.h"
 #include "stim/io/read_write.pybind.h"
@@ -139,6 +140,7 @@ PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
     auto c_tableau_iter = pybind_tableau_iter(m);
     auto c_circuit_gate_target = pybind_circuit_gate_target(m);
     auto c_circuit_instruction = pybind_circuit_instruction(m);
+    auto c_circuit_repeat_block = pybind_circuit_repeat_block(m);
     auto c_circuit = pybind_circuit(m);
     auto c_detector_error_model = pybind_detector_error_model(m);
     pybind_compiled_detector_sampler_methods(c_compiled_detector_sampler);
@@ -421,6 +423,7 @@ PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
     m.def("_UNSTABLE_raw_format_data", &raw_format_data);
     pybind_circuit_instruction_methods(m, c_circuit_instruction);
     pybind_circuit_gate_target_methods(m, c_circuit_gate_target);
+    pybind_circuit_repeat_block_methods(m, c_circuit_repeat_block);
     pybind_circuit_methods(m, c_circuit);
     pybind_tableau_iter_after_types_all_defined(m, c_tableau_iter);
     pybind_dem_sampler_after_types_all_defined(m, c_dem_sampler);

--- a/src/stim/py/stim.pybind.cc
+++ b/src/stim/py/stim.pybind.cc
@@ -16,6 +16,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include "stim/circuit/circuit_instruction.pybind.h"
 #include "stim/circuit/circuit_gate_target.pybind.h"
 #include "stim/circuit/circuit.pybind.h"
 #include "stim/dem/detector_error_model.pybind.h"
@@ -137,6 +138,7 @@ PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
     auto c_tableau = pybind_tableau(m);
     auto c_tableau_iter = pybind_tableau_iter(m);
     auto c_circuit_gate_target = pybind_circuit_gate_target(m);
+    auto c_circuit_instruction = pybind_circuit_instruction(m);
     auto c_circuit = pybind_circuit(m);
     auto c_detector_error_model = pybind_detector_error_model(m);
     pybind_compiled_detector_sampler_methods(c_compiled_detector_sampler);
@@ -417,6 +419,7 @@ PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
 
     m.def("_UNSTABLE_raw_gate_data", &raw_gate_data);
     m.def("_UNSTABLE_raw_format_data", &raw_format_data);
+    pybind_circuit_instruction_methods(m, c_circuit_instruction);
     pybind_circuit_gate_target_methods(m, c_circuit_gate_target);
     pybind_circuit_methods(m, c_circuit);
     pybind_tableau_iter_after_types_all_defined(m, c_tableau_iter);

--- a/src/stim/py/stim.pybind.cc
+++ b/src/stim/py/stim.pybind.cc
@@ -156,7 +156,16 @@ PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
     auto c_detector_error_model = pybind_detector_error_model(m);
 
     auto c_tableau_simulator = pybind_tableau_simulator(m);
-    pybind_matched_error(m);
+
+
+    auto c_circuit_error_location_stack_frame = pybind_circuit_error_location_stack_frame(m);
+    auto c_gate_target_with_coords = pybind_gate_target_with_coords(m);
+    auto c_dem_target_with_coords = pybind_dem_target_with_coords(m);
+    auto c_flipped_measurement = pybind_flipped_measurement(m);
+    auto c_circuit_targets_inside_instruction = pybind_circuit_targets_inside_instruction(m);
+    auto c_circuit_error_location = pybind_circuit_error_location(m);
+    auto c_circuit_error_location_methods = pybind_explained_error(m);
+
 
     /// top level function definitions
     pybind_read_write(m);
@@ -453,5 +462,13 @@ PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
     pybind_compiled_measurements_to_detection_events_converter_methods(m, c_compiled_m2d_converter);
 
     pybind_tableau_simulator_methods(m, c_tableau_simulator);
+
+    pybind_circuit_error_location_stack_frame_methods(m, c_circuit_error_location_stack_frame);
+    pybind_gate_target_with_coords_methods(m, c_gate_target_with_coords);
+    pybind_dem_target_with_coords_methods(m, c_dem_target_with_coords);
+    pybind_flipped_measurement_methods(m, c_flipped_measurement);
+    pybind_circuit_targets_inside_instruction_methods(m, c_circuit_targets_inside_instruction);
+    pybind_circuit_error_location_methods(m, c_circuit_error_location);
+    pybind_explained_error_methods(m, c_circuit_error_location_methods);
 
 }

--- a/src/stim/py/stim.pybind.cc
+++ b/src/stim/py/stim.pybind.cc
@@ -135,10 +135,13 @@ PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
     // For example, if DetectorErrorModel is defined after Circuit then Circuit.detector_error_model's return type is
     // described as `stim::DetectorErrorModel` instead of `stim.DetectorErrorModel`.
 
+
+    /// class definitions
     auto c_dem_sampler = pybind_dem_sampler(m);
     auto c_compiled_detector_sampler = pybind_compiled_detector_sampler_class(m);
     auto c_compiled_measurement_sampler = pybind_compiled_measurement_sampler_class(m);
     auto c_compiled_m2d_converter = pybind_compiled_measurements_to_detection_events_converter_class(m);
+    auto c_pauli_string = pybind_pauli_string(m);
     auto c_tableau = pybind_tableau(m);
     auto c_tableau_iter = pybind_tableau_iter(m);
 
@@ -152,10 +155,10 @@ PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
     auto c_detector_error_model_repeat_block = pybind_detector_error_model_repeat_block(m);
     auto c_detector_error_model = pybind_detector_error_model(m);
 
-
-    auto c_pauli_string = pybind_pauli_string(m);
-    pybind_tableau_simulator(m);
+    auto c_tableau_simulator = pybind_tableau_simulator(m);
     pybind_matched_error(m);
+
+    /// top level function definitions
     pybind_read_write(m);
 
     m.def(
@@ -434,8 +437,8 @@ PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
     pybind_circuit_repeat_block_methods(m, c_circuit_repeat_block);
     pybind_circuit_methods(m, c_circuit);
 
-    pybind_tableau_iter_after_types_all_defined(m, c_tableau_iter);
-    pybind_dem_sampler_after_types_all_defined(m, c_dem_sampler);
+    pybind_tableau_iter_methods(m, c_tableau_iter);
+    pybind_dem_sampler_methods(m, c_dem_sampler);
 
     pybind_detector_error_model_instruction_methods(m, c_detector_error_model_instruction);
     pybind_detector_error_model_repeat_block_methods(m, c_detector_error_model_repeat_block);
@@ -448,4 +451,7 @@ PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
     pybind_compiled_detector_sampler_methods(m, c_compiled_detector_sampler);
     pybind_compiled_measurement_sampler_methods(m, c_compiled_measurement_sampler);
     pybind_compiled_measurements_to_detection_events_converter_methods(m, c_compiled_m2d_converter);
+
+    pybind_tableau_simulator_methods(m, c_tableau_simulator);
+
 }

--- a/src/stim/py/stim.pybind.cc
+++ b/src/stim/py/stim.pybind.cc
@@ -16,6 +16,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include "stim/circuit/circuit_gate_target.pybind.h"
 #include "stim/circuit/circuit.pybind.h"
 #include "stim/dem/detector_error_model.pybind.h"
 #include "stim/io/read_write.pybind.h"
@@ -135,6 +136,7 @@ PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
     auto c_compiled_m2d_converter = pybind_compiled_measurements_to_detection_events_converter_class(m);
     auto c_tableau = pybind_tableau(m);
     auto c_tableau_iter = pybind_tableau_iter(m);
+    auto c_circuit_gate_target = pybind_circuit_gate_target(m);
     auto c_circuit = pybind_circuit(m);
     auto c_detector_error_model = pybind_detector_error_model(m);
     pybind_compiled_detector_sampler_methods(c_compiled_detector_sampler);
@@ -415,6 +417,7 @@ PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
 
     m.def("_UNSTABLE_raw_gate_data", &raw_gate_data);
     m.def("_UNSTABLE_raw_format_data", &raw_format_data);
+    pybind_circuit_gate_target_methods(m, c_circuit_gate_target);
     pybind_circuit_methods(m, c_circuit);
     pybind_tableau_iter_after_types_all_defined(m, c_tableau_iter);
     pybind_dem_sampler_after_types_all_defined(m, c_dem_sampler);

--- a/src/stim/py/stim.pybind.cc
+++ b/src/stim/py/stim.pybind.cc
@@ -124,52 +124,7 @@ pybind11::dict raw_format_data() {
 }
 
 
-PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
-    m.attr("__version__") = xstr(VERSION_INFO);
-    m.doc() = R"pbdoc(
-        Stim: A fast stabilizer circuit library.
-    )pbdoc";
-
-    // CAUTION: The ordering of these is important!
-    // If a class references another before it is registered, method signatures can get messed up.
-    // For example, if DetectorErrorModel is defined after Circuit then Circuit.detector_error_model's return type is
-    // described as `stim::DetectorErrorModel` instead of `stim.DetectorErrorModel`.
-
-
-    /// class definitions
-    auto c_dem_sampler = pybind_dem_sampler(m);
-    auto c_compiled_detector_sampler = pybind_compiled_detector_sampler_class(m);
-    auto c_compiled_measurement_sampler = pybind_compiled_measurement_sampler_class(m);
-    auto c_compiled_m2d_converter = pybind_compiled_measurements_to_detection_events_converter_class(m);
-    auto c_pauli_string = pybind_pauli_string(m);
-    auto c_tableau = pybind_tableau(m);
-    auto c_tableau_iter = pybind_tableau_iter(m);
-
-    auto c_circuit_gate_target = pybind_circuit_gate_target(m);
-    auto c_circuit_instruction = pybind_circuit_instruction(m);
-    auto c_circuit_repeat_block = pybind_circuit_repeat_block(m);
-    auto c_circuit = pybind_circuit(m);
-
-    auto c_detector_error_model_instruction = pybind_detector_error_model_instruction(m);
-    auto c_detector_error_model_target = pybind_detector_error_model_target(m);
-    auto c_detector_error_model_repeat_block = pybind_detector_error_model_repeat_block(m);
-    auto c_detector_error_model = pybind_detector_error_model(m);
-
-    auto c_tableau_simulator = pybind_tableau_simulator(m);
-
-
-    auto c_circuit_error_location_stack_frame = pybind_circuit_error_location_stack_frame(m);
-    auto c_gate_target_with_coords = pybind_gate_target_with_coords(m);
-    auto c_dem_target_with_coords = pybind_dem_target_with_coords(m);
-    auto c_flipped_measurement = pybind_flipped_measurement(m);
-    auto c_circuit_targets_inside_instruction = pybind_circuit_targets_inside_instruction(m);
-    auto c_circuit_error_location = pybind_circuit_error_location(m);
-    auto c_circuit_error_location_methods = pybind_explained_error(m);
-
-
-    /// top level function definitions
-    pybind_read_write(m);
-
+void top_level(pybind11::module &m) {
     m.def(
         "target_rec",
         &target_rec,
@@ -440,7 +395,58 @@ PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
 
     m.def("_UNSTABLE_raw_gate_data", &raw_gate_data);
     m.def("_UNSTABLE_raw_format_data", &raw_format_data);
+}
 
+
+PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
+    m.attr("__version__") = xstr(VERSION_INFO);
+    m.doc() = R"pbdoc(
+        Stim: A fast stabilizer circuit library.
+    )pbdoc";
+
+    // CAUTION: The ordering of these is important!
+    // If a class references another before it is registered, method signatures can get messed up.
+    // For example, if DetectorErrorModel is defined after Circuit then Circuit.detector_error_model's return type is
+    // described as `stim::DetectorErrorModel` instead of `stim.DetectorErrorModel`.
+
+
+    /// class definitions
+    auto c_dem_sampler = pybind_dem_sampler(m);
+    auto c_compiled_detector_sampler = pybind_compiled_detector_sampler_class(m);
+    auto c_compiled_measurement_sampler = pybind_compiled_measurement_sampler_class(m);
+    auto c_compiled_m2d_converter = pybind_compiled_measurements_to_detection_events_converter_class(m);
+    auto c_pauli_string = pybind_pauli_string(m);
+    auto c_tableau = pybind_tableau(m);
+    auto c_tableau_iter = pybind_tableau_iter(m);
+
+    auto c_circuit_gate_target = pybind_circuit_gate_target(m);
+    auto c_circuit_instruction = pybind_circuit_instruction(m);
+    auto c_circuit_repeat_block = pybind_circuit_repeat_block(m);
+    auto c_circuit = pybind_circuit(m);
+
+    auto c_detector_error_model_instruction = pybind_detector_error_model_instruction(m);
+    auto c_detector_error_model_target = pybind_detector_error_model_target(m);
+    auto c_detector_error_model_repeat_block = pybind_detector_error_model_repeat_block(m);
+    auto c_detector_error_model = pybind_detector_error_model(m);
+
+    auto c_tableau_simulator = pybind_tableau_simulator(m);
+
+
+    auto c_circuit_error_location_stack_frame = pybind_circuit_error_location_stack_frame(m);
+    auto c_gate_target_with_coords = pybind_gate_target_with_coords(m);
+    auto c_dem_target_with_coords = pybind_dem_target_with_coords(m);
+    auto c_flipped_measurement = pybind_flipped_measurement(m);
+    auto c_circuit_targets_inside_instruction = pybind_circuit_targets_inside_instruction(m);
+    auto c_circuit_error_location = pybind_circuit_error_location(m);
+    auto c_circuit_error_location_methods = pybind_explained_error(m);
+
+
+    /// top level function definitions
+    top_level(m);
+    pybind_read_write(m);
+
+
+    // method definitions
     pybind_circuit_instruction_methods(m, c_circuit_instruction);
     pybind_circuit_gate_target_methods(m, c_circuit_gate_target);
     pybind_circuit_repeat_block_methods(m, c_circuit_repeat_block);
@@ -470,5 +476,4 @@ PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
     pybind_circuit_targets_inside_instruction_methods(m, c_circuit_targets_inside_instruction);
     pybind_circuit_error_location_methods(m, c_circuit_error_location);
     pybind_explained_error_methods(m, c_circuit_error_location_methods);
-
 }

--- a/src/stim/py/stim.pybind.cc
+++ b/src/stim/py/stim.pybind.cc
@@ -415,7 +415,7 @@ PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
 
     m.def("_UNSTABLE_raw_gate_data", &raw_gate_data);
     m.def("_UNSTABLE_raw_format_data", &raw_format_data);
-    pybind_circuit_after_types_all_defined(c_circuit);
+    pybind_circuit_methods(m, c_circuit);
     pybind_tableau_iter_after_types_all_defined(m, c_tableau_iter);
     pybind_dem_sampler_after_types_all_defined(m, c_dem_sampler);
     pybind_detector_error_model_after_types_all_defined(m, c_detector_error_model);

--- a/src/stim/py/stim.pybind.cc
+++ b/src/stim/py/stim.pybind.cc
@@ -141,14 +141,17 @@ PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
     auto c_compiled_m2d_converter = pybind_compiled_measurements_to_detection_events_converter_class(m);
     auto c_tableau = pybind_tableau(m);
     auto c_tableau_iter = pybind_tableau_iter(m);
+
     auto c_circuit_gate_target = pybind_circuit_gate_target(m);
     auto c_circuit_instruction = pybind_circuit_instruction(m);
     auto c_circuit_repeat_block = pybind_circuit_repeat_block(m);
     auto c_circuit = pybind_circuit(m);
+
     auto c_detector_error_model_instruction = pybind_detector_error_model_instruction(m);
     pybind_detector_error_model_target(m);
-    pybind_detector_error_model_repeat_block(m);
+    auto c_detector_error_model_repeat_block = pybind_detector_error_model_repeat_block(m);
     auto c_detector_error_model = pybind_detector_error_model(m);
+
     pybind_compiled_detector_sampler_methods(c_compiled_detector_sampler);
     pybind_compiled_measurement_sampler_methods(c_compiled_measurement_sampler);
     pybind_compiled_measurements_to_detection_events_converter_methods(c_compiled_m2d_converter);
@@ -427,13 +430,18 @@ PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
 
     m.def("_UNSTABLE_raw_gate_data", &raw_gate_data);
     m.def("_UNSTABLE_raw_format_data", &raw_format_data);
+
     pybind_circuit_instruction_methods(m, c_circuit_instruction);
     pybind_circuit_gate_target_methods(m, c_circuit_gate_target);
     pybind_circuit_repeat_block_methods(m, c_circuit_repeat_block);
     pybind_circuit_methods(m, c_circuit);
+
     pybind_tableau_iter_after_types_all_defined(m, c_tableau_iter);
     pybind_dem_sampler_after_types_all_defined(m, c_dem_sampler);
+
     pybind_detector_error_model_instruction_methods(m, c_detector_error_model_instruction);
+    pybind_detector_error_model_repeat_block_methods(m, c_detector_error_model_repeat_block);
     pybind_detector_error_model_methods(m, c_detector_error_model);
+
     pybind_tableau_methods(m, c_tableau);
 }

--- a/src/stim/py/stim.pybind.cc
+++ b/src/stim/py/stim.pybind.cc
@@ -20,6 +20,9 @@
 #include "stim/circuit/circuit_gate_target.pybind.h"
 #include "stim/circuit/circuit_repeat_block.pybind.h"
 #include "stim/circuit/circuit.pybind.h"
+#include "stim/dem/detector_error_model_instruction.pybind.h"
+#include "stim/dem/detector_error_model_repeat_block.pybind.h"
+#include "stim/dem/detector_error_model_target.pybind.h"
 #include "stim/dem/detector_error_model.pybind.h"
 #include "stim/io/read_write.pybind.h"
 #include "stim/main_namespaced.h"
@@ -142,6 +145,9 @@ PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
     auto c_circuit_instruction = pybind_circuit_instruction(m);
     auto c_circuit_repeat_block = pybind_circuit_repeat_block(m);
     auto c_circuit = pybind_circuit(m);
+    auto c_detector_error_model_instruction = pybind_detector_error_model_instruction(m);
+    pybind_detector_error_model_target(m);
+    pybind_detector_error_model_repeat_block(m);
     auto c_detector_error_model = pybind_detector_error_model(m);
     pybind_compiled_detector_sampler_methods(c_compiled_detector_sampler);
     pybind_compiled_measurement_sampler_methods(c_compiled_measurement_sampler);
@@ -427,6 +433,7 @@ PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
     pybind_circuit_methods(m, c_circuit);
     pybind_tableau_iter_after_types_all_defined(m, c_tableau_iter);
     pybind_dem_sampler_after_types_all_defined(m, c_dem_sampler);
+    pybind_detector_error_model_instruction_methods(m, c_detector_error_model_instruction);
     pybind_detector_error_model_methods(m, c_detector_error_model);
     pybind_tableau_methods(m, c_tableau);
 }

--- a/src/stim/py/stim.pybind.cc
+++ b/src/stim/py/stim.pybind.cc
@@ -427,6 +427,6 @@ PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
     pybind_circuit_methods(m, c_circuit);
     pybind_tableau_iter_after_types_all_defined(m, c_tableau_iter);
     pybind_dem_sampler_after_types_all_defined(m, c_dem_sampler);
-    pybind_detector_error_model_after_types_all_defined(m, c_detector_error_model);
+    pybind_detector_error_model_methods(m, c_detector_error_model);
     pybind_tableau_methods(m, c_tableau);
 }

--- a/src/stim/py/stim.pybind.cc
+++ b/src/stim/py/stim.pybind.cc
@@ -152,10 +152,8 @@ PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
     auto c_detector_error_model_repeat_block = pybind_detector_error_model_repeat_block(m);
     auto c_detector_error_model = pybind_detector_error_model(m);
 
-    pybind_compiled_detector_sampler_methods(c_compiled_detector_sampler);
-    pybind_compiled_measurement_sampler_methods(c_compiled_measurement_sampler);
-    pybind_compiled_measurements_to_detection_events_converter_methods(c_compiled_m2d_converter);
-    pybind_pauli_string(m);
+
+    auto c_pauli_string = pybind_pauli_string(m);
     pybind_tableau_simulator(m);
     pybind_matched_error(m);
     pybind_read_write(m);
@@ -445,4 +443,9 @@ PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
     pybind_detector_error_model_methods(m, c_detector_error_model);
 
     pybind_tableau_methods(m, c_tableau);
+    pybind_pauli_string_methods(m, c_pauli_string);
+
+    pybind_compiled_detector_sampler_methods(m, c_compiled_detector_sampler);
+    pybind_compiled_measurement_sampler_methods(m, c_compiled_measurement_sampler);
+    pybind_compiled_measurements_to_detection_events_converter_methods(m, c_compiled_m2d_converter);
 }

--- a/src/stim/simulators/dem_sampler.pybind.cc
+++ b/src/stim/simulators/dem_sampler.pybind.cc
@@ -108,7 +108,7 @@ pybind11::class_<DemSampler> stim_pybind::pybind_dem_sampler(pybind11::module &m
             .data());
 }
 
-void stim_pybind::pybind_dem_sampler_after_types_all_defined(
+void stim_pybind::pybind_dem_sampler_methods(
     pybind11::module &m, pybind11::class_<stim::DemSampler> &c) {
     c.def(
         "sample",

--- a/src/stim/simulators/dem_sampler.pybind.h
+++ b/src/stim/simulators/dem_sampler.pybind.h
@@ -22,7 +22,7 @@
 namespace stim_pybind {
 
 pybind11::class_<stim::DemSampler> pybind_dem_sampler(pybind11::module &m);
-void pybind_dem_sampler_after_types_all_defined(pybind11::module &m, pybind11::class_<stim::DemSampler> &c);
+void pybind_dem_sampler_methods(pybind11::module &m, pybind11::class_<stim::DemSampler> &c);
 
 }  // namespace stim_pybind
 

--- a/src/stim/simulators/matched_error.h
+++ b/src/stim/simulators/matched_error.h
@@ -175,4 +175,6 @@ std::ostream &operator<<(std::ostream &out, const ExplainedError &e);
 
 }  // namespace stim
 
+
+
 #endif

--- a/src/stim/simulators/matched_error.pybind.cc
+++ b/src/stim/simulators/matched_error.pybind.cc
@@ -132,8 +132,9 @@ std::string MatchedError_repr(const ExplainedError &self) {
     return out.str();
 }
 
-void pybind_CircuitErrorLocationStackFrame(pybind11::module &m) {
-    auto c = pybind11::class_<CircuitErrorLocationStackFrame>(
+pybind11::class_<CircuitErrorLocationStackFrame> stim_pybind::pybind_circuit_error_location_stack_frame(
+    pybind11::module &m) {
+    return pybind11::class_<CircuitErrorLocationStackFrame>(
         m,
         "CircuitErrorLocationStackFrame",
         clean_doc_string(u8R"DOC(
@@ -145,6 +146,10 @@ void pybind_CircuitErrorLocationStackFrame(pybind11::module &m) {
             that the instruction is within.
         )DOC")
             .data());
+}
+void stim_pybind::pybind_circuit_error_location_stack_frame_methods(
+        pybind11::module &m,
+        pybind11::class_<stim::CircuitErrorLocationStackFrame> &c) {
 
     c.def_readonly(
         "instruction_offset",
@@ -206,8 +211,8 @@ void pybind_CircuitErrorLocationStackFrame(pybind11::module &m) {
     c.def("__repr__", &CircuitErrorLocationStackFrame_repr);
 }
 
-void pybind_GateTargetWithCoords(pybind11::module &m) {
-    auto c = pybind11::class_<GateTargetWithCoords>(
+pybind11::class_<GateTargetWithCoords> stim_pybind::pybind_gate_target_with_coords(pybind11::module &m) {
+    return pybind11::class_<GateTargetWithCoords>(
         m,
         "GateTargetWithCoords",
         clean_doc_string(u8R"DOC(
@@ -223,7 +228,11 @@ void pybind_GateTargetWithCoords(pybind11::module &m) {
             what is happening.
         )DOC")
             .data());
+}
 
+void stim_pybind::pybind_gate_target_with_coords_methods(
+    pybind11::module &m,
+    pybind11::class_<stim::GateTargetWithCoords> &c) {
     c.def_readonly(
         "gate_target",
         &GateTargetWithCoords::gate_target,
@@ -263,8 +272,8 @@ void pybind_GateTargetWithCoords(pybind11::module &m) {
     c.def("__repr__", &GateTargetWithCoords_repr);
 }
 
-void pybind_DemTargetWithCoords(pybind11::module &m) {
-    auto c = pybind11::class_<DemTargetWithCoords>(
+pybind11::class_<DemTargetWithCoords> stim_pybind::pybind_dem_target_with_coords(pybind11::module &m) {
+    return pybind11::class_<DemTargetWithCoords>(
         m,
         "DemTargetWithCoords",
         clean_doc_string(u8R"DOC(
@@ -284,7 +293,9 @@ void pybind_DemTargetWithCoords(pybind11::module &m) {
             what is happening.
         )DOC")
             .data());
+}
 
+void stim_pybind::pybind_dem_target_with_coords_methods(pybind11::module &m, pybind11::class_<stim::DemTargetWithCoords> &c) {
     c.def_property_readonly(
         "dem_target",
         [](const DemTargetWithCoords &self) -> ExposedDemTarget {
@@ -327,8 +338,8 @@ void pybind_DemTargetWithCoords(pybind11::module &m) {
     c.def("__repr__", DemTargetWithCoords_repr);
 }
 
-void pybind_FlippedMeasurement(pybind11::module &m) {
-    auto c = pybind11::class_<FlippedMeasurement>(
+pybind11::class_<FlippedMeasurement> stim_pybind::pybind_flipped_measurement(pybind11::module &m) {
+    return pybind11::class_<FlippedMeasurement>(
         m,
         "FlippedMeasurement",
         clean_doc_string(u8R"DOC(
@@ -338,7 +349,8 @@ void pybind_FlippedMeasurement(pybind11::module &m) {
             the observable of the measurement.
         )DOC")
             .data());
-
+}
+void stim_pybind::pybind_flipped_measurement_methods(pybind11::module &m, pybind11::class_<stim::FlippedMeasurement> &c) {
     c.def_readonly(
         "record_index",
         &FlippedMeasurement::measurement_record_index,
@@ -385,15 +397,19 @@ void pybind_FlippedMeasurement(pybind11::module &m) {
     c.def("__str__", &FlippedMeasurement_repr);
 }
 
-void pybind_CircuitTargetsInsideInstruction(pybind11::module &m) {
-    auto c = pybind11::class_<CircuitTargetsInsideInstruction>(
+pybind11::class_<CircuitTargetsInsideInstruction> stim_pybind::pybind_circuit_targets_inside_instruction(pybind11::module &m) {
+    return pybind11::class_<CircuitTargetsInsideInstruction>(
         m,
         "CircuitTargetsInsideInstruction",
         clean_doc_string(u8R"DOC(
             Describes a range of targets within a circuit instruction.
         )DOC")
             .data());
+}
 
+void stim_pybind::pybind_circuit_targets_inside_instruction_methods(
+    pybind11::module &m,
+    pybind11::class_<stim::CircuitTargetsInsideInstruction> &c) {
     c.def_property_readonly(
         "gate",
         [](const CircuitTargetsInsideInstruction &self) -> pybind11::object {
@@ -472,15 +488,16 @@ void pybind_CircuitTargetsInsideInstruction(pybind11::module &m) {
     c.def("__str__", &CircuitTargetsInsideInstruction::str);
 }
 
-void pybind_CircuitErrorLocation(pybind11::module &m) {
-    auto c = pybind11::class_<CircuitErrorLocation>(
+pybind11::class_<CircuitErrorLocation> stim_pybind::pybind_circuit_error_location(pybind11::module &m) {
+    return pybind11::class_<CircuitErrorLocation>(
         m,
         "CircuitErrorLocation",
         clean_doc_string(u8R"DOC(
             Describes the location of an error mechanism from a stim circuit.
         )DOC")
             .data());
-
+}
+void stim_pybind::pybind_circuit_error_location_methods(pybind11::module &m, pybind11::class_<stim::CircuitErrorLocation> &c) {
     c.def_readonly(
         "tick_offset",
         &CircuitErrorLocation::tick_offset,
@@ -572,15 +589,16 @@ void pybind_CircuitErrorLocation(pybind11::module &m) {
     c.def("__str__", &CircuitErrorLocation::str);
 }
 
-void pybind_MatchedError(pybind11::module &m) {
-    auto c = pybind11::class_<ExplainedError>(
+pybind11::class_<ExplainedError> stim_pybind::pybind_explained_error(pybind11::module &m) {
+    return pybind11::class_<ExplainedError>(
         m,
         "ExplainedError",
         clean_doc_string(u8R"DOC(
             Describes the location of an error mechanism from a stim circuit.
         )DOC")
             .data());
-
+}
+void stim_pybind::pybind_explained_error_methods(pybind11::module &m, pybind11::class_<stim::ExplainedError> &c) {
     c.def_readonly(
         "dem_error_terms",
         &ExplainedError::dem_error_terms,
@@ -632,12 +650,3 @@ void pybind_MatchedError(pybind11::module &m) {
     c.def("__str__", &ExplainedError::str);
 }
 
-void stim_pybind::pybind_matched_error(pybind11::module &m) {
-    pybind_CircuitErrorLocationStackFrame(m);
-    pybind_GateTargetWithCoords(m);
-    pybind_DemTargetWithCoords(m);
-    pybind_FlippedMeasurement(m);
-    pybind_CircuitTargetsInsideInstruction(m);
-    pybind_CircuitErrorLocation(m);
-    pybind_MatchedError(m);
-}

--- a/src/stim/simulators/matched_error.pybind.h
+++ b/src/stim/simulators/matched_error.pybind.h
@@ -16,10 +16,38 @@
 #define _STIM_SIMULATORS_MATCHED_ERROR_PYBIND_H
 
 #include <pybind11/pybind11.h>
+#include "stim/simulators/matched_error.h"
+
 
 namespace stim_pybind {
 
-void pybind_matched_error(pybind11::module &m);
+pybind11::class_<stim::CircuitErrorLocationStackFrame> pybind_circuit_error_location_stack_frame(pybind11::module &m);
+pybind11::class_<stim::GateTargetWithCoords> pybind_gate_target_with_coords(pybind11::module &m);
+pybind11::class_<stim::DemTargetWithCoords> pybind_dem_target_with_coords(pybind11::module &m);
+pybind11::class_<stim::FlippedMeasurement> pybind_flipped_measurement(pybind11::module &m);
+pybind11::class_<stim::CircuitTargetsInsideInstruction> pybind_circuit_targets_inside_instruction(
+    pybind11::module &m);
+pybind11::class_<stim::CircuitErrorLocation> pybind_circuit_error_location(pybind11::module &m);
+pybind11::class_<stim::ExplainedError> pybind_explained_error(pybind11::module &m);
+
+void pybind_circuit_error_location_stack_frame_methods(
+    pybind11::module &m,
+    pybind11::class_<stim::CircuitErrorLocationStackFrame> &c);
+
+void pybind_gate_target_with_coords_methods(
+    pybind11::module &m,
+    pybind11::class_<stim::GateTargetWithCoords> &c);
+
+void pybind_dem_target_with_coords_methods(pybind11::module &m, pybind11::class_<stim::DemTargetWithCoords> &c);
+void pybind_flipped_measurement_methods(pybind11::module &m, pybind11::class_<stim::FlippedMeasurement> &c);
+void pybind_circuit_targets_inside_instruction_methods(
+    pybind11::module &m,
+    pybind11::class_<stim::CircuitTargetsInsideInstruction> &c);
+
+void pybind_circuit_error_location_methods(pybind11::module &m, pybind11::class_<stim::CircuitErrorLocation> &c);
+void pybind_explained_error_methods(pybind11::module &m, pybind11::class_<stim::ExplainedError> &c);
+
+
 
 }
 

--- a/src/stim/simulators/measurements_to_detection_events.pybind.cc
+++ b/src/stim/simulators/measurements_to_detection_events.pybind.cc
@@ -168,6 +168,7 @@ CompiledMeasurementsToDetectionEventsConverter stim_pybind::py_init_compiled_mea
 }
 
 void stim_pybind::pybind_compiled_measurements_to_detection_events_converter_methods(
+    pybind11::module &m,
     pybind11::class_<CompiledMeasurementsToDetectionEventsConverter> &c) {
     c.def(
         pybind11::init(&py_init_compiled_measurements_to_detection_events_converter),

--- a/src/stim/simulators/measurements_to_detection_events.pybind.h
+++ b/src/stim/simulators/measurements_to_detection_events.pybind.h
@@ -64,6 +64,7 @@ struct CompiledMeasurementsToDetectionEventsConverter {
 pybind11::class_<CompiledMeasurementsToDetectionEventsConverter>
 pybind_compiled_measurements_to_detection_events_converter_class(pybind11::module &m);
 void pybind_compiled_measurements_to_detection_events_converter_methods(
+    pybind11::module &m,
     pybind11::class_<CompiledMeasurementsToDetectionEventsConverter> &c);
 CompiledMeasurementsToDetectionEventsConverter py_init_compiled_measurements_to_detection_events_converter(
     const stim::Circuit &circuit, bool skip_reference_sample);

--- a/src/stim/simulators/tableau_simulator.pybind.cc
+++ b/src/stim/simulators/tableau_simulator.pybind.cc
@@ -116,8 +116,8 @@ TempViewableData args_to_target_pairs(PyTableauSimulator &self, const pybind11::
     return result;
 }
 
-void stim_pybind::pybind_tableau_simulator(pybind11::module &m) {
-    auto c = pybind11::class_<PyTableauSimulator>(
+pybind11::class_<PyTableauSimulator> stim_pybind::pybind_tableau_simulator(pybind11::module &m) {
+    return pybind11::class_<PyTableauSimulator>(
         m,
         "TableauSimulator",
         clean_doc_string(u8R"DOC(
@@ -151,6 +151,8 @@ void stim_pybind::pybind_tableau_simulator(pybind11::module &m) {
                 )
         )DOC")
             .data());
+}
+void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11::class_<PyTableauSimulator> &c) {
 
     c.def(pybind11::init(&create_tableau_simulator));
 

--- a/src/stim/simulators/tableau_simulator.pybind.h
+++ b/src/stim/simulators/tableau_simulator.pybind.h
@@ -26,7 +26,9 @@ struct PyTableauSimulator : stim::TableauSimulator {
     explicit PyTableauSimulator(std::shared_ptr<std::mt19937_64> rng);
 };
 
-void pybind_tableau_simulator(pybind11::module &m);
+pybind11::class_<PyTableauSimulator> pybind_tableau_simulator(pybind11::module &m);
+void  pybind_tableau_simulator_methods(pybind11::module &m, pybind11::class_<PyTableauSimulator> &c);
+
 
 }  // namespace stim_pybind
 

--- a/src/stim/stabilizers/pauli_string.pybind.cc
+++ b/src/stim/stabilizers/pauli_string.pybind.cc
@@ -215,8 +215,8 @@ PyPauliString PyPauliString::from_text(const char *text) {
     return value;
 }
 
-void stim_pybind::pybind_pauli_string(pybind11::module &m) {
-    auto c = pybind11::class_<PyPauliString>(
+pybind11::class_<PyPauliString> stim_pybind::pybind_pauli_string(pybind11::module &m) {
+    return pybind11::class_<PyPauliString>(
         m,
         "PauliString",
         clean_doc_string(u8R"DOC(
@@ -233,7 +233,9 @@ void stim_pybind::pybind_pauli_string(pybind11::module &m) {
                 +_____
         )DOC")
             .data());
+}
 
+void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::class_<PyPauliString> &c) {
     c.def(
         pybind11::init([](size_t num_qubits) {
             PyPauliString result{PauliString(num_qubits), false};

--- a/src/stim/stabilizers/pauli_string.pybind.h
+++ b/src/stim/stabilizers/pauli_string.pybind.h
@@ -52,7 +52,8 @@ struct PyPauliString {
     std::string str() const;
 };
 
-void pybind_pauli_string(pybind11::module &m);
+pybind11::class_<PyPauliString> pybind_pauli_string(pybind11::module &m);
+void pybind_pauli_string_methods(pybind11::module &m, pybind11::class_<PyPauliString> &c);
 
 }  // namespace stim_pybind
 

--- a/src/stim/stabilizers/tableau_iter.pybind.cc
+++ b/src/stim/stabilizers/tableau_iter.pybind.cc
@@ -39,7 +39,7 @@ pybind11::class_<TableauIterator> stim_pybind::pybind_tableau_iter(pybind11::mod
     return c;
 }
 
-void stim_pybind::pybind_tableau_iter_after_types_all_defined(
+void stim_pybind::pybind_tableau_iter_methods(
     pybind11::module &m, pybind11::class_<TableauIterator> &c) {
     c.def(
         "__iter__",

--- a/src/stim/stabilizers/tableau_iter.pybind.h
+++ b/src/stim/stabilizers/tableau_iter.pybind.h
@@ -21,7 +21,7 @@
 
 namespace stim_pybind {
 pybind11::class_<stim::TableauIterator> pybind_tableau_iter(pybind11::module &m);
-void pybind_tableau_iter_after_types_all_defined(pybind11::module &m, pybind11::class_<stim::TableauIterator> &c);
+void pybind_tableau_iter_methods(pybind11::module &m, pybind11::class_<stim::TableauIterator> &c);
 }  // namespace stim_pybind
 
 #endif


### PR DESCRIPTION
the purpose of this PR is twofold:

1. Make sure that all pybind classes are registered before their respective methods. This makes sure that C++ types do not show up in the docs
2. float all python class/function definitions up to the top level. This is nice so we don't need to go digging through the implementations to find all the places where classes are registered.