### PR TITLE
Dem sampler rng refactor

### DIFF
--- a/src/stim/dem/detector_error_model.pybind.cc
+++ b/src/stim/dem/detector_error_model.pybind.cc
@@ -24,7 +24,7 @@
 #include "stim/py/base.pybind.h"
 #include "stim/search/search.h"
 #include "stim/simulators/dem_sampler.h"
-
+#include "stim/simulators/dem_sampler.pybind.h"
 using namespace stim;
 
 std::string stim_pybind::detector_error_model_repr(const DetectorErrorModel &self) {
@@ -968,8 +968,8 @@ void stim_pybind::pybind_detector_error_model_methods(pybind11::module &m, pybin
 
     c.def(
         "compile_sampler",
-        [](const DetectorErrorModel &self, const pybind11::object &seed) -> DemSampler {
-            return DemSampler(self, *make_py_seeded_rng(seed), 1024);
+        [](const DetectorErrorModel &self, const pybind11::object &seed) -> stim_pybind::PyDemSampler {
+            return stim_pybind::PyDemSampler(DemSampler(self, *make_py_seeded_rng(seed), 1024));
         },
         pybind11::kw_only(),
         pybind11::arg("seed") = pybind11::none(),

--- a/src/stim/dem/detector_error_model.pybind.cc
+++ b/src/stim/dem/detector_error_model.pybind.cc
@@ -27,6 +27,7 @@
 #include "stim/simulators/dem_sampler.pybind.h"
 using namespace stim;
 
+
 std::string stim_pybind::detector_error_model_repr(const DetectorErrorModel &self) {
     if (self.instructions.empty()) {
         return "stim.DetectorErrorModel()";
@@ -969,7 +970,8 @@ void stim_pybind::pybind_detector_error_model_methods(pybind11::module &m, pybin
     c.def(
         "compile_sampler",
         [](const DetectorErrorModel &self, const pybind11::object &seed) -> stim_pybind::PyDemSampler {
-            return stim_pybind::PyDemSampler(DemSampler(self, *make_py_seeded_rng(seed), 1024));
+            std::mt19937_64 rng = make_py_seeded_rng_move(seed);
+            return stim_pybind::PyDemSampler(self, std::move(rng), 1024);
         },
         pybind11::kw_only(),
         pybind11::arg("seed") = pybind11::none(),

--- a/src/stim/dem/detector_error_model.pybind.cc
+++ b/src/stim/dem/detector_error_model.pybind.cc
@@ -971,6 +971,9 @@ void stim_pybind::pybind_detector_error_model_methods(pybind11::module &m, pybin
         "compile_sampler",
         [](const DetectorErrorModel &self, const pybind11::object &seed) -> stim_pybind::PyDemSampler {
             std::mt19937_64 rng = make_py_seeded_rng_move(seed);
+            // Since PyDemSampler expects a DectorErrorModel, there is an implicit copy here
+            // We want this copy anyway, since it would be strange at the python level if
+            // compiling a DectectorErrorModel invalidated it
             return stim_pybind::PyDemSampler(self, std::move(rng), 1024);
         },
         pybind11::kw_only(),

--- a/src/stim/main_namespaced.cc
+++ b/src/stim/main_namespaced.cc
@@ -344,7 +344,8 @@ int main_mode_sample_dem(int argc, const char **argv) {
     auto dem = DetectorErrorModel::from_file(in.f);
     in.done();
 
-    DemSampler sampler(std::move(dem), optionally_seeded_rng(argc, argv), 1024);
+    std::mt19937_64 rng = optionally_seeded_rng(argc, argv);
+    DemSampler sampler(std::move(dem), rng, 1024);
     sampler.sample_write(
         num_shots,
         out.f,

--- a/src/stim/py/base.pybind.cc
+++ b/src/stim/py/base.pybind.cc
@@ -20,6 +20,7 @@
 
 using namespace stim;
 
+// TODO: eventually phase out use of make_py_seeded_rng
 std::shared_ptr<std::mt19937_64> stim_pybind::make_py_seeded_rng(const pybind11::object &seed) {
     if (seed.is_none()) {
         return std::make_shared<std::mt19937_64>(externally_seeded_rng());
@@ -28,6 +29,19 @@ std::shared_ptr<std::mt19937_64> stim_pybind::make_py_seeded_rng(const pybind11:
     try {
         uint64_t s = pybind11::cast<uint64_t>(seed) ^ INTENTIONAL_VERSION_SEED_INCOMPATIBILITY;
         return std::make_shared<std::mt19937_64>(s);
+    } catch (const pybind11::cast_error &) {
+        throw std::invalid_argument("Expected seed to be None or a 64 bit unsigned integer.");
+    }
+}
+
+std::mt19937_64 stim_pybind::make_py_seeded_rng_move(const pybind11::object &seed) {
+    if (seed.is_none()) {
+        return std::mt19937_64(externally_seeded_rng());
+    }
+
+    try {
+        uint64_t s = pybind11::cast<uint64_t>(seed) ^ INTENTIONAL_VERSION_SEED_INCOMPATIBILITY;
+        return std::mt19937_64(s);
     } catch (const pybind11::cast_error &) {
         throw std::invalid_argument("Expected seed to be None or a 64 bit unsigned integer.");
     }

--- a/src/stim/py/base.pybind.h
+++ b/src/stim/py/base.pybind.h
@@ -27,6 +27,7 @@
 namespace stim_pybind {
 
 std::shared_ptr<std::mt19937_64> make_py_seeded_rng(const pybind11::object &seed);
+std::mt19937_64 make_py_seeded_rng_move(const pybind11::object &seed);
 std::string clean_doc_string(const char *c);
 stim::SampleFormat format_to_enum(const std::string &format);
 bool normalize_index_or_slice(
@@ -47,6 +48,7 @@ pybind11::tuple tuple_tree(const std::vector<T> &val, size_t offset = 0) {
     }
     return pybind11::make_tuple(val[offset], tuple_tree(val, offset + 1));
 }
+
 
 }  // namespace stim_pybind
 

--- a/src/stim/simulators/dem_sampler.cc
+++ b/src/stim/simulators/dem_sampler.cc
@@ -24,7 +24,7 @@
 
 using namespace stim;
 
-DemSampler::DemSampler(DetectorErrorModel init_model, std::mt19937_64 rng, size_t min_stripes)
+DemSampler::DemSampler(DetectorErrorModel init_model, std::mt19937_64 &rng, size_t min_stripes)
     : model(std::move(init_model)),
       num_detectors(model.count_detectors()),
       num_observables(model.count_observables()),

--- a/src/stim/simulators/dem_sampler.h
+++ b/src/stim/simulators/dem_sampler.h
@@ -31,7 +31,7 @@ struct DemSampler {
     uint64_t num_detectors;
     uint64_t num_observables;
     uint64_t num_errors;
-    std::mt19937_64 rng;
+    std::mt19937_64 &rng;
     // TODO: allow these buffers to be streamed instead of entirely stored in memory.
     simd_bit_table<MAX_BITWORD_WIDTH> det_buffer;
     simd_bit_table<MAX_BITWORD_WIDTH> obs_buffer;
@@ -39,7 +39,7 @@ struct DemSampler {
     size_t num_stripes;
 
     /// Compiles a sampler for the given detector error model.
-    DemSampler(DetectorErrorModel model, std::mt19937_64 rng, size_t min_stripes);
+    DemSampler(DetectorErrorModel model, std::mt19937_64 &rng, size_t min_stripes);
 
     /// Clears the buffers and refills them with sampled shot data.
     void resample(bool replay_errors);

--- a/src/stim/simulators/dem_sampler.perf.cc
+++ b/src/stim/simulators/dem_sampler.perf.cc
@@ -28,7 +28,7 @@ BENCHMARK(DemSampler_surface_code_rotated_memory_z_distance11_100rounds_1024stri
     auto circuit = generate_surface_code_circuit(params).circuit;
     auto dem = ErrorAnalyzer::circuit_to_detector_error_model(circuit, true, true, false, false, false, false);
     std::mt19937_64 rng(0);
-    DemSampler sampler(dem, std::mt19937_64(0), 1024);
+    DemSampler sampler(dem, rng, 1024);
     size_t count = 0;
     benchmark_go([&]() {
         sampler.resample(false);

--- a/src/stim/simulators/dem_sampler.pybind.cc
+++ b/src/stim/simulators/dem_sampler.pybind.cc
@@ -41,9 +41,11 @@ pybind11::object dem_sampler_py_sample(
     PyDemSampler &self, size_t shots, bool bit_packed, bool return_errors, pybind11::object &recorded_errors_to_replay) {
     bool replay = !recorded_errors_to_replay.is_none();
     if (replay && min_bits_to_num_bits_padded<MAX_BITWORD_WIDTH>(shots) != self.dem_sampler.num_stripes) {
-        PyDemSampler perfect_size(DemSampler(self.dem_sampler.model, std::move(self.dem_sampler.rng), shots));
+        PyDemSampler perfect_size(
+            std::move(self.dem_sampler.model),
+            std::move(self.dem_sampler.rng),
+            shots);
         auto result = dem_sampler_py_sample(perfect_size, shots, bit_packed, return_errors, recorded_errors_to_replay);
-        self.dem_sampler.rng = std::move(perfect_size.dem_sampler.rng);
         return result;
     }
 

--- a/src/stim/simulators/dem_sampler.pybind.h
+++ b/src/stim/simulators/dem_sampler.pybind.h
@@ -21,8 +21,13 @@
 
 namespace stim_pybind {
 
-pybind11::class_<stim::DemSampler> pybind_dem_sampler(pybind11::module &m);
-void pybind_dem_sampler_methods(pybind11::module &m, pybind11::class_<stim::DemSampler> &c);
+struct PyDemSampler {
+    stim::DemSampler dem_sampler;
+    PyDemSampler(stim::DemSampler dem_sampler) : dem_sampler(dem_sampler) {};
+};
+
+pybind11::class_<PyDemSampler> pybind_dem_sampler(pybind11::module &m);
+void pybind_dem_sampler_methods(pybind11::module &m, pybind11::class_<PyDemSampler> &c);
 
 }  // namespace stim_pybind
 

--- a/src/stim/simulators/dem_sampler.pybind.h
+++ b/src/stim/simulators/dem_sampler.pybind.h
@@ -22,11 +22,11 @@
 namespace stim_pybind {
 
 struct PyDemSampler {
-    stim::DemSampler dem_sampler;
     std::mt19937_64 rng;
+    stim::DemSampler dem_sampler;
     PyDemSampler(stim::DetectorErrorModel model, std::mt19937_64 rng, size_t min_stripes) :
-        dem_sampler(model, rng, min_stripes),
-        rng(rng) {};
+        rng(std::move(rng)),
+        dem_sampler(std::move(model), this->rng, min_stripes) {};
 };
 
 pybind11::class_<PyDemSampler> pybind_dem_sampler(pybind11::module &m);

--- a/src/stim/simulators/dem_sampler.pybind.h
+++ b/src/stim/simulators/dem_sampler.pybind.h
@@ -23,7 +23,10 @@ namespace stim_pybind {
 
 struct PyDemSampler {
     stim::DemSampler dem_sampler;
-    PyDemSampler(stim::DemSampler dem_sampler) : dem_sampler(dem_sampler) {};
+    std::mt19937_64 rng;
+    PyDemSampler(stim::DetectorErrorModel model, std::mt19937_64 rng, size_t min_stripes) :
+        dem_sampler(model, rng, min_stripes),
+        rng(rng) {};
 };
 
 pybind11::class_<PyDemSampler> pybind_dem_sampler(pybind11::module &m);

--- a/src/stim/simulators/dem_sampler.test.cc
+++ b/src/stim/simulators/dem_sampler.test.cc
@@ -31,20 +31,20 @@ TEST(DemSampler, basic_sizing) {
     ASSERT_FALSE(sampler.obs_buffer.data.not_zero());
     ASSERT_FALSE(sampler.det_buffer.data.not_zero());
 
-    sampler = DemSampler(
+    DemSampler sampler2 = DemSampler(
         DetectorErrorModel(R"DEM(
             logical_observable L2000
             detector D1000
          )DEM"),
         irrelevant_rng,
         200);
-    ASSERT_GE(sampler.det_buffer.num_major_bits_padded(), 1000);
-    ASSERT_GE(sampler.obs_buffer.num_major_bits_padded(), 2000);
-    ASSERT_GE(sampler.det_buffer.num_minor_bits_padded(), 200);
-    ASSERT_GE(sampler.obs_buffer.num_minor_bits_padded(), 200);
-    sampler.resample(false);
-    ASSERT_FALSE(sampler.obs_buffer.data.not_zero());
-    ASSERT_FALSE(sampler.det_buffer.data.not_zero());
+    ASSERT_GE(sampler2.det_buffer.num_major_bits_padded(), 1000);
+    ASSERT_GE(sampler2.obs_buffer.num_major_bits_padded(), 2000);
+    ASSERT_GE(sampler2.det_buffer.num_minor_bits_padded(), 200);
+    ASSERT_GE(sampler2.obs_buffer.num_minor_bits_padded(), 200);
+    sampler2.resample(false);
+    ASSERT_FALSE(sampler2.obs_buffer.data.not_zero());
+    ASSERT_FALSE(sampler2.det_buffer.data.not_zero());
 }
 
 TEST(DemSampler, resample_basic_probabilities) {


### PR DESCRIPTION
As described in https://github.com/quantumlib/Stim/pull/346, it would be good to unify how we handle rng state so that we don't accidentally share state between python simulation objects. 

Here is the pattern that I am thinking: 
- C++ classes maintain a pointer to an rng object. 
- Python wrapper classes own an rng object which is referenced by the wrapped C++ class.

This PR is a proof of concept for DemSampler, which currently owns its own rng, in contrast to classes like TableauSimulator which just have a reference.