### PR TITLE
Make bazel display test errors by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+test --test_output=errors


### PR DESCRIPTION
By default, one has to look for test output in a test log file.