### PR TITLE
Add stim.{PauliString,Tableau}.{to,from}_numpy

### DIFF
--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -202,8 +202,10 @@ API references for stable versions are kept on the [stim github wiki](https://gi
     - [`stim.PauliString.__truediv__`](#stim.PauliString.__truediv__)
     - [`stim.PauliString.commutes`](#stim.PauliString.commutes)
     - [`stim.PauliString.copy`](#stim.PauliString.copy)
+    - [`stim.PauliString.from_numpy`](#stim.PauliString.from_numpy)
     - [`stim.PauliString.random`](#stim.PauliString.random)
     - [`stim.PauliString.sign`](#stim.PauliString.sign)
+    - [`stim.PauliString.to_numpy`](#stim.PauliString.to_numpy)
     - [`stim.PauliString.to_tableau`](#stim.PauliString.to_tableau)
 - [`stim.Tableau`](#stim.Tableau)
     - [`stim.Tableau.__add__`](#stim.Tableau.__add__)
@@ -1298,7 +1300,6 @@ def flattened(
 def from_file(
     file: Union[io.TextIOBase, str, pathlib.Path],
 ) -> stim.Circuit:
-
     """Reads a stim circuit from a file.
 
     The file format is defined at
@@ -1831,7 +1832,6 @@ def to_file(
     self,
     file: Union[io.TextIOBase, str, pathlib.Path],
 ) -> None:
-
     """Writes the stim circuit to a file.
 
     The file format is defined at
@@ -1935,7 +1935,6 @@ def __init__(
 def flipped_measurement(
     self,
 ) -> Optional[stim.FlippedMeasurement]:
-
     """The measurement that was flipped by the error mechanism.
     If the error isn't a measurement error, this will be None.
     """
@@ -2406,7 +2405,6 @@ def args(
 def gate(
     self,
 ) -> Optional[str]:
-
     """Returns the name of the gate / instruction that was being executed.
     """
 ```
@@ -2503,7 +2501,6 @@ def sample(
     return_errors: bool = False,
     recorded_errors_to_replay: Optional[np.ndarray] = None,
 ) -> Tuple[np.ndarray, np.ndarray, Optional[np.ndarray]]:
-
     """Samples the detector error model's error mechanisms to produce sample data.
 
     Args:
@@ -2666,7 +2663,6 @@ def sample_write(
     replay_err_in_file: Union[None, str, pathlib.Path] = None,
     replay_err_in_format: str = "01",
 ) -> None:
-
     """Samples the detector error model and writes the results to disk.
 
     Args:
@@ -3233,7 +3229,6 @@ def convert(
     append_observables: bool = False,
     bit_pack_result: bool = False,
 ) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
-
     """Converts measurement data into detection event data.
 
     Args:
@@ -3508,7 +3503,6 @@ def args_copy(
 def targets_copy(
     self,
 ) -> List[Union[int, stim.DemTarget]]:
-
     """Returns a copy of the instruction's targets.
 
     (Making a copy is enforced to make it clear that editing the result won't change
@@ -4579,7 +4573,6 @@ def flattened(
 def from_file(
     file: Union[io.TextIOBase, str, pathlib.Path],
 ) -> stim.DetectorErrorModel:
-
     """Reads a detector error model from a file.
 
     The file format is defined at
@@ -4904,7 +4897,6 @@ def to_file(
     self,
     file: Union[io.TextIOBase, str, pathlib.Path],
 ) -> None:
-
     """Writes the detector error model to a file.
 
     The file format is defined at
@@ -5988,6 +5980,63 @@ def copy(
     """
 ```
 
+<a name="stim.PauliString.from_numpy"></a>
+```python
+# stim.PauliString.from_numpy
+
+# (in class stim.PauliString)
+@staticmethod
+def from_numpy(
+    *,
+    xs: np.ndarray,
+    zs: np.ndarray,
+    sign: Union[int, float, complex] = +1,
+    num: Optional[int] = None,
+) -> stim.PauliString:
+    """Creates a pauli string from X bit and Z bit numpy arrays, using the encoding:
+
+        x=0 and z=0 -> P=I
+        x=1 and z=0 -> P=X
+        x=1 and z=1 -> P=Y
+        x=0 and z=1 -> P=Z
+
+    Args:
+        xs: The X bits of the pauli string. This array can either be a 1-dimensional
+            numpy array with dtype=np.bool8, or a bit packed 1-dimensional numpy
+            array with dtype=np.uint8. If the dtype is np.uint8 then the array is
+            assumed to be bit packed in little endian order and the "num" argument
+            must be specified. When bit packed, the x bit with offset k is stored at
+            (xs[k // 8] >> (k % 8)) & 1.
+        zs: The Z bits of the pauli string. This array can either be a 1-dimensional
+            numpy array with dtype=np.bool8, or a bit packed 1-dimensional numpy
+            array with dtype=np.uint8. If the dtype is np.uint8 then the array is
+            assumed to be bit packed in little endian order and the "num" argument
+            must be specified. When bit packed, the x bit with offset k is stored at
+            (xs[k // 8] >> (k % 8)) & 1.
+        sign: Defaults to +1. Set to +1, -1, 1j, or -1j to control the sign of the
+            returned Pauli string.
+        num: Must be specified if xs or zs is a bit packed array. Specifies the
+            expected length of the Pauli string.
+
+    Returns:
+        The created pauli string.
+
+    Examples:
+        >>> import stim
+        >>> import numpy as np
+
+        >>> xs = np.array([1, 1, 1, 1, 1, 1, 1, 0, 0], dtype=np.bool8)
+        >>> zs = np.array([0, 0, 0, 0, 1, 1, 1, 1, 1], dtype=np.bool8)
+        >>> stim.PauliString.from_numpy(xs=xs, zs=zs, sign=-1)
+        stim.PauliString("-XXXXYYYZZ")
+
+        >>> xs = np.array([127, 0], dtype=np.uint8)
+        >>> zs = np.array([240, 1], dtype=np.uint8)
+        >>> stim.PauliString.from_numpy(xs=xs, zs=zs, num=9)
+        stim.PauliString("+XXXXYYYZZ")
+    """
+```
+
 <a name="stim.PauliString.random"></a>
 ```python
 # stim.PauliString.random
@@ -6051,6 +6100,65 @@ def sign(
 @sign.setter
 def sign(self, value: complex):
     pass
+```
+
+<a name="stim.PauliString.to_numpy"></a>
+```python
+# stim.PauliString.to_numpy
+
+# (in class stim.PauliString)
+def to_numpy(
+    self,
+    *,
+    bit_packed: bool = False,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Decomposes the contents of the pauli string into X bit and Z bit numpy arrays.
+
+    Args:
+        bit_packed: Defaults to False. Determines whether the output numpy arrays
+            use dtype=bool8 or dtype=uint8 with 8 bools packed into each byte.
+
+    Returns:
+        An (xs, zs) tuple encoding the paulis from the string. The k'th Pauli from
+        the string is encoded into k'th bit of xs and the k'th bit of zs using
+        the "xz" encoding:
+
+            P=I -> x=0 and z=0
+            P=X -> x=1 and z=0
+            P=Y -> x=1 and z=1
+            P=Z -> x=0 and z=1
+
+        The dtype and shape of the result depends on the bit_packed argument.
+
+        If bit_packed=False:
+            Each bit gets its own byte.
+            xs.dtype = zs.dtype = np.bool8
+            xs.shape = zs.shape = len(self)
+            xs_k = xs[k]
+            zs_k = zs[k]
+
+        If bit_packed=True:
+            Equivalent to applying np.packbits(bitorder='little') to the result.
+            xs.dtype = zs.dtype = np.uint8
+            xs.shape = zs.shape = math.ceil(len(self) / 8)
+            xs_k = (xs[k // 8] >> (k % 8)) & 1
+            zs_k = (zs[k // 8] >> (k % 8)) & 1
+
+    Examples:
+        >>> import stim
+
+        >>> xs, zs = stim.PauliString("XXXXYYYZZ").to_numpy()
+        >>> xs
+        array([ True,  True,  True,  True,  True,  True,  True, False, False])
+        >>> zs
+        array([False, False, False, False,  True,  True,  True,  True,  True])
+
+        >>> xs, zs = stim.PauliString("XXXXYYYZZ").to_numpy(bit_packed=True)
+        >>> xs
+        array([127,   0], dtype=uint8)
+        >>> zs
+        array([240,   1], dtype=uint8)
+    """
 ```
 
 <a name="stim.PauliString.to_tableau"></a>
@@ -6457,7 +6565,6 @@ def from_circuit(
     ignore_measurement: bool = False,
     ignore_reset: bool = False,
 ) -> stim.Tableau:
-
     """Converts a circuit into an equivalent stabilizer tableau.
 
     Args:
@@ -6597,7 +6704,6 @@ def from_unitary_matrix(
     *,
     endian: str = 'little',
 ) -> stim.Tableau:
-
     """Creates a tableau from the unitary matrix of a Clifford operation.
 
     Args:
@@ -7114,7 +7220,6 @@ def to_circuit(
     *,
     method: str,
 ) -> stim.Circuit:
-
     """Synthesizes a circuit that implements the tableau's Clifford operation.
 
     The circuits returned by this method are not guaranteed to be stable
@@ -7215,7 +7320,6 @@ def to_unitary_matrix(
     *,
     endian: str,
 ) -> np.ndarray[np.complex64]:
-
     """Converts the tableau into a unitary matrix.
 
     Args:
@@ -8426,7 +8530,6 @@ def postselect_x(
     *,
     desired_value: bool,
 ) -> None:
-
     """Postselects qubits in the X basis, or raises an exception.
 
     Postselecting a qubit forces it to collapse to a specific state, as
@@ -8458,7 +8561,6 @@ def postselect_y(
     *,
     desired_value: bool,
 ) -> None:
-
     """Postselects qubits in the Y basis, or raises an exception.
 
     Postselecting a qubit forces it to collapse to a specific state, as
@@ -8490,7 +8592,6 @@ def postselect_z(
     *,
     desired_value: bool,
 ) -> None:
-
     """Postselects qubits in the Z basis, or raises an exception.
 
     Postselecting a qubit forces it to collapse to a specific state, as if it was
@@ -8727,7 +8828,6 @@ def set_state_from_stabilizers(
     allow_redundant: bool = False,
     allow_underconstrained: bool = False,
 ) -> None:
-
     """Sets the tableau simulator's state to a state satisfying the given stabilizers.
 
     The old quantum state is completely overwritten, even if the new state is
@@ -8824,7 +8924,6 @@ def set_state_from_state_vector(
     *,
     endian: str,
 ) -> None:
-
     """Sets the simulator's state to a superposition specified by an amplitude vector.
 
     Args:
@@ -8958,7 +9057,6 @@ def state_vector(
     *,
     endian: str = 'little',
 ) -> np.ndarray[np.complex64]:
-
     """Returns a wavefunction for the simulator's current state.
 
     This function takes O(n * 2**n) time and O(2**n) space, where n is the number of
@@ -9326,7 +9424,6 @@ def read_shot_data_file(
     num_observables: int = 0,
     bit_pack: bool = False,
 ) -> np.ndarray:
-
     """Reads shot data, such as measurement samples, from a file.
 
     Args:

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -6700,7 +6700,7 @@ def from_named_gate(
 # stim.Tableau.from_numpy
 
 # (in class stim.Tableau)
-def to_numpy(
+def from_numpy(
     self,
     *,
     bit_packed: bool = False,

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -7420,7 +7420,7 @@ def to_numpy(
         If bit_packed=True then:
             *.dtype = = np.uint8
             *2*.shape = (len(tableau), math.ceil(len(tableau) / 8))
-            *_signs.shape = len(tableau)
+            *_signs.shape = math.ceil(len(tableau) / 8)
             (x2x[i, j // 8] >> (j % 8)) & 1 = tableau.x_output_pauli(i, j) in [1, 2]
             (x2z[i, j // 8] >> (j % 8)) & 1 = tableau.x_output_pauli(i, j) in [2, 3]
             (z2x[i, j // 8] >> (j % 8)) & 1 = tableau.z_output_pauli(i, j) in [1, 2]

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -224,6 +224,7 @@ API references for stable versions are kept on the [stim github wiki](https://gi
     - [`stim.Tableau.from_circuit`](#stim.Tableau.from_circuit)
     - [`stim.Tableau.from_conjugated_generators`](#stim.Tableau.from_conjugated_generators)
     - [`stim.Tableau.from_named_gate`](#stim.Tableau.from_named_gate)
+    - [`stim.Tableau.from_numpy`](#stim.Tableau.from_numpy)
     - [`stim.Tableau.from_unitary_matrix`](#stim.Tableau.from_unitary_matrix)
     - [`stim.Tableau.inverse`](#stim.Tableau.inverse)
     - [`stim.Tableau.inverse_x_output`](#stim.Tableau.inverse_x_output)
@@ -237,6 +238,7 @@ API references for stable versions are kept on the [stim github wiki](https://gi
     - [`stim.Tableau.random`](#stim.Tableau.random)
     - [`stim.Tableau.then`](#stim.Tableau.then)
     - [`stim.Tableau.to_circuit`](#stim.Tableau.to_circuit)
+    - [`stim.Tableau.to_numpy`](#stim.Tableau.to_numpy)
     - [`stim.Tableau.to_pauli_string`](#stim.Tableau.to_pauli_string)
     - [`stim.Tableau.to_unitary_matrix`](#stim.Tableau.to_unitary_matrix)
     - [`stim.Tableau.x_output`](#stim.Tableau.x_output)
@@ -5991,7 +5993,7 @@ def from_numpy(
     xs: np.ndarray,
     zs: np.ndarray,
     sign: Union[int, float, complex] = +1,
-    num: Optional[int] = None,
+    num_qubits: Optional[int] = None,
 ) -> stim.PauliString:
     """Creates a pauli string from X bit and Z bit numpy arrays, using the encoding:
 
@@ -6004,19 +6006,19 @@ def from_numpy(
         xs: The X bits of the pauli string. This array can either be a 1-dimensional
             numpy array with dtype=np.bool8, or a bit packed 1-dimensional numpy
             array with dtype=np.uint8. If the dtype is np.uint8 then the array is
-            assumed to be bit packed in little endian order and the "num" argument
-            must be specified. When bit packed, the x bit with offset k is stored at
-            (xs[k // 8] >> (k % 8)) & 1.
+            assumed to be bit packed in little endian order and the "num_qubits"
+            argument must be specified. When bit packed, the x bit with offset k is
+            stored at (xs[k // 8] >> (k % 8)) & 1.
         zs: The Z bits of the pauli string. This array can either be a 1-dimensional
             numpy array with dtype=np.bool8, or a bit packed 1-dimensional numpy
             array with dtype=np.uint8. If the dtype is np.uint8 then the array is
-            assumed to be bit packed in little endian order and the "num" argument
-            must be specified. When bit packed, the x bit with offset k is stored at
-            (xs[k // 8] >> (k % 8)) & 1.
+            assumed to be bit packed in little endian order and the "num_qubits"
+            argument must be specified. When bit packed, the x bit with offset k is
+            stored at (xs[k // 8] >> (k % 8)) & 1.
         sign: Defaults to +1. Set to +1, -1, 1j, or -1j to control the sign of the
             returned Pauli string.
-        num: Must be specified if xs or zs is a bit packed array. Specifies the
-            expected length of the Pauli string.
+        num_qubits: Must be specified if xs or zs is a bit packed array. Specifies
+            the expected length of the Pauli string.
 
     Returns:
         The created pauli string.
@@ -6032,7 +6034,7 @@ def from_numpy(
 
         >>> xs = np.array([127, 0], dtype=np.uint8)
         >>> zs = np.array([240, 1], dtype=np.uint8)
-        >>> stim.PauliString.from_numpy(xs=xs, zs=zs, num=9)
+        >>> stim.PauliString.from_numpy(xs=xs, zs=zs, num_qubits=9)
         stim.PauliString("+XXXXYYYZZ")
     """
 ```
@@ -6693,6 +6695,107 @@ def from_named_gate(
     """
 ```
 
+<a name="stim.Tableau.from_numpy"></a>
+```python
+# stim.Tableau.from_numpy
+
+# (in class stim.Tableau)
+def to_numpy(
+    self,
+    *,
+    bit_packed: bool = False,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Creates a tableau from numpy arrays x2x, x2z, z2x, z2z, x_signs, and z_signs.
+
+    The x2x, x2z, z2x, z2z arrays are the four quadrants of the table defined in
+    Aaronson and Gottesman's "Improved Simulation of Stabilizer Circuits"
+    ( https://arxiv.org/abs/quant-ph/0406196 ).
+
+    Args:
+        x2x: A 2d numpy array containing the x-to-x coupling bits. The bits can be
+            bit packed (dtype=uint8) or not (dtype=bool8). When not bit packed, the
+            result will satisfy result.x_output_pauli(i, j) in [1, 2] == x2x[i, j].
+            Bit packing must be in little endian order and only applies to the
+            second axis.
+        x2z: A 2d numpy array containing the x-to-z coupling bits. The bits can be
+            bit packed (dtype=uint8) or not (dtype=bool8). When not bit packed, the
+            result will satisfy result.x_output_pauli(i, j) in [2, 3] == x2z[i, j].
+            Bit packing must be in little endian order and only applies to the
+            second axis.
+        z2x: A 2d numpy array containing the z-to-x coupling bits. The bits can be
+            bit packed (dtype=uint8) or not (dtype=bool8). When not bit packed, the
+            result will satisfy result.z_output_pauli(i, j) in [1, 2] == z2x[i, j].
+            Bit packing must be in little endian order and only applies to the
+            second axis.
+        z2z: A 2d numpy array containing the z-to-z coupling bits. The bits can be
+            bit packed (dtype=uint8) or not (dtype=bool8). When not bit packed, the
+            result will satisfy result.z_output_pauli(i, j) in [2, 3] == z2z[i, j].
+            Bit packing must be in little endian order and only applies to the
+            second axis.
+        x_signs: Defaults to all-positive if not specified. A 1d numpy array
+            containing the sign bits for the X generator outputs. False means
+            positive and True means negative. The bits can be bit packed
+            (dtype=uint8) or not (dtype=bool8). Bit packing must be in little endian
+            order.
+        z_signs: Defaults to all-positive if not specified. A 1d numpy array
+            containing the sign bits for the Z generator outputs. False means
+            positive and True means negative. The bits can be bit packed
+            (dtype=uint8) or not (dtype=bool8). Bit packing must be in little endian
+            order.
+
+    Returns:
+        The tableau created from the numpy data.
+
+    Examples:
+        >>> import stim
+        >>> import numpy as np
+
+        >>> tableau = stim.Tableau.from_numpy(
+        ...     x2x=np.array([[1, 1], [0, 1]], dtype=np.bool8),
+        ...     z2x=np.array([[0, 0], [0, 0]], dtype=np.bool8),
+        ...     x2z=np.array([[0, 0], [0, 0]], dtype=np.bool8),
+        ...     z2z=np.array([[1, 0], [1, 1]], dtype=np.bool8),
+        ... )
+        >>> print(repr(tableau))
+        stim.Tableau.from_conjugated_generators(
+            xs=[
+                stim.PauliString("+XX"),
+                stim.PauliString("+_X"),
+            ],
+            zs=[
+                stim.PauliString("+Z_"),
+                stim.PauliString("+ZZ"),
+            ],
+        )
+        >>> tableau == stim.Tableau.from_named_gate("CNOT")
+        True
+
+        >>> tableau = stim.Tableau.from_numpy(
+        ...     x2x=np.array([[9], [5], [7], [6]], dtype=np.uint8),
+        ...     x2z=np.array([[13], [13], [0], [3]], dtype=np.uint8),
+        ...     z2x=np.array([[8], [5], [9], [15]], dtype=np.uint8),
+        ...     z2z=np.array([[6], [11], [2], [3]], dtype=np.uint8),
+        ...     x_signs=np.array([7], dtype=np.uint8),
+        ...     z_signs=np.array([9], dtype=np.uint8),
+        ... )
+        >>> print(repr(tableau))
+        stim.Tableau.from_conjugated_generators(
+            xs=[
+                stim.PauliString("-Y_ZY"),
+                stim.PauliString("-Y_YZ"),
+                stim.PauliString("-XXX_"),
+                stim.PauliString("+ZYX_"),
+            ],
+            zs=[
+                stim.PauliString("-_ZZX"),
+                stim.PauliString("+YZXZ"),
+                stim.PauliString("+XZ_X"),
+                stim.PauliString("-YYXX"),
+            ],
+        )
+    """
+```
+
 <a name="stim.Tableau.from_unitary_matrix"></a>
 ```python
 # stim.Tableau.from_unitary_matrix
@@ -7270,6 +7373,157 @@ def to_circuit(
             H 0 1 2
             S 1 1 2 2
         ''')
+    """
+```
+
+<a name="stim.Tableau.to_numpy"></a>
+```python
+# stim.Tableau.to_numpy
+
+# (in class stim.Tableau)
+def to_numpy(
+    self,
+    *,
+    bit_packed: bool = False,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Decomposes the contents of the tableau into six numpy arrays.
+
+    The first four numpy arrays correspond to the four quadrants of the table
+    defined in Aaronson and Gottesman's "Improved Simulation of Stabilizer Circuits"
+    ( https://arxiv.org/abs/quant-ph/0406196 ).
+
+    The last two numpy arrays are the X and Z sign bit vectors of the tableau.
+
+    Args:
+        bit_packed: Defaults to False. Determines whether the output numpy arrays
+            use dtype=bool8 or dtype=uint8 with 8 bools packed into each byte.
+
+    Returns:
+        An (x2x, x2z, z2x, z2x, x_signs, z_signs) tuple encoding the tableau.
+
+        x2x: A 2d table of whether tableau(X_i)_j is X or Y (instead of I or Z).
+        x2z: A 2d table of whether tableau(X_i)_j is Z or Y (instead of I or X).
+        z2x: A 2d table of whether tableau(Z_i)_j is X or Y (instead of I or Z).
+        z2z: A 2d table of whether tableau(Z_i)_j is Z or Y (instead of I or X).
+        x_signs: A vector of whether tableau(X_i) is negative.
+        z_signs: A vector of whether tableau(Z_i) is negative.
+
+        If bit_packed=False then:
+            *.dtype = = np.bool8
+            *2*.shape = (len(tableau), len(tableau))
+            *_signs.shape = len(tableau)
+            x2x[i, j] = tableau.x_output_pauli(i, j) in [1, 2]
+            x2z[i, j] = tableau.x_output_pauli(i, j) in [2, 3]
+            z2x[i, j] = tableau.z_output_pauli(i, j) in [1, 2]
+            z2z[i, j] = tableau.z_output_pauli(i, j) in [2, 3]
+
+        If bit_packed=True then:
+            *.dtype = = np.uint8
+            *2*.shape = (len(tableau), math.ceil(len(tableau) / 8))
+            *_signs.shape = len(tableau)
+            (x2x[i, j // 8] >> (j % 8)) & 1 = tableau.x_output_pauli(i, j) in [1, 2]
+            (x2z[i, j // 8] >> (j % 8)) & 1 = tableau.x_output_pauli(i, j) in [2, 3]
+            (z2x[i, j // 8] >> (j % 8)) & 1 = tableau.z_output_pauli(i, j) in [1, 2]
+            (z2z[i, j // 8] >> (j % 8)) & 1 = tableau.z_output_pauli(i, j) in [2, 3]
+
+    Examples:
+        >>> import stim
+        >>> cnot = stim.Tableau.from_named_gate("CNOT")
+        >>> print(repr(cnot))
+        stim.Tableau.from_conjugated_generators(
+            xs=[
+                stim.PauliString("+XX"),
+                stim.PauliString("+_X"),
+            ],
+            zs=[
+                stim.PauliString("+Z_"),
+                stim.PauliString("+ZZ"),
+            ],
+        )
+        >>> x2x, x2z, z2x, z2z, x_signs, z_signs = cnot.to_numpy()
+        >>> x2x
+        array([[ True,  True],
+               [False,  True]])
+        >>> x2z
+        array([[False, False],
+               [False, False]])
+        >>> z2x
+        array([[False, False],
+               [False, False]])
+        >>> z2z
+        array([[ True, False],
+               [ True,  True]])
+        >>> x_signs
+        array([False, False])
+        >>> z_signs
+        array([False, False])
+
+        >>> t = stim.Tableau.from_conjugated_generators(
+        ...     xs=[
+        ...         stim.PauliString("-Y_ZY"),
+        ...         stim.PauliString("-Y_YZ"),
+        ...         stim.PauliString("-XXX_"),
+        ...         stim.PauliString("+ZYX_"),
+        ...     ],
+        ...     zs=[
+        ...         stim.PauliString("-_ZZX"),
+        ...         stim.PauliString("+YZXZ"),
+        ...         stim.PauliString("+XZ_X"),
+        ...         stim.PauliString("-YYXX"),
+        ...     ],
+        ... )
+
+        >>> x2x, x2z, z2x, z2z, x_signs, z_signs = t.to_numpy()
+        >>> x2x
+        array([[ True, False, False,  True],
+               [ True, False,  True, False],
+               [ True,  True,  True, False],
+               [False,  True,  True, False]])
+        >>> x2z
+        array([[ True, False,  True,  True],
+               [ True, False,  True,  True],
+               [False, False, False, False],
+               [ True,  True, False, False]])
+        >>> z2x
+        array([[False, False, False,  True],
+               [ True, False,  True, False],
+               [ True, False, False,  True],
+               [ True,  True,  True,  True]])
+        >>> z2z
+        array([[False,  True,  True, False],
+               [ True,  True, False,  True],
+               [False,  True, False, False],
+               [ True,  True, False, False]])
+        >>> x_signs
+        array([ True,  True,  True, False])
+        >>> z_signs
+        array([ True, False, False,  True])
+
+        >>> x2x, x2z, z2x, z2z, x_signs, z_signs = t.to_numpy(bit_packed=True)
+        >>> x2x
+        array([[9],
+               [5],
+               [7],
+               [6]], dtype=uint8)
+        >>> x2z
+        array([[13],
+               [13],
+               [ 0],
+               [ 3]], dtype=uint8)
+        >>> z2x
+        array([[ 8],
+               [ 5],
+               [ 9],
+               [15]], dtype=uint8)
+        >>> z2z
+        array([[ 6],
+               [11],
+               [ 2],
+               [ 3]], dtype=uint8)
+        >>> x_signs
+        array([7], dtype=uint8)
+        >>> z_signs
+        array([9], dtype=uint8)
     """
 ```
 

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -5498,7 +5498,7 @@ class Tableau:
             If bit_packed=True then:
                 *.dtype = = np.uint8
                 *2*.shape = (len(tableau), math.ceil(len(tableau) / 8))
-                *_signs.shape = len(tableau)
+                *_signs.shape = math.ceil(len(tableau) / 8)
                 (x2x[i, j // 8] >> (j % 8)) & 1 = tableau.x_output_pauli(i, j) in [1, 2]
                 (x2z[i, j // 8] >> (j % 8)) & 1 = tableau.x_output_pauli(i, j) in [2, 3]
                 (z2x[i, j // 8] >> (j % 8)) & 1 = tableau.z_output_pauli(i, j) in [1, 2]

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -4876,7 +4876,7 @@ class Tableau:
             | ++
             | YZ
         """
-    def to_numpy(
+    def from_numpy(
         self,
         *,
         bit_packed: bool = False,

--- a/file_lists/python_api_files
+++ b/file_lists/python_api_files
@@ -11,6 +11,7 @@ src/stim/py/base.pybind.cc
 src/stim/py/compiled_detector_sampler.pybind.cc
 src/stim/py/compiled_measurement_sampler.pybind.cc
 src/stim/py/march.pybind.cc
+src/stim/py/numpy.pybind.cc
 src/stim/py/stim.pybind.cc
 src/stim/simulators/dem_sampler.pybind.cc
 src/stim/simulators/matched_error.pybind.cc

--- a/glue/python/generate_stub_file.py
+++ b/glue/python/generate_stub_file.py
@@ -193,8 +193,10 @@ def print_doc(*, full_name: str, parent: object, obj: object, level: int) -> Opt
     else:
         text = f"class {term_name}:"
     if doc:
-        text += "\n" + indented(paragraph=f"\"\"\"{doc}\n\"\"\"",
-                                indentation="    ")
+        if text:
+            text += "\n"
+        text += indented(paragraph=f"\"\"\"{doc}\n\"\"\"",
+                         indentation="    ")
     out_obj.lines.append(text.replace('._stim_avx2', ''))
     if has_setter:
         if '->' in sig_name:

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -5498,7 +5498,7 @@ class Tableau:
             If bit_packed=True then:
                 *.dtype = = np.uint8
                 *2*.shape = (len(tableau), math.ceil(len(tableau) / 8))
-                *_signs.shape = len(tableau)
+                *_signs.shape = math.ceil(len(tableau) / 8)
                 (x2x[i, j // 8] >> (j % 8)) & 1 = tableau.x_output_pauli(i, j) in [1, 2]
                 (x2z[i, j // 8] >> (j % 8)) & 1 = tableau.x_output_pauli(i, j) in [2, 3]
                 (z2x[i, j // 8] >> (j % 8)) & 1 = tableau.z_output_pauli(i, j) in [1, 2]

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -4876,7 +4876,7 @@ class Tableau:
             | ++
             | YZ
         """
-    def to_numpy(
+    def from_numpy(
         self,
         *,
         bit_packed: bool = False,

--- a/src/stim/io/read_write.pybind.cc
+++ b/src/stim/io/read_write.pybind.cc
@@ -139,12 +139,12 @@ pybind11::object read_shot_data_file(
 
 simd_bit_table<MAX_BITWORD_WIDTH> bit_packed_numpy_uint8_array_to_transposed_simd_table(
     const pybind11::array_t<uint8_t> &data_u8, size_t expected_bits_per_shot, size_t *num_shots_out) {
-    size_t num_shots = data_u8.shape(0);
-    *num_shots_out = num_shots;
-
     if (data_u8.ndim() != 2) {
         throw std::invalid_argument("data must be a 2-dimensional numpy array with dtype=np.uint8 or dtype=np.bool8");
     }
+
+    size_t num_shots = data_u8.shape(0);
+    *num_shots_out = num_shots;
 
     size_t expected_bytes_per_shot = (expected_bits_per_shot + 7) / 8;
     size_t actual_bytes_per_shot = data_u8.shape(1);

--- a/src/stim/io/read_write.pybind.cc
+++ b/src/stim/io/read_write.pybind.cc
@@ -20,61 +20,10 @@
 #include "stim/io/raii_file.h"
 #include "stim/mem/simd_bits.h"
 #include "stim/py/base.pybind.h"
-#include "stim/simulators/measurements_to_detection_events.pybind.h"
+#include "stim/py/numpy.pybind.h"
 
 using namespace stim;
 using namespace stim_pybind;
-
-pybind11::object transposed_simd_bit_table_to_numpy_uint8(
-    const simd_bit_table<MAX_BITWORD_WIDTH> &table, size_t bits_per_shot, size_t num_shots) {
-    std::vector<uint8_t> bytes;
-    bytes.resize(bits_per_shot * num_shots);
-    size_t bytes_per_shot = (bits_per_shot + 7) / 8;
-    for (size_t shot_index = 0; shot_index < num_shots; shot_index++) {
-        size_t shot_offset = bytes_per_shot * shot_index;
-        for (size_t o_index = 0; o_index < bits_per_shot; o_index += 8) {
-            for (size_t b = 0; b < 8; b++) {
-                bool bit = table[o_index + b][shot_index];
-                bytes[shot_offset + o_index / 8] |= bit << b;
-            }
-        }
-    }
-    void *ptr = bytes.data();
-    pybind11::ssize_t itemsize = sizeof(uint8_t);
-    std::vector<pybind11::ssize_t> shape{(pybind11::ssize_t)num_shots, (pybind11::ssize_t)bytes_per_shot};
-    std::vector<pybind11::ssize_t> stride{(pybind11::ssize_t)bytes_per_shot, 1};
-    const std::string &np_format = pybind11::format_descriptor<uint8_t>::value;
-    bool readonly = true;
-    return pybind11::array_t<uint8_t>(pybind11::buffer_info(ptr, itemsize, np_format, 2, shape, stride, readonly));
-}
-
-pybind11::object transposed_simd_bit_table_to_numpy_bool8(
-    const simd_bit_table<MAX_BITWORD_WIDTH> &table, size_t bits_per_shot, size_t num_shots) {
-    std::vector<uint8_t> bytes;
-    bytes.resize(bits_per_shot * num_shots);
-    size_t k = 0;
-    for (size_t shot_index = 0; shot_index < num_shots; shot_index++) {
-        for (size_t o_index = 0; o_index < bits_per_shot; o_index++) {
-            bytes[k++] = table[o_index][shot_index];
-        }
-    }
-    void *ptr = bytes.data();
-    pybind11::ssize_t itemsize = sizeof(uint8_t);
-    std::vector<pybind11::ssize_t> shape{(pybind11::ssize_t)num_shots, (pybind11::ssize_t)bits_per_shot};
-    std::vector<pybind11::ssize_t> stride{(pybind11::ssize_t)bits_per_shot, 1};
-    const std::string &format = pybind11::format_descriptor<bool>::value;
-    bool readonly = true;
-    return pybind11::array_t<bool>(pybind11::buffer_info(ptr, itemsize, format, 2, shape, stride, readonly));
-}
-
-pybind11::object stim_pybind::transposed_simd_bit_table_to_numpy(
-    const simd_bit_table<MAX_BITWORD_WIDTH> &table, size_t bits_per_shot, size_t num_shots, bool bit_pack_result) {
-    if (bit_pack_result) {
-        return transposed_simd_bit_table_to_numpy_uint8(table, bits_per_shot, num_shots);
-    } else {
-        return transposed_simd_bit_table_to_numpy_bool8(table, bits_per_shot, num_shots);
-    }
-}
 
 pybind11::object read_shot_data_file(
     const char *path,
@@ -137,81 +86,6 @@ pybind11::object read_shot_data_file(
     }
 }
 
-simd_bit_table<MAX_BITWORD_WIDTH> bit_packed_numpy_uint8_array_to_transposed_simd_table(
-    const pybind11::array_t<uint8_t> &data_u8, size_t expected_bits_per_shot, size_t *num_shots_out) {
-    if (data_u8.ndim() != 2) {
-        throw std::invalid_argument("data must be a 2-dimensional numpy array with dtype=np.uint8 or dtype=np.bool8");
-    }
-
-    size_t num_shots = data_u8.shape(0);
-    *num_shots_out = num_shots;
-
-    size_t expected_bytes_per_shot = (expected_bits_per_shot + 7) / 8;
-    size_t actual_bytes_per_shot = data_u8.shape(1);
-    if (actual_bytes_per_shot != expected_bytes_per_shot) {
-        std::stringstream ss;
-        ss << "Expected " << expected_bits_per_shot << " bits per shot. ";
-        ss << "Got bit packed data (dtype=np.uint8) but data.shape[1]=";
-        ss << actual_bytes_per_shot << " != math.ceil(" << expected_bits_per_shot
-           << " / 8)=" << expected_bytes_per_shot;
-        throw std::invalid_argument(ss.str());
-    }
-
-    simd_bit_table<MAX_BITWORD_WIDTH> result(actual_bytes_per_shot * 8, num_shots);
-
-    auto u = data_u8.unchecked();
-    for (size_t a = 0; a < num_shots; a++) {
-        for (size_t b = 0; b < actual_bytes_per_shot; b++) {
-            uint8_t v = u(a, b);
-            for (size_t k = 0; k < 8; k++) {
-                result[b * 8 + k][a] |= ((v >> k) & 1) != 0;
-            }
-        }
-    }
-
-    return result;
-}
-
-simd_bit_table<MAX_BITWORD_WIDTH> bit_packed_numpy_bool8_array_to_transposed_simd_table(
-    const pybind11::array_t<bool> &data_bool8, size_t expected_bits_per_shot, size_t *num_shots_out) {
-    size_t num_shots = data_bool8.shape(0);
-    *num_shots_out = num_shots;
-
-    if (data_bool8.ndim() != 2) {
-        throw std::invalid_argument("data must be a 2-dimensional numpy array with dtype=np.uint8 or dtype=np.bool8");
-    }
-
-    size_t actual_bits_per_shot = data_bool8.shape(1);
-    if (actual_bits_per_shot != expected_bits_per_shot) {
-        std::stringstream ss;
-        ss << "Expected " << expected_bits_per_shot << " bits per shot. ";
-        ss << "Got unpacked boolean data (dtype=np.bool8) but data.shape[1]=" << actual_bits_per_shot;
-        throw std::invalid_argument(ss.str());
-    }
-    simd_bit_table<MAX_BITWORD_WIDTH> result(actual_bits_per_shot, num_shots);
-
-    auto u = data_bool8.unchecked();
-    for (size_t a = 0; a < num_shots; a++) {
-        for (size_t b = 0; b < actual_bits_per_shot; b++) {
-            result[b][a] |= u(a, b);
-        }
-    }
-
-    return result;
-}
-
-simd_bit_table<MAX_BITWORD_WIDTH> stim_pybind::numpy_array_to_transposed_simd_table(
-    const pybind11::object &data, size_t bits_per_shot, size_t *num_shots_out) {
-    if (pybind11::isinstance<pybind11::array_t<uint8_t>>(data)) {
-        return bit_packed_numpy_uint8_array_to_transposed_simd_table(
-            pybind11::cast<pybind11::array_t<uint8_t>>(data), bits_per_shot, num_shots_out);
-    } else if (pybind11::isinstance<pybind11::array_t<bool>>(data)) {
-        return bit_packed_numpy_bool8_array_to_transposed_simd_table(
-            pybind11::cast<pybind11::array_t<bool>>(data), bits_per_shot, num_shots_out);
-    } else {
-        throw std::invalid_argument("data must be a 2-dimensional numpy array with dtype=np.uint8 or dtype=np.bool8");
-    }
-}
 
 void write_shot_data_file(
     const pybind11::object &data,

--- a/src/stim/io/read_write.pybind.h
+++ b/src/stim/io/read_write.pybind.h
@@ -22,12 +22,6 @@
 
 namespace stim_pybind {
 
-stim::simd_bit_table<stim::MAX_BITWORD_WIDTH> numpy_array_to_transposed_simd_table(
-    const pybind11::object &data, size_t expected_bits_per_shot, size_t *num_shots_out);
-
-pybind11::object transposed_simd_bit_table_to_numpy(
-    const stim::simd_bit_table<stim::MAX_BITWORD_WIDTH> &table, size_t bits_per_shot, size_t num_shots, bool bit_pack_result);
-
 void pybind_read_write(pybind11::module &m);
 
 }  // namespace stim_pybind

--- a/src/stim/py/numpy.pybind.cc
+++ b/src/stim/py/numpy.pybind.cc
@@ -1,0 +1,283 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "stim/py/numpy.pybind.h"
+
+using namespace stim;
+using namespace stim_pybind;
+
+pybind11::object transposed_simd_bit_table_to_numpy_uint8(
+    const simd_bit_table<MAX_BITWORD_WIDTH> &table, size_t bits_per_shot, size_t num_shots) {
+    std::vector<uint8_t> bytes;
+    bytes.resize(bits_per_shot * num_shots);
+    size_t bytes_per_shot = (bits_per_shot + 7) / 8;
+    for (size_t shot_index = 0; shot_index < num_shots; shot_index++) {
+        size_t shot_offset = bytes_per_shot * shot_index;
+        for (size_t o_index = 0; o_index < bits_per_shot; o_index += 8) {
+            for (size_t b = 0; b < 8; b++) {
+                bool bit = table[o_index + b][shot_index];
+                bytes[shot_offset + o_index / 8] |= bit << b;
+            }
+        }
+    }
+    void *ptr = bytes.data();
+    pybind11::ssize_t itemsize = sizeof(uint8_t);
+    std::vector<pybind11::ssize_t> shape{(pybind11::ssize_t)num_shots, (pybind11::ssize_t)bytes_per_shot};
+    std::vector<pybind11::ssize_t> stride{(pybind11::ssize_t)bytes_per_shot, 1};
+    const std::string &np_format = pybind11::format_descriptor<uint8_t>::value;
+    bool readonly = true;
+    return pybind11::array_t<uint8_t>(pybind11::buffer_info(ptr, itemsize, np_format, 2, shape, stride, readonly));
+}
+
+pybind11::object transposed_simd_bit_table_to_numpy_bool8(
+    const simd_bit_table<MAX_BITWORD_WIDTH> &table, size_t bits_per_shot, size_t num_shots) {
+    std::vector<uint8_t> bytes;
+    bytes.resize(bits_per_shot * num_shots);
+    size_t k = 0;
+    for (size_t shot_index = 0; shot_index < num_shots; shot_index++) {
+        for (size_t o_index = 0; o_index < bits_per_shot; o_index++) {
+            bytes[k++] = table[o_index][shot_index];
+        }
+    }
+    void *ptr = bytes.data();
+    pybind11::ssize_t itemsize = sizeof(uint8_t);
+    std::vector<pybind11::ssize_t> shape{(pybind11::ssize_t)num_shots, (pybind11::ssize_t)bits_per_shot};
+    std::vector<pybind11::ssize_t> stride{(pybind11::ssize_t)bits_per_shot, 1};
+    const std::string &format = pybind11::format_descriptor<bool>::value;
+    bool readonly = true;
+    return pybind11::array_t<bool>(pybind11::buffer_info(ptr, itemsize, format, 2, shape, stride, readonly));
+}
+
+pybind11::object stim_pybind::transposed_simd_bit_table_to_numpy(
+    const simd_bit_table<MAX_BITWORD_WIDTH> &table, size_t bits_per_shot, size_t num_shots, bool bit_pack_result) {
+    if (bit_pack_result) {
+        return transposed_simd_bit_table_to_numpy_uint8(table, bits_per_shot, num_shots);
+    } else {
+        return transposed_simd_bit_table_to_numpy_bool8(table, bits_per_shot, num_shots);
+    }
+}
+
+pybind11::object simd_bit_table_to_numpy_uint8(
+    const simd_bit_table<MAX_BITWORD_WIDTH> &table, size_t num_major, size_t num_minor) {
+    void *ptr = table.data.ptr_simd;
+    pybind11::ssize_t itemsize = sizeof(uint8_t);
+    std::vector<pybind11::ssize_t> shape{(pybind11::ssize_t)num_major, (pybind11::ssize_t)(num_minor + 7) / 8};
+    std::vector<pybind11::ssize_t> stride{(pybind11::ssize_t)table.num_minor_bits_padded() >> 3, 1};
+    const std::string &np_format = pybind11::format_descriptor<uint8_t>::value;
+    bool readonly = true;
+    return pybind11::array_t<uint8_t>(pybind11::buffer_info(ptr, itemsize, np_format, 2, shape, stride, readonly));
+}
+
+pybind11::object simd_bit_table_to_numpy_bool8(
+    const simd_bit_table<MAX_BITWORD_WIDTH> &table, size_t num_major, size_t num_minor) {
+    std::vector<uint8_t> bytes;
+    bytes.resize(num_major * num_minor);
+    size_t k = 0;
+    for (size_t major = 0; major < num_major; major++) {
+        auto row = table[major];
+        for (size_t minor = 0; minor < num_minor; minor++) {
+            bytes[k++] = row[minor];
+        }
+    }
+    void *ptr = bytes.data();
+    pybind11::ssize_t itemsize = sizeof(uint8_t);
+    std::vector<pybind11::ssize_t> shape{(pybind11::ssize_t)num_major, (pybind11::ssize_t)num_minor};
+    std::vector<pybind11::ssize_t> stride{(pybind11::ssize_t)num_minor, 1};
+    const std::string &format = pybind11::format_descriptor<bool>::value;
+    bool readonly = true;
+    return pybind11::array_t<bool>(pybind11::buffer_info(ptr, itemsize, format, 2, shape, stride, readonly));
+}
+
+pybind11::object stim_pybind::simd_bit_table_to_numpy(
+    const simd_bit_table<MAX_BITWORD_WIDTH> &table, size_t num_major, size_t num_minor, bool bit_pack_result) {
+    if (bit_pack_result) {
+        return simd_bit_table_to_numpy_uint8(table, num_major, num_minor);
+    } else {
+        return simd_bit_table_to_numpy_bool8(table, num_major, num_minor);
+    }
+}
+
+void stim_pybind::memcpy_bits_from_numpy_to_simd_bit_table(
+    size_t num_major,
+    size_t num_minor,
+    const pybind11::object &src,
+    stim::simd_bit_table<stim::MAX_BITWORD_WIDTH> &dst) {
+
+    if (pybind11::isinstance<pybind11::array_t<uint8_t>>(src)) {
+        auto arr = pybind11::cast<pybind11::array_t<uint8_t>>(src);
+        size_t num_minor_bytes = (num_minor + 7) / 8;
+        auto u = arr.unchecked();
+        for (size_t major = 0; major < num_major; major++) {
+            auto row = dst[major];
+            for (size_t minor_byte = 0; minor_byte < num_minor_bytes; minor_byte++) {
+                uint8_t v = u(major, minor_byte);
+                row.u8[minor_byte] = v;
+            }
+            // Clear overwrite.
+            for (size_t k = num_minor; k < num_minor_bytes * 8; k++) {
+                row[k] = false;
+            }
+        }
+    } else if (pybind11::isinstance<pybind11::array_t<bool>>(src)) {
+        auto arr = pybind11::cast<pybind11::array_t<bool>>(src);
+        auto u = arr.unchecked();
+        for (size_t major = 0; major < num_major; major++) {
+            auto row = dst[major];
+            for (size_t minor = 0; minor < num_minor; minor++) {
+                row[minor] = u(major, minor);
+            }
+        }
+    } else {
+        throw std::invalid_argument("Expected a 2-dimensional numpy array with dtype=np.uint8 or dtype=np.bool8");
+    }
+}
+
+simd_bit_table<MAX_BITWORD_WIDTH> bit_packed_numpy_uint8_array_to_transposed_simd_table(
+    const pybind11::array_t<uint8_t> &data_u8, size_t expected_bits_per_shot, size_t *num_shots_out) {
+    if (data_u8.ndim() != 2) {
+        throw std::invalid_argument("data must be a 2-dimensional numpy array with dtype=np.uint8 or dtype=np.bool8");
+    }
+
+    size_t num_shots = data_u8.shape(0);
+    *num_shots_out = num_shots;
+
+    size_t expected_bytes_per_shot = (expected_bits_per_shot + 7) / 8;
+    size_t actual_bytes_per_shot = data_u8.shape(1);
+    if (actual_bytes_per_shot != expected_bytes_per_shot) {
+        std::stringstream ss;
+        ss << "Expected " << expected_bits_per_shot << " bits per shot. ";
+        ss << "Got bit packed data (dtype=np.uint8) but data.shape[1]=";
+        ss << actual_bytes_per_shot << " != math.ceil(" << expected_bits_per_shot
+           << " / 8)=" << expected_bytes_per_shot;
+        throw std::invalid_argument(ss.str());
+    }
+
+    simd_bit_table<MAX_BITWORD_WIDTH> result(actual_bytes_per_shot * 8, num_shots);
+
+    auto u = data_u8.unchecked();
+    for (size_t a = 0; a < num_shots; a++) {
+        for (size_t b = 0; b < actual_bytes_per_shot; b++) {
+            uint8_t v = u(a, b);
+            for (size_t k = 0; k < 8; k++) {
+                result[b * 8 + k][a] |= ((v >> k) & 1) != 0;
+            }
+        }
+    }
+
+    return result;
+}
+
+simd_bit_table<MAX_BITWORD_WIDTH> bit_packed_numpy_bool8_array_to_transposed_simd_table(
+    const pybind11::array_t<bool> &data_bool8, size_t expected_bits_per_shot, size_t *num_shots_out) {
+    size_t num_shots = data_bool8.shape(0);
+    *num_shots_out = num_shots;
+
+    if (data_bool8.ndim() != 2) {
+        throw std::invalid_argument("data must be a 2-dimensional numpy array with dtype=np.uint8 or dtype=np.bool8");
+    }
+
+    size_t actual_bits_per_shot = data_bool8.shape(1);
+    if (actual_bits_per_shot != expected_bits_per_shot) {
+        std::stringstream ss;
+        ss << "Expected " << expected_bits_per_shot << " bits per shot. ";
+        ss << "Got unpacked boolean data (dtype=np.bool8) but data.shape[1]=" << actual_bits_per_shot;
+        throw std::invalid_argument(ss.str());
+    }
+    simd_bit_table<MAX_BITWORD_WIDTH> result(actual_bits_per_shot, num_shots);
+
+    auto u = data_bool8.unchecked();
+    for (size_t a = 0; a < num_shots; a++) {
+        for (size_t b = 0; b < actual_bits_per_shot; b++) {
+            result[b][a] |= u(a, b);
+        }
+    }
+
+    return result;
+}
+
+simd_bit_table<MAX_BITWORD_WIDTH> stim_pybind::numpy_array_to_transposed_simd_table(
+    const pybind11::object &data, size_t bits_per_shot, size_t *num_shots_out) {
+    if (pybind11::isinstance<pybind11::array_t<uint8_t>>(data)) {
+        return bit_packed_numpy_uint8_array_to_transposed_simd_table(
+            pybind11::cast<pybind11::array_t<uint8_t>>(data), bits_per_shot, num_shots_out);
+    } else if (pybind11::isinstance<pybind11::array_t<bool>>(data)) {
+        return bit_packed_numpy_bool8_array_to_transposed_simd_table(
+            pybind11::cast<pybind11::array_t<bool>>(data), bits_per_shot, num_shots_out);
+    } else {
+        throw std::invalid_argument("data must be a 2-dimensional numpy array with dtype=np.uint8 or dtype=np.bool8");
+    }
+}
+
+pybind11::object bits_to_numpy_bool8(simd_bits_range_ref<MAX_BITWORD_WIDTH> bits, size_t num_bits) {
+    std::vector<uint8_t> bytes;
+    bytes.reserve(num_bits);
+    for (size_t k = 0; k < num_bits; k++) {
+        bytes.push_back(bits[k]);
+    }
+    void *ptr = bytes.data();
+    pybind11::ssize_t itemsize = sizeof(uint8_t);
+    std::vector<pybind11::ssize_t> shape{(pybind11::ssize_t)num_bits};
+    std::vector<pybind11::ssize_t> stride{1};
+    const std::string &np_format = pybind11::format_descriptor<bool>::value;
+    bool readonly = true;
+    return pybind11::array_t<bool>(pybind11::buffer_info(ptr, itemsize, np_format, (pybind11::ssize_t)shape.size(), shape, stride, readonly));
+}
+
+pybind11::object bits_to_numpy_uint8_packed(simd_bits_range_ref<MAX_BITWORD_WIDTH> bits, size_t num_bits) {
+    void *ptr = bits.ptr_simd;
+    pybind11::ssize_t itemsize = sizeof(uint8_t);
+    std::vector<pybind11::ssize_t> shape{(pybind11::ssize_t)(num_bits + 7) / 8};
+    std::vector<pybind11::ssize_t> stride{1};
+    const std::string &np_format = pybind11::format_descriptor<uint8_t>::value;
+    bool readonly = true;
+    return pybind11::array_t<uint8_t>(pybind11::buffer_info(ptr, itemsize, np_format, (pybind11::ssize_t)shape.size(), shape, stride, readonly));
+}
+
+pybind11::object stim_pybind::simd_bits_to_numpy(simd_bits_range_ref<MAX_BITWORD_WIDTH> bits, size_t num_bits, bool bit_packed) {
+    if (bit_packed) {
+        return bits_to_numpy_uint8_packed(bits, num_bits);
+    }
+    return bits_to_numpy_bool8(bits, num_bits);
+}
+
+void stim_pybind::memcpy_bits_from_numpy_to_simd(size_t num_bits, const pybind11::object &src, simd_bits_range_ref<MAX_BITWORD_WIDTH> dst) {
+    if (pybind11::isinstance<pybind11::array_t<uint8_t>>(src)) {
+        auto arr = pybind11::cast<pybind11::array_t<uint8_t>>(src);
+        if (arr.ndim() == 1) {
+            size_t num_bytes = (num_bits + 7) / 8;
+            auto u = arr.unchecked();
+            for (size_t k = 0; k < num_bytes; k++) {
+                uint8_t v = u(k);
+                dst.u8[k] = v;
+            }
+
+            // Clear overwrite.
+            for (size_t k = num_bits; k < num_bytes * 8; k++) {
+                dst[k] = false;
+            }
+            return;
+        }
+    } else if (pybind11::isinstance<pybind11::array_t<bool>>(src)) {
+        auto arr = pybind11::cast<pybind11::array_t<bool>>(src);
+        if (arr.ndim() == 1) {
+            auto u = arr.unchecked();
+            for (size_t k = 0; k < num_bits; k++) {
+                dst[k] = u(k);
+            }
+            return;
+        }
+    }
+
+    throw std::invalid_argument("Expected a 1-dimensional numpy array with dtype=np.uint8 or dtype=np.bool8");
+}

--- a/src/stim/py/numpy.pybind.h
+++ b/src/stim/py/numpy.pybind.h
@@ -1,0 +1,32 @@
+#ifndef _STIM_PY_NUMPY_PYBIND_H
+#define _STIM_PY_NUMPY_PYBIND_H
+
+#include "stim/py/base.pybind.h"
+#include "stim/mem/simd_bit_table.h"
+
+namespace stim_pybind {
+
+stim::simd_bit_table<stim::MAX_BITWORD_WIDTH> numpy_array_to_transposed_simd_table(
+    const pybind11::object &data, size_t expected_bits_per_shot, size_t *num_shots_out);
+
+pybind11::object transposed_simd_bit_table_to_numpy(
+    const stim::simd_bit_table<stim::MAX_BITWORD_WIDTH> &table, size_t bits_per_shot, size_t num_shots, bool bit_pack_result);
+
+pybind11::object simd_bit_table_to_numpy(
+    const stim::simd_bit_table<stim::MAX_BITWORD_WIDTH> &table,
+    size_t num_major,
+    size_t num_minor,
+    bool bit_pack_result);
+
+void memcpy_bits_from_numpy_to_simd_bit_table(
+    size_t num_major,
+    size_t num_minor,
+    const pybind11::object &src,
+    stim::simd_bit_table<stim::MAX_BITWORD_WIDTH> &dst);
+
+pybind11::object simd_bits_to_numpy(stim::simd_bits_range_ref<stim::MAX_BITWORD_WIDTH> bits, size_t num_bits, bool bit_packed);
+void memcpy_bits_from_numpy_to_simd(size_t num_bits, const pybind11::object &src, stim::simd_bits_range_ref<stim::MAX_BITWORD_WIDTH> dst);
+
+}
+
+#endif

--- a/src/stim/simulators/dem_sampler.pybind.cc
+++ b/src/stim/simulators/dem_sampler.pybind.cc
@@ -15,8 +15,8 @@
 #include "stim/simulators/dem_sampler.pybind.h"
 
 #include "stim/io/raii_file.h"
-#include "stim/io/read_write.pybind.h"
 #include "stim/py/base.pybind.h"
+#include "stim/py/numpy.pybind.h"
 
 using namespace stim;
 using namespace stim_pybind;

--- a/src/stim/simulators/measurements_to_detection_events.pybind.cc
+++ b/src/stim/simulators/measurements_to_detection_events.pybind.cc
@@ -16,8 +16,8 @@
 
 #include "stim/circuit/circuit.pybind.h"
 #include "stim/io/raii_file.h"
-#include "stim/io/read_write.pybind.h"
 #include "stim/py/base.pybind.h"
+#include "stim/py/numpy.pybind.h"
 #include "stim/simulators/detection_simulator.h"
 #include "stim/simulators/frame_simulator.h"
 #include "stim/simulators/measurements_to_detection_events.h"

--- a/src/stim/stabilizers/pauli_string.pybind.cc
+++ b/src/stim/stabilizers/pauli_string.pybind.cc
@@ -15,10 +15,9 @@
 #include "stim/stabilizers/pauli_string.h"
 
 #include "stim/py/base.pybind.h"
-#include "stim/simulators/tableau_simulator.h"
+#include "stim/py/numpy.pybind.h"
 #include "stim/stabilizers/pauli_string.pybind.h"
 #include "stim/stabilizers/tableau.h"
-#include "stim/stabilizers/tableau.pybind.h"
 
 using namespace stim;
 using namespace stim_pybind;
@@ -154,38 +153,6 @@ bool PyPauliString::operator!=(const PyPauliString &other) const {
     return !(*this == other);
 }
 
-pybind11::object bits_to_numpy_bool8(simd_bits_range_ref<MAX_BITWORD_WIDTH> bits, size_t num_bits) {
-    std::vector<uint8_t> bytes;
-    bytes.reserve(num_bits);
-    for (size_t k = 0; k < num_bits; k++) {
-        bytes.push_back(bits[k]);
-    }
-    void *ptr = bytes.data();
-    pybind11::ssize_t itemsize = sizeof(uint8_t);
-    std::vector<pybind11::ssize_t> shape{(pybind11::ssize_t)num_bits};
-    std::vector<pybind11::ssize_t> stride{1};
-    const std::string &np_format = pybind11::format_descriptor<bool>::value;
-    bool readonly = true;
-    return pybind11::array_t<bool>(pybind11::buffer_info(ptr, itemsize, np_format, (pybind11::ssize_t)shape.size(), shape, stride, readonly));
-}
-
-pybind11::object bits_to_numpy_uint8_packed(simd_bits_range_ref<MAX_BITWORD_WIDTH> bits, size_t num_bits) {
-    void *ptr = bits.ptr_simd;
-    pybind11::ssize_t itemsize = sizeof(uint8_t);
-    std::vector<pybind11::ssize_t> shape{(pybind11::ssize_t)(num_bits + 7) / 8};
-    std::vector<pybind11::ssize_t> stride{1};
-    const std::string &np_format = pybind11::format_descriptor<uint8_t>::value;
-    bool readonly = true;
-    return pybind11::array_t<uint8_t>(pybind11::buffer_info(ptr, itemsize, np_format, (pybind11::ssize_t)shape.size(), shape, stride, readonly));
-}
-
-pybind11::object bits_to_numpy(simd_bits_range_ref<MAX_BITWORD_WIDTH> bits, size_t num_bits, bool bit_packed) {
-    if (bit_packed) {
-        return bits_to_numpy_uint8_packed(bits, num_bits);
-    }
-    return bits_to_numpy_bool8(bits, num_bits);
-}
-
 size_t numpy_to_size(const pybind11::object &numpy_array, size_t expected_size) {
     if (pybind11::isinstance<pybind11::array_t<uint8_t>>(numpy_array)) {
         auto arr = pybind11::cast<pybind11::array_t<uint8_t>>(numpy_array);
@@ -194,8 +161,8 @@ size_t numpy_to_size(const pybind11::object &numpy_array, size_t expected_size) 
             size_t min_n = max_n == 0 ? 0 : max_n - 7;
             if (expected_size == SIZE_MAX) {
                 throw std::invalid_argument(
-                    "Need to specify expected number of pauli terms (the `num` argument) when bit packing.\n"
-                    "A numpy array is bit packed (has dtype=np.uint8) but `num=None`.");
+                    "Need to specify expected number of pauli terms (the `num_qubits` argument) when bit packing.\n"
+                    "A numpy array is bit packed (has dtype=np.uint8) but `num_qubits=None`.");
             }
             if (expected_size < min_n || expected_size > max_n) {
                 std::stringstream ss;
@@ -233,37 +200,6 @@ size_t numpy_pair_to_size(const pybind11::object &numpy_array1, const pybind11::
         throw std::invalid_argument("Inconsistent array shapes.");
     }
     return n2;
-}
-
-void memcpy_bits_from_numpy_to_simd(size_t num_bits, const pybind11::object &src, simd_bits_range_ref<MAX_BITWORD_WIDTH> dst) {
-    if (pybind11::isinstance<pybind11::array_t<uint8_t>>(src)) {
-        auto arr = pybind11::cast<pybind11::array_t<uint8_t>>(src);
-        if (arr.ndim() == 1) {
-            size_t num_bytes = (num_bits + 7) / 8;
-            auto u = arr.unchecked();
-            for (size_t k = 0; k < num_bytes; k++) {
-                uint8_t v = u(k);
-                dst.u8[k] = v;
-            }
-
-            // Clear overwrite.
-            for (size_t k = num_bits; k < num_bytes * 8; k++) {
-                dst[k] = false;
-            }
-            return;
-        }
-    } else if (pybind11::isinstance<pybind11::array_t<bool>>(src)) {
-        auto arr = pybind11::cast<pybind11::array_t<bool>>(src);
-        if (arr.ndim() == 1) {
-            auto u = arr.unchecked();
-            for (size_t k = 0; k < num_bits; k++) {
-                dst[k] = u(k);
-            }
-            return;
-        }
-    }
-
-    throw std::invalid_argument("Expected a 1-dimensional numpy array with dtype=np.uint8 or dtype=np.bool8");
 }
 
 std::complex<float> PyPauliString::get_phase() const {
@@ -961,8 +897,8 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
         "to_numpy",
         [](const PyPauliString &self, bool bit_packed) {
             return pybind11::make_tuple(
-                bits_to_numpy(self.value.xs, self.value.num_qubits, bit_packed),
-                bits_to_numpy(self.value.zs, self.value.num_qubits, bit_packed));
+                simd_bits_to_numpy(self.value.xs, self.value.num_qubits, bit_packed),
+                simd_bits_to_numpy(self.value.zs, self.value.num_qubits, bit_packed));
         },
         pybind11::kw_only(),
         pybind11::arg("bit_packed") = false,
@@ -1020,8 +956,8 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
 
     c.def_static(
         "from_numpy",
-        [](const pybind11::object &xs, const pybind11::object &zs, const pybind11::object &sign, const pybind11::object &num) -> PyPauliString {
-            size_t n = numpy_pair_to_size(xs, zs, num);
+        [](const pybind11::object &xs, const pybind11::object &zs, const pybind11::object &sign, const pybind11::object &num_qubits) -> PyPauliString {
+            size_t n = numpy_pair_to_size(xs, zs, num_qubits);
             PyPauliString result{PauliString(n)};
             memcpy_bits_from_numpy_to_simd(n, xs, result.value.xs);
             memcpy_bits_from_numpy_to_simd(n, zs, result.value.zs);
@@ -1032,9 +968,9 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
         pybind11::arg("xs"),
         pybind11::arg("zs"),
         pybind11::arg("sign") = +1,
-        pybind11::arg("num") = pybind11::none(),
+        pybind11::arg("num_qubits") = pybind11::none(),
         clean_doc_string(u8R"DOC(
-            @signature def from_numpy(*, xs: np.ndarray, zs: np.ndarray, sign: Union[int, float, complex] = +1, num: Optional[int] = None) -> stim.PauliString:
+            @signature def from_numpy(*, xs: np.ndarray, zs: np.ndarray, sign: Union[int, float, complex] = +1, num_qubits: Optional[int] = None) -> stim.PauliString:
 
             Creates a pauli string from X bit and Z bit numpy arrays, using the encoding:
 
@@ -1047,19 +983,19 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
                 xs: The X bits of the pauli string. This array can either be a 1-dimensional
                     numpy array with dtype=np.bool8, or a bit packed 1-dimensional numpy
                     array with dtype=np.uint8. If the dtype is np.uint8 then the array is
-                    assumed to be bit packed in little endian order and the "num" argument
-                    must be specified. When bit packed, the x bit with offset k is stored at
-                    (xs[k // 8] >> (k % 8)) & 1.
+                    assumed to be bit packed in little endian order and the "num_qubits"
+                    argument must be specified. When bit packed, the x bit with offset k is
+                    stored at (xs[k // 8] >> (k % 8)) & 1.
                 zs: The Z bits of the pauli string. This array can either be a 1-dimensional
                     numpy array with dtype=np.bool8, or a bit packed 1-dimensional numpy
                     array with dtype=np.uint8. If the dtype is np.uint8 then the array is
-                    assumed to be bit packed in little endian order and the "num" argument
-                    must be specified. When bit packed, the x bit with offset k is stored at
-                    (xs[k // 8] >> (k % 8)) & 1.
+                    assumed to be bit packed in little endian order and the "num_qubits"
+                    argument must be specified. When bit packed, the x bit with offset k is
+                    stored at (xs[k // 8] >> (k % 8)) & 1.
                 sign: Defaults to +1. Set to +1, -1, 1j, or -1j to control the sign of the
                     returned Pauli string.
-                num: Must be specified if xs or zs is a bit packed array. Specifies the
-                    expected length of the Pauli string.
+                num_qubits: Must be specified if xs or zs is a bit packed array. Specifies
+                    the expected length of the Pauli string.
 
             Returns:
                 The created pauli string.
@@ -1075,7 +1011,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
 
                 >>> xs = np.array([127, 0], dtype=np.uint8)
                 >>> zs = np.array([240, 1], dtype=np.uint8)
-                >>> stim.PauliString.from_numpy(xs=xs, zs=zs, num=9)
+                >>> stim.PauliString.from_numpy(xs=xs, zs=zs, num_qubits=9)
                 stim.PauliString("+XXXXYYYZZ")
         )DOC")
             .data());

--- a/src/stim/stabilizers/pauli_string.pybind.cc
+++ b/src/stim/stabilizers/pauli_string.pybind.cc
@@ -166,7 +166,7 @@ pybind11::object bits_to_numpy_bool8(simd_bits_range_ref<MAX_BITWORD_WIDTH> bits
     std::vector<pybind11::ssize_t> stride{1};
     const std::string &np_format = pybind11::format_descriptor<bool>::value;
     bool readonly = true;
-    return pybind11::array_t<bool>(pybind11::buffer_info(ptr, itemsize, np_format, (ssize_t)shape.size(), shape, stride, readonly));
+    return pybind11::array_t<bool>(pybind11::buffer_info(ptr, itemsize, np_format, (pybind11::ssize_t)shape.size(), shape, stride, readonly));
 }
 
 pybind11::object bits_to_numpy_uint8_packed(simd_bits_range_ref<MAX_BITWORD_WIDTH> bits, size_t num_bits) {
@@ -176,7 +176,7 @@ pybind11::object bits_to_numpy_uint8_packed(simd_bits_range_ref<MAX_BITWORD_WIDT
     std::vector<pybind11::ssize_t> stride{1};
     const std::string &np_format = pybind11::format_descriptor<uint8_t>::value;
     bool readonly = true;
-    return pybind11::array_t<uint8_t>(pybind11::buffer_info(ptr, itemsize, np_format, (ssize_t)shape.size(), shape, stride, readonly));
+    return pybind11::array_t<uint8_t>(pybind11::buffer_info(ptr, itemsize, np_format, (pybind11::ssize_t)shape.size(), shape, stride, readonly));
 }
 
 pybind11::object bits_to_numpy(simd_bits_range_ref<MAX_BITWORD_WIDTH> bits, size_t num_bits, bool bit_packed) {

--- a/src/stim/stabilizers/pauli_string_pybind_test.py
+++ b/src/stim/stabilizers/pauli_string_pybind_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import numpy as np
 import stim
 import pytest
 
@@ -488,3 +488,106 @@ def test_pickle():
     t = stim.PauliString("i_XYZ")
     a = pickle.dumps(t)
     assert pickle.loads(a) == t
+
+
+def test_to_numpy():
+    p = stim.PauliString("_XYZ___XYXZYZ")
+
+    xs, zs = p.to_numpy()
+    assert xs.dtype == np.bool8
+    assert zs.dtype == np.bool8
+    np.testing.assert_array_equal(xs, [0, 1, 1, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0])
+    np.testing.assert_array_equal(zs, [0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 1])
+
+    xs, zs = p.to_numpy(bit_packed=True)
+    assert xs.dtype == np.uint8
+    assert zs.dtype == np.uint8
+    np.testing.assert_array_equal(xs, [0x86, 0x0B])
+    np.testing.assert_array_equal(zs, [0x0C, 0x1D])
+
+
+def test_from_numpy():
+    p = stim.PauliString.from_numpy(
+        xs=np.array([0, 1, 1, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0], dtype=np.bool8),
+        zs=np.array([0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 1], dtype=np.bool8))
+    assert p == stim.PauliString("_XYZ___XYXZYZ")
+
+    p = stim.PauliString.from_numpy(
+        xs=np.array([0x86, 0x0B], dtype=np.uint8),
+        zs=np.array([0x0C, 0x1D], dtype=np.uint8),
+        num=13)
+
+    assert p == stim.PauliString("_XYZ___XYXZYZ")
+    p = stim.PauliString.from_numpy(
+        xs=np.array([0x86, 0x0B], dtype=np.uint8),
+        zs=np.array([0x0C, 0x1D], dtype=np.uint8),
+        num=15,
+        sign=1j)
+    assert p == stim.PauliString("i_XYZ___XYXZYZ__")
+
+
+def test_from_numpy_bad_bit_packed_len():
+    xs = np.array([0x86, 0x0B], dtype=np.uint8)
+    zs = np.array([0x0C, 0x1D], dtype=np.uint8)
+    with pytest.raises(ValueError, match="specify expected number"):
+        stim.PauliString.from_numpy(xs=xs, zs=zs)
+
+    with pytest.raises(ValueError, match="between 9 and 16 bits"):
+        stim.PauliString.from_numpy(xs=xs, zs=zs, num=100)
+
+    with pytest.raises(ValueError, match="between 9 and 16 bits"):
+        stim.PauliString.from_numpy(xs=xs, zs=zs, num=0)
+
+    with pytest.raises(ValueError, match="between 9 and 16 bits"):
+        stim.PauliString.from_numpy(xs=xs, zs=zs, num=8)
+
+    with pytest.raises(ValueError, match="between 9 and 16 bits"):
+        stim.PauliString.from_numpy(xs=xs, zs=zs, num=17)
+
+    with pytest.raises(ValueError, match="between 0 and 0 bits"):
+        stim.PauliString.from_numpy(xs=xs[:0], zs=zs, num=9)
+
+    with pytest.raises(ValueError, match="between 1 and 8 bits"):
+        stim.PauliString.from_numpy(xs=xs[:1], zs=zs, num=9)
+
+    with pytest.raises(ValueError, match="between 1 and 8 bits"):
+        stim.PauliString.from_numpy(xs=xs, zs=zs[:1], num=9)
+
+    with pytest.raises(ValueError, match="1-dimensional"):
+        stim.PauliString.from_numpy(xs=np.array([xs, xs]), zs=np.array([zs, zs]), num=9)
+
+    with pytest.raises(ValueError, match="uint8"):
+        stim.PauliString.from_numpy(xs=np.array(xs, dtype=np.uint64), zs=np.array(xs, dtype=np.uint64), num=9)
+
+
+def test_from_numpy_bad_bool_len():
+    xs = np.array([0, 1, 1, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0], dtype=np.bool8)
+    zs = np.array([0, 1, 1, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0], dtype=np.bool8)
+    with pytest.raises(ValueError, match="shape=13"):
+        stim.PauliString.from_numpy(xs=xs, zs=zs, num=12)
+
+    with pytest.raises(ValueError, match="shape=13"):
+        stim.PauliString.from_numpy(xs=xs, zs=zs, num=14)
+
+    with pytest.raises(ValueError, match="shape=12"):
+        stim.PauliString.from_numpy(xs=xs[:-1], zs=zs, num=13)
+
+    with pytest.raises(ValueError, match="shape=12"):
+        stim.PauliString.from_numpy(xs=xs, zs=zs[:-1], num=13)
+
+    with pytest.raises(ValueError, match="Inconsistent"):
+        stim.PauliString.from_numpy(xs=xs, zs=zs[:-1])
+
+    with pytest.raises(RuntimeError, match="Unable to cast"):
+        stim.PauliString.from_numpy(xs=xs, zs=zs, num=-1)
+
+
+@pytest.mark.parametrize("n", [0, 1, 41, 42, 1023, 1024, 1025])
+def test_to_from_numpy_round_trip(n: int):
+    p = stim.PauliString.random(n)
+    xs, zs = p.to_numpy()
+    p2 = stim.PauliString.from_numpy(xs=xs, zs=zs, sign=p.sign)
+    assert p2 == p
+    xs, zs = p.to_numpy(bit_packed=True)
+    p2 = stim.PauliString.from_numpy(xs=xs, zs=zs, num=n, sign=p.sign)
+    assert p2 == p

--- a/src/stim/stabilizers/pauli_string_pybind_test.py
+++ b/src/stim/stabilizers/pauli_string_pybind_test.py
@@ -515,13 +515,13 @@ def test_from_numpy():
     p = stim.PauliString.from_numpy(
         xs=np.array([0x86, 0x0B], dtype=np.uint8),
         zs=np.array([0x0C, 0x1D], dtype=np.uint8),
-        num=13)
+        num_qubits=13)
 
     assert p == stim.PauliString("_XYZ___XYXZYZ")
     p = stim.PauliString.from_numpy(
         xs=np.array([0x86, 0x0B], dtype=np.uint8),
         zs=np.array([0x0C, 0x1D], dtype=np.uint8),
-        num=15,
+        num_qubits=15,
         sign=1j)
     assert p == stim.PauliString("i_XYZ___XYXZYZ__")
 
@@ -533,53 +533,53 @@ def test_from_numpy_bad_bit_packed_len():
         stim.PauliString.from_numpy(xs=xs, zs=zs)
 
     with pytest.raises(ValueError, match="between 9 and 16 bits"):
-        stim.PauliString.from_numpy(xs=xs, zs=zs, num=100)
+        stim.PauliString.from_numpy(xs=xs, zs=zs, num_qubits=100)
 
     with pytest.raises(ValueError, match="between 9 and 16 bits"):
-        stim.PauliString.from_numpy(xs=xs, zs=zs, num=0)
+        stim.PauliString.from_numpy(xs=xs, zs=zs, num_qubits=0)
 
     with pytest.raises(ValueError, match="between 9 and 16 bits"):
-        stim.PauliString.from_numpy(xs=xs, zs=zs, num=8)
+        stim.PauliString.from_numpy(xs=xs, zs=zs, num_qubits=8)
 
     with pytest.raises(ValueError, match="between 9 and 16 bits"):
-        stim.PauliString.from_numpy(xs=xs, zs=zs, num=17)
+        stim.PauliString.from_numpy(xs=xs, zs=zs, num_qubits=17)
 
     with pytest.raises(ValueError, match="between 0 and 0 bits"):
-        stim.PauliString.from_numpy(xs=xs[:0], zs=zs, num=9)
+        stim.PauliString.from_numpy(xs=xs[:0], zs=zs, num_qubits=9)
 
     with pytest.raises(ValueError, match="between 1 and 8 bits"):
-        stim.PauliString.from_numpy(xs=xs[:1], zs=zs, num=9)
+        stim.PauliString.from_numpy(xs=xs[:1], zs=zs, num_qubits=9)
 
     with pytest.raises(ValueError, match="between 1 and 8 bits"):
-        stim.PauliString.from_numpy(xs=xs, zs=zs[:1], num=9)
+        stim.PauliString.from_numpy(xs=xs, zs=zs[:1], num_qubits=9)
 
     with pytest.raises(ValueError, match="1-dimensional"):
-        stim.PauliString.from_numpy(xs=np.array([xs, xs]), zs=np.array([zs, zs]), num=9)
+        stim.PauliString.from_numpy(xs=np.array([xs, xs]), zs=np.array([zs, zs]), num_qubits=9)
 
     with pytest.raises(ValueError, match="uint8"):
-        stim.PauliString.from_numpy(xs=np.array(xs, dtype=np.uint64), zs=np.array(xs, dtype=np.uint64), num=9)
+        stim.PauliString.from_numpy(xs=np.array(xs, dtype=np.uint64), zs=np.array(xs, dtype=np.uint64), num_qubits=9)
 
 
 def test_from_numpy_bad_bool_len():
     xs = np.array([0, 1, 1, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0], dtype=np.bool8)
     zs = np.array([0, 1, 1, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0], dtype=np.bool8)
     with pytest.raises(ValueError, match="shape=13"):
-        stim.PauliString.from_numpy(xs=xs, zs=zs, num=12)
+        stim.PauliString.from_numpy(xs=xs, zs=zs, num_qubits=12)
 
     with pytest.raises(ValueError, match="shape=13"):
-        stim.PauliString.from_numpy(xs=xs, zs=zs, num=14)
+        stim.PauliString.from_numpy(xs=xs, zs=zs, num_qubits=14)
 
     with pytest.raises(ValueError, match="shape=12"):
-        stim.PauliString.from_numpy(xs=xs[:-1], zs=zs, num=13)
+        stim.PauliString.from_numpy(xs=xs[:-1], zs=zs, num_qubits=13)
 
     with pytest.raises(ValueError, match="shape=12"):
-        stim.PauliString.from_numpy(xs=xs, zs=zs[:-1], num=13)
+        stim.PauliString.from_numpy(xs=xs, zs=zs[:-1], num_qubits=13)
 
     with pytest.raises(ValueError, match="Inconsistent"):
         stim.PauliString.from_numpy(xs=xs, zs=zs[:-1])
 
     with pytest.raises(RuntimeError, match="Unable to cast"):
-        stim.PauliString.from_numpy(xs=xs, zs=zs, num=-1)
+        stim.PauliString.from_numpy(xs=xs, zs=zs, num_qubits=-1)
 
 
 @pytest.mark.parametrize("n", [0, 1, 41, 42, 1023, 1024, 1025])
@@ -589,5 +589,5 @@ def test_to_from_numpy_round_trip(n: int):
     p2 = stim.PauliString.from_numpy(xs=xs, zs=zs, sign=p.sign)
     assert p2 == p
     xs, zs = p.to_numpy(bit_packed=True)
-    p2 = stim.PauliString.from_numpy(xs=xs, zs=zs, num=n, sign=p.sign)
+    p2 = stim.PauliString.from_numpy(xs=xs, zs=zs, num_qubits=n, sign=p.sign)
     assert p2 == p

--- a/src/stim/stabilizers/tableau.pybind.cc
+++ b/src/stim/stabilizers/tableau.pybind.cc
@@ -15,6 +15,7 @@
 #include "stim/stabilizers/tableau.pybind.h"
 
 #include "stim/py/base.pybind.h"
+#include "stim/py/numpy.pybind.h"
 #include "stim/simulators/tableau_simulator.h"
 #include "stim/stabilizers/conversions.h"
 #include "stim/stabilizers/pauli_string.h"
@@ -24,6 +25,95 @@
 
 using namespace stim;
 using namespace stim_pybind;
+
+void check_tableau_signs_shape(const pybind11::object &numpy_array, size_t n, const char *name) {
+    if (pybind11::isinstance<pybind11::array_t<uint8_t>>(numpy_array)) {
+        auto arr = pybind11::cast<pybind11::array_t<uint8_t>>(numpy_array);
+        if (arr.ndim() == 1) {
+            size_t minor = arr.shape(0);
+            if (minor != (n + 7) / 8) {
+                std::stringstream ss;
+                ss << name << " had dtype=uint8 (meaning it is bit packed) ";
+                ss << "but its shape was " << minor << " instead of ";
+                ss << (n + 7) / 8 << ".";
+                throw std::invalid_argument(ss.str());
+            }
+            return;
+        }
+    } else if (pybind11::isinstance<pybind11::array_t<bool>>(numpy_array)) {
+        auto arr = pybind11::cast<pybind11::array_t<bool>>(numpy_array);
+        if (arr.ndim() == 1) {
+            size_t minor = arr.shape(0);
+            if (minor != n) {
+                std::stringstream ss;
+                ss << name << " had dtype=bool8 ";
+                ss << "but its shape was " << minor << " instead of ";
+                ss << n << ".";
+                throw std::invalid_argument(ss.str());
+            }
+        }
+        return;
+    }
+
+    std::stringstream ss;
+    ss << name << " wasn't a 1d numpy array with dtype=bool8 or dtype=uint8";
+    throw std::invalid_argument(ss.str());
+}
+
+void check_tableau_shape(const pybind11::object &numpy_array, size_t n, const char *name) {
+    if (pybind11::isinstance<pybind11::array_t<uint8_t>>(numpy_array)) {
+        auto arr = pybind11::cast<pybind11::array_t<uint8_t>>(numpy_array);
+        if (arr.ndim() == 2) {
+            size_t major = arr.shape(0);
+            size_t minor = arr.shape(1);
+            if (major != n || minor != (n + 7) / 8) {
+                std::stringstream ss;
+                ss << name << " had dtype=uint8 (meaning it is bit packed) ";
+                ss << "but its shape was (" << major << ", " << minor << ") instead of (";
+                ss << n << ", " << (n + 7) / 8 << ").";
+                throw std::invalid_argument(ss.str());
+            }
+            return;
+        }
+    } else if (pybind11::isinstance<pybind11::array_t<bool>>(numpy_array)) {
+        auto arr = pybind11::cast<pybind11::array_t<bool>>(numpy_array);
+        if (arr.ndim() == 2) {
+            size_t major = arr.shape(0);
+            size_t minor = arr.shape(1);
+            if (major != n || minor != n) {
+                std::stringstream ss;
+                ss << name << " had dtype=bool8 ";
+                ss << "but its shape was (" << major << ", " << minor << ") instead of (";
+                ss << n << ", " << n << ").";
+                throw std::invalid_argument(ss.str());
+            }
+        }
+        return;
+    }
+
+    std::stringstream ss;
+    ss << name << " wasn't a 2d numpy array with dtype=bool8 or dtype=uint8";
+    throw std::invalid_argument(ss.str());
+}
+
+size_t determine_tableau_shape(const pybind11::object &numpy_array, const char *name) {
+    size_t n = 0;
+    if (pybind11::isinstance<pybind11::array_t<uint8_t>>(numpy_array)) {
+        auto arr = pybind11::cast<pybind11::array_t<uint8_t>>(numpy_array);
+        if (arr.ndim() == 2) {
+            n = arr.shape(0);
+        }
+    } else if (pybind11::isinstance<pybind11::array_t<bool>>(numpy_array)) {
+        auto arr = pybind11::cast<pybind11::array_t<bool>>(numpy_array);
+        if (arr.ndim() == 2) {
+            n = arr.shape(0);
+        }
+    }
+
+    check_tableau_shape(numpy_array, n, name);
+    return n;
+}
+
 
 pybind11::class_<Tableau> stim_pybind::pybind_tableau(pybind11::module &m) {
     return pybind11::class_<Tableau>(
@@ -207,6 +297,304 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
                        [0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j],
                        [0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j],
                        [0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j]], dtype=complex64)
+        )DOC")
+            .data());
+
+    c.def(
+        "to_numpy",
+        [](const Tableau &self, bool bit_packed) {
+            auto n = self.num_qubits;
+            return pybind11::make_tuple(
+                simd_bit_table_to_numpy(self.xs.xt, n, n, bit_packed),
+                simd_bit_table_to_numpy(self.xs.zt, n, n, bit_packed),
+                simd_bit_table_to_numpy(self.zs.xt, n, n, bit_packed),
+                simd_bit_table_to_numpy(self.zs.zt, n, n, bit_packed),
+                simd_bits_to_numpy(self.xs.signs, n, bit_packed),
+                simd_bits_to_numpy(self.zs.signs, n, bit_packed));
+        },
+        pybind11::kw_only(),
+        pybind11::arg("bit_packed") = false,
+        clean_doc_string(u8R"DOC(
+            @signature def to_numpy(self, *, bit_packed: bool = False) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+
+            Decomposes the contents of the tableau into six numpy arrays.
+
+            The first four numpy arrays correspond to the four quadrants of the table
+            defined in Aaronson and Gottesman's "Improved Simulation of Stabilizer Circuits"
+            ( https://arxiv.org/abs/quant-ph/0406196 ).
+
+            The last two numpy arrays are the X and Z sign bit vectors of the tableau.
+
+            Args:
+                bit_packed: Defaults to False. Determines whether the output numpy arrays
+                    use dtype=bool8 or dtype=uint8 with 8 bools packed into each byte.
+
+            Returns:
+                An (x2x, x2z, z2x, z2x, x_signs, z_signs) tuple encoding the tableau.
+
+                x2x: A 2d table of whether tableau(X_i)_j is X or Y (instead of I or Z).
+                x2z: A 2d table of whether tableau(X_i)_j is Z or Y (instead of I or X).
+                z2x: A 2d table of whether tableau(Z_i)_j is X or Y (instead of I or Z).
+                z2z: A 2d table of whether tableau(Z_i)_j is Z or Y (instead of I or X).
+                x_signs: A vector of whether tableau(X_i) is negative.
+                z_signs: A vector of whether tableau(Z_i) is negative.
+
+                If bit_packed=False then:
+                    *.dtype = = np.bool8
+                    *2*.shape = (len(tableau), len(tableau))
+                    *_signs.shape = len(tableau)
+                    x2x[i, j] = tableau.x_output_pauli(i, j) in [1, 2]
+                    x2z[i, j] = tableau.x_output_pauli(i, j) in [2, 3]
+                    z2x[i, j] = tableau.z_output_pauli(i, j) in [1, 2]
+                    z2z[i, j] = tableau.z_output_pauli(i, j) in [2, 3]
+
+                If bit_packed=True then:
+                    *.dtype = = np.uint8
+                    *2*.shape = (len(tableau), math.ceil(len(tableau) / 8))
+                    *_signs.shape = len(tableau)
+                    (x2x[i, j // 8] >> (j % 8)) & 1 = tableau.x_output_pauli(i, j) in [1, 2]
+                    (x2z[i, j // 8] >> (j % 8)) & 1 = tableau.x_output_pauli(i, j) in [2, 3]
+                    (z2x[i, j // 8] >> (j % 8)) & 1 = tableau.z_output_pauli(i, j) in [1, 2]
+                    (z2z[i, j // 8] >> (j % 8)) & 1 = tableau.z_output_pauli(i, j) in [2, 3]
+
+            Examples:
+                >>> import stim
+                >>> cnot = stim.Tableau.from_named_gate("CNOT")
+                >>> print(repr(cnot))
+                stim.Tableau.from_conjugated_generators(
+                    xs=[
+                        stim.PauliString("+XX"),
+                        stim.PauliString("+_X"),
+                    ],
+                    zs=[
+                        stim.PauliString("+Z_"),
+                        stim.PauliString("+ZZ"),
+                    ],
+                )
+                >>> x2x, x2z, z2x, z2z, x_signs, z_signs = cnot.to_numpy()
+                >>> x2x
+                array([[ True,  True],
+                       [False,  True]])
+                >>> x2z
+                array([[False, False],
+                       [False, False]])
+                >>> z2x
+                array([[False, False],
+                       [False, False]])
+                >>> z2z
+                array([[ True, False],
+                       [ True,  True]])
+                >>> x_signs
+                array([False, False])
+                >>> z_signs
+                array([False, False])
+
+                >>> t = stim.Tableau.from_conjugated_generators(
+                ...     xs=[
+                ...         stim.PauliString("-Y_ZY"),
+                ...         stim.PauliString("-Y_YZ"),
+                ...         stim.PauliString("-XXX_"),
+                ...         stim.PauliString("+ZYX_"),
+                ...     ],
+                ...     zs=[
+                ...         stim.PauliString("-_ZZX"),
+                ...         stim.PauliString("+YZXZ"),
+                ...         stim.PauliString("+XZ_X"),
+                ...         stim.PauliString("-YYXX"),
+                ...     ],
+                ... )
+
+                >>> x2x, x2z, z2x, z2z, x_signs, z_signs = t.to_numpy()
+                >>> x2x
+                array([[ True, False, False,  True],
+                       [ True, False,  True, False],
+                       [ True,  True,  True, False],
+                       [False,  True,  True, False]])
+                >>> x2z
+                array([[ True, False,  True,  True],
+                       [ True, False,  True,  True],
+                       [False, False, False, False],
+                       [ True,  True, False, False]])
+                >>> z2x
+                array([[False, False, False,  True],
+                       [ True, False,  True, False],
+                       [ True, False, False,  True],
+                       [ True,  True,  True,  True]])
+                >>> z2z
+                array([[False,  True,  True, False],
+                       [ True,  True, False,  True],
+                       [False,  True, False, False],
+                       [ True,  True, False, False]])
+                >>> x_signs
+                array([ True,  True,  True, False])
+                >>> z_signs
+                array([ True, False, False,  True])
+
+                >>> x2x, x2z, z2x, z2z, x_signs, z_signs = t.to_numpy(bit_packed=True)
+                >>> x2x
+                array([[9],
+                       [5],
+                       [7],
+                       [6]], dtype=uint8)
+                >>> x2z
+                array([[13],
+                       [13],
+                       [ 0],
+                       [ 3]], dtype=uint8)
+                >>> z2x
+                array([[ 8],
+                       [ 5],
+                       [ 9],
+                       [15]], dtype=uint8)
+                >>> z2z
+                array([[ 6],
+                       [11],
+                       [ 2],
+                       [ 3]], dtype=uint8)
+                >>> x_signs
+                array([7], dtype=uint8)
+                >>> z_signs
+                array([9], dtype=uint8)
+        )DOC")
+            .data());
+
+    c.def_static(
+        "from_numpy",
+        [](const pybind11::object &x2x,
+           const pybind11::object &x2z,
+           const pybind11::object &z2x,
+           const pybind11::object &z2z,
+           const pybind11::object &x_signs,
+           const pybind11::object &z_signs) {
+
+            size_t n = determine_tableau_shape(x2x, "x2x");
+            check_tableau_shape(x2z, n, "x2z");
+            check_tableau_shape(z2x, n, "z2x");
+            check_tableau_shape(z2z, n, "z2z");
+            if (!x_signs.is_none()) {
+                check_tableau_signs_shape(x_signs, n, "x_signs");
+            }
+            if (!z_signs.is_none()) {
+                check_tableau_signs_shape(z_signs, n, "z_signs");
+            }
+
+            Tableau result(n);
+            memcpy_bits_from_numpy_to_simd_bit_table(n, n, x2x, result.xs.xt);
+            memcpy_bits_from_numpy_to_simd_bit_table(n, n, x2z, result.xs.zt);
+            memcpy_bits_from_numpy_to_simd_bit_table(n, n, z2x, result.zs.xt);
+            memcpy_bits_from_numpy_to_simd_bit_table(n, n, z2z, result.zs.zt);
+            if (!x_signs.is_none()) {
+                memcpy_bits_from_numpy_to_simd(n, x_signs, result.xs.signs);
+            }
+            if (!z_signs.is_none()) {
+                memcpy_bits_from_numpy_to_simd(n, z_signs, result.zs.signs);
+            }
+            if (!result.satisfies_invariants()) {
+                throw std::invalid_argument(
+                    "The given tableau data don't describe a valid Clifford operation.\n"
+                    "It doesn't preserve commutativity.\n"
+                    "All generator outputs must commute, except for the output of X_k anticommuting with the output of Z_k for each k.");
+            }
+            return result;
+        },
+        pybind11::kw_only(),
+        pybind11::arg("x2x"),
+        pybind11::arg("x2z"),
+        pybind11::arg("z2x"),
+        pybind11::arg("z2z"),
+        pybind11::arg("x_signs") = pybind11::none(),
+        pybind11::arg("z_signs") = pybind11::none(),
+        clean_doc_string(u8R"DOC(
+            @signature def to_numpy(self, *, bit_packed: bool = False) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+
+            Creates a tableau from numpy arrays x2x, x2z, z2x, z2z, x_signs, and z_signs.
+
+            The x2x, x2z, z2x, z2z arrays are the four quadrants of the table defined in
+            Aaronson and Gottesman's "Improved Simulation of Stabilizer Circuits"
+            ( https://arxiv.org/abs/quant-ph/0406196 ).
+
+            Args:
+                x2x: A 2d numpy array containing the x-to-x coupling bits. The bits can be
+                    bit packed (dtype=uint8) or not (dtype=bool8). When not bit packed, the
+                    result will satisfy result.x_output_pauli(i, j) in [1, 2] == x2x[i, j].
+                    Bit packing must be in little endian order and only applies to the
+                    second axis.
+                x2z: A 2d numpy array containing the x-to-z coupling bits. The bits can be
+                    bit packed (dtype=uint8) or not (dtype=bool8). When not bit packed, the
+                    result will satisfy result.x_output_pauli(i, j) in [2, 3] == x2z[i, j].
+                    Bit packing must be in little endian order and only applies to the
+                    second axis.
+                z2x: A 2d numpy array containing the z-to-x coupling bits. The bits can be
+                    bit packed (dtype=uint8) or not (dtype=bool8). When not bit packed, the
+                    result will satisfy result.z_output_pauli(i, j) in [1, 2] == z2x[i, j].
+                    Bit packing must be in little endian order and only applies to the
+                    second axis.
+                z2z: A 2d numpy array containing the z-to-z coupling bits. The bits can be
+                    bit packed (dtype=uint8) or not (dtype=bool8). When not bit packed, the
+                    result will satisfy result.z_output_pauli(i, j) in [2, 3] == z2z[i, j].
+                    Bit packing must be in little endian order and only applies to the
+                    second axis.
+                x_signs: Defaults to all-positive if not specified. A 1d numpy array
+                    containing the sign bits for the X generator outputs. False means
+                    positive and True means negative. The bits can be bit packed
+                    (dtype=uint8) or not (dtype=bool8). Bit packing must be in little endian
+                    order.
+                z_signs: Defaults to all-positive if not specified. A 1d numpy array
+                    containing the sign bits for the Z generator outputs. False means
+                    positive and True means negative. The bits can be bit packed
+                    (dtype=uint8) or not (dtype=bool8). Bit packing must be in little endian
+                    order.
+
+            Returns:
+                The tableau created from the numpy data.
+
+            Examples:
+                >>> import stim
+                >>> import numpy as np
+
+                >>> tableau = stim.Tableau.from_numpy(
+                ...     x2x=np.array([[1, 1], [0, 1]], dtype=np.bool8),
+                ...     z2x=np.array([[0, 0], [0, 0]], dtype=np.bool8),
+                ...     x2z=np.array([[0, 0], [0, 0]], dtype=np.bool8),
+                ...     z2z=np.array([[1, 0], [1, 1]], dtype=np.bool8),
+                ... )
+                >>> print(repr(tableau))
+                stim.Tableau.from_conjugated_generators(
+                    xs=[
+                        stim.PauliString("+XX"),
+                        stim.PauliString("+_X"),
+                    ],
+                    zs=[
+                        stim.PauliString("+Z_"),
+                        stim.PauliString("+ZZ"),
+                    ],
+                )
+                >>> tableau == stim.Tableau.from_named_gate("CNOT")
+                True
+
+                >>> tableau = stim.Tableau.from_numpy(
+                ...     x2x=np.array([[9], [5], [7], [6]], dtype=np.uint8),
+                ...     x2z=np.array([[13], [13], [0], [3]], dtype=np.uint8),
+                ...     z2x=np.array([[8], [5], [9], [15]], dtype=np.uint8),
+                ...     z2z=np.array([[6], [11], [2], [3]], dtype=np.uint8),
+                ...     x_signs=np.array([7], dtype=np.uint8),
+                ...     z_signs=np.array([9], dtype=np.uint8),
+                ... )
+                >>> print(repr(tableau))
+                stim.Tableau.from_conjugated_generators(
+                    xs=[
+                        stim.PauliString("-Y_ZY"),
+                        stim.PauliString("-Y_YZ"),
+                        stim.PauliString("-XXX_"),
+                        stim.PauliString("+ZYX_"),
+                    ],
+                    zs=[
+                        stim.PauliString("-_ZZX"),
+                        stim.PauliString("+YZXZ"),
+                        stim.PauliString("+XZ_X"),
+                        stim.PauliString("-YYXX"),
+                    ],
+                )
         )DOC")
             .data());
 

--- a/src/stim/stabilizers/tableau.pybind.cc
+++ b/src/stim/stabilizers/tableau.pybind.cc
@@ -505,7 +505,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
         pybind11::arg("x_signs") = pybind11::none(),
         pybind11::arg("z_signs") = pybind11::none(),
         clean_doc_string(u8R"DOC(
-            @signature def to_numpy(self, *, bit_packed: bool = False) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+            @signature def from_numpy(self, *, bit_packed: bool = False) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
 
             Creates a tableau from numpy arrays x2x, x2z, z2x, z2z, x_signs, and z_signs.
 

--- a/src/stim/stabilizers/tableau.pybind.cc
+++ b/src/stim/stabilizers/tableau.pybind.cc
@@ -351,7 +351,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
                 If bit_packed=True then:
                     *.dtype = = np.uint8
                     *2*.shape = (len(tableau), math.ceil(len(tableau) / 8))
-                    *_signs.shape = len(tableau)
+                    *_signs.shape = math.ceil(len(tableau) / 8)
                     (x2x[i, j // 8] >> (j % 8)) & 1 = tableau.x_output_pauli(i, j) in [1, 2]
                     (x2z[i, j // 8] >> (j % 8)) & 1 = tableau.x_output_pauli(i, j) in [2, 3]
                     (z2x[i, j // 8] >> (j % 8)) & 1 = tableau.z_output_pauli(i, j) in [1, 2]


### PR DESCRIPTION
- Fix some spurious empty lines in the api reference and stub file
- Move numpy-vs-simd utility methods to `stim/py/numpy.pybind.{h,cc}`

Fixes of https://github.com/quantumlib/Stim/issues/355