### PR TITLE
Add stim.Circuit.diagram

### DIFF
--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -27,6 +27,7 @@ API references for stable versions are kept on the [stim github wiki](https://gi
     - [`stim.Circuit.compile_sampler`](#stim.Circuit.compile_sampler)
     - [`stim.Circuit.copy`](#stim.Circuit.copy)
     - [`stim.Circuit.detector_error_model`](#stim.Circuit.detector_error_model)
+    - [`stim.Circuit.diagram`](#stim.Circuit.diagram)
     - [`stim.Circuit.explain_detector_error_model_errors`](#stim.Circuit.explain_detector_error_model_errors)
     - [`stim.Circuit.flattened`](#stim.Circuit.flattened)
     - [`stim.Circuit.from_file`](#stim.Circuit.from_file)
@@ -1184,6 +1185,114 @@ def detector_error_model(
             error(0.375) D0 D1
             error(0.25) D1
         ''')
+    """
+```
+
+<a name="stim.Circuit.diagram"></a>
+```python
+# stim.Circuit.diagram
+
+# (in class stim.Circuit)
+@overload
+def diagram(
+    self,
+    *,
+    type: Literal["timeline-text"],
+) -> Any:
+    pass
+@overload
+def diagram(
+    self,
+    *,
+    type: Literal["detector-slice-text"],
+    tick: int,
+) -> Any:
+    pass
+@overload
+def diagram(
+    self,
+    *,
+    type: Literal["timeline-svg"],
+) -> Any:
+    pass
+@overload
+def diagram(
+    self,
+    *,
+    type: Literal["detector-slice-svg"],
+    tick: int,
+) -> Any:
+    pass
+def diagram(
+    self,
+    *,
+    type: Union[Literal["timeline-text", "timeline-svg", "detector-slice-text", "detector-slice-svg"], str],
+    tick: Optional[int] = None,
+) -> Any:
+    """Returns a diagram of the circuit, from a variety of options.
+
+    Args:
+        type: The type of diagram. Available types are:
+            "timeline-text" (default): An ASCII diagram of the
+                operations applied by the circuit over time. Includes
+                annotations showing the measurement record index that
+                each measurement writes to, and the measurements used
+                by detectors.
+            "timeline-svg": An SVG image of the operations applied by
+                the circuit over time. Includes annotations showing the
+                measurement record index that each measurement writes
+                to, and the measurements used by detectors.
+            "detector-slice-text": An ASCII diagram of the stabilizers
+                that detectors declared by the circuit correspond to
+                during the TICK instruction identified by the `tick`
+                argument.
+            "detector-slice-svg": An SVG image of the stabilizers
+                that detectors declared by the circuit correspond to
+                during the TICK instruction identified by the `tick`
+                argument. For example, a detector slice diagram of a
+                CSS surface code circuit during the TICK between a
+                measurement layer and a reset layer will produce the
+                usual diagram of a surface code.
+
+                Uses the Pauli color convention XYZ=RGB.
+        tick: Required for detector slice diagrams. Specifies which TICK
+            instruction to slice at. Note that the first TICK in the
+            circuit is tick=1. The value tick=0 refers to the very start
+            of the circuit.
+
+    Returns:
+        An object whose `__str__` method returns the diagram, so that
+        writing the diagram to a file works correctly. The returned
+        object may also define methods such as `_repr_html_`, so that
+        ipython notebooks recognize it can be shown using a specialized
+        viewer instead of as raw text.
+
+    Examples:
+        >>> import stim
+        >>> circuit = stim.Circuit('''
+        ...     H 0
+        ...     CNOT 0 1 1 2
+        ... ''')
+
+        >>> print(circuit.diagram(type="timeline-text"))
+        q0: -H-@---
+               |
+        q1: ---X-@-
+                 |
+        q2: -----X-
+
+        >>> circuit = stim.Circuit('''
+        ...     H 0
+        ...     CNOT 0 1
+        ...     TICK
+        ...     M 0 1
+        ...     DETECTOR rec[-1] rec[-2]
+        ... ''')
+
+        >>> print(circuit.diagram(type="detector-slice-text", tick=1))
+        q0: -Z:D0-
+             |
+        q1: -Z:D0-
     """
 ```
 

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -1197,14 +1197,14 @@ def detector_error_model(
 def diagram(
     self,
     *,
-    type: Literal["timeline-text"],
+    type: 'Literal["timeline-text"]',
 ) -> Any:
     pass
 @overload
 def diagram(
     self,
     *,
-    type: Literal["detector-slice-text"],
+    type: 'Literal["detector-slice-text"]',
     tick: int,
 ) -> Any:
     pass
@@ -1212,21 +1212,21 @@ def diagram(
 def diagram(
     self,
     *,
-    type: Literal["timeline-svg"],
+    type: 'Literal["timeline-svg"]',
 ) -> Any:
     pass
 @overload
 def diagram(
     self,
     *,
-    type: Literal["detector-slice-svg"],
+    type: 'Literal["detector-slice-svg"]',
     tick: int,
 ) -> Any:
     pass
 def diagram(
     self,
     *,
-    type: Union[Literal["timeline-text", "timeline-svg", "detector-slice-text", "detector-slice-svg"], str],
+    type: Union['Literal["timeline-text", "timeline-svg", "detector-slice-text", "detector-slice-svg"]', str],
     tick: Optional[int] = None,
 ) -> Any:
     """Returns a diagram of the circuit, from a variety of options.
@@ -3364,7 +3364,7 @@ def convert(
     *,
     measurements: np.ndarray,
     sweep_bits: Optional[np.ndarray] = None,
-    separate_observables: Literal[True],
+    separate_observables: 'Literal[True]',
     append_observables: bool = False,
     bit_pack_result: bool = False,
 ) -> Tuple[np.ndarray, np.ndarray]:

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -1,7 +1,7 @@
 """Stim (Development Version): a fast quantum stabilizer circuit library."""
 # (This a stubs file describing the classes and methods in stim.)
 from __future__ import annotations
-from typing import overload, TYPE_CHECKING, List, Dict, Tuple, Any, Union, Iterable
+from typing import overload, TYPE_CHECKING, List, Dict, Tuple, Any, Union, Iterable, Literal
 if TYPE_CHECKING:
     import io
     import pathlib
@@ -713,6 +713,107 @@ class Circuit:
                 error(0.375) D0 D1
                 error(0.25) D1
             ''')
+        """
+    @overload
+    def diagram(
+        self,
+        *,
+        type: Literal["timeline-text"],
+    ) -> Any:
+        pass
+    @overload
+    def diagram(
+        self,
+        *,
+        type: Literal["detector-slice-text"],
+        tick: int,
+    ) -> Any:
+        pass
+    @overload
+    def diagram(
+        self,
+        *,
+        type: Literal["timeline-svg"],
+    ) -> Any:
+        pass
+    @overload
+    def diagram(
+        self,
+        *,
+        type: Literal["detector-slice-svg"],
+        tick: int,
+    ) -> Any:
+        pass
+    def diagram(
+        self,
+        *,
+        type: Union[Literal["timeline-text", "timeline-svg", "detector-slice-text", "detector-slice-svg"], str],
+        tick: Optional[int] = None,
+    ) -> Any:
+        """Returns a diagram of the circuit, from a variety of options.
+
+        Args:
+            type: The type of diagram. Available types are:
+                "timeline-text" (default): An ASCII diagram of the
+                    operations applied by the circuit over time. Includes
+                    annotations showing the measurement record index that
+                    each measurement writes to, and the measurements used
+                    by detectors.
+                "timeline-svg": An SVG image of the operations applied by
+                    the circuit over time. Includes annotations showing the
+                    measurement record index that each measurement writes
+                    to, and the measurements used by detectors.
+                "detector-slice-text": An ASCII diagram of the stabilizers
+                    that detectors declared by the circuit correspond to
+                    during the TICK instruction identified by the `tick`
+                    argument.
+                "detector-slice-svg": An SVG image of the stabilizers
+                    that detectors declared by the circuit correspond to
+                    during the TICK instruction identified by the `tick`
+                    argument. For example, a detector slice diagram of a
+                    CSS surface code circuit during the TICK between a
+                    measurement layer and a reset layer will produce the
+                    usual diagram of a surface code.
+
+                    Uses the Pauli color convention XYZ=RGB.
+            tick: Required for detector slice diagrams. Specifies which TICK
+                instruction to slice at. Note that the first TICK in the
+                circuit is tick=1. The value tick=0 refers to the very start
+                of the circuit.
+
+        Returns:
+            An object whose `__str__` method returns the diagram, so that
+            writing the diagram to a file works correctly. The returned
+            object may also define methods such as `_repr_html_`, so that
+            ipython notebooks recognize it can be shown using a specialized
+            viewer instead of as raw text.
+
+        Examples:
+            >>> import stim
+            >>> circuit = stim.Circuit('''
+            ...     H 0
+            ...     CNOT 0 1 1 2
+            ... ''')
+
+            >>> print(circuit.diagram(type="timeline-text"))
+            q0: -H-@---
+                   |
+            q1: ---X-@-
+                     |
+            q2: -----X-
+
+            >>> circuit = stim.Circuit('''
+            ...     H 0
+            ...     CNOT 0 1
+            ...     TICK
+            ...     M 0 1
+            ...     DETECTOR rec[-1] rec[-2]
+            ... ''')
+
+            >>> print(circuit.diagram(type="detector-slice-text", tick=1))
+            q0: -Z:D0-
+                 |
+            q1: -Z:D0-
         """
     def explain_detector_error_model_errors(
         self,

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -1,7 +1,7 @@
 """Stim (Development Version): a fast quantum stabilizer circuit library."""
 # (This a stubs file describing the classes and methods in stim.)
 from __future__ import annotations
-from typing import overload, TYPE_CHECKING, List, Dict, Tuple, Any, Union, Iterable, Literal
+from typing import overload, TYPE_CHECKING, List, Dict, Tuple, Any, Union, Iterable
 if TYPE_CHECKING:
     import io
     import pathlib
@@ -718,14 +718,14 @@ class Circuit:
     def diagram(
         self,
         *,
-        type: Literal["timeline-text"],
+        type: 'Literal["timeline-text"]',
     ) -> Any:
         pass
     @overload
     def diagram(
         self,
         *,
-        type: Literal["detector-slice-text"],
+        type: 'Literal["detector-slice-text"]',
         tick: int,
     ) -> Any:
         pass
@@ -733,21 +733,21 @@ class Circuit:
     def diagram(
         self,
         *,
-        type: Literal["timeline-svg"],
+        type: 'Literal["timeline-svg"]',
     ) -> Any:
         pass
     @overload
     def diagram(
         self,
         *,
-        type: Literal["detector-slice-svg"],
+        type: 'Literal["detector-slice-svg"]',
         tick: int,
     ) -> Any:
         pass
     def diagram(
         self,
         *,
-        type: Union[Literal["timeline-text", "timeline-svg", "detector-slice-text", "detector-slice-svg"], str],
+        type: Union['Literal["timeline-text", "timeline-svg", "detector-slice-text", "detector-slice-svg"]', str],
         tick: Optional[int] = None,
     ) -> Any:
         """Returns a diagram of the circuit, from a variety of options.
@@ -2497,7 +2497,7 @@ class CompiledMeasurementsToDetectionEventsConverter:
         *,
         measurements: np.ndarray,
         sweep_bits: Optional[np.ndarray] = None,
-        separate_observables: Literal[True],
+        separate_observables: 'Literal[True]',
         append_observables: bool = False,
         bit_pack_result: bool = False,
     ) -> Tuple[np.ndarray, np.ndarray]:

--- a/doc/usage_command_line.md
+++ b/doc/usage_command_line.md
@@ -599,9 +599,9 @@ OPTIONS
         input circuit.
 
         In detector-slice diagrams, `--tick` identifies which TICK is the
-        instant at which the time slice is taken. Note that TICKs are
-        zero-indexed, meaning `--tick=0` refers to the instant of
-        the first TICK in the circuit.
+        instant at which the time slice is taken. Note that `--tick=0` is
+        the very beginning of the circuit and `--tick=1` is the instant of
+        the first TICK instruction.
 
 
     --type

--- a/file_lists/python_api_files
+++ b/file_lists/python_api_files
@@ -2,6 +2,7 @@ src/stim/circuit/circuit.pybind.cc
 src/stim/circuit/circuit_gate_target.pybind.cc
 src/stim/circuit/circuit_instruction.pybind.cc
 src/stim/circuit/circuit_repeat_block.pybind.cc
+src/stim/cmd/command_diagram.pybind.cc
 src/stim/dem/detector_error_model.pybind.cc
 src/stim/dem/detector_error_model_instruction.pybind.cc
 src/stim/dem/detector_error_model_repeat_block.pybind.cc

--- a/file_lists/source_files_no_main
+++ b/file_lists/source_files_no_main
@@ -26,6 +26,7 @@ src/stim/cmd/command_sample.cc
 src/stim/cmd/command_sample_dem.cc
 src/stim/dem/detector_error_model.cc
 src/stim/diagram/ascii_diagram.cc
+src/stim/diagram/base64.cc
 src/stim/diagram/circuit_timeline_helper.cc
 src/stim/diagram/detector_slice/detector_slice_set.cc
 src/stim/diagram/diagram_util.cc

--- a/file_lists/test_files
+++ b/file_lists/test_files
@@ -12,6 +12,7 @@ src/stim/cmd/command_m2d.test.cc
 src/stim/cmd/command_sample.test.cc
 src/stim/cmd/command_sample_dem.test.cc
 src/stim/dem/detector_error_model.test.cc
+src/stim/diagram/base64.test.cc
 src/stim/diagram/detector_slice/detector_slice_set.test.cc
 src/stim/diagram/timeline/timeline_ascii_drawer.test.cc
 src/stim/diagram/timeline/timeline_svg_drawer.test.cc

--- a/glue/python/generate_stub_file.py
+++ b/glue/python/generate_stub_file.py
@@ -246,7 +246,7 @@ def main():
 """Stim {version}: a fast quantum stabilizer circuit library."""
 # (This a stubs file describing the classes and methods in stim.)
 from __future__ import annotations
-from typing import overload, TYPE_CHECKING, List, Dict, Tuple, Any, Union, Iterable
+from typing import overload, TYPE_CHECKING, List, Dict, Tuple, Any, Union, Iterable, Literal
 if TYPE_CHECKING:
     import io
     import pathlib

--- a/glue/python/generate_stub_file.py
+++ b/glue/python/generate_stub_file.py
@@ -246,7 +246,7 @@ def main():
 """Stim {version}: a fast quantum stabilizer circuit library."""
 # (This a stubs file describing the classes and methods in stim.)
 from __future__ import annotations
-from typing import overload, TYPE_CHECKING, List, Dict, Tuple, Any, Union, Iterable, Literal
+from typing import overload, TYPE_CHECKING, List, Dict, Tuple, Any, Union, Iterable
 if TYPE_CHECKING:
     import io
     import pathlib

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -1,7 +1,7 @@
 """Stim (Development Version): a fast quantum stabilizer circuit library."""
 # (This a stubs file describing the classes and methods in stim.)
 from __future__ import annotations
-from typing import overload, TYPE_CHECKING, List, Dict, Tuple, Any, Union, Iterable
+from typing import overload, TYPE_CHECKING, List, Dict, Tuple, Any, Union, Iterable, Literal
 if TYPE_CHECKING:
     import io
     import pathlib
@@ -713,6 +713,107 @@ class Circuit:
                 error(0.375) D0 D1
                 error(0.25) D1
             ''')
+        """
+    @overload
+    def diagram(
+        self,
+        *,
+        type: Literal["timeline-text"],
+    ) -> Any:
+        pass
+    @overload
+    def diagram(
+        self,
+        *,
+        type: Literal["detector-slice-text"],
+        tick: int,
+    ) -> Any:
+        pass
+    @overload
+    def diagram(
+        self,
+        *,
+        type: Literal["timeline-svg"],
+    ) -> Any:
+        pass
+    @overload
+    def diagram(
+        self,
+        *,
+        type: Literal["detector-slice-svg"],
+        tick: int,
+    ) -> Any:
+        pass
+    def diagram(
+        self,
+        *,
+        type: Union[Literal["timeline-text", "timeline-svg", "detector-slice-text", "detector-slice-svg"], str],
+        tick: Optional[int] = None,
+    ) -> Any:
+        """Returns a diagram of the circuit, from a variety of options.
+
+        Args:
+            type: The type of diagram. Available types are:
+                "timeline-text" (default): An ASCII diagram of the
+                    operations applied by the circuit over time. Includes
+                    annotations showing the measurement record index that
+                    each measurement writes to, and the measurements used
+                    by detectors.
+                "timeline-svg": An SVG image of the operations applied by
+                    the circuit over time. Includes annotations showing the
+                    measurement record index that each measurement writes
+                    to, and the measurements used by detectors.
+                "detector-slice-text": An ASCII diagram of the stabilizers
+                    that detectors declared by the circuit correspond to
+                    during the TICK instruction identified by the `tick`
+                    argument.
+                "detector-slice-svg": An SVG image of the stabilizers
+                    that detectors declared by the circuit correspond to
+                    during the TICK instruction identified by the `tick`
+                    argument. For example, a detector slice diagram of a
+                    CSS surface code circuit during the TICK between a
+                    measurement layer and a reset layer will produce the
+                    usual diagram of a surface code.
+
+                    Uses the Pauli color convention XYZ=RGB.
+            tick: Required for detector slice diagrams. Specifies which TICK
+                instruction to slice at. Note that the first TICK in the
+                circuit is tick=1. The value tick=0 refers to the very start
+                of the circuit.
+
+        Returns:
+            An object whose `__str__` method returns the diagram, so that
+            writing the diagram to a file works correctly. The returned
+            object may also define methods such as `_repr_html_`, so that
+            ipython notebooks recognize it can be shown using a specialized
+            viewer instead of as raw text.
+
+        Examples:
+            >>> import stim
+            >>> circuit = stim.Circuit('''
+            ...     H 0
+            ...     CNOT 0 1 1 2
+            ... ''')
+
+            >>> print(circuit.diagram(type="timeline-text"))
+            q0: -H-@---
+                   |
+            q1: ---X-@-
+                     |
+            q2: -----X-
+
+            >>> circuit = stim.Circuit('''
+            ...     H 0
+            ...     CNOT 0 1
+            ...     TICK
+            ...     M 0 1
+            ...     DETECTOR rec[-1] rec[-2]
+            ... ''')
+
+            >>> print(circuit.diagram(type="detector-slice-text", tick=1))
+            q0: -Z:D0-
+                 |
+            q1: -Z:D0-
         """
     def explain_detector_error_model_errors(
         self,

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -1,7 +1,7 @@
 """Stim (Development Version): a fast quantum stabilizer circuit library."""
 # (This a stubs file describing the classes and methods in stim.)
 from __future__ import annotations
-from typing import overload, TYPE_CHECKING, List, Dict, Tuple, Any, Union, Iterable, Literal
+from typing import overload, TYPE_CHECKING, List, Dict, Tuple, Any, Union, Iterable
 if TYPE_CHECKING:
     import io
     import pathlib
@@ -718,14 +718,14 @@ class Circuit:
     def diagram(
         self,
         *,
-        type: Literal["timeline-text"],
+        type: 'Literal["timeline-text"]',
     ) -> Any:
         pass
     @overload
     def diagram(
         self,
         *,
-        type: Literal["detector-slice-text"],
+        type: 'Literal["detector-slice-text"]',
         tick: int,
     ) -> Any:
         pass
@@ -733,21 +733,21 @@ class Circuit:
     def diagram(
         self,
         *,
-        type: Literal["timeline-svg"],
+        type: 'Literal["timeline-svg"]',
     ) -> Any:
         pass
     @overload
     def diagram(
         self,
         *,
-        type: Literal["detector-slice-svg"],
+        type: 'Literal["detector-slice-svg"]',
         tick: int,
     ) -> Any:
         pass
     def diagram(
         self,
         *,
-        type: Union[Literal["timeline-text", "timeline-svg", "detector-slice-text", "detector-slice-svg"], str],
+        type: Union['Literal["timeline-text", "timeline-svg", "detector-slice-text", "detector-slice-svg"]', str],
         tick: Optional[int] = None,
     ) -> Any:
         """Returns a diagram of the circuit, from a variety of options.
@@ -2497,7 +2497,7 @@ class CompiledMeasurementsToDetectionEventsConverter:
         *,
         measurements: np.ndarray,
         sweep_bits: Optional[np.ndarray] = None,
-        separate_observables: Literal[True],
+        separate_observables: 'Literal[True]',
         append_observables: bool = False,
         bit_pack_result: bool = False,
     ) -> Tuple[np.ndarray, np.ndarray]:

--- a/src/stim.h
+++ b/src/stim.h
@@ -19,6 +19,7 @@
 #include "stim/cmd/command_sample_dem.h"
 #include "stim/dem/detector_error_model.h"
 #include "stim/diagram/ascii_diagram.h"
+#include "stim/diagram/base64.h"
 #include "stim/diagram/circuit_timeline_helper.h"
 #include "stim/diagram/coord.h"
 #include "stim/diagram/detector_slice/detector_slice_set.h"

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -1811,11 +1811,11 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
         pybind11::arg("type") = "timeline-text",
         pybind11::arg("tick") = pybind11::none(),
         clean_doc_string(u8R"DOC(
-            @overload def diagram(self, *, type: Literal["timeline-text"]) -> Any:
-            @overload def diagram(self, *, type: Literal["detector-slice-text"], tick: int) -> Any:
-            @overload def diagram(self, *, type: Literal["timeline-svg"]) -> Any:
-            @overload def diagram(self, *, type: Literal["detector-slice-svg"], tick: int) -> Any:
-            @signature def diagram(self, *, type: Union[Literal["timeline-text", "timeline-svg", "detector-slice-text", "detector-slice-svg"], str], tick: Optional[int] = None) -> Any:
+            @overload def diagram(self, *, type: 'Literal["timeline-text"]') -> Any:
+            @overload def diagram(self, *, type: 'Literal["detector-slice-text"]', tick: int) -> Any:
+            @overload def diagram(self, *, type: 'Literal["timeline-svg"]') -> Any:
+            @overload def diagram(self, *, type: 'Literal["detector-slice-svg"]', tick: int) -> Any:
+            @signature def diagram(self, *, type: Union['Literal["timeline-text", "timeline-svg", "detector-slice-text", "detector-slice-svg"]', str], tick: Optional[int] = None) -> Any:
             Returns a diagram of the circuit, from a variety of options.
 
             Args:

--- a/src/stim/circuit/circuit_pybind_test.py
+++ b/src/stim/circuit/circuit_pybind_test.py
@@ -906,3 +906,29 @@ def test_circuit_to_file():
         c.to_file(object())
     with pytest.raises(ValueError, match="how to write"):
         c.to_file(123)
+
+
+def test_diagram():
+    c = stim.Circuit("""
+        H 0
+        CX 0 1
+    """)
+    assert str(c.diagram()).strip() == """
+q0: -H-@-
+       |
+q1: ---X-
+    """.strip()
+    assert str(c.diagram(type='timeline-text')) == str(c.diagram())
+
+    c = stim.Circuit("""
+        H 0
+        CNOT 0 1
+        TICK
+        M 0 1
+        DETECTOR rec[-1] rec[-2]
+    """)
+    assert str(c.diagram(type='detector-slice-text', tick=1)).strip() == """
+q0: -Z:D0-
+     |
+q1: -Z:D0-
+    """.strip()

--- a/src/stim/cmd/command_diagram.cc
+++ b/src/stim/cmd/command_diagram.cc
@@ -156,9 +156,9 @@ SubCommandHelp stim::command_diagram_help() {
             input circuit.
 
             In detector-slice diagrams, `--tick` identifies which TICK is the
-            instant at which the time slice is taken. Note that TICKs are
-            zero-indexed, meaning `--tick=0` refers to the instant of
-            the first TICK in the circuit.
+            instant at which the time slice is taken. Note that `--tick=0` is
+            the very beginning of the circuit and `--tick=1` is the instant of
+            the first TICK instruction.
         )PARAGRAPH"),
     });
 

--- a/src/stim/cmd/command_diagram.cc
+++ b/src/stim/cmd/command_diagram.cc
@@ -108,6 +108,7 @@ int stim::command_diagram(int argc, const char **argv) {
             throw std::invalid_argument("Unknown type");
         }
     }
+    out << '\n';
 
     return EXIT_SUCCESS;
 }

--- a/src/stim/cmd/command_diagram.pybind.cc
+++ b/src/stim/cmd/command_diagram.pybind.cc
@@ -1,0 +1,103 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "stim/cmd/command_diagram.pybind.h"
+#include "stim/cmd/command_help.h"
+#include "stim/diagram/timeline/timeline_ascii_drawer.h"
+#include "stim/diagram/timeline/timeline_svg_drawer.h"
+#include "stim/diagram/detector_slice/detector_slice_set.h"
+#include "stim/diagram/base64.h"
+
+using namespace stim;
+using namespace stim_pybind;
+using namespace stim_draw_internal;
+
+
+pybind11::class_<DiagramHelper> stim_pybind::pybind_diagram(pybind11::module &m) {
+    auto c = pybind11::class_<DiagramHelper>(
+        m,
+        "_DiagramHelper",
+        clean_doc_string(u8R"DOC(
+            A helper class for displaying diagrams in IPython notebooks.
+
+            To write the diagram's contents to a file (for example, to write an
+            SVG image to an SVG file), use `print(diagram, file=file)`.
+        )DOC")
+            .data());
+
+    return c;
+}
+
+void stim_pybind::pybind_diagram_methods(pybind11::module &m, pybind11::class_<DiagramHelper> &c) {
+    c.def("_repr_html_", [](const DiagramHelper &self) -> pybind11::object {
+        if (self.type == DIAGRAM_TYPE_TEXT) {
+            return pybind11::cast("<pre>" + self.content + "</pre>");
+        }
+        if (self.type == DIAGRAM_TYPE_SVG) {
+            std::stringstream out;
+            out << R"HTML(<div style="border: 1px dashed gray; margin-bottom: 50px; width: 300px; resize: both; overflow: hidden">)HTML";
+            out << R"HTML(<img style="max-width: 100%; max-height: 100%" src="data:image/svg+xml;base64,)HTML";
+            write_data_as_base64_to(self.content.data(), self.content.size(), out);
+            out << R"HTML("/></div>)HTML";
+            return pybind11::cast(out.str());
+        }
+        return pybind11::none();
+    });
+    c.def("_repr_svg_", [](const DiagramHelper &self) -> pybind11::object {
+        if (self.type != DIAGRAM_TYPE_SVG) {
+            return pybind11::none();
+        }
+        return pybind11::cast(self.content);
+    });
+    c.def("_repr_pretty_", [](const DiagramHelper &self, pybind11::object p, pybind11::object cycle) -> void {
+        pybind11::getattr(p, "text")(self.content);
+    });
+    c.def("__str__", [](const DiagramHelper &self) {
+        return self.content;
+    });
+}
+
+DiagramHelper stim_pybind::circuit_diagram(const Circuit &self, const std::string &type, const pybind11::object &tick) {
+    if (type == "timeline-text") {
+        if (!tick.is_none()) {
+            throw std::invalid_argument("`tick` isn't used with type='timeline-text'");
+        }
+        std::stringstream out;
+        out << DiagramTimelineAsciiDrawer::make_diagram(self);
+        return DiagramHelper{DIAGRAM_TYPE_TEXT, out.str()};
+    } else if (type == "timeline-svg") {
+        if (!tick.is_none()) {
+            throw std::invalid_argument("`tick` isn't used with type='timeline-svg'");
+        }
+        std::stringstream out;
+        DiagramTimelineSvgDrawer::make_diagram_write_to(self, out);
+        return DiagramHelper{DIAGRAM_TYPE_SVG, out.str()};
+    } else if (type == "detector-slice-text") {
+        if (tick.is_none()) {
+            throw std::invalid_argument("You must specify the tick= argument when using type='detector-slice-text'");
+        }
+        std::stringstream out;
+        DetectorSliceSet::from_circuit_tick(self, pybind11::cast<uint64_t>(tick)).write_text_diagram_to(out);
+        return DiagramHelper{DIAGRAM_TYPE_TEXT, out.str()};
+    } else if (type == "detector-slice-svg") {
+        if (tick.is_none()) {
+            throw std::invalid_argument("You must specify the tick= argument when using type='detector-slice-svg'");
+        }
+        std::stringstream out;
+        DetectorSliceSet::from_circuit_tick(self, pybind11::cast<uint64_t>(tick)).write_svg_diagram_to(out);
+        return DiagramHelper{DIAGRAM_TYPE_SVG, out.str()};
+    } else {
+        throw std::invalid_argument("Unrecognized diagram type: " + type);
+    }
+}

--- a/src/stim/cmd/command_diagram.pybind.h
+++ b/src/stim/cmd/command_diagram.pybind.h
@@ -1,0 +1,40 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _STIM_CMD_COMMAND_DIAGRAM_PYBIND_H
+#define _STIM_CMD_COMMAND_DIAGRAM_PYBIND_H
+
+#include <pybind11/pybind11.h>
+
+#include "stim/circuit/circuit.h"
+
+namespace stim_pybind {
+
+enum DiagramType {
+    DIAGRAM_TYPE_SVG,
+    DIAGRAM_TYPE_TEXT,
+};
+
+struct DiagramHelper {
+    DiagramType type;
+    std::string content;
+};
+
+pybind11::class_<DiagramHelper> pybind_diagram(pybind11::module &m);
+void pybind_diagram_methods(pybind11::module &m, pybind11::class_<DiagramHelper> &c);
+DiagramHelper circuit_diagram(const stim::Circuit &self, const std::string &type, const pybind11::object &tick);
+
+}  // namespace stim_pybind
+
+#endif

--- a/src/stim/diagram/ascii_diagram.cc
+++ b/src/stim/diagram/ascii_diagram.cc
@@ -124,9 +124,11 @@ void strip_padding_from_lines_and_write_to(PointerRange<std::string> out_lines, 
     }
 
     // Output while stripping empty lines at start of diagram.
-    for (const auto &line : out_lines) {
-        out.write(line.data() + indentation, line.size() - indentation);
-        out.put('\n');
+    for (size_t k = 0; k < out_lines.size(); k++) {
+        if (k) {
+            out.put('\n');
+        }
+        out.write(out_lines[k].data() + indentation, out_lines[k].size() - indentation);
     }
 }
 

--- a/src/stim/diagram/base64.cc
+++ b/src/stim/diagram/base64.cc
@@ -1,0 +1,42 @@
+#include "stim/diagram/base64.h"
+
+using namespace stim_draw_internal;
+
+char u6_to_base64_char(uint8_t v) {
+    if (v < 26) {
+        return 'A' + v;
+    } else if (v < 52) {
+        return 'a' + v - 26;
+    } else if (v < 62) {
+        return '0' + v - 52;
+    } else if (v == 62) {
+        return '+';
+    } else {
+        return '/';
+    }
+}
+
+void stim_draw_internal::write_data_as_base64_to(const char *data, size_t n, std::ostream &out) {
+    uint32_t buf = 0;
+    size_t bits_in_buf = 0;
+    for (size_t k = 0; k < n; k++) {
+        buf <<= 8;
+        buf |= (uint8_t) data[k];
+        bits_in_buf += 8;
+        if (bits_in_buf == 24) {
+            out << u6_to_base64_char((buf >> 18) & 0x3F);
+            out << u6_to_base64_char((buf >> 12) & 0x3F);
+            out << u6_to_base64_char((buf >> 6) & 0x3F);
+            out << u6_to_base64_char((buf >> 0) & 0x3F);
+            bits_in_buf = 0;
+            buf = 0;
+        }
+    }
+    if (bits_in_buf) {
+        buf <<= (24 - bits_in_buf);
+        out << u6_to_base64_char((buf >> 18) & 0x3F);
+        out << u6_to_base64_char((buf >> 12) & 0x3F);
+        out << (bits_in_buf == 8 ? '=' : u6_to_base64_char((buf >> 6) & 0x3F));
+        out << '=';
+    }
+}

--- a/src/stim/diagram/base64.h
+++ b/src/stim/diagram/base64.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _STIM_DIAGRAM_BASE64_H
+#define _STIM_DIAGRAM_BASE64_H
+
+#include <iostream>
+
+namespace stim_draw_internal {
+
+void write_data_as_base64_to(const char *data, size_t n, std::ostream &out);
+
+}  // namespace stim_draw_internal
+
+#endif

--- a/src/stim/diagram/base64.test.cc
+++ b/src/stim/diagram/base64.test.cc
@@ -1,0 +1,26 @@
+#include "gtest/gtest.h"
+
+#include "stim/diagram/base64.h"
+
+using namespace stim_draw_internal;
+
+TEST(base64, write_base64) {
+    auto f = [](const char *c){
+        std::stringstream ss;
+        write_data_as_base64_to(c, strlen(c), ss);
+        return ss.str();
+    };
+
+    EXPECT_EQ(f("light work."), "bGlnaHQgd29yay4=");
+    EXPECT_EQ(f("light work"), "bGlnaHQgd29yaw==");
+    EXPECT_EQ(f("light wor"), "bGlnaHQgd29y");
+    EXPECT_EQ(f("light wo"), "bGlnaHQgd28=");
+    EXPECT_EQ(f("light w"), "bGlnaHQgdw==");
+    EXPECT_EQ(f(""), "");
+    EXPECT_EQ(f("f"), "Zg==");
+    EXPECT_EQ(f("fo"), "Zm8=");
+    EXPECT_EQ(f("foo"), "Zm9v");
+    EXPECT_EQ(f("foob"), "Zm9vYg==");
+    EXPECT_EQ(f("fooba"), "Zm9vYmE=");
+    EXPECT_EQ(f("foobar"), "Zm9vYmFy");
+}

--- a/src/stim/diagram/detector_slice/detector_slice_set.cc
+++ b/src/stim/diagram/detector_slice/detector_slice_set.cc
@@ -56,7 +56,7 @@ bool DetectorSliceSetComputer::process_op_rev(const Circuit &parent, const Opera
 }
 DetectorSliceSetComputer::DetectorSliceSetComputer(const Circuit &circuit, uint64_t tick_index)
     : analyzer(circuit.count_detectors(), circuit.count_qubits(), false, true, true, 1, false, false) {
-    num_ticks_left = circuit.count_ticks();
+    num_ticks_left = circuit.count_ticks() + 1;  // + 1 because "first tick" is start of circuit.
     if (num_ticks_left == 0) {
         throw std::invalid_argument("Circuit contains no TICK instructions to slice at.");
     }
@@ -496,5 +496,4 @@ void DetectorSliceSet::write_svg_diagram_to(std::ostream &out) const {
     }
 
     out << R"SVG(</svg>)SVG";
-    out << "\n";
 }

--- a/src/stim/diagram/detector_slice/detector_slice_set.h
+++ b/src/stim/diagram/detector_slice/detector_slice_set.h
@@ -30,11 +30,17 @@ struct DetectorSliceSet {
     std::map<uint64_t, std::vector<double>> detector_coordinates;
     std::map<stim::DemTarget, std::vector<stim::GateTarget>> slices;
 
-    std::set<uint64_t> used_qubits() const;
+    /// Args:
+    ///     circuit: The circuit to make a detector slice diagram from.
+    ///     tick_index: The tick to target. tick_index=0 is the start of the
+    ///         circuit. tick_index=1 is the first TICK instruction, and so
+    ///         forth.
     static DetectorSliceSet from_circuit_tick(const stim::Circuit &circuit, uint64_t tick_index);
-    void write_text_diagram_to(std::ostream &out) const;
+
+    std::set<uint64_t> used_qubits() const;
     std::string str() const;
 
+    void write_text_diagram_to(std::ostream &out) const;
     void write_svg_diagram_to(std::ostream &out) const;
 };
 std::ostream &operator<<(std::ostream &out, const DetectorSliceSet &slice);

--- a/src/stim/diagram/detector_slice/detector_slice_set.test.cc
+++ b/src/stim/diagram/detector_slice/detector_slice_set.test.cc
@@ -50,7 +50,7 @@ TEST(detector_slice_set, from_circuit) {
             DETECTOR rec[-1]
         }
 )CIRCUIT"),
-        1);
+        2);
     ASSERT_EQ(slice_set.coordinates, (std::map<uint64_t, std::vector<double>>{{1, {3, 5}}}));
     ASSERT_EQ(
         slice_set.slices,
@@ -84,7 +84,7 @@ TEST(detector_slice_set, big_loop_seeking) {
     )CIRCUIT");
 
     uint64_t inner = 10 * 100 * 1000 + 1;
-    auto slice_set = DetectorSliceSet::from_circuit_tick(circuit, inner * 10000ULL * 50ULL + 1ULL);
+    auto slice_set = DetectorSliceSet::from_circuit_tick(circuit, inner * 10000ULL * 50ULL + 2ULL);
     ASSERT_EQ(slice_set.coordinates, (std::map<uint64_t, std::vector<double>>{}));
     ASSERT_EQ(
         slice_set.slices,
@@ -92,7 +92,7 @@ TEST(detector_slice_set, big_loop_seeking) {
             {DemTarget::relative_detector_id(inner * 10000ULL * 50ULL + 1ULL), {GateTarget::y(0)}},
         }));
 
-    slice_set = DetectorSliceSet::from_circuit_tick(circuit, inner * 10000ULL * 25ULL + 1000ULL * 100ULL * 10ULL);
+    slice_set = DetectorSliceSet::from_circuit_tick(circuit, inner * 10000ULL * 25ULL + 1000ULL * 100ULL * 10ULL + 1ULL);
     ASSERT_EQ(slice_set.coordinates, (std::map<uint64_t, std::vector<double>>{}));
     ASSERT_EQ(
         slice_set.slices,
@@ -105,9 +105,9 @@ TEST(detector_slice_set, big_loop_seeking) {
 TEST(detector_slice_set_text_diagram, repetition_code) {
     CircuitGenParameters params(10, 5, "memory");
     auto circuit = generate_rep_code_circuit(params).circuit;
-    auto slice_set = DetectorSliceSet::from_circuit_tick(circuit, 8);
+    auto slice_set = DetectorSliceSet::from_circuit_tick(circuit, 9);
     ASSERT_EQ(slice_set.slices.size(), circuit.count_qubits());
-    ASSERT_EQ("\n" + slice_set.str(), R"DIAGRAM(
+    ASSERT_EQ("\n" + slice_set.str() + "\n", R"DIAGRAM(
 q0: --------Z:D12----------------------------
             |
 q1: -Z:D8---Z:D12----------------------------
@@ -127,7 +127,7 @@ q7: -Z:D11-----------------------Z:D15-------
 q8: -----------------------------Z:D15--Z:L0-
 )DIAGRAM");
 
-    ASSERT_EQ("\n" + DetectorSliceSet::from_circuit_tick(circuit, 10).str(), R"DIAGRAM(
+    ASSERT_EQ("\n" + DetectorSliceSet::from_circuit_tick(circuit, 11).str() + "\n", R"DIAGRAM(
 q0: --------Z:D16-
             |
 q1: -Z:D12--Z:D16-
@@ -151,9 +151,9 @@ q8: -Z:D15--Z:L0--
 TEST(detector_slice_set_text_diagram, surface_code) {
     CircuitGenParameters params(10, 2, "unrotated_memory_z");
     auto circuit = generate_surface_code_circuit(params).circuit;
-    auto slice_set = DetectorSliceSet::from_circuit_tick(circuit, 10);
+    auto slice_set = DetectorSliceSet::from_circuit_tick(circuit, 11);
     ASSERT_EQ(slice_set.slices.size(), circuit.count_qubits());
-    ASSERT_EQ("\n" + slice_set.str(), R"DIAGRAM(
+    ASSERT_EQ("\n" + slice_set.str() + "\n", R"DIAGRAM(
 q0:(0, 0) -X:D2--Z:D3--------------------------------Z:L0-
            |     |                                   |
 q1:(1, 0) -X:D2--|-----------------X:D6--Z:D7--------Z:L0-
@@ -177,11 +177,11 @@ q8:(2, 2) -------------------------------------Z:D8--X:D9-
 TEST(detector_slice_set_svg_diagram, surface_code) {
     CircuitGenParameters params(10, 2, "rotated_memory_z");
     auto circuit = generate_surface_code_circuit(params).circuit;
-    auto slice_set = DetectorSliceSet::from_circuit_tick(circuit, 7);
+    auto slice_set = DetectorSliceSet::from_circuit_tick(circuit, 8);
     std::stringstream ss;
     slice_set.write_svg_diagram_to(ss);
     ASSERT_EQ(
-        "\n" + ss.str(),
+        "\n" + ss.str() + "\n",
         u8R"SVG(
 <svg viewBox="0 0 77.2548 122.51" xmlns="http://www.w3.org/2000/svg">
 <path d="M38.6274,16 61.2548,38.6274 16,38.6274 Z" stroke="none" fill-opacity="0.75" fill="#AAAAAA" />

--- a/src/stim/diagram/diagram_util.cc
+++ b/src/stim/diagram/diagram_util.cc
@@ -1,4 +1,4 @@
-#include "diagram_util.h"
+#include "stim/diagram/diagram_util.h"
 
 using namespace stim;
 using namespace stim_draw_internal;

--- a/src/stim/diagram/timeline/timeline_ascii_drawer.test.cc
+++ b/src/stim/diagram/timeline/timeline_ascii_drawer.test.cc
@@ -45,7 +45,7 @@ TEST(circuit_diagram_timeline_text, single_qubit_gates) {
         S_DAG 1
         H 2 0 3
     )CIRCUIT");
-    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit).str(), R"DIAGRAM(
+    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit) .str() + "\n", R"DIAGRAM(
 q0: -I-C_XYZ-H------SQRT_X_DAG-S_DAG-H-
 
 q1: -X-C_ZYX-H_YZ---SQRT_Y-----S_DAG---
@@ -81,7 +81,7 @@ TEST(circuit_diagram_timeline_text, two_qubits_gates) {
         ZCY 4 5
         ZCZ 0 5 2 3 1 4
     )CIRCUIT");
-    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit).str(), R"DIAGRAM(
+    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit) .str() + "\n", R"DIAGRAM(
 q0: -@-@-------------------------SQRT_XX_DAG---------SQRT_YY_DAG-SWAP----------X-Y---@-----
      | |                         |                   |           |             | |   |
 q1: -X-|-ISWAP-------------------|-------------------SQRT_YY_DAG-SWAP----------@-@---|---@-
@@ -104,7 +104,7 @@ TEST(circuit_diagram_timeline_text, noise_gates) {
         Y_ERROR(0.125) 0 1 4
         Z_ERROR(0.125) 2 3 5
     )CIRCUIT");
-    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit).str(), R"DIAGRAM(
+    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit) .str() + "\n", R"DIAGRAM(
 q0: -DEPOLARIZE1(0.125)-DEPOLARIZE2(0.125)-X_ERROR(0.125)-Y_ERROR(0.125)-
                         |
 q1: -DEPOLARIZE1(0.125)-|------------------X_ERROR(0.125)-Y_ERROR(0.125)-
@@ -124,7 +124,7 @@ q5: --------------------DEPOLARIZE2(0.125)----------------Z_ERROR(0.125)-
         ELSE_CORRELATED_ERROR(0.25) X2 Y4 Z3
         ELSE_CORRELATED_ERROR(0.25) X5
     )CIRCUIT");
-    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit).str(), R"DIAGRAM(
+    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit) .str() + "\n", R"DIAGRAM(
 q0: --------------------------------------------------------------------------------------
 
 q1: -E[X](0.25)-E[X](0.125)---------------------------------------------------------------
@@ -142,7 +142,7 @@ q5: -------------------------------------------------------ELSE_CORRELATED_ERROR
         PAULI_CHANNEL_1(0.125,0.25,0.125) 0 1 2 3
         PAULI_CHANNEL_2(0.01,0.01,0.01,0.02,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01) 0 1 2 4
     )CIRCUIT");
-    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit).str(), R"DIAGRAM(
+    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit) .str() + "\n", R"DIAGRAM(
 q0: -PAULI_CHANNEL_1(0.125,0.25,0.125)-PAULI_CHANNEL_2[0](0.01,0.01,0.01,0.02,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01)-
                                        |
 q1: -PAULI_CHANNEL_1(0.125,0.25,0.125)-PAULI_CHANNEL_2[1](0.01,0.01,0.01,0.02,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01)-
@@ -171,7 +171,7 @@ TEST(circuit_diagram_timeline_text, collapsing) {
         MZ 3
         MPP X0*Y2 Z3 X1 Z2*Y3
     )CIRCUIT");
-    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit).str(), R"DIAGRAM(
+    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit) .str() + "\n", R"DIAGRAM(
 q0: -R--M(0.001):rec[0]-MR:rec[3]-MRY:rec[6]-MR:rec[9]-------------MPP[X]:rec[13]----------------
                                                                    |
 q1: -RX-M(0.001):rec[1]-MR:rec[2]-MRX:rec[4]-MRY:rec[8]-MX:rec[10]-|--------------MPP[X]:rec[15]-
@@ -195,7 +195,7 @@ TEST(circuit_diagram_timeline_text, measurement_looping) {
             }
         }
     )CIRCUIT");
-    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit).str(), R"DIAGRAM(
+    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit) .str() + "\n", R"DIAGRAM(
               /REP 100                  /REP 5                        \ /REP 7                             \ \
 q0: -M:rec[0]-|-------------------------|-----------------------------|-|----------------------------------|-|---
               |                         |                             | |                                  | |
@@ -220,7 +220,7 @@ TEST(circuit_diagram_timeline_text, repeat) {
             }
         }
     )CIRCUIT");
-    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit).str(), R"DIAGRAM(
+    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit) .str() + "\n", R"DIAGRAM(
        /REP 5    /REP 100     \ \
 q0: -H-|---------|--------H---|-|---
        |         |            | |
@@ -239,7 +239,7 @@ TEST(circuit_diagram_timeline_text, classical_feedback) {
         CX rec[-1] 1
         YCZ 2 sweep[5]
     )CIRCUIT");
-    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit).str(), R"DIAGRAM(
+    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit) .str() + "\n", R"DIAGRAM(
 q0: -M:rec[0]---
 
 q1: -X^rec[0]---
@@ -258,7 +258,7 @@ TEST(circuit_diagram_timeline_text, lattice_surgery_cnot) {
         CX rec[-2] 1
         CZ rec[-1] 0
     )CIRCUIT");
-    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit).str(), R"DIAGRAM(
+    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit) .str() + "\n", R"DIAGRAM(
 q0: -----------------MPP[Z]:rec[1]-Z^rec[0]--Z^rec[2]-
                      |
 q1: ---MPP[X]:rec[0]-|-------------X^rec[1]-----------
@@ -266,7 +266,7 @@ q1: ---MPP[X]:rec[0]-|-------------X^rec[1]-----------
 q2: -R-MPP[X]:rec[0]-MPP[Z]:rec[1]-MX:rec[2]----------
 )DIAGRAM");
 
-    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit).transposed().str(), R"DIAGRAM(
+    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit).transposed() .str() + "\n", R"DIAGRAM(
     q0:           q1:           q2:
       |             |             |
       |             |             R
@@ -300,7 +300,7 @@ TEST(circuit_diagram_timeline_text, tick) {
         TICK
         H 0 0
     )CIRCUIT");
-    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit).str(), R"DIAGRAM(
+    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit) .str() + "\n", R"DIAGRAM(
      /-\     /REP 1   /-\ \ /--------\
 q0: -H-H-H-H-|------H-H-S-|-H-H-SQRT_X-H-H-
              |            |
@@ -324,7 +324,7 @@ TEST(circuit_diagram_timeline_text, shifted_coords) {
         QUBIT_COORDS(1, 2) 5
         DETECTOR(4, 5, 6)
     )CIRCUIT");
-    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit).str(), R"DIAGRAM(
+    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit) .str() + "\n", R"DIAGRAM(
                                                   /REP 100                                                  \
 q0: -DETECTOR(4,5,6):D0=1-DETECTOR(14,25,36):D1=1-|--------DETECTOR(19,30+iter*200,41+iter*300):D[2+iter]=1-|-DETECTOR(14,20025,30036):D102=1-
                                                   |                                                         |
@@ -354,7 +354,7 @@ TEST(circuit_diagram_timeline_text, detector_pseudo_targets) {
         DETECTOR(5) rec[-1] rec[-2]
         OBSERVABLE_INCLUDE(100) rec[-201] rec[-203]
     )CIRCUIT");
-    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit).str(), R"DIAGRAM(
+    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit) .str() + "\n", R"DIAGRAM(
               /REP 100                 \
 q0: -M:rec[0]-|------------------------|----------------------------------------------------------------------------------------
               |                        |
@@ -374,7 +374,7 @@ q5: -M:rec[5]-|------------------------|----------------------------------------
 TEST(circuit_diagram_timeline_text, surface_code) {
     CircuitGenParameters params(10, 3, "unrotated_memory_z");
     auto circuit = generate_surface_code_circuit(params).circuit;
-    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit).str(), R"DIAGRAM(
+    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit) .str() + "\n", R"DIAGRAM(
       /-----------------\     /-------\ /-------\     /----------------------------------\ /REP 9       /-------\ /-------\     /-----------------------------------------------------------------------------------\ \
  q0: -QUBIT_COORDS(0,0)-R-----------------@-------X----------------------------------------|------------------------@-------X-----------------------------------------------------------------------------------------|-M:rec[120]---------------------------------------------------------OBSERVABLE_INCLUDE:L0*=rec[122]*rec[121]*rec[120]-
                                           |       |                                        |                        |       |                                                                                         |
@@ -432,7 +432,7 @@ q24: -QUBIT_COORDS(4,4)-R---X---------@-----------------------------------------
 TEST(circuit_diagram_timeline_text, repetition_code) {
     CircuitGenParameters params(10, 9, "memory");
     auto circuit = generate_rep_code_circuit(params).circuit;
-    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit).str(), R"DIAGRAM(
+    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit) .str() + "\n", R"DIAGRAM(
             /--------------------------------\ /REP 9       /-----------------------------------------------------------------------------\ \
  q0: -R-@--------------------------------------|--------@-----------------------------------------------------------------------------------|-M:rec[80]-DETECTOR(1,10):D80=rec[81]*rec[80]*rec[72]--
         |                                      |        |                                                                                   |
@@ -474,7 +474,7 @@ q16: -R---@------------------------------------|----------@---------------------
 TEST(circuit_diagram_timeline_text, repetition_code_transposed) {
     CircuitGenParameters params(10, 3, "memory");
     auto circuit = generate_rep_code_circuit(params).circuit;
-    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit).transposed().str(), R"DIAGRAM(
+    ASSERT_EQ("\n" + DiagramTimelineAsciiDrawer::make_diagram(circuit).transposed() .str() + "\n", R"DIAGRAM(
                          q0:                                                q1:                                                q2:                                                q3:                                          q4:
                           |                                                  |                                                  |                                                  |                                            |
                           R                                                  R                                                  R                                                  R                                            R

--- a/src/stim/diagram/timeline/timeline_svg_drawer.test.cc
+++ b/src/stim/diagram/timeline/timeline_svg_drawer.test.cc
@@ -26,7 +26,9 @@ using namespace stim_draw_internal;
 
 std::string svg_diagram(const Circuit &circuit) {
     std::stringstream ss;
+    ss << '\n';
     DiagramTimelineSvgDrawer::make_diagram_write_to(circuit, ss);
+    ss << '\n';
     return ss.str();
 }
 
@@ -53,59 +55,59 @@ TEST(circuit_diagram_timeline_svg, single_qubit_gates) {
         H 2 0 3
     )CIRCUIT");
     ASSERT_EQ(
-        "\n" + svg_diagram(circuit),
+        svg_diagram(circuit),
         u8R"DIAGRAM(
-<svg width="448" height="288" version="1.1" xmlns="http://www.w3.org/2000/svg">
-<path d="M32,32 L448,32 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="32">q0</text>
-<path d="M32,96 L448,96 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="96">q1</text>
-<path d="M32,160 L448,160 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="160">q2</text>
-<path d="M32,224 L448,224 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="224">q3</text>
-<rect x="48" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="32">I</text>
-<rect x="48" y="80" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="96">X</text>
-<rect x="48" y="144" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="160">Y</text>
-<rect x="48" y="208" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="224">Z</text>
-<rect x="112" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="128" y="32">C<tspan baseline-shift="sub" font-size="10">XYZ</tspan></text>
-<rect x="112" y="80" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="128" y="96">C<tspan baseline-shift="sub" font-size="10">ZYX</tspan></text>
-<rect x="112" y="144" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="128" y="160">H</text>
-<rect x="112" y="208" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="128" y="224">H<tspan baseline-shift="sub" font-size="10">XY</tspan></text>
-<rect x="176" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="192" y="32">H</text>
-<rect x="176" y="80" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="192" y="96">H<tspan baseline-shift="sub" font-size="10">YZ</tspan></text>
-<rect x="176" y="144" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="192" y="160">S</text>
-<rect x="176" y="208" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="192" y="224">√X</text>
-<rect x="240" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="256" y="32">√X<tspan baseline-shift="super" font-size="10">†</tspan></text>
-<rect x="240" y="80" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="256" y="96">√Y</text>
-<rect x="240" y="144" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="256" y="160">√Y<tspan baseline-shift="super" font-size="10">†</tspan></text>
-<rect x="240" y="208" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="256" y="224">S</text>
-<rect x="304" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="320" y="32">S<tspan baseline-shift="super" font-size="10">†</tspan></text>
-<rect x="304" y="80" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="320" y="96">S<tspan baseline-shift="super" font-size="10">†</tspan></text>
-<rect x="304" y="144" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="320" y="160">H</text>
-<rect x="368" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="384" y="32">H</text>
-<rect x="368" y="208" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="384" y="224">H</text>
+<svg viewBox="0 0 512 352"  version="1.1" xmlns="http://www.w3.org/2000/svg">
+<path d="M64,64 L480,64 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="64">q0</text>
+<path d="M64,128 L480,128 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="128">q1</text>
+<path d="M64,192 L480,192 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="192">q2</text>
+<path d="M64,256 L480,256 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="256">q3</text>
+<rect x="80" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="64">I</text>
+<rect x="80" y="112" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="128">X</text>
+<rect x="80" y="176" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="192">Y</text>
+<rect x="80" y="240" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="256">Z</text>
+<rect x="144" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="160" y="64">C<tspan baseline-shift="sub" font-size="10">XYZ</tspan></text>
+<rect x="144" y="112" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="160" y="128">C<tspan baseline-shift="sub" font-size="10">ZYX</tspan></text>
+<rect x="144" y="176" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="160" y="192">H</text>
+<rect x="144" y="240" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="160" y="256">H<tspan baseline-shift="sub" font-size="10">XY</tspan></text>
+<rect x="208" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="64">H</text>
+<rect x="208" y="112" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="128">H<tspan baseline-shift="sub" font-size="10">YZ</tspan></text>
+<rect x="208" y="176" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="192">S</text>
+<rect x="208" y="240" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="256">√X</text>
+<rect x="272" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="64">√X<tspan baseline-shift="super" font-size="10">†</tspan></text>
+<rect x="272" y="112" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="128">√Y</text>
+<rect x="272" y="176" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="192">√Y<tspan baseline-shift="super" font-size="10">†</tspan></text>
+<rect x="272" y="240" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="256">S</text>
+<rect x="336" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="64">S<tspan baseline-shift="super" font-size="10">†</tspan></text>
+<rect x="336" y="112" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="128">S<tspan baseline-shift="super" font-size="10">†</tspan></text>
+<rect x="336" y="176" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="192">H</text>
+<rect x="400" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="64">H</text>
+<rect x="400" y="240" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="256">H</text>
 </svg>
 )DIAGRAM");
 }
@@ -136,127 +138,127 @@ TEST(circuit_diagram_timeline_svg, two_qubits_gates) {
         ZCZ 0 5 2 3 1 4
     )CIRCUIT");
     ASSERT_EQ(
-        "\n" + svg_diagram(circuit),
+        svg_diagram(circuit),
         u8R"DIAGRAM(
-<svg width="1088" height="416" version="1.1" xmlns="http://www.w3.org/2000/svg">
-<path d="M32,32 L1088,32 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="32">q0</text>
-<path d="M32,96 L1088,96 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="96">q1</text>
-<path d="M32,160 L1088,160 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="160">q2</text>
-<path d="M32,224 L1088,224 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="224">q3</text>
-<path d="M32,288 L1088,288 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="288">q4</text>
-<path d="M32,352 L1088,352 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="352">q5</text>
-<path d="M64,32 L64,96 " stroke="black"/>
-<circle cx="64" cy="32" r="8" stroke="none" fill="black"/>
-<circle cx="64" cy="96" r="8" stroke="black" fill="white"/>
-<path d="M56,96 L72,96 M64,88 L64,104 " stroke="black"/>
-<path d="M64,160 L64,224 " stroke="black"/>
-<circle cx="64" cy="160" r="8" stroke="none" fill="black"/>
-<circle cx="64" cy="224" r="8" stroke="black" fill="white"/>
-<path d="M56,224 L72,224 M64,216 L64,232 " stroke="black"/>
-<path d="M64,288 L64,352 " stroke="black"/>
-<circle cx="64" cy="288" r="8" stroke="none" fill="black"/>
-<path d="M64,362 L55.3397,347 L72.6603,347 Z" stroke="black" fill="gray"/>
-<path d="M128,288 L128,352 " stroke="black"/>
-<circle cx="128" cy="352" r="8" stroke="none" fill="black"/>
-<path d="M128,298 L119.34,283 L136.66,283 Z" stroke="black" fill="gray"/>
-<path d="M128,32 L128,160 " stroke="black"/>
-<circle cx="128" cy="32" r="8" stroke="none" fill="black"/>
-<circle cx="128" cy="160" r="8" stroke="none" fill="black"/>
-<path d="M192,96 L192,224 " stroke="black"/>
-<circle cx="192" cy="96" r="8" stroke="none" fill="gray"/>
-<path d="M188,92 L196,100 M196,92 L188,100 " stroke="black"/>
-<circle cx="192" cy="224" r="8" stroke="none" fill="gray"/>
-<path d="M188,220 L196,228 M196,220 L188,228 " stroke="black"/>
-<path d="M256,160 L256,288 " stroke="black"/>
-<circle cx="256" cy="160" r="8" stroke="none" fill="gray"/>
-<path d="M252,156 L260,164 M260,156 L252,164 " stroke="black"/>
-<path d="M260,150 L268,150 M264,146 L264,158 " stroke="black"/>
-<circle cx="256" cy="288" r="8" stroke="none" fill="gray"/>
-<path d="M252,284 L260,292 M260,284 L252,292 " stroke="black"/>
-<path d="M260,278 L268,278 M264,274 L264,286 " stroke="black"/>
-<path d="M320,224 L320,352 " stroke="black"/>
-<rect x="304" y="208" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="320" y="224">√XX</text>
-<rect x="304" y="336" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="320" y="352">√XX</text>
-<path d="M384,32 L384,352 " stroke="black"/>
-<rect x="368" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="384" y="32">√XX<tspan baseline-shift="super" font-size="10">†</tspan></text>
-<rect x="368" y="336" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="384" y="352">√XX<tspan baseline-shift="super" font-size="10">†</tspan></text>
-<path d="M448,224 L448,288 " stroke="black"/>
-<rect x="432" y="208" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="448" y="224">√YY</text>
-<rect x="432" y="272" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="448" y="288">√YY</text>
-<path d="M512,224 L512,288 " stroke="black"/>
-<rect x="496" y="272" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="512" y="288">√YY</text>
-<rect x="496" y="208" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="512" y="224">√YY</text>
-<path d="M512,32 L512,96 " stroke="black"/>
-<rect x="496" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="512" y="32">√YY<tspan baseline-shift="super" font-size="10">†</tspan></text>
-<rect x="496" y="80" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="512" y="96">√YY<tspan baseline-shift="super" font-size="10">†</tspan></text>
-<path d="M576,160 L576,224 " stroke="black"/>
-<rect x="560" y="144" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="576" y="160">√ZZ</text>
-<rect x="560" y="208" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="576" y="224">√ZZ</text>
-<path d="M576,288 L576,352 " stroke="black"/>
-<rect x="560" y="272" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="576" y="288">√ZZ<tspan baseline-shift="super" font-size="10">†</tspan></text>
-<rect x="560" y="336" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="576" y="352">√ZZ<tspan baseline-shift="super" font-size="10">†</tspan></text>
-<path d="M576,32 L576,96 " stroke="black"/>
-<path d="M572,28 L580,36 M580,28 L572,36 " stroke="black"/>
-<path d="M572,92 L580,100 M580,92 L572,100 " stroke="black"/>
-<path d="M640,160 L640,224 " stroke="black"/>
-<circle cx="640" cy="160" r="8" stroke="black" fill="white"/>
-<path d="M632,160 L648,160 M640,152 L640,168 " stroke="black"/>
-<circle cx="640" cy="224" r="8" stroke="black" fill="white"/>
-<path d="M632,224 L648,224 M640,216 L640,232 " stroke="black"/>
-<path d="M704,224 L704,288 " stroke="black"/>
-<circle cx="704" cy="224" r="8" stroke="black" fill="white"/>
-<path d="M696,224 L712,224 M704,216 L704,232 " stroke="black"/>
-<path d="M704,298 L695.34,283 L712.66,283 Z" stroke="black" fill="gray"/>
-<path d="M704,32 L704,96 " stroke="black"/>
-<circle cx="704" cy="32" r="8" stroke="black" fill="white"/>
-<path d="M696,32 L712,32 M704,24 L704,40 " stroke="black"/>
-<circle cx="704" cy="96" r="8" stroke="none" fill="black"/>
-<path d="M768,160 L768,224 " stroke="black"/>
-<path d="M768,170 L759.34,155 L776.66,155 Z" stroke="black" fill="gray"/>
-<circle cx="768" cy="224" r="8" stroke="black" fill="white"/>
-<path d="M760,224 L776,224 M768,216 L768,232 " stroke="black"/>
-<path d="M768,288 L768,352 " stroke="black"/>
-<path d="M768,298 L759.34,283 L776.66,283 Z" stroke="black" fill="gray"/>
-<path d="M768,362 L759.34,347 L776.66,347 Z" stroke="black" fill="gray"/>
-<path d="M768,32 L768,96 " stroke="black"/>
-<path d="M768,42 L759.34,27 L776.66,27 Z" stroke="black" fill="gray"/>
-<circle cx="768" cy="96" r="8" stroke="none" fill="black"/>
-<path d="M832,160 L832,224 " stroke="black"/>
-<circle cx="832" cy="160" r="8" stroke="none" fill="black"/>
-<circle cx="832" cy="224" r="8" stroke="black" fill="white"/>
-<path d="M824,224 L840,224 M832,216 L832,232 " stroke="black"/>
-<path d="M832,288 L832,352 " stroke="black"/>
-<circle cx="832" cy="288" r="8" stroke="none" fill="black"/>
-<path d="M832,362 L823.34,347 L840.66,347 Z" stroke="black" fill="gray"/>
-<path d="M896,32 L896,352 " stroke="black"/>
-<circle cx="896" cy="32" r="8" stroke="none" fill="black"/>
-<circle cx="896" cy="352" r="8" stroke="none" fill="black"/>
-<path d="M960,160 L960,224 " stroke="black"/>
-<circle cx="960" cy="160" r="8" stroke="none" fill="black"/>
-<circle cx="960" cy="224" r="8" stroke="none" fill="black"/>
-<path d="M1024,96 L1024,288 " stroke="black"/>
-<circle cx="1024" cy="96" r="8" stroke="none" fill="black"/>
-<circle cx="1024" cy="288" r="8" stroke="none" fill="black"/>
+<svg viewBox="0 0 1152 480"  version="1.1" xmlns="http://www.w3.org/2000/svg">
+<path d="M64,64 L1120,64 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="64">q0</text>
+<path d="M64,128 L1120,128 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="128">q1</text>
+<path d="M64,192 L1120,192 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="192">q2</text>
+<path d="M64,256 L1120,256 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="256">q3</text>
+<path d="M64,320 L1120,320 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="320">q4</text>
+<path d="M64,384 L1120,384 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="384">q5</text>
+<path d="M96,64 L96,128 " stroke="black"/>
+<circle cx="96" cy="64" r="8" stroke="none" fill="black"/>
+<circle cx="96" cy="128" r="8" stroke="black" fill="white"/>
+<path d="M88,128 L104,128 M96,120 L96,136 " stroke="black"/>
+<path d="M96,192 L96,256 " stroke="black"/>
+<circle cx="96" cy="192" r="8" stroke="none" fill="black"/>
+<circle cx="96" cy="256" r="8" stroke="black" fill="white"/>
+<path d="M88,256 L104,256 M96,248 L96,264 " stroke="black"/>
+<path d="M96,320 L96,384 " stroke="black"/>
+<circle cx="96" cy="320" r="8" stroke="none" fill="black"/>
+<path d="M96,394 L87.3397,379 L104.66,379 Z" stroke="black" fill="gray"/>
+<path d="M160,320 L160,384 " stroke="black"/>
+<circle cx="160" cy="384" r="8" stroke="none" fill="black"/>
+<path d="M160,330 L151.34,315 L168.66,315 Z" stroke="black" fill="gray"/>
+<path d="M160,64 L160,192 " stroke="black"/>
+<circle cx="160" cy="64" r="8" stroke="none" fill="black"/>
+<circle cx="160" cy="192" r="8" stroke="none" fill="black"/>
+<path d="M224,128 L224,256 " stroke="black"/>
+<circle cx="224" cy="128" r="8" stroke="none" fill="gray"/>
+<path d="M220,124 L228,132 M228,124 L220,132 " stroke="black"/>
+<circle cx="224" cy="256" r="8" stroke="none" fill="gray"/>
+<path d="M220,252 L228,260 M228,252 L220,260 " stroke="black"/>
+<path d="M288,192 L288,320 " stroke="black"/>
+<circle cx="288" cy="192" r="8" stroke="none" fill="gray"/>
+<path d="M284,188 L292,196 M292,188 L284,196 " stroke="black"/>
+<path d="M292,182 L300,182 M296,178 L296,190 " stroke="black"/>
+<circle cx="288" cy="320" r="8" stroke="none" fill="gray"/>
+<path d="M284,316 L292,324 M292,316 L284,324 " stroke="black"/>
+<path d="M292,310 L300,310 M296,306 L296,318 " stroke="black"/>
+<path d="M352,256 L352,384 " stroke="black"/>
+<rect x="336" y="240" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="256">√XX</text>
+<rect x="336" y="368" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="384">√XX</text>
+<path d="M416,64 L416,384 " stroke="black"/>
+<rect x="400" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="416" y="64">√XX<tspan baseline-shift="super" font-size="10">†</tspan></text>
+<rect x="400" y="368" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="416" y="384">√XX<tspan baseline-shift="super" font-size="10">†</tspan></text>
+<path d="M480,256 L480,320 " stroke="black"/>
+<rect x="464" y="240" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="480" y="256">√YY</text>
+<rect x="464" y="304" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="480" y="320">√YY</text>
+<path d="M544,256 L544,320 " stroke="black"/>
+<rect x="528" y="304" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="544" y="320">√YY</text>
+<rect x="528" y="240" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="544" y="256">√YY</text>
+<path d="M544,64 L544,128 " stroke="black"/>
+<rect x="528" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="544" y="64">√YY<tspan baseline-shift="super" font-size="10">†</tspan></text>
+<rect x="528" y="112" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="544" y="128">√YY<tspan baseline-shift="super" font-size="10">†</tspan></text>
+<path d="M608,192 L608,256 " stroke="black"/>
+<rect x="592" y="176" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="608" y="192">√ZZ</text>
+<rect x="592" y="240" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="608" y="256">√ZZ</text>
+<path d="M608,320 L608,384 " stroke="black"/>
+<rect x="592" y="304" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="608" y="320">√ZZ<tspan baseline-shift="super" font-size="10">†</tspan></text>
+<rect x="592" y="368" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="608" y="384">√ZZ<tspan baseline-shift="super" font-size="10">†</tspan></text>
+<path d="M608,64 L608,128 " stroke="black"/>
+<path d="M604,60 L612,68 M612,60 L604,68 " stroke="black"/>
+<path d="M604,124 L612,132 M612,124 L604,132 " stroke="black"/>
+<path d="M672,192 L672,256 " stroke="black"/>
+<circle cx="672" cy="192" r="8" stroke="black" fill="white"/>
+<path d="M664,192 L680,192 M672,184 L672,200 " stroke="black"/>
+<circle cx="672" cy="256" r="8" stroke="black" fill="white"/>
+<path d="M664,256 L680,256 M672,248 L672,264 " stroke="black"/>
+<path d="M736,256 L736,320 " stroke="black"/>
+<circle cx="736" cy="256" r="8" stroke="black" fill="white"/>
+<path d="M728,256 L744,256 M736,248 L736,264 " stroke="black"/>
+<path d="M736,330 L727.34,315 L744.66,315 Z" stroke="black" fill="gray"/>
+<path d="M736,64 L736,128 " stroke="black"/>
+<circle cx="736" cy="64" r="8" stroke="black" fill="white"/>
+<path d="M728,64 L744,64 M736,56 L736,72 " stroke="black"/>
+<circle cx="736" cy="128" r="8" stroke="none" fill="black"/>
+<path d="M800,192 L800,256 " stroke="black"/>
+<path d="M800,202 L791.34,187 L808.66,187 Z" stroke="black" fill="gray"/>
+<circle cx="800" cy="256" r="8" stroke="black" fill="white"/>
+<path d="M792,256 L808,256 M800,248 L800,264 " stroke="black"/>
+<path d="M800,320 L800,384 " stroke="black"/>
+<path d="M800,330 L791.34,315 L808.66,315 Z" stroke="black" fill="gray"/>
+<path d="M800,394 L791.34,379 L808.66,379 Z" stroke="black" fill="gray"/>
+<path d="M800,64 L800,128 " stroke="black"/>
+<path d="M800,74 L791.34,59 L808.66,59 Z" stroke="black" fill="gray"/>
+<circle cx="800" cy="128" r="8" stroke="none" fill="black"/>
+<path d="M864,192 L864,256 " stroke="black"/>
+<circle cx="864" cy="192" r="8" stroke="none" fill="black"/>
+<circle cx="864" cy="256" r="8" stroke="black" fill="white"/>
+<path d="M856,256 L872,256 M864,248 L864,264 " stroke="black"/>
+<path d="M864,320 L864,384 " stroke="black"/>
+<circle cx="864" cy="320" r="8" stroke="none" fill="black"/>
+<path d="M864,394 L855.34,379 L872.66,379 Z" stroke="black" fill="gray"/>
+<path d="M928,64 L928,384 " stroke="black"/>
+<circle cx="928" cy="64" r="8" stroke="none" fill="black"/>
+<circle cx="928" cy="384" r="8" stroke="none" fill="black"/>
+<path d="M992,192 L992,256 " stroke="black"/>
+<circle cx="992" cy="192" r="8" stroke="none" fill="black"/>
+<circle cx="992" cy="256" r="8" stroke="none" fill="black"/>
+<path d="M1056,128 L1056,320 " stroke="black"/>
+<circle cx="1056" cy="128" r="8" stroke="none" fill="black"/>
+<circle cx="1056" cy="320" r="8" stroke="none" fill="black"/>
 </svg>
 )DIAGRAM");
 }
@@ -270,66 +272,66 @@ TEST(circuit_diagram_timeline_svg, noise_gates) {
         Z_ERROR(0.125) 2 3 5
     )CIRCUIT");
     ASSERT_EQ(
-        "\n" + svg_diagram(circuit),
+        svg_diagram(circuit),
         u8R"DIAGRAM(
-<svg width="320" height="416" version="1.1" xmlns="http://www.w3.org/2000/svg">
-<path d="M32,32 L320,32 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="32">q0</text>
-<path d="M32,96 L320,96 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="96">q1</text>
-<path d="M32,160 L320,160 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="160">q2</text>
-<path d="M32,224 L320,224 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="224">q3</text>
-<path d="M32,288 L320,288 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="288">q4</text>
-<path d="M32,352 L320,352 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="352">q5</text>
-<rect x="48" y="16" width="32" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="64" y="32">DEP<tspan baseline-shift="sub" font-size="10">1</tspan></text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="64" y="52">0.125</text>
-<rect x="48" y="80" width="32" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="64" y="96">DEP<tspan baseline-shift="sub" font-size="10">1</tspan></text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="64" y="116">0.125</text>
-<path d="M128,32 L128,160 " stroke="black"/>
-<rect x="112" y="16" width="32" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="128" y="32">DEP<tspan baseline-shift="sub" font-size="10">2</tspan></text>
-<rect x="112" y="144" width="32" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="128" y="160">DEP<tspan baseline-shift="sub" font-size="10">2</tspan></text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="128" y="180">0.125</text>
-<path d="M128,288 L128,352 " stroke="black"/>
-<rect x="112" y="272" width="32" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="128" y="288">DEP<tspan baseline-shift="sub" font-size="10">2</tspan></text>
-<rect x="112" y="336" width="32" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="128" y="352">DEP<tspan baseline-shift="sub" font-size="10">2</tspan></text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="128" y="372">0.125</text>
-<rect x="176" y="16" width="32" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="192" y="32">ERR<tspan baseline-shift="sub" font-size="10">X</tspan></text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="192" y="52">0.125</text>
-<rect x="176" y="80" width="32" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="192" y="96">ERR<tspan baseline-shift="sub" font-size="10">X</tspan></text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="192" y="116">0.125</text>
-<rect x="176" y="144" width="32" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="192" y="160">ERR<tspan baseline-shift="sub" font-size="10">X</tspan></text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="192" y="180">0.125</text>
-<rect x="240" y="16" width="32" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="256" y="32">ERR<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="256" y="52">0.125</text>
-<rect x="240" y="80" width="32" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="256" y="96">ERR<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="256" y="116">0.125</text>
-<rect x="240" y="272" width="32" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="256" y="288">ERR<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="256" y="308">0.125</text>
-<rect x="240" y="144" width="32" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="256" y="160">ERR<tspan baseline-shift="sub" font-size="10">Z</tspan></text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="256" y="180">0.125</text>
-<rect x="240" y="208" width="32" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="256" y="224">ERR<tspan baseline-shift="sub" font-size="10">Z</tspan></text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="256" y="244">0.125</text>
-<rect x="240" y="336" width="32" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="256" y="352">ERR<tspan baseline-shift="sub" font-size="10">Z</tspan></text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="256" y="372">0.125</text>
+<svg viewBox="0 0 384 480"  version="1.1" xmlns="http://www.w3.org/2000/svg">
+<path d="M64,64 L352,64 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="64">q0</text>
+<path d="M64,128 L352,128 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="128">q1</text>
+<path d="M64,192 L352,192 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="192">q2</text>
+<path d="M64,256 L352,256 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="256">q3</text>
+<path d="M64,320 L352,320 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="320">q4</text>
+<path d="M64,384 L352,384 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="384">q5</text>
+<rect x="80" y="48" width="32" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="96" y="64">DEP<tspan baseline-shift="sub" font-size="10">1</tspan></text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="96" y="84">0.125</text>
+<rect x="80" y="112" width="32" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="96" y="128">DEP<tspan baseline-shift="sub" font-size="10">1</tspan></text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="96" y="148">0.125</text>
+<path d="M160,64 L160,192 " stroke="black"/>
+<rect x="144" y="48" width="32" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="160" y="64">DEP<tspan baseline-shift="sub" font-size="10">2</tspan></text>
+<rect x="144" y="176" width="32" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="160" y="192">DEP<tspan baseline-shift="sub" font-size="10">2</tspan></text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="160" y="212">0.125</text>
+<path d="M160,320 L160,384 " stroke="black"/>
+<rect x="144" y="304" width="32" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="160" y="320">DEP<tspan baseline-shift="sub" font-size="10">2</tspan></text>
+<rect x="144" y="368" width="32" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="160" y="384">DEP<tspan baseline-shift="sub" font-size="10">2</tspan></text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="160" y="404">0.125</text>
+<rect x="208" y="48" width="32" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="224" y="64">ERR<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="224" y="84">0.125</text>
+<rect x="208" y="112" width="32" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="224" y="128">ERR<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="224" y="148">0.125</text>
+<rect x="208" y="176" width="32" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="224" y="192">ERR<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="224" y="212">0.125</text>
+<rect x="272" y="48" width="32" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="288" y="64">ERR<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="288" y="84">0.125</text>
+<rect x="272" y="112" width="32" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="288" y="128">ERR<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="288" y="148">0.125</text>
+<rect x="272" y="304" width="32" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="288" y="320">ERR<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="288" y="340">0.125</text>
+<rect x="272" y="176" width="32" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="288" y="192">ERR<tspan baseline-shift="sub" font-size="10">Z</tspan></text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="288" y="212">0.125</text>
+<rect x="272" y="240" width="32" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="288" y="256">ERR<tspan baseline-shift="sub" font-size="10">Z</tspan></text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="288" y="276">0.125</text>
+<rect x="272" y="368" width="32" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="288" y="384">ERR<tspan baseline-shift="sub" font-size="10">Z</tspan></text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="288" y="404">0.125</text>
 </svg>
 )DIAGRAM");
 
@@ -340,46 +342,46 @@ TEST(circuit_diagram_timeline_svg, noise_gates) {
         ELSE_CORRELATED_ERROR(0.25) X5
     )CIRCUIT");
     ASSERT_EQ(
-        "\n" + svg_diagram(circuit),
+        svg_diagram(circuit),
         u8R"DIAGRAM(
-<svg width="320" height="416" version="1.1" xmlns="http://www.w3.org/2000/svg">
-<path d="M32,32 L320,32 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="32">q0</text>
-<path d="M32,96 L320,96 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="96">q1</text>
-<path d="M32,160 L320,160 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="160">q2</text>
-<path d="M32,224 L320,224 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="224">q3</text>
-<path d="M32,288 L320,288 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="288">q4</text>
-<path d="M32,352 L320,352 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="352">q5</text>
-<path d="M64,96 L64,160 " stroke="black"/>
-<rect x="48" y="80" width="32" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="96">E<tspan baseline-shift="sub" font-size="10">X</tspan></text>
-<rect x="48" y="144" width="32" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="160">E<tspan baseline-shift="sub" font-size="10">X</tspan></text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="64" y="180">0.25</text>
-<path d="M128,96 L128,224 " stroke="black"/>
-<rect x="112" y="80" width="32" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="128" y="96">E<tspan baseline-shift="sub" font-size="10">X</tspan></text>
-<rect x="112" y="144" width="32" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="128" y="160">E<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
-<rect x="112" y="208" width="32" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="128" y="224">E<tspan baseline-shift="sub" font-size="10">Z</tspan></text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="128" y="244">0.125</text>
-<path d="M192,160 L192,288 " stroke="black"/>
-<rect x="176" y="144" width="32" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="192" y="160">EE<tspan baseline-shift="sub" font-size="10">X</tspan></text>
-<rect x="176" y="272" width="32" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="192" y="288">EE<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="192" y="308">0.25</text>
-<rect x="176" y="208" width="32" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="192" y="224">EE<tspan baseline-shift="sub" font-size="10">Z</tspan></text>
-<rect x="240" y="336" width="32" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="256" y="352">EE<tspan baseline-shift="sub" font-size="10">X</tspan></text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="256" y="372">0.25</text>
+<svg viewBox="0 0 384 480"  version="1.1" xmlns="http://www.w3.org/2000/svg">
+<path d="M64,64 L352,64 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="64">q0</text>
+<path d="M64,128 L352,128 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="128">q1</text>
+<path d="M64,192 L352,192 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="192">q2</text>
+<path d="M64,256 L352,256 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="256">q3</text>
+<path d="M64,320 L352,320 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="320">q4</text>
+<path d="M64,384 L352,384 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="384">q5</text>
+<path d="M96,128 L96,192 " stroke="black"/>
+<rect x="80" y="112" width="32" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="128">E<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<rect x="80" y="176" width="32" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="192">E<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="96" y="212">0.25</text>
+<path d="M160,128 L160,256 " stroke="black"/>
+<rect x="144" y="112" width="32" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="160" y="128">E<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<rect x="144" y="176" width="32" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="160" y="192">E<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
+<rect x="144" y="240" width="32" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="160" y="256">E<tspan baseline-shift="sub" font-size="10">Z</tspan></text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="160" y="276">0.125</text>
+<path d="M224,192 L224,320 " stroke="black"/>
+<rect x="208" y="176" width="32" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="192">EE<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<rect x="208" y="304" width="32" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="320">EE<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="224" y="340">0.25</text>
+<rect x="208" y="240" width="32" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="256">EE<tspan baseline-shift="sub" font-size="10">Z</tspan></text>
+<rect x="272" y="368" width="32" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="384">EE<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="288" y="404">0.25</text>
 </svg>
 )DIAGRAM");
 
@@ -388,43 +390,43 @@ TEST(circuit_diagram_timeline_svg, noise_gates) {
         PAULI_CHANNEL_2(0.01,0.01,0.01,0.02,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01) 0 1 2 4
     )CIRCUIT");
     ASSERT_EQ(
-        "\n" + svg_diagram(circuit),
+        svg_diagram(circuit),
         u8R"DIAGRAM(
-<svg width="1344" height="352" version="1.1" xmlns="http://www.w3.org/2000/svg">
-<path d="M32,32 L1344,32 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="32">q0</text>
-<path d="M32,96 L1344,96 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="96">q1</text>
-<path d="M32,160 L1344,160 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="160">q2</text>
-<path d="M32,224 L1344,224 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="224">q3</text>
-<path d="M32,288 L1344,288 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="288">q4</text>
-<rect x="48" y="16" width="224" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="160" y="32">PAULI_CHANNEL_1</text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="160" y="52">0.125,0.25,0.125</text>
-<rect x="48" y="80" width="224" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="160" y="96">PAULI_CHANNEL_1</text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="160" y="116">0.125,0.25,0.125</text>
-<rect x="48" y="144" width="224" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="160" y="160">PAULI_CHANNEL_1</text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="160" y="180">0.125,0.25,0.125</text>
-<rect x="48" y="208" width="224" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="160" y="224">PAULI_CHANNEL_1</text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="160" y="244">0.125,0.25,0.125</text>
-<path d="M320,32 L320,96 " stroke="black"/>
-<rect x="304" y="16" width="992" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="800" y="32">PAULI_CHANNEL_2<tspan baseline-shift="sub" font-size="10">0</tspan></text>
-<rect x="304" y="80" width="992" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="800" y="96">PAULI_CHANNEL_2<tspan baseline-shift="sub" font-size="10">1</tspan></text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="800" y="116">0.01,0.01,0.01,0.02,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01</text>
-<path d="M320,160 L320,288 " stroke="black"/>
-<rect x="304" y="144" width="992" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="800" y="160">PAULI_CHANNEL_2<tspan baseline-shift="sub" font-size="10">0</tspan></text>
-<rect x="304" y="272" width="992" height="32" stroke="black" fill="pink"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="800" y="288">PAULI_CHANNEL_2<tspan baseline-shift="sub" font-size="10">1</tspan></text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="800" y="308">0.01,0.01,0.01,0.02,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01</text>
+<svg viewBox="0 0 1408 416"  version="1.1" xmlns="http://www.w3.org/2000/svg">
+<path d="M64,64 L1376,64 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="64">q0</text>
+<path d="M64,128 L1376,128 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="128">q1</text>
+<path d="M64,192 L1376,192 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="192">q2</text>
+<path d="M64,256 L1376,256 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="256">q3</text>
+<path d="M64,320 L1376,320 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="320">q4</text>
+<rect x="80" y="48" width="224" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="192" y="64">PAULI_CHANNEL_1</text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="192" y="84">0.125,0.25,0.125</text>
+<rect x="80" y="112" width="224" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="192" y="128">PAULI_CHANNEL_1</text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="192" y="148">0.125,0.25,0.125</text>
+<rect x="80" y="176" width="224" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="192" y="192">PAULI_CHANNEL_1</text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="192" y="212">0.125,0.25,0.125</text>
+<rect x="80" y="240" width="224" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="192" y="256">PAULI_CHANNEL_1</text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="192" y="276">0.125,0.25,0.125</text>
+<path d="M352,64 L352,128 " stroke="black"/>
+<rect x="336" y="48" width="992" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="832" y="64">PAULI_CHANNEL_2<tspan baseline-shift="sub" font-size="10">0</tspan></text>
+<rect x="336" y="112" width="992" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="832" y="128">PAULI_CHANNEL_2<tspan baseline-shift="sub" font-size="10">1</tspan></text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="832" y="148">0.01,0.01,0.01,0.02,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01</text>
+<path d="M352,192 L352,320 " stroke="black"/>
+<rect x="336" y="176" width="992" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="832" y="192">PAULI_CHANNEL_2<tspan baseline-shift="sub" font-size="10">0</tspan></text>
+<rect x="336" y="304" width="992" height="32" stroke="black" fill="pink"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="832" y="320">PAULI_CHANNEL_2<tspan baseline-shift="sub" font-size="10">1</tspan></text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="832" y="340">0.01,0.01,0.01,0.02,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01</text>
 </svg>
 )DIAGRAM");
 }
@@ -446,84 +448,84 @@ TEST(circuit_diagram_timeline_svg, collapsing) {
         MPP X0*Y2 Z3 X1 Z2*Y3
     )CIRCUIT");
     ASSERT_EQ(
-        "\n" + svg_diagram(circuit),
+        svg_diagram(circuit),
         u8R"DIAGRAM(
-<svg width="576" height="288" version="1.1" xmlns="http://www.w3.org/2000/svg">
-<path d="M32,32 L576,32 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="32">q0</text>
-<path d="M32,96 L576,96 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="96">q1</text>
-<path d="M32,160 L576,160 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="160">q2</text>
-<path d="M32,224 L576,224 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="224">q3</text>
-<rect x="48" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="32">R</text>
-<rect x="48" y="80" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="96">R<tspan baseline-shift="sub" font-size="10">X</tspan></text>
-<rect x="48" y="144" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="160">R<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
-<rect x="48" y="208" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="224">R</text>
-<rect x="112" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="128" y="32">M</text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="128" y="52">0.001</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="128" y="12">rec[0]</text>
-<rect x="112" y="80" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="128" y="96">M</text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="128" y="116">0.001</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="128" y="76">rec[1]</text>
-<rect x="176" y="80" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="192" y="96">MR</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="192" y="76">rec[2]</text>
-<rect x="176" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="192" y="32">MR</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="192" y="12">rec[3]</text>
-<rect x="240" y="80" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="256" y="96">MR<tspan baseline-shift="sub" font-size="10">X</tspan></text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="256" y="76">rec[4]</text>
-<rect x="240" y="144" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="256" y="160">MR<tspan baseline-shift="sub" font-size="10">X</tspan></text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="256" y="140">rec[5]</text>
-<rect x="240" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="256" y="32">MR<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="256" y="12">rec[6]</text>
-<rect x="240" y="208" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="256" y="224">MR<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="256" y="204">rec[7]</text>
-<rect x="304" y="80" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="320" y="96">MR<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="320" y="76">rec[8]</text>
-<rect x="304" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="320" y="32">MR</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="320" y="12">rec[9]</text>
-<rect x="368" y="80" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="384" y="96">M<tspan baseline-shift="sub" font-size="10">X</tspan></text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="384" y="76">rec[10]</text>
-<rect x="368" y="144" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="384" y="160">M<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="384" y="140">rec[11]</text>
-<rect x="368" y="208" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="384" y="224">M</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="384" y="204">rec[12]</text>
-<path d="M448,32 L448,160 " stroke="black"/>
-<rect x="432" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="448" y="32">MPP<tspan baseline-shift="sub" font-size="10">X</tspan></text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="448" y="12">rec[13]</text>
-<rect x="432" y="144" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="448" y="160">MPP<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
-<rect x="432" y="208" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="448" y="224">MPP<tspan baseline-shift="sub" font-size="10">Z</tspan></text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="448" y="204">rec[14]</text>
-<rect x="496" y="80" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="512" y="96">MPP<tspan baseline-shift="sub" font-size="10">X</tspan></text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="512" y="76">rec[15]</text>
-<path d="M512,160 L512,224 " stroke="black"/>
-<rect x="496" y="144" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="512" y="160">MPP<tspan baseline-shift="sub" font-size="10">Z</tspan></text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="512" y="140">rec[16]</text>
-<rect x="496" y="208" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="512" y="224">MPP<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
+<svg viewBox="0 0 640 352"  version="1.1" xmlns="http://www.w3.org/2000/svg">
+<path d="M64,64 L608,64 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="64">q0</text>
+<path d="M64,128 L608,128 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="128">q1</text>
+<path d="M64,192 L608,192 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="192">q2</text>
+<path d="M64,256 L608,256 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="256">q3</text>
+<rect x="80" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="64">R</text>
+<rect x="80" y="112" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="128">R<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<rect x="80" y="176" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="192">R<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
+<rect x="80" y="240" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="256">R</text>
+<rect x="144" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="160" y="64">M</text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="160" y="84">0.001</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="160" y="44">rec[0]</text>
+<rect x="144" y="112" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="160" y="128">M</text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="160" y="148">0.001</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="160" y="108">rec[1]</text>
+<rect x="208" y="112" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="128">MR</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="224" y="108">rec[2]</text>
+<rect x="208" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="64">MR</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="224" y="44">rec[3]</text>
+<rect x="272" y="112" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="128">MR<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="288" y="108">rec[4]</text>
+<rect x="272" y="176" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="192">MR<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="288" y="172">rec[5]</text>
+<rect x="272" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="64">MR<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="288" y="44">rec[6]</text>
+<rect x="272" y="240" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="256">MR<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="288" y="236">rec[7]</text>
+<rect x="336" y="112" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="128">MR<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="352" y="108">rec[8]</text>
+<rect x="336" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="64">MR</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="352" y="44">rec[9]</text>
+<rect x="400" y="112" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="128">M<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="416" y="108">rec[10]</text>
+<rect x="400" y="176" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="192">M<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="416" y="172">rec[11]</text>
+<rect x="400" y="240" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="256">M</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="416" y="236">rec[12]</text>
+<path d="M480,64 L480,192 " stroke="black"/>
+<rect x="464" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="480" y="64">MPP<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="480" y="44">rec[13]</text>
+<rect x="464" y="176" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="480" y="192">MPP<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
+<rect x="464" y="240" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="480" y="256">MPP<tspan baseline-shift="sub" font-size="10">Z</tspan></text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="480" y="236">rec[14]</text>
+<rect x="528" y="112" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="544" y="128">MPP<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="544" y="108">rec[15]</text>
+<path d="M544,192 L544,256 " stroke="black"/>
+<rect x="528" y="176" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="544" y="192">MPP<tspan baseline-shift="sub" font-size="10">Z</tspan></text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="544" y="172">rec[16]</text>
+<rect x="528" y="240" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="544" y="256">MPP<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
 </svg>
 )DIAGRAM");
 }
@@ -542,43 +544,43 @@ TEST(circuit_diagram_timeline_svg, measurement_looping) {
         }
     )CIRCUIT");
     ASSERT_EQ(
-        "\n" + svg_diagram(circuit),
+        svg_diagram(circuit),
         u8R"DIAGRAM(
-<svg width="704" height="352" version="1.1" xmlns="http://www.w3.org/2000/svg">
-<path d="M32,32 L704,32 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="32">q0</text>
-<path d="M32,96 L704,96 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="96">q1</text>
-<path d="M32,160 L704,160 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="160">q2</text>
-<path d="M32,224 L704,224 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="224">q3</text>
-<path d="M32,288 L704,288 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="288">q4</text>
-<rect x="48" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="32">M</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="64" y="12">rec[0]</text>
-<path d="M136,0 L128,0 L128,352 L136,352 " stroke="black" fill="none"/>
-<text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="132" y="348">REP100</text>
-<rect x="176" y="80" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="192" y="96">M</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="192" y="76">rec[1+iter*13]</text>
-<path d="M264,4 L256,4 L256,348 L264,348 " stroke="black" fill="none"/>
-<text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="260" y="344">REP5</text>
-<rect x="304" y="144" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="320" y="160">M</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="320" y="140">rec[2+iter*13+iter2]</text>
-<path d="M376,4 L384,4 L384,348 L376,348 " stroke="black" fill="none"/>
-<path d="M456,4 L448,4 L448,348 L456,348 " stroke="black" fill="none"/>
-<text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="452" y="344">REP7</text>
-<path d="M512,224 L512,288 " stroke="black"/>
-<rect x="496" y="208" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="512" y="224">MPP<tspan baseline-shift="sub" font-size="10">X</tspan></text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="512" y="204">rec[7+iter*13+iter2]</text>
-<rect x="496" y="272" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="512" y="288">MPP<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
-<path d="M568,4 L576,4 L576,348 L568,348 " stroke="black" fill="none"/>
-<path d="M632,0 L640,0 L640,352 L632,352 " stroke="black" fill="none"/>
+<svg viewBox="0 0 768 416"  version="1.1" xmlns="http://www.w3.org/2000/svg">
+<path d="M64,64 L736,64 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="64">q0</text>
+<path d="M64,128 L736,128 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="128">q1</text>
+<path d="M64,192 L736,192 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="192">q2</text>
+<path d="M64,256 L736,256 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="256">q3</text>
+<path d="M64,320 L736,320 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="320">q4</text>
+<rect x="80" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="64">M</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="96" y="44">rec[0]</text>
+<path d="M168,32 L160,32 L160,384 L168,384 " stroke="black" fill="none"/>
+<text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="164" y="380">REP100</text>
+<rect x="208" y="112" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="128">M</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="224" y="108">rec[1+iter*13]</text>
+<path d="M296,36 L288,36 L288,380 L296,380 " stroke="black" fill="none"/>
+<text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="292" y="376">REP5</text>
+<rect x="336" y="176" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="192">M</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="352" y="172">rec[2+iter*13+iter2]</text>
+<path d="M408,36 L416,36 L416,380 L408,380 " stroke="black" fill="none"/>
+<path d="M488,36 L480,36 L480,380 L488,380 " stroke="black" fill="none"/>
+<text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="484" y="376">REP7</text>
+<path d="M544,256 L544,320 " stroke="black"/>
+<rect x="528" y="240" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="544" y="256">MPP<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="544" y="236">rec[7+iter*13+iter2]</text>
+<rect x="528" y="304" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="544" y="320">MPP<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
+<path d="M600,36 L608,36 L608,380 L600,380 " stroke="black" fill="none"/>
+<path d="M664,32 L672,32 L672,384 L664,384 " stroke="black" fill="none"/>
 </svg>
 )DIAGRAM");
 }
@@ -594,39 +596,39 @@ TEST(circuit_diagram_timeline_svg, repeat) {
         }
     )CIRCUIT");
     ASSERT_EQ(
-        "\n" + svg_diagram(circuit),
+        svg_diagram(circuit),
         u8R"DIAGRAM(
-<svg width="576" height="288" version="1.1" xmlns="http://www.w3.org/2000/svg">
-<path d="M32,32 L576,32 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="32">q0</text>
-<path d="M32,96 L576,96 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="96">q1</text>
-<path d="M32,160 L576,160 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="160">q2</text>
-<path d="M32,224 L576,224 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="224">q3</text>
-<rect x="48" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="32">H</text>
-<rect x="48" y="80" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="96">H</text>
-<rect x="48" y="144" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="160">H</text>
-<path d="M136,0 L128,0 L128,288 L136,288 " stroke="black" fill="none"/>
-<text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="132" y="284">REP5</text>
-<rect x="176" y="144" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="192" y="160">R<tspan baseline-shift="sub" font-size="10">X</tspan></text>
-<path d="M264,4 L256,4 L256,284 L264,284 " stroke="black" fill="none"/>
-<text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="260" y="280">REP100</text>
-<rect x="304" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="320" y="32">H</text>
-<rect x="304" y="80" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="320" y="96">H</text>
-<rect x="304" y="208" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="320" y="224">H</text>
-<rect x="368" y="208" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="384" y="224">H</text>
-<path d="M440,4 L448,4 L448,284 L440,284 " stroke="black" fill="none"/>
-<path d="M504,0 L512,0 L512,288 L504,288 " stroke="black" fill="none"/>
+<svg viewBox="0 0 640 352"  version="1.1" xmlns="http://www.w3.org/2000/svg">
+<path d="M64,64 L608,64 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="64">q0</text>
+<path d="M64,128 L608,128 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="128">q1</text>
+<path d="M64,192 L608,192 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="192">q2</text>
+<path d="M64,256 L608,256 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="256">q3</text>
+<rect x="80" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="64">H</text>
+<rect x="80" y="112" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="128">H</text>
+<rect x="80" y="176" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="192">H</text>
+<path d="M168,32 L160,32 L160,320 L168,320 " stroke="black" fill="none"/>
+<text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="164" y="316">REP5</text>
+<rect x="208" y="176" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="192">R<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<path d="M296,36 L288,36 L288,316 L296,316 " stroke="black" fill="none"/>
+<text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="292" y="312">REP100</text>
+<rect x="336" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="64">H</text>
+<rect x="336" y="112" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="128">H</text>
+<rect x="336" y="240" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="256">H</text>
+<rect x="400" y="240" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="256">H</text>
+<path d="M472,36 L480,36 L480,316 L472,316 " stroke="black" fill="none"/>
+<path d="M536,32 L544,32 L544,320 L536,320 " stroke="black" fill="none"/>
 </svg>
 )DIAGRAM");
 }
@@ -638,22 +640,22 @@ TEST(circuit_diagram_timeline_svg, classical_feedback) {
         YCZ 2 sweep[5]
     )CIRCUIT");
     ASSERT_EQ(
-        "\n" + svg_diagram(circuit),
+        svg_diagram(circuit),
         u8R"DIAGRAM(
-<svg width="192" height="224" version="1.1" xmlns="http://www.w3.org/2000/svg">
-<path d="M32,32 L192,32 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="32">q0</text>
-<path d="M32,96 L192,96 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="96">q1</text>
-<path d="M32,160 L192,160 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="160">q2</text>
-<rect x="48" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="32">M</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="64" y="12">rec[0]</text>
-<rect x="48" y="80" width="96" height="32" stroke="black" fill="lightgray"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="96">X<tspan baseline-shift="super" font-size="10">rec[0]</tspan></text>
-<rect x="48" y="144" width="96" height="32" stroke="black" fill="lightgray"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="160">Y<tspan baseline-shift="super" font-size="10">sweep[5]</tspan></text>
+<svg viewBox="0 0 256 288"  version="1.1" xmlns="http://www.w3.org/2000/svg">
+<path d="M64,64 L224,64 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="64">q0</text>
+<path d="M64,128 L224,128 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="128">q1</text>
+<path d="M64,192 L224,192 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="192">q2</text>
+<rect x="80" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="64">M</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="96" y="44">rec[0]</text>
+<rect x="80" y="112" width="96" height="32" stroke="black" fill="lightgray"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="128" y="128">X<tspan baseline-shift="super" font-size="10">rec[0]</tspan></text>
+<rect x="80" y="176" width="96" height="32" stroke="black" fill="lightgray"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="128" y="192">Y<tspan baseline-shift="super" font-size="10">sweep[5]</tspan></text>
 </svg>
 )DIAGRAM");
 }
@@ -669,38 +671,38 @@ TEST(circuit_diagram_timeline_svg, lattice_surgery_cnot) {
         CZ rec[-1] 0
     )CIRCUIT");
     ASSERT_EQ(
-        "\n" + svg_diagram(circuit),
+        svg_diagram(circuit),
         u8R"DIAGRAM(
-<svg width="512" height="224" version="1.1" xmlns="http://www.w3.org/2000/svg">
-<path d="M32,32 L512,32 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="32">q0</text>
-<path d="M32,96 L512,96 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="96">q1</text>
-<path d="M32,160 L512,160 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="160">q2</text>
-<rect x="48" y="144" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="160">R</text>
-<path d="M128,96 L128,160 " stroke="black"/>
-<rect x="112" y="80" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="128" y="96">MPP<tspan baseline-shift="sub" font-size="10">X</tspan></text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="128" y="76">rec[0]</text>
-<rect x="112" y="144" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="128" y="160">MPP<tspan baseline-shift="sub" font-size="10">X</tspan></text>
-<path d="M192,32 L192,160 " stroke="black"/>
-<rect x="176" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="192" y="32">MPP<tspan baseline-shift="sub" font-size="10">Z</tspan></text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="192" y="12">rec[1]</text>
-<rect x="176" y="144" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="192" y="160">MPP<tspan baseline-shift="sub" font-size="10">Z</tspan></text>
-<rect x="240" y="144" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="256" y="160">M<tspan baseline-shift="sub" font-size="10">X</tspan></text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="256" y="140">rec[2]</text>
-<rect x="240" y="16" width="96" height="32" stroke="black" fill="lightgray"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="32">Z<tspan baseline-shift="super" font-size="10">rec[0]</tspan></text>
-<rect x="240" y="80" width="96" height="32" stroke="black" fill="lightgray"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="96">X<tspan baseline-shift="super" font-size="10">rec[1]</tspan></text>
-<rect x="368" y="16" width="96" height="32" stroke="black" fill="lightgray"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="32">Z<tspan baseline-shift="super" font-size="10">rec[2]</tspan></text>
+<svg viewBox="0 0 576 288"  version="1.1" xmlns="http://www.w3.org/2000/svg">
+<path d="M64,64 L544,64 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="64">q0</text>
+<path d="M64,128 L544,128 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="128">q1</text>
+<path d="M64,192 L544,192 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="192">q2</text>
+<rect x="80" y="176" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="192">R</text>
+<path d="M160,128 L160,192 " stroke="black"/>
+<rect x="144" y="112" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="160" y="128">MPP<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="160" y="108">rec[0]</text>
+<rect x="144" y="176" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="160" y="192">MPP<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<path d="M224,64 L224,192 " stroke="black"/>
+<rect x="208" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="224" y="64">MPP<tspan baseline-shift="sub" font-size="10">Z</tspan></text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="224" y="44">rec[1]</text>
+<rect x="208" y="176" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="224" y="192">MPP<tspan baseline-shift="sub" font-size="10">Z</tspan></text>
+<rect x="272" y="176" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="192">M<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="288" y="172">rec[2]</text>
+<rect x="272" y="48" width="96" height="32" stroke="black" fill="lightgray"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="320" y="64">Z<tspan baseline-shift="super" font-size="10">rec[0]</tspan></text>
+<rect x="272" y="112" width="96" height="32" stroke="black" fill="lightgray"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="320" y="128">X<tspan baseline-shift="super" font-size="10">rec[1]</tspan></text>
+<rect x="400" y="48" width="96" height="32" stroke="black" fill="lightgray"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="448" y="64">Z<tspan baseline-shift="super" font-size="10">rec[2]</tspan></text>
 </svg>
 )DIAGRAM");
 }
@@ -724,50 +726,50 @@ TEST(circuit_diagram_timeline_svg, tick) {
         H 0 0
     )CIRCUIT");
     ASSERT_EQ(
-        u8"\n" + svg_diagram(circuit),
+        svg_diagram(circuit),
         u8R"DIAGRAM(
-<svg width="960" height="160" version="1.1" xmlns="http://www.w3.org/2000/svg">
-<path d="M32,32 L960,32 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="32">q0</text>
-<path d="M32,96 L960,96 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="96">q1</text>
-<rect x="48" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="32">H</text>
-<rect x="112" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="128" y="32">H</text>
-<path d="M36,8 L36,0 L156,0 L156,8 " stroke="black" fill="none"/>
-<path d="M36,152 L36,160 L156,160 L156,152 " stroke="black" fill="none"/>
-<rect x="176" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="192" y="32">H</text>
-<rect x="176" y="80" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="192" y="96">H</text>
-<rect x="240" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="256" y="32">H</text>
-<path d="M328,0 L320,0 L320,160 L328,160 " stroke="black" fill="none"/>
-<text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="324" y="156">REP1</text>
-<rect x="368" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="384" y="32">H</text>
-<rect x="368" y="80" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="384" y="96">H</text>
-<rect x="432" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="448" y="32">H</text>
-<rect x="496" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="512" y="32">S</text>
-<path d="M420,8 L420,0 L540,0 L540,8 " stroke="black" fill="none"/>
-<path d="M420,152 L420,160 L540,160 L540,152 " stroke="black" fill="none"/>
-<path d="M568,0 L576,0 L576,160 L568,160 " stroke="black" fill="none"/>
-<rect x="624" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="640" y="32">H</text>
-<rect x="688" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="704" y="32">H</text>
-<rect x="752" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="768" y="32">√X</text>
-<path d="M612,8 L612,0 L796,0 L796,8 " stroke="black" fill="none"/>
-<path d="M612,152 L612,160 L796,160 L796,152 " stroke="black" fill="none"/>
-<rect x="816" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="832" y="32">H</text>
-<rect x="880" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="896" y="32">H</text>
+<svg viewBox="0 0 1024 224"  version="1.1" xmlns="http://www.w3.org/2000/svg">
+<path d="M64,64 L992,64 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="64">q0</text>
+<path d="M64,128 L992,128 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="128">q1</text>
+<rect x="80" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="64">H</text>
+<rect x="144" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="160" y="64">H</text>
+<path d="M68,40 L68,32 L188,32 L188,40 " stroke="black" fill="none"/>
+<path d="M68,184 L68,192 L188,192 L188,184 " stroke="black" fill="none"/>
+<rect x="208" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="64">H</text>
+<rect x="208" y="112" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="128">H</text>
+<rect x="272" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="64">H</text>
+<path d="M360,32 L352,32 L352,192 L360,192 " stroke="black" fill="none"/>
+<text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="356" y="188">REP1</text>
+<rect x="400" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="64">H</text>
+<rect x="400" y="112" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="128">H</text>
+<rect x="464" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="480" y="64">H</text>
+<rect x="528" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="544" y="64">S</text>
+<path d="M452,40 L452,32 L572,32 L572,40 " stroke="black" fill="none"/>
+<path d="M452,184 L452,192 L572,192 L572,184 " stroke="black" fill="none"/>
+<path d="M600,32 L608,32 L608,192 L600,192 " stroke="black" fill="none"/>
+<rect x="656" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="672" y="64">H</text>
+<rect x="720" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="736" y="64">H</text>
+<rect x="784" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="800" y="64">√X</text>
+<path d="M644,40 L644,32 L828,32 L828,40 " stroke="black" fill="none"/>
+<path d="M644,184 L644,192 L828,192 L828,184 " stroke="black" fill="none"/>
+<rect x="848" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="864" y="64">H</text>
+<rect x="912" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="928" y="64">H</text>
 </svg>
 )DIAGRAM");
 }
@@ -788,50 +790,50 @@ TEST(circuit_diagram_timeline_svg, shifted_coords) {
         DETECTOR(4, 5, 6)
     )CIRCUIT");
     ASSERT_EQ(
-        "\n" + svg_diagram(circuit),
+        svg_diagram(circuit),
         u8R"DIAGRAM(
-<svg width="1216" height="416" version="1.1" xmlns="http://www.w3.org/2000/svg">
-<path d="M32,32 L1216,32 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="32">q0</text>
-<path d="M32,96 L1216,96 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="96">q1</text>
-<path d="M32,160 L1216,160 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="160">q2</text>
-<path d="M32,224 L1216,224 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="224">q3</text>
-<path d="M32,288 L1216,288 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="288">q4</text>
-<path d="M32,352 L1216,352 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="352">q5</text>
-<rect x="48" y="80" width="224" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="160" y="96">COORDS(1,2)</text>
-<rect x="48" y="16" width="224" height="32" stroke="black" fill="lightgray"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="160" y="32">DETECTOR</text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="160" y="52">coords=(4,5,6)</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="160" y="12">D0 = 1 (vacuous)</text>
-<rect x="48" y="144" width="224" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="160" y="160">COORDS(11,22)</text>
-<rect x="304" y="16" width="224" height="32" stroke="black" fill="lightgray"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="32">DETECTOR</text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="416" y="52">coords=(14,25,36)</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="416" y="12">D1 = 1 (vacuous)</text>
-<path d="M584,0 L576,0 L576,416 L584,416 " stroke="black" fill="none"/>
-<text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="580" y="412">REP100</text>
-<rect x="624" y="208" width="224" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="736" y="224">COORDS(17,28+iter*200)</text>
-<rect x="624" y="272" width="224" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="736" y="288">COORDS(17,28+iter*200)</text>
-<rect x="624" y="16" width="224" height="32" stroke="black" fill="lightgray"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="736" y="32">DETECTOR</text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="736" y="52">coords=(19,30+iter*200,41+iter*300)</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="736" y="12">D[2+iter] = 1 (vacuous)</text>
-<path d="M888,0 L896,0 L896,416 L888,416 " stroke="black" fill="none"/>
-<rect x="944" y="336" width="224" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1056" y="352">COORDS(11,20022)</text>
-<rect x="944" y="16" width="224" height="32" stroke="black" fill="lightgray"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1056" y="32">DETECTOR</text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="1056" y="52">coords=(14,20025,30036)</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="1056" y="12">D102 = 1 (vacuous)</text>
+<svg viewBox="0 0 1280 480"  version="1.1" xmlns="http://www.w3.org/2000/svg">
+<path d="M64,64 L1248,64 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="64">q0</text>
+<path d="M64,128 L1248,128 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="128">q1</text>
+<path d="M64,192 L1248,192 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="192">q2</text>
+<path d="M64,256 L1248,256 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="256">q3</text>
+<path d="M64,320 L1248,320 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="320">q4</text>
+<path d="M64,384 L1248,384 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="384">q5</text>
+<rect x="80" y="112" width="224" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="192" y="128">COORDS(1,2)</text>
+<rect x="80" y="48" width="224" height="32" stroke="black" fill="lightgray"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="192" y="64">DETECTOR</text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="192" y="84">coords=(4,5,6)</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="192" y="44">D0 = 1 (vacuous)</text>
+<rect x="80" y="176" width="224" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="192" y="192">COORDS(11,22)</text>
+<rect x="336" y="48" width="224" height="32" stroke="black" fill="lightgray"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="448" y="64">DETECTOR</text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="448" y="84">coords=(14,25,36)</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="448" y="44">D1 = 1 (vacuous)</text>
+<path d="M616,32 L608,32 L608,448 L616,448 " stroke="black" fill="none"/>
+<text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="612" y="444">REP100</text>
+<rect x="656" y="240" width="224" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="768" y="256">COORDS(17,28+iter*200)</text>
+<rect x="656" y="304" width="224" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="768" y="320">COORDS(17,28+iter*200)</text>
+<rect x="656" y="48" width="224" height="32" stroke="black" fill="lightgray"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="768" y="64">DETECTOR</text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="768" y="84">coords=(19,30+iter*200,41+iter*300)</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="768" y="44">D[2+iter] = 1 (vacuous)</text>
+<path d="M920,32 L928,32 L928,448 L920,448 " stroke="black" fill="none"/>
+<rect x="976" y="368" width="224" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1088" y="384">COORDS(11,20022)</text>
+<rect x="976" y="48" width="224" height="32" stroke="black" fill="lightgray"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1088" y="64">DETECTOR</text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="1088" y="84">coords=(14,20025,30036)</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="1088" y="44">D102 = 1 (vacuous)</text>
 </svg>
 )DIAGRAM");
 }
@@ -850,71 +852,71 @@ TEST(circuit_diagram_timeline_svg, detector_pseudo_targets) {
         OBSERVABLE_INCLUDE(100) rec[-201] rec[-203]
     )CIRCUIT");
     ASSERT_EQ(
-        "\n" + svg_diagram(circuit),
+        svg_diagram(circuit),
         u8R"DIAGRAM(
-<svg width="960" height="416" version="1.1" xmlns="http://www.w3.org/2000/svg">
-<path d="M32,32 L960,32 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="32">q0</text>
-<path d="M32,96 L960,96 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="96">q1</text>
-<path d="M32,160 L960,160 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="160">q2</text>
-<path d="M32,224 L960,224 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="224">q3</text>
-<path d="M32,288 L960,288 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="288">q4</text>
-<path d="M32,352 L960,352 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="352">q5</text>
-<rect x="48" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="32">M</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="64" y="12">rec[0]</text>
-<rect x="48" y="80" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="96">M</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="64" y="76">rec[1]</text>
-<rect x="48" y="144" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="160">M</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="64" y="140">rec[2]</text>
-<rect x="48" y="208" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="224">M</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="64" y="204">rec[3]</text>
-<rect x="48" y="272" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="288">M</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="64" y="268">rec[4]</text>
-<rect x="48" y="336" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="352">M</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="64" y="332">rec[5]</text>
-<path d="M136,0 L128,0 L128,416 L136,416 " stroke="black" fill="none"/>
-<text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="132" y="412">REP100</text>
-<rect x="176" y="80" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="192" y="96">M</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="192" y="76">rec[6+iter*2]</text>
-<rect x="176" y="144" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="192" y="160">M</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="192" y="140">rec[7+iter*2]</text>
-<path d="M248,0 L256,0 L256,416 L248,416 " stroke="black" fill="none"/>
-<rect x="304" y="144" width="160" height="32" stroke="black" fill="lightgray"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="384" y="160">DETECTOR</text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="384" y="180">coords=(1)</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="384" y="140">D0 = rec[205]</text>
-<rect x="304" y="80" width="160" height="32" stroke="black" fill="lightgray"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="384" y="96">DETECTOR</text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="384" y="116">coords=(2)</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="384" y="76">D1 = rec[204]</text>
-<rect x="496" y="144" width="160" height="32" stroke="black" fill="lightgray"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="576" y="160">DETECTOR</text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="576" y="180">coords=(3)</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="576" y="140">D2 = rec[203]</text>
-<rect x="496" y="80" width="160" height="32" stroke="black" fill="lightgray"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="576" y="96">DETECTOR</text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="576" y="116">coords=(4)</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="576" y="76">D3 = rec[202]</text>
-<rect x="688" y="80" width="224" height="32" stroke="black" fill="lightgray"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="800" y="96">DETECTOR</text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="800" y="116">coords=(5)</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="800" y="76">D4 = rec[205]*rec[204]</text>
-<rect x="688" y="208" width="224" height="32" stroke="black" fill="lightgray"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="800" y="224">OBS_INCLUDE(100)</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="800" y="204">L100 *= rec[5]*rec[3]</text>
+<svg viewBox="0 0 1024 480"  version="1.1" xmlns="http://www.w3.org/2000/svg">
+<path d="M64,64 L992,64 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="64">q0</text>
+<path d="M64,128 L992,128 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="128">q1</text>
+<path d="M64,192 L992,192 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="192">q2</text>
+<path d="M64,256 L992,256 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="256">q3</text>
+<path d="M64,320 L992,320 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="320">q4</text>
+<path d="M64,384 L992,384 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="384">q5</text>
+<rect x="80" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="64">M</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="96" y="44">rec[0]</text>
+<rect x="80" y="112" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="128">M</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="96" y="108">rec[1]</text>
+<rect x="80" y="176" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="192">M</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="96" y="172">rec[2]</text>
+<rect x="80" y="240" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="256">M</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="96" y="236">rec[3]</text>
+<rect x="80" y="304" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="320">M</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="96" y="300">rec[4]</text>
+<rect x="80" y="368" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="384">M</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="96" y="364">rec[5]</text>
+<path d="M168,32 L160,32 L160,448 L168,448 " stroke="black" fill="none"/>
+<text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="164" y="444">REP100</text>
+<rect x="208" y="112" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="128">M</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="224" y="108">rec[6+iter*2]</text>
+<rect x="208" y="176" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="192">M</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="224" y="172">rec[7+iter*2]</text>
+<path d="M280,32 L288,32 L288,448 L280,448 " stroke="black" fill="none"/>
+<rect x="336" y="176" width="160" height="32" stroke="black" fill="lightgray"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="192">DETECTOR</text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="416" y="212">coords=(1)</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="416" y="172">D0 = rec[205]</text>
+<rect x="336" y="112" width="160" height="32" stroke="black" fill="lightgray"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="128">DETECTOR</text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="416" y="148">coords=(2)</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="416" y="108">D1 = rec[204]</text>
+<rect x="528" y="176" width="160" height="32" stroke="black" fill="lightgray"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="608" y="192">DETECTOR</text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="608" y="212">coords=(3)</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="608" y="172">D2 = rec[203]</text>
+<rect x="528" y="112" width="160" height="32" stroke="black" fill="lightgray"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="608" y="128">DETECTOR</text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="608" y="148">coords=(4)</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="608" y="108">D3 = rec[202]</text>
+<rect x="720" y="112" width="224" height="32" stroke="black" fill="lightgray"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="832" y="128">DETECTOR</text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="832" y="148">coords=(5)</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="832" y="108">D4 = rec[205]*rec[204]</text>
+<rect x="720" y="240" width="224" height="32" stroke="black" fill="lightgray"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="832" y="256">OBS_INCLUDE(100)</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="832" y="236">L100 *= rec[5]*rec[3]</text>
 </svg>
 )DIAGRAM");
 }
@@ -923,116 +925,116 @@ TEST(circuit_diagram_timeline_svg, repetition_code) {
     CircuitGenParameters params(10, 3, "memory");
     auto circuit = generate_rep_code_circuit(params).circuit;
     ASSERT_EQ(
-        "\n" + svg_diagram(circuit),
+        svg_diagram(circuit),
         u8R"DIAGRAM(
-<svg width="1536" height="352" version="1.1" xmlns="http://www.w3.org/2000/svg">
-<path d="M32,32 L1536,32 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="32">q0</text>
-<path d="M32,96 L1536,96 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="96">q1</text>
-<path d="M32,160 L1536,160 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="160">q2</text>
-<path d="M32,224 L1536,224 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="224">q3</text>
-<path d="M32,288 L1536,288 " stroke="black"/>
-<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="32" y="288">q4</text>
-<rect x="48" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="32">R</text>
-<rect x="48" y="80" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="96">R</text>
-<rect x="48" y="144" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="160">R</text>
-<rect x="48" y="208" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="224">R</text>
-<rect x="48" y="272" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="64" y="288">R</text>
-<path d="M128,32 L128,96 " stroke="black"/>
-<circle cx="128" cy="32" r="8" stroke="none" fill="black"/>
-<circle cx="128" cy="96" r="8" stroke="black" fill="white"/>
-<path d="M120,96 L136,96 M128,88 L128,104 " stroke="black"/>
-<path d="M128,160 L128,224 " stroke="black"/>
-<circle cx="128" cy="160" r="8" stroke="none" fill="black"/>
-<circle cx="128" cy="224" r="8" stroke="black" fill="white"/>
-<path d="M120,224 L136,224 M128,216 L128,232 " stroke="black"/>
-<path d="M192,96 L192,160 " stroke="black"/>
-<circle cx="192" cy="160" r="8" stroke="none" fill="black"/>
-<circle cx="192" cy="96" r="8" stroke="black" fill="white"/>
-<path d="M184,96 L200,96 M192,88 L192,104 " stroke="black"/>
-<path d="M192,224 L192,288 " stroke="black"/>
-<circle cx="192" cy="288" r="8" stroke="none" fill="black"/>
-<circle cx="192" cy="224" r="8" stroke="black" fill="white"/>
-<path d="M184,224 L200,224 M192,216 L192,232 " stroke="black"/>
-<rect x="240" y="80" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="256" y="96">MR</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="256" y="76">rec[0]</text>
-<rect x="240" y="208" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="256" y="224">MR</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="256" y="204">rec[1]</text>
-<rect x="304" y="80" width="160" height="32" stroke="black" fill="lightgray"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="384" y="96">DETECTOR</text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="384" y="116">coords=(1,0)</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="384" y="76">D0 = rec[0]</text>
-<rect x="304" y="208" width="160" height="32" stroke="black" fill="lightgray"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="384" y="224">DETECTOR</text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="384" y="244">coords=(3,0)</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="384" y="204">D1 = rec[1]</text>
-<path d="M228,8 L228,0 L476,0 L476,8 " stroke="black" fill="none"/>
-<path d="M228,344 L228,352 L476,352 L476,344 " stroke="black" fill="none"/>
-<path d="M520,0 L512,0 L512,352 L520,352 " stroke="black" fill="none"/>
-<text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="516" y="348">REP9</text>
-<path d="M640,32 L640,96 " stroke="black"/>
-<circle cx="640" cy="32" r="8" stroke="none" fill="black"/>
-<circle cx="640" cy="96" r="8" stroke="black" fill="white"/>
-<path d="M632,96 L648,96 M640,88 L640,104 " stroke="black"/>
-<path d="M640,160 L640,224 " stroke="black"/>
-<circle cx="640" cy="160" r="8" stroke="none" fill="black"/>
-<circle cx="640" cy="224" r="8" stroke="black" fill="white"/>
-<path d="M632,224 L648,224 M640,216 L640,232 " stroke="black"/>
-<path d="M704,96 L704,160 " stroke="black"/>
-<circle cx="704" cy="160" r="8" stroke="none" fill="black"/>
-<circle cx="704" cy="96" r="8" stroke="black" fill="white"/>
-<path d="M696,96 L712,96 M704,88 L704,104 " stroke="black"/>
-<path d="M704,224 L704,288 " stroke="black"/>
-<circle cx="704" cy="288" r="8" stroke="none" fill="black"/>
-<circle cx="704" cy="224" r="8" stroke="black" fill="white"/>
-<path d="M696,224 L712,224 M704,216 L704,232 " stroke="black"/>
-<rect x="752" y="80" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="768" y="96">MR</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="768" y="76">rec[2+iter*2]</text>
-<rect x="752" y="208" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="768" y="224">MR</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="768" y="204">rec[3+iter*2]</text>
-<rect x="816" y="80" width="224" height="32" stroke="black" fill="lightgray"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="928" y="96">DETECTOR</text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="928" y="116">coords=(1,1+iter)</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="928" y="76">D[2+iter*2] = rec[2+iter*2]*rec[0+iter*2]</text>
-<rect x="816" y="208" width="224" height="32" stroke="black" fill="lightgray"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="928" y="224">DETECTOR</text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="928" y="244">coords=(3,1+iter)</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="928" y="204">D[3+iter*2] = rec[3+iter*2]*rec[1+iter*2]</text>
-<path d="M740,8 L740,0 L1052,0 L1052,8 " stroke="black" fill="none"/>
-<path d="M740,344 L740,352 L1052,352 L1052,344 " stroke="black" fill="none"/>
-<path d="M1080,0 L1088,0 L1088,352 L1080,352 " stroke="black" fill="none"/>
-<rect x="1136" y="16" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1152" y="32">M</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="1152" y="12">rec[20]</text>
-<rect x="1136" y="144" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1152" y="160">M</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="1152" y="140">rec[21]</text>
-<rect x="1136" y="272" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1152" y="288">M</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="1152" y="268">rec[22]</text>
-<rect x="1200" y="16" width="288" height="32" stroke="black" fill="lightgray"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1344" y="32">DETECTOR</text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="1344" y="52">coords=(1,10)</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="1344" y="12">D20 = rec[21]*rec[20]*rec[18]</text>
-<rect x="1200" y="144" width="288" height="32" stroke="black" fill="lightgray"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1344" y="160">DETECTOR</text>
-<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="1344" y="180">coords=(3,10)</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="1344" y="140">D21 = rec[22]*rec[21]*rec[19]</text>
-<rect x="1200" y="272" width="160" height="32" stroke="black" fill="lightgray"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1280" y="288">OBS_INCLUDE(0)</text>
-<text text-anchor="middle" font-family="monospace" font-size="8" x="1280" y="268">L0 *= rec[22]</text>
+<svg viewBox="0 0 1600 416"  version="1.1" xmlns="http://www.w3.org/2000/svg">
+<path d="M64,64 L1568,64 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="64">q0</text>
+<path d="M64,128 L1568,128 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="128">q1</text>
+<path d="M64,192 L1568,192 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="192">q2</text>
+<path d="M64,256 L1568,256 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="256">q3</text>
+<path d="M64,320 L1568,320 " stroke="black"/>
+<text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="320">q4</text>
+<rect x="80" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="64">R</text>
+<rect x="80" y="112" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="128">R</text>
+<rect x="80" y="176" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="192">R</text>
+<rect x="80" y="240" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="256">R</text>
+<rect x="80" y="304" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="320">R</text>
+<path d="M160,64 L160,128 " stroke="black"/>
+<circle cx="160" cy="64" r="8" stroke="none" fill="black"/>
+<circle cx="160" cy="128" r="8" stroke="black" fill="white"/>
+<path d="M152,128 L168,128 M160,120 L160,136 " stroke="black"/>
+<path d="M160,192 L160,256 " stroke="black"/>
+<circle cx="160" cy="192" r="8" stroke="none" fill="black"/>
+<circle cx="160" cy="256" r="8" stroke="black" fill="white"/>
+<path d="M152,256 L168,256 M160,248 L160,264 " stroke="black"/>
+<path d="M224,128 L224,192 " stroke="black"/>
+<circle cx="224" cy="192" r="8" stroke="none" fill="black"/>
+<circle cx="224" cy="128" r="8" stroke="black" fill="white"/>
+<path d="M216,128 L232,128 M224,120 L224,136 " stroke="black"/>
+<path d="M224,256 L224,320 " stroke="black"/>
+<circle cx="224" cy="320" r="8" stroke="none" fill="black"/>
+<circle cx="224" cy="256" r="8" stroke="black" fill="white"/>
+<path d="M216,256 L232,256 M224,248 L224,264 " stroke="black"/>
+<rect x="272" y="112" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="128">MR</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="288" y="108">rec[0]</text>
+<rect x="272" y="240" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="256">MR</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="288" y="236">rec[1]</text>
+<rect x="336" y="112" width="160" height="32" stroke="black" fill="lightgray"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="128">DETECTOR</text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="416" y="148">coords=(1,0)</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="416" y="108">D0 = rec[0]</text>
+<rect x="336" y="240" width="160" height="32" stroke="black" fill="lightgray"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="256">DETECTOR</text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="416" y="276">coords=(3,0)</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="416" y="236">D1 = rec[1]</text>
+<path d="M260,40 L260,32 L508,32 L508,40 " stroke="black" fill="none"/>
+<path d="M260,376 L260,384 L508,384 L508,376 " stroke="black" fill="none"/>
+<path d="M552,32 L544,32 L544,384 L552,384 " stroke="black" fill="none"/>
+<text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="548" y="380">REP9</text>
+<path d="M672,64 L672,128 " stroke="black"/>
+<circle cx="672" cy="64" r="8" stroke="none" fill="black"/>
+<circle cx="672" cy="128" r="8" stroke="black" fill="white"/>
+<path d="M664,128 L680,128 M672,120 L672,136 " stroke="black"/>
+<path d="M672,192 L672,256 " stroke="black"/>
+<circle cx="672" cy="192" r="8" stroke="none" fill="black"/>
+<circle cx="672" cy="256" r="8" stroke="black" fill="white"/>
+<path d="M664,256 L680,256 M672,248 L672,264 " stroke="black"/>
+<path d="M736,128 L736,192 " stroke="black"/>
+<circle cx="736" cy="192" r="8" stroke="none" fill="black"/>
+<circle cx="736" cy="128" r="8" stroke="black" fill="white"/>
+<path d="M728,128 L744,128 M736,120 L736,136 " stroke="black"/>
+<path d="M736,256 L736,320 " stroke="black"/>
+<circle cx="736" cy="320" r="8" stroke="none" fill="black"/>
+<circle cx="736" cy="256" r="8" stroke="black" fill="white"/>
+<path d="M728,256 L744,256 M736,248 L736,264 " stroke="black"/>
+<rect x="784" y="112" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="800" y="128">MR</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="800" y="108">rec[2+iter*2]</text>
+<rect x="784" y="240" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="800" y="256">MR</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="800" y="236">rec[3+iter*2]</text>
+<rect x="848" y="112" width="224" height="32" stroke="black" fill="lightgray"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="960" y="128">DETECTOR</text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="960" y="148">coords=(1,1+iter)</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="960" y="108">D[2+iter*2] = rec[2+iter*2]*rec[0+iter*2]</text>
+<rect x="848" y="240" width="224" height="32" stroke="black" fill="lightgray"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="960" y="256">DETECTOR</text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="960" y="276">coords=(3,1+iter)</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="960" y="236">D[3+iter*2] = rec[3+iter*2]*rec[1+iter*2]</text>
+<path d="M772,40 L772,32 L1084,32 L1084,40 " stroke="black" fill="none"/>
+<path d="M772,376 L772,384 L1084,384 L1084,376 " stroke="black" fill="none"/>
+<path d="M1112,32 L1120,32 L1120,384 L1112,384 " stroke="black" fill="none"/>
+<rect x="1168" y="48" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1184" y="64">M</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="1184" y="44">rec[20]</text>
+<rect x="1168" y="176" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1184" y="192">M</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="1184" y="172">rec[21]</text>
+<rect x="1168" y="304" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1184" y="320">M</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="1184" y="300">rec[22]</text>
+<rect x="1232" y="48" width="288" height="32" stroke="black" fill="lightgray"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1376" y="64">DETECTOR</text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="1376" y="84">coords=(1,10)</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="1376" y="44">D20 = rec[21]*rec[20]*rec[18]</text>
+<rect x="1232" y="176" width="288" height="32" stroke="black" fill="lightgray"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1376" y="192">DETECTOR</text>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="8" x="1376" y="212">coords=(3,10)</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="1376" y="172">D21 = rec[22]*rec[21]*rec[19]</text>
+<rect x="1232" y="304" width="160" height="32" stroke="black" fill="lightgray"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1312" y="320">OBS_INCLUDE(0)</text>
+<text text-anchor="middle" font-family="monospace" font-size="8" x="1312" y="300">L0 *= rec[22]</text>
 </svg>
 )DIAGRAM");
 }

--- a/src/stim/py/stim.pybind.cc
+++ b/src/stim/py/stim.pybind.cc
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 #include <pybind11/iostream.h>
-#include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 
 #include "stim/circuit/circuit.pybind.h"
 #include "stim/circuit/circuit_gate_target.pybind.h"
@@ -39,6 +37,7 @@
 #include "stim/stabilizers/tableau.h"
 #include "stim/stabilizers/tableau.pybind.h"
 #include "stim/stabilizers/tableau_iter.pybind.h"
+#include "stim/cmd/command_diagram.pybind.h"
 
 #define xstr(s) str(s)
 #define str(s) #s
@@ -441,6 +440,8 @@ PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
     auto c_circuit_error_location = pybind_circuit_error_location(m);
     auto c_circuit_error_location_methods = pybind_explained_error(m);
 
+    auto c_diagram_helper = pybind_diagram(m);
+
     /// top level function definitions
     top_level(m);
     pybind_read_write(m);
@@ -475,4 +476,6 @@ PYBIND11_MODULE(STIM_PYBIND11_MODULE_NAME, m) {
     pybind_circuit_targets_inside_instruction_methods(m, c_circuit_targets_inside_instruction);
     pybind_circuit_error_location_methods(m, c_circuit_error_location);
     pybind_explained_error_methods(m, c_circuit_error_location_methods);
+
+    pybind_diagram_methods(m, c_diagram_helper);
 }

--- a/src/stim/simulators/measurements_to_detection_events.pybind.cc
+++ b/src/stim/simulators/measurements_to_detection_events.pybind.cc
@@ -296,7 +296,7 @@ void stim_pybind::pybind_compiled_measurements_to_detection_events_converter_met
         clean_doc_string(u8R"DOC(
             Converts measurement data into detection event data.
             @overload def convert(self, *, measurements: np.ndarray, sweep_bits: Optional[np.ndarray] = None, append_observables: bool = False, bit_pack_result: bool = False) -> np.ndarray:
-            @overload def convert(self, *, measurements: np.ndarray, sweep_bits: Optional[np.ndarray] = None, separate_observables: Literal[True], append_observables: bool = False, bit_pack_result: bool = False) -> Tuple[np.ndarray, np.ndarray]:
+            @overload def convert(self, *, measurements: np.ndarray, sweep_bits: Optional[np.ndarray] = None, separate_observables: 'Literal[True]', append_observables: bool = False, bit_pack_result: bool = False) -> Tuple[np.ndarray, np.ndarray]:
             @signature def convert(self, *, measurements: np.ndarray, sweep_bits: Optional[np.ndarray] = None, separate_observables: bool = False, append_observables: bool = False, bit_pack_result: bool = False) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
 
             Args:


### PR DESCRIPTION
- Change TICK convention so that first TICK is index 1 instead of index 0
- Fix circuit timeline svg diagrams using width/height instead of viewbox property
- Add stim._DiagramHelper with HTML viewers for text and SVG
- Add a bit of whitespace padding around svg timeline diagrams

![image](https://user-images.githubusercontent.com/79941/196601247-f1e28e74-d20c-40cd-972b-f03250047e17.png)
