### PR TITLE
Speed up numpy output methods

### DIFF
--- a/src/stim/py/base.pybind.h
+++ b/src/stim/py/base.pybind.h
@@ -15,6 +15,7 @@
 #ifndef _STIM_PY_BASE_PYBIND_H
 #define _STIM_PY_BASE_PYBIND_H
 
+#include <pybind11/complex.h>
 #include <pybind11/numpy.h>
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>

--- a/src/stim/py/compiled_detector_sampler.pybind.h
+++ b/src/stim/py/compiled_detector_sampler.pybind.h
@@ -32,8 +32,7 @@ struct CompiledDetectorSampler {
     CompiledDetectorSampler(const CompiledDetectorSampler &) = delete;
     CompiledDetectorSampler(CompiledDetectorSampler &&) = default;
     CompiledDetectorSampler(stim::Circuit circuit, std::shared_ptr<std::mt19937_64> prng);
-    pybind11::array_t<bool> sample(size_t num_shots, bool prepend_observables, bool append_observables);
-    pybind11::array_t<uint8_t> sample_bit_packed(size_t num_shots, bool prepend_observables, bool append_observables);
+    pybind11::object sample_to_numpy(size_t num_shots, bool prepend_observables, bool append_observables, bool bit_packed);
     void sample_write(
         size_t num_samples,
         const std::string &filepath,

--- a/src/stim/py/compiled_detector_sampler_pybind_test.py
+++ b/src/stim/py/compiled_detector_sampler_pybind_test.py
@@ -76,6 +76,15 @@ def test_compiled_detector_sampler_sample():
             [0b011],
             [0b011],
         ], dtype=np.uint8))
+    np.testing.assert_array_equal(
+        c.compile_detector_sampler().sample(5, bit_packed=True),
+        np.array([
+            [0b011],
+            [0b011],
+            [0b011],
+            [0b011],
+            [0b011],
+        ], dtype=np.uint8))
 
     with tempfile.TemporaryDirectory() as d:
         path = f"{d}/tmp.dat"

--- a/src/stim/py/compiled_measurement_sampler.pybind.cc
+++ b/src/stim/py/compiled_measurement_sampler.pybind.cc
@@ -16,6 +16,7 @@
 
 #include "stim/circuit/circuit.pybind.h"
 #include "stim/py/base.pybind.h"
+#include "stim/py/numpy.pybind.h"
 #include "stim/simulators/detection_simulator.h"
 #include "stim/simulators/frame_simulator.h"
 #include "stim/simulators/tableau_simulator.h"
@@ -28,41 +29,11 @@ CompiledMeasurementSampler::CompiledMeasurementSampler(
     : ref_sample(ref_sample), circuit(circuit), skip_reference_sample(skip_reference_sample), prng(prng) {
 }
 
-pybind11::array_t<bool> CompiledMeasurementSampler::sample(size_t num_samples) {
-    auto sample = FrameSimulator::sample(circuit, ref_sample, num_samples, *prng);
-
-    const simd_bits<MAX_BITWORD_WIDTH> &flat = sample.data;
-    std::vector<uint8_t> bytes;
-    bytes.reserve(flat.num_bits_padded());
-    auto *end = flat.u64 + flat.num_u64_padded();
-    for (auto u64 = flat.u64; u64 != end; u64++) {
-        auto v = *u64;
-        for (size_t k = 0; k < 64; k++) {
-            bytes.push_back((v >> k) & 1);
-        }
-    }
-
-    void *ptr = bytes.data();
-    pybind11::ssize_t itemsize = sizeof(uint8_t);
-    std::vector<pybind11::ssize_t> shape{
-        (pybind11::ssize_t)num_samples, (pybind11::ssize_t)circuit.count_measurements()};
-    std::vector<pybind11::ssize_t> stride{(pybind11::ssize_t)sample.num_minor_bits_padded(), 1};
-    const std::string &format = pybind11::format_descriptor<bool>::value;
-    bool readonly = true;
-    return pybind11::array_t<uint8_t>(pybind11::buffer_info(ptr, itemsize, format, 2, shape, stride, readonly));
-}
-
-pybind11::array_t<uint8_t> CompiledMeasurementSampler::sample_bit_packed(size_t num_samples) {
-    auto sample = FrameSimulator::sample(circuit, ref_sample, num_samples, *prng);
-
-    void *ptr = sample.data.u8;
-    pybind11::ssize_t itemsize = sizeof(uint8_t);
-    std::vector<pybind11::ssize_t> shape{
-        (pybind11::ssize_t)num_samples, (pybind11::ssize_t)(circuit.count_measurements() + 7) / 8};
-    std::vector<pybind11::ssize_t> stride{(pybind11::ssize_t)sample.num_minor_u8_padded(), 1};
-    const std::string &format = pybind11::format_descriptor<uint8_t>::value;
-    bool readonly = true;
-    return pybind11::array_t<uint8_t>(pybind11::buffer_info(ptr, itemsize, format, 2, shape, stride, readonly));
+pybind11::object CompiledMeasurementSampler::sample_to_numpy(size_t num_shots, bool bit_packed) {
+    simd_bit_table<MAX_BITWORD_WIDTH> sample =
+        FrameSimulator::sample(circuit, ref_sample, num_shots, *prng);
+    size_t bits_per_sample = circuit.count_measurements();
+    return simd_bit_table_to_numpy(sample, num_shots, bits_per_sample, bit_packed);
 }
 
 void CompiledMeasurementSampler::sample_write(
@@ -175,17 +146,33 @@ void stim_pybind::pybind_compiled_measurement_sampler_methods(
 
     c.def(
         "sample",
-        &CompiledMeasurementSampler::sample,
+        [](CompiledMeasurementSampler &self, size_t shots, bool bit_packed) {
+            return self.sample_to_numpy(shots, bit_packed);
+        },
         pybind11::arg("shots"),
+        pybind11::kw_only(),
+        pybind11::arg("bit_packed") = false,
         clean_doc_string(u8R"DOC(
             Samples a batch of measurement samples from the circuit.
 
             Args:
                 shots: The number of times to sample every measurement in the circuit.
+                bit_packed: Returns a uint8 numpy array with 8 bits per byte, instead of
+                    a bool8 numpy array with 1 bit per byte. Uses little endian packing.
 
             Returns:
-                A numpy array with `dtype=uint8` and `shape=(shots, num_measurements)`.
-                The bit for measurement `m` in shot `s` is at `result[s, m]`.
+                A numpy array containing the samples.
+
+                If bit_packed=False:
+                    dtype=bool8
+                    shape=(shots, circuit.num_measurements)
+                    The bit for measurement `m` in shot `s` is at
+                        result[s, m]
+                If bit_packed=True:
+                    dtype=uint8
+                    shape=(shots, math.ceil(circuit.num_measurements / 8))
+                    The bit for measurement `m` in shot `s` is at
+                        (result[s, m // 8] >> (m % 8)) & 1
 
             Examples:
                 >>> import stim
@@ -201,9 +188,13 @@ void stim_pybind::pybind_compiled_measurement_sampler_methods(
 
     c.def(
         "sample_bit_packed",
-        &CompiledMeasurementSampler::sample_bit_packed,
+        [](CompiledMeasurementSampler &self, size_t shots) {
+            return self.sample_to_numpy(shots, true);
+        },
         pybind11::arg("shots"),
         clean_doc_string(u8R"DOC(
+            [DEPRECATED] Use sampler.sample(..., bit_packed=True) instead.
+
             Samples a bit packed batch of measurement samples from the circuit.
 
             Args:

--- a/src/stim/py/compiled_measurement_sampler.pybind.h
+++ b/src/stim/py/compiled_measurement_sampler.pybind.h
@@ -37,8 +37,7 @@ struct CompiledMeasurementSampler {
         stim::Circuit circuit,
         bool skip_reference_sample,
         std::shared_ptr<std::mt19937_64> prng);
-    pybind11::array_t<bool> sample(size_t num_samples);
-    pybind11::array_t<uint8_t> sample_bit_packed(size_t num_samples);
+    pybind11::object sample_to_numpy(size_t num_shots, bool bit_packed);
     void sample_write(size_t num_samples, const std::string &filepath, const std::string &format);
     std::string repr() const;
 };

--- a/src/stim/py/compiled_measurement_sampler_pybind_test.py
+++ b/src/stim/py/compiled_measurement_sampler_pybind_test.py
@@ -29,6 +29,15 @@ def test_compiled_measurement_sampler_sample():
             [0, 1, 0, 0],
             [0, 1, 0, 0],
             [0, 1, 0, 0],
+        ], dtype=np.bool8))
+    np.testing.assert_array_equal(
+        c.compile_sampler().sample(5, bit_packed=True),
+        np.array([
+            [0b00010],
+            [0b00010],
+            [0b00010],
+            [0b00010],
+            [0b00010],
         ], dtype=np.uint8))
     np.testing.assert_array_equal(
         c.compile_sampler().sample_bit_packed(5),

--- a/src/stim/py/numpy.pybind.h
+++ b/src/stim/py/numpy.pybind.h
@@ -10,7 +10,7 @@ stim::simd_bit_table<stim::MAX_BITWORD_WIDTH> numpy_array_to_transposed_simd_tab
     const pybind11::object &data, size_t expected_bits_per_shot, size_t *num_shots_out);
 
 pybind11::object transposed_simd_bit_table_to_numpy(
-    const stim::simd_bit_table<stim::MAX_BITWORD_WIDTH> &table, size_t bits_per_shot, size_t num_shots, bool bit_pack_result);
+    const stim::simd_bit_table<stim::MAX_BITWORD_WIDTH> &table, size_t num_major_in, size_t num_minor_in, bool bit_pack_result);
 
 pybind11::object simd_bit_table_to_numpy(
     const stim::simd_bit_table<stim::MAX_BITWORD_WIDTH> &table,

--- a/src/stim/simulators/tableau_simulator.pybind.cc
+++ b/src/stim/simulators/tableau_simulator.pybind.cc
@@ -207,20 +207,21 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
                 throw std::invalid_argument("endian not in ['little', 'big']");
             }
             auto complex_vec = self.to_state_vector(little_endian);
-            std::vector<float> float_vec;
-            float_vec.reserve(complex_vec.size() * 2);
-            for (const auto &e : complex_vec) {
-                float_vec.push_back(e.real());
-                float_vec.push_back(e.imag());
+
+            std::complex<float> *buffer = new std::complex<float>[complex_vec.size()];
+            for (size_t k = 0; k < complex_vec.size(); k++) {
+                buffer[k] = complex_vec[k];
             }
-            void *ptr = float_vec.data();
-            pybind11::ssize_t itemsize = sizeof(float) * 2;
-            std::vector<pybind11::ssize_t> shape{(pybind11::ssize_t)complex_vec.size()};
-            std::vector<pybind11::ssize_t> stride{itemsize};
-            const std::string &format = pybind11::format_descriptor<std::complex<float>>::value;
-            bool readonly = true;
-            return pybind11::array_t<float>(
-                pybind11::buffer_info(ptr, itemsize, format, shape.size(), shape, stride, readonly));
+
+            pybind11::capsule free_when_done(buffer, [](void *f) {
+                delete[] reinterpret_cast<std::complex<float> *>(f);
+            });
+
+            return pybind11::array_t<std::complex<float>>(
+                {(pybind11::ssize_t)complex_vec.size()},
+                {(pybind11::ssize_t)sizeof(std::complex<float>)},
+                buffer,
+                free_when_done);
         },
         pybind11::kw_only(),
         pybind11::arg("endian") = "little",


### PR DESCRIPTION
- Use pybind11::capsure to own memory instead of relying on implicit redundant copies from readonly buffers
- Add "bit_packed=False" argument to `stim.Compiled{Measurement,Detector}Sampler.sample`
- Deprecate `stim.Compiled{Measurement,Detectpr}Sampler.sample_bit_packed`
- Fix a typo in the `stim.Tableau.to_numpy` doc string

Example benefit: for small tableaus, stim.Tableau.to_numpy improved from 32us to 2us