### PR TITLE
Add `failure_units_per_shot_func` argument to sinter

### DIFF
--- a/glue/sample/src/sinter/_main_plot.py
+++ b/glue/sample/src/sinter/_main_plot.py
@@ -3,6 +3,7 @@ import argparse
 
 import matplotlib.pyplot as plt
 
+from sinter import shot_error_rate_to_piece_error_rate
 from sinter._main_combine import ExistingData
 from sinter._plotting import plot_discard_rate
 from sinter._plotting import plot_error_rate
@@ -64,6 +65,39 @@ def parse_args(args: List[str]) -> Any:
                              '''    --group_func "(decoder, metadata['d'])"\n'''
                              '''    --group_func "metadata['path'].split('/')[-2]"\n'''
                         )
+    parser.add_argument('--failure_unit_name',
+                        type=str,
+                        default=None,
+                        help='The unit of failure, typically either "shot" (the default) or "round".\n'
+                             'If this argument is specified, --failure_units_per_shot_func must also be specified.\n'''
+                        )
+    parser.add_argument('--failure_units_per_shot_func',
+                        type=str,
+                        default=None,
+                        help='A python expression that evaluates to the number of failure units there are per shot.\n'
+                             'For example, if the failure unit is rounds, this should be an expression that returns\n'
+                             'the number of rounds in a shot. Sinter has no way of knowing what you consider a round\n'
+                             'to be, otherwise.\n'
+                             '\n'
+                             'This value is used to rescale the logical error rate plots. For example, if there are 4\n'
+                             'failure units per shot then a shot error rate of 10% corresponds to a unit failure rate\n'
+                             'of 2.7129%. The conversion formula (assuming <50% error rates) is:\n'
+                             '\n'
+                             '    P_unit = 0.5 - 0.5 * (1 - 2 * P_shot)**(1/units_per_shot)\n'
+                             '\n'
+                             'Available values:\n'
+                             '    metadata: The parsed value from the json_metadata column.\n'
+                             '    decoder: The decoder that decoded the case.\n'
+                             '    strong_id: The cryptographic hash of the case that was sampled.\n'
+                             '\n'
+                             'Expected expression type:\n'
+                             '    float.\n'
+                             '\n'
+                             'Examples:\n'
+                             '''    --failure_units_per_shot_func "metadata['rounds']"\n'''
+                             '''    --failure_units_per_shot_func "metadata['distance'] * 3"\n'''
+                             '''    --failure_units_per_shot_func "10"\n'''
+                        )
     parser.add_argument('--plot_args_func',
                         type=str,
                         default='''{'marker': 'ov*sp^<>8PhH+xXDd|'[index % 18]}''',
@@ -118,6 +152,13 @@ def parse_args(args: List[str]) -> Any:
     a = parser.parse_args(args=args)
     if not a.show and a.out is None:
         raise ValueError("Must specify '--out file' or '--show'.")
+    if (a.failure_units_per_shot_func is not None) != (a.failure_unit_name is not None):
+        raise ValueError("--failure_units_per_shot_func and --failure_unit_name can only be specified together.")
+    if a.failure_units_per_shot_func is None:
+        a.failure_units_per_shot_func = "1"
+    if a.failure_unit_name is None:
+        a.failure_unit_name = 'shot'
+
     a.x_func = eval(compile(
         'lambda *, decoder, metadata, strong_id: ' + a.x_func,
         filename='x_func:command_line_arg',
@@ -129,6 +170,10 @@ def parse_args(args: List[str]) -> Any:
     a.filter_func = eval(compile(
         'lambda *, decoder, metadata, strong_id: ' + a.filter_func,
         filename='filter_func:command_line_arg',
+        mode='eval'))
+    a.failure_units_per_shot_func = eval(compile(
+        'lambda *, decoder, metadata, strong_id: ' + a.failure_units_per_shot_func,
+        filename='failure_units_per_shot_func:command_line_arg',
         mode='eval'))
     a.plot_args_func = eval(compile(
         'lambda index, key: ' + a.plot_args_func,
@@ -142,7 +187,9 @@ def _plot_helper(
     samples: Union[Iterable['sinter.TaskStats'], ExistingData],
     group_func: Callable[['sinter.TaskStats'], Any],
     filter_func: Callable[['sinter.TaskStats'], Any],
+    failure_units_per_shot_func: Callable[['sinter.TaskStats'], Any],
     x_func: Callable[['sinter.TaskStats'], Any],
+    failure_unit: str,
     include_discard_rate_plot: bool,
     include_error_rate_plot: bool,
     highlight_max_likelihood_factor: Optional[float],
@@ -202,11 +249,20 @@ def _plot_helper(
             stats=plotted_stats,
             group_func=group_func,
             x_func=x_func,
+            failure_units_per_shot_func=failure_units_per_shot_func,
             highlight_max_likelihood_factor=highlight_max_likelihood_factor,
             plot_args_func=plot_args_func,
         )
         if min_y is None:
-            min_y = min((stat.errors / (stat.shots - stat.discards) for stat in plotted_stats if stat.errors), default=1e-4)
+            min_y = 1
+            for stat in plotted_stats:
+                err_rate = stat.errors / (stat.shots - stat.discards)
+                pieces = failure_units_per_shot_func(stat)
+                err_rate = shot_error_rate_to_piece_error_rate(err_rate, pieces=pieces)
+                if err_rate < min_y:
+                    min_y = err_rate
+            if not plotted_stats:
+                min_y = 1e-4
             low_d = 4
             while 10**-low_d > min_y*0.9 and low_d < 10:
                 low_d += 1
@@ -217,7 +273,7 @@ def _plot_helper(
         ax_err.set_yticks([10**-d for d in range(major_tick_steps)])
         ax_err.set_yticks([b*10**-d for d in range(1, major_tick_steps) for b in range(2, 10)], minor=True)
         ax_err.set_ylim(min_y, 1e-0)
-        ax_err.set_ylabel("Logical Error Probability (per shot)")
+        ax_err.set_ylabel(f"Logical Error Rate (per {failure_unit})")
         ax_err.grid(which='major', color='#000000')
         ax_err.grid(which='minor', color='#DDDDDD')
         ax_err.legend()
@@ -226,29 +282,32 @@ def _plot_helper(
             ax=ax_dis,
             stats=plotted_stats,
             group_func=group_func,
+            failure_units_per_shot_func=failure_units_per_shot_func,
             x_func=x_func,
             highlight_max_likelihood_factor=highlight_max_likelihood_factor,
             plot_args_func=plot_args_func,
         )
         ax_dis.set_ylim(0, 1)
         ax_err.grid()
-        ax_dis.set_ylabel("Discard Probability")
+        ax_dis.set_ylabel(f"Discard Rate (per {failure_unit}")
         ax_dis.legend()
 
     if xaxis:
         if ax_err is not None:
             ax_err.set_xlabel(xaxis)
-            ax_err.set_title('Logical Error Rate vs ' + xaxis)
         if ax_dis is not None:
             ax_dis.set_xlabel(xaxis)
-            ax_dis.set_title('Discard Rate vs ' + xaxis)
-    else:
-        if ax_err is not None:
-            ax_err.set_title('Logical Error Rates')
-        if ax_dis is not None:
-            ax_dis.set_title('Discard Rates')
-    if ax_err is not None and title is not None:
-        ax_err.set_title(title)
+
+    vs_suffix = ''
+    if xaxis is not None:
+        vs_suffix = f' vs {xaxis}'
+    if ax_err is not None:
+        ax_err.set_title(f'Logical Error Rate per {failure_unit}{vs_suffix}')
+        if title is not None:
+            ax_err.set_title(title)
+    if ax_dis is not None:
+        ax_dis.set_title(f'Discard Rate per {failure_unit}{vs_suffix}')
+
     if fig_size is None:
         fig.set_size_inches(10 * (include_discard_rate_plot + include_error_rate_plot), 10)
         fig.set_dpi(100)
@@ -281,6 +340,11 @@ def main_plot(*, command_line_args: List[str]):
             decoder=summary.decoder,
             metadata=summary.json_metadata,
             strong_id=summary.strong_id),
+        failure_units_per_shot_func=lambda summary: args.failure_units_per_shot_func(
+            decoder=summary.decoder,
+            metadata=summary.json_metadata,
+            strong_id=summary.strong_id),
+        failure_unit=args.failure_unit_name,
         include_discard_rate_plot='discard_rate' in args.type,
         include_error_rate_plot='error_rate' in args.type,
         xaxis=args.xaxis,

--- a/glue/sample/src/sinter/_main_plot.py
+++ b/glue/sample/src/sinter/_main_plot.py
@@ -256,6 +256,8 @@ def _plot_helper(
         if min_y is None:
             min_y = 1
             for stat in plotted_stats:
+                if stat.shots <= stat.discards:
+                    continue
                 err_rate = stat.errors / (stat.shots - stat.discards)
                 pieces = failure_units_per_shot_func(stat)
                 err_rate = shot_error_rate_to_piece_error_rate(err_rate, pieces=pieces)

--- a/glue/sample/src/sinter/_main_test.py
+++ b/glue/sample/src/sinter/_main_test.py
@@ -5,6 +5,7 @@ import tempfile
 
 import stim
 
+import pytest
 import sinter
 from sinter._main import main
 from sinter._main_combine import ExistingData
@@ -274,6 +275,66 @@ shots,errors,discards,seconds,decoder,strong_id,json_metadata
                 "decoder",
                 "--plot_args_func",
                 "{'lw': 2}",
+            ])
+        assert (d / "output.png").exists()
+
+
+def test_main_plot_failure_units():
+    with tempfile.TemporaryDirectory() as d:
+        d = pathlib.Path(d)
+        with open(d / f'input.csv', 'w') as f:
+            print("""
+shots,errors,discards,seconds,decoder,strong_id,json_metadata
+300,1,20,1.0,pymatching,f256bab362f516ebe4d59a08ae67330ff7771ff738757cd738f4b30605ddccf6,"{""r"":15,""d"":5}"
+300,100,200,2.0,pymatching,f256bab362f516ebe4d59a08ae67330ff7771ff738757cd738f4b30605ddccf7,"{""r"":9,""d"":3}"
+9,5,4,6.0,pymatching,5fe5a6cd4226b1a910d57e5479d1ba6572e0b3115983c9516360916d1670000f,"{""r"":6,""d"":2}"
+            """.strip(), file=f)
+
+        out = io.StringIO()
+        with pytest.raises(ValueError,  match="specified together"):
+            main(command_line_args=[
+                "plot",
+                "--in",
+                str(d / "input.csv"),
+                "--out",
+                str(d / "output.png"),
+                "--x_func",
+                "metadata['d']",
+                "--group_func",
+                "decoder",
+                "--failure_units_per_shot_func",
+                "metadata['r']",
+            ])
+        with pytest.raises(ValueError,  match="specified together"):
+            main(command_line_args=[
+                "plot",
+                "--in",
+                str(d / "input.csv"),
+                "--out",
+                str(d / "output.png"),
+                "--x_func",
+                "metadata['d']",
+                "--group_func",
+                "decoder",
+                "--failure_unit_name",
+                "Rounds",
+            ])
+        assert not (d / "output.png").exists()
+        with contextlib.redirect_stdout(out):
+            main(command_line_args=[
+                "plot",
+                "--in",
+                str(d / "input.csv"),
+                "--out",
+                str(d / "output.png"),
+                "--x_func",
+                "metadata['d']",
+                "--group_func",
+                "decoder",
+                "--failure_units_per_shot_func",
+                "metadata['r']",
+                "--failure_unit_name",
+                "Rounds",
             ])
         assert (d / "output.png").exists()
 

--- a/glue/sample/src/sinter/_plotting_test.py
+++ b/glue/sample/src/sinter/_plotting_test.py
@@ -50,12 +50,28 @@ def test_plotting_does_not_crash():
         x_func=lambda e: e.json_metadata['p'],
         plot_args_func=lambda k, e: {'marker': "ov*sp^<>8PhH+xXDd|"[k]},
     )
+    sinter.plot_error_rate(
+        ax=ax,
+        stats=stats,
+        group_func=lambda e: f"Rotated Surface Code d={e.json_metadata['d']}",
+        x_func=lambda e: e.json_metadata['p'],
+        plot_args_func=lambda k, e: {'marker': "ov*sp^<>8PhH+xXDd|"[k]},
+        failure_units_per_shot_func=lambda stats: stats.json_metadata['d'] * 3,
+    )
     sinter.plot_discard_rate(
         ax=ax,
         stats=stats,
         group_func=lambda e: f"Rotated Surface Code d={e.json_metadata['d']}",
         x_func=lambda e: e.json_metadata['p'],
         plot_args_func=lambda k, e: {'marker': "ov*sp^<>8PhH+xXDd|"[k]},
+    )
+    sinter.plot_discard_rate(
+        ax=ax,
+        stats=stats,
+        group_func=lambda e: f"Rotated Surface Code d={e.json_metadata['d']}",
+        x_func=lambda e: e.json_metadata['p'],
+        plot_args_func=lambda k, e: {'marker': "ov*sp^<>8PhH+xXDd|"[k]},
+        failure_units_per_shot_func=lambda stats: stats.json_metadata['d'] * 3,
     )
 
 

--- a/glue/sample/src/sinter/_probability_util.py
+++ b/glue/sample/src/sinter/_probability_util.py
@@ -286,14 +286,18 @@ def fit_binomial(
     return Fit(best=num_hits / num_shots, low=low / num_shots, high=high / num_shots)
 
 
-def shot_error_rate_to_piece_error_rate(shot_error_rate: float, *, pieces: int) -> float:
+def shot_error_rate_to_piece_error_rate(shot_error_rate: float, *, pieces: float) -> float:
     """Convert from total error rate to per-piece error rate.
 
     Works by assuming pieces fail independently and a shot fails if an any single
     piece fails.
     """
     if not (0 <= shot_error_rate <= 1):
-        raise ValueError(f'not (0 <= shot_error_rate={shot_error_rate} <= 1)')
+        raise ValueError(f'need (0 <= shot_error_rate={shot_error_rate} <= 1)')
+    if pieces <= 0:
+        raise ValueError('need pieces > 0')
+    if not isinstance(pieces, (int, float)):
+        raise ValueError('need isinstance(pieces, (int, float)')
     if pieces == 1:
         return shot_error_rate
     if shot_error_rate > 0.5:


### PR DESCRIPTION
- Add command line argument `--failure_unit_name`
- Add command line argument `--failure_units_per_shot_func`
- Add argument `failure_units_per_shot_func` to `sinter.plot_discard_rate`
- Add argument `failure_units_per_shot_func` to `sinter.plot_error_rate`