### PR TITLE
use logical or instead of bitwise or

### DIFF
--- a/src/stim/simulators/vector_simulator.cc
+++ b/src/stim/simulators/vector_simulator.cc
@@ -155,11 +155,24 @@ float VectorSimulator::project(const PauliStringRef &observable) {
     };
 
     uint64_t mask = 0;
+
+    /// clang 14+ has flag -Wbitwise-instead-of-logical.
+    /// we want bitwise or here since observable.xs[k] and
+    /// observable.zs[k] are bit_refs pointing into simd words
+    #if defined __clang__ && __clang_major__ >= 14
+      #pragma clang diagnostic push
+      #pragma clang diagnostic ignored "-Wbitwise-instead-of-logical"
+    #endif
+
     for (size_t k = 0; k < observable.num_qubits; k++) {
         if (observable.xs[k] | observable.zs[k]) {
             mask |= 1ULL << k;
         }
     }
+
+    #if defined __clang__ && __clang_major__ >= 14
+      #pragma clang diagnostic pop
+    #endif
 
     basis_change();
     float mag2 = 0;


### PR DESCRIPTION
On clang 14.0.6, I am getting the following error while compiling:
```
/home/danielbarter/stim_dev/Stim/src/stim/simulators/vector_simulator.cc:159:13: error: use of bitwise '|' with boolean operands [-Werror,-Wbitwise-instead-of-logical]
        if (observable.xs[k] | observable.zs[k]) {
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                             ||
/home/danielbarter/stim_dev/Stim/src/stim/simulators/vector_simulator.cc:159:13: note: cast one or both operands to int to silence this warning
1 error generated.
```
easily fixed by using logical or instead of bitwise or