### PR TITLE
Fix various file io bugs

### DIFF
--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -3537,7 +3537,7 @@ def convert_file(
         ...    DETECTOR rec[-1]
         ... ''').compile_m2d_converter()
         >>> with tempfile.TemporaryDirectory() as d:
-        ...    with open(f"{d}/measurements.01", "wb") as f:
+        ...    with open(f"{d}/measurements.01", "w") as f:
         ...        print("0", file=f)
         ...        print("1", file=f)
         ...    converter.convert_file(
@@ -4761,12 +4761,12 @@ def diagram(
 
         >>> with tempfile.TemporaryDirectory() as d:
         ...     diagram = circuit.diagram(type="match-graph-svg")
-        ...     with open(f"{d}/dem_image.svg", "wb") as f:
+        ...     with open(f"{d}/dem_image.svg", "w") as f:
         ...         print(diagram, file=f)
 
         >>> with tempfile.TemporaryDirectory() as d:
         ...     diagram = circuit.diagram(type="match-graph-3d")
-        ...     with open(f"{d}/dem_3d_model.gltf", "wb") as f:
+        ...     with open(f"{d}/dem_3d_model.gltf", "w") as f:
         ...         print(diagram, file=f)
     """
 ```

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -3537,7 +3537,7 @@ def convert_file(
         ...    DETECTOR rec[-1]
         ... ''').compile_m2d_converter()
         >>> with tempfile.TemporaryDirectory() as d:
-        ...    with open(f"{d}/measurements.01", "w") as f:
+        ...    with open(f"{d}/measurements.01", "wb") as f:
         ...        print("0", file=f)
         ...        print("1", file=f)
         ...    converter.convert_file(
@@ -3545,7 +3545,7 @@ def convert_file(
         ...        detection_events_filepath=f"{d}/detections.01",
         ...        append_observables=False,
         ...    )
-        ...    with open(f"{d}/detections.01", "r") as f:
+        ...    with open(f"{d}/detections.01") as f:
         ...        print(f.read(), end="")
         1
         0
@@ -4761,12 +4761,12 @@ def diagram(
 
         >>> with tempfile.TemporaryDirectory() as d:
         ...     diagram = circuit.diagram(type="match-graph-svg")
-        ...     with open(f"{d}/dem_image.svg", "w") as f:
+        ...     with open(f"{d}/dem_image.svg", "wb") as f:
         ...         print(diagram, file=f)
 
         >>> with tempfile.TemporaryDirectory() as d:
         ...     diagram = circuit.diagram(type="match-graph-3d")
-        ...     with open(f"{d}/dem_3d_model.gltf", "w") as f:
+        ...     with open(f"{d}/dem_3d_model.gltf", "wb") as f:
         ...         print(diagram, file=f)
     """
 ```

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -2662,7 +2662,7 @@ class CompiledMeasurementsToDetectionEventsConverter:
             ...    DETECTOR rec[-1]
             ... ''').compile_m2d_converter()
             >>> with tempfile.TemporaryDirectory() as d:
-            ...    with open(f"{d}/measurements.01", "w") as f:
+            ...    with open(f"{d}/measurements.01", "wb") as f:
             ...        print("0", file=f)
             ...        print("1", file=f)
             ...    converter.convert_file(
@@ -2670,7 +2670,7 @@ class CompiledMeasurementsToDetectionEventsConverter:
             ...        detection_events_filepath=f"{d}/detections.01",
             ...        append_observables=False,
             ...    )
-            ...    with open(f"{d}/detections.01", "r") as f:
+            ...    with open(f"{d}/detections.01") as f:
             ...        print(f.read(), end="")
             1
             0
@@ -3529,12 +3529,12 @@ class DetectorErrorModel:
 
             >>> with tempfile.TemporaryDirectory() as d:
             ...     diagram = circuit.diagram(type="match-graph-svg")
-            ...     with open(f"{d}/dem_image.svg", "w") as f:
+            ...     with open(f"{d}/dem_image.svg", "wb") as f:
             ...         print(diagram, file=f)
 
             >>> with tempfile.TemporaryDirectory() as d:
             ...     diagram = circuit.diagram(type="match-graph-3d")
-            ...     with open(f"{d}/dem_3d_model.gltf", "w") as f:
+            ...     with open(f"{d}/dem_3d_model.gltf", "wb") as f:
             ...         print(diagram, file=f)
         """
     def flattened(

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -2662,7 +2662,7 @@ class CompiledMeasurementsToDetectionEventsConverter:
             ...    DETECTOR rec[-1]
             ... ''').compile_m2d_converter()
             >>> with tempfile.TemporaryDirectory() as d:
-            ...    with open(f"{d}/measurements.01", "wb") as f:
+            ...    with open(f"{d}/measurements.01", "w") as f:
             ...        print("0", file=f)
             ...        print("1", file=f)
             ...    converter.convert_file(
@@ -3529,12 +3529,12 @@ class DetectorErrorModel:
 
             >>> with tempfile.TemporaryDirectory() as d:
             ...     diagram = circuit.diagram(type="match-graph-svg")
-            ...     with open(f"{d}/dem_image.svg", "wb") as f:
+            ...     with open(f"{d}/dem_image.svg", "w") as f:
             ...         print(diagram, file=f)
 
             >>> with tempfile.TemporaryDirectory() as d:
             ...     diagram = circuit.diagram(type="match-graph-3d")
-            ...     with open(f"{d}/dem_3d_model.gltf", "wb") as f:
+            ...     with open(f"{d}/dem_3d_model.gltf", "w") as f:
             ...         print(diagram, file=f)
         """
     def flattened(

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -2662,7 +2662,7 @@ class CompiledMeasurementsToDetectionEventsConverter:
             ...    DETECTOR rec[-1]
             ... ''').compile_m2d_converter()
             >>> with tempfile.TemporaryDirectory() as d:
-            ...    with open(f"{d}/measurements.01", "w") as f:
+            ...    with open(f"{d}/measurements.01", "wb") as f:
             ...        print("0", file=f)
             ...        print("1", file=f)
             ...    converter.convert_file(
@@ -3529,12 +3529,12 @@ class DetectorErrorModel:
 
             >>> with tempfile.TemporaryDirectory() as d:
             ...     diagram = circuit.diagram(type="match-graph-svg")
-            ...     with open(f"{d}/dem_image.svg", "w") as f:
+            ...     with open(f"{d}/dem_image.svg", "wb") as f:
             ...         print(diagram, file=f)
 
             >>> with tempfile.TemporaryDirectory() as d:
             ...     diagram = circuit.diagram(type="match-graph-3d")
-            ...     with open(f"{d}/dem_3d_model.gltf", "w") as f:
+            ...     with open(f"{d}/dem_3d_model.gltf", "wb") as f:
             ...         print(diagram, file=f)
         """
     def flattened(

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -2670,7 +2670,7 @@ class CompiledMeasurementsToDetectionEventsConverter:
             ...        detection_events_filepath=f"{d}/detections.01",
             ...        append_observables=False,
             ...    )
-            ...    with open(f"{d}/detections.01", "r") as f:
+            ...    with open(f"{d}/detections.01") as f:
             ...        print(f.read(), end="")
             1
             0

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -2662,7 +2662,7 @@ class CompiledMeasurementsToDetectionEventsConverter:
             ...    DETECTOR rec[-1]
             ... ''').compile_m2d_converter()
             >>> with tempfile.TemporaryDirectory() as d:
-            ...    with open(f"{d}/measurements.01", "wb") as f:
+            ...    with open(f"{d}/measurements.01", "w") as f:
             ...        print("0", file=f)
             ...        print("1", file=f)
             ...    converter.convert_file(
@@ -3529,12 +3529,12 @@ class DetectorErrorModel:
 
             >>> with tempfile.TemporaryDirectory() as d:
             ...     diagram = circuit.diagram(type="match-graph-svg")
-            ...     with open(f"{d}/dem_image.svg", "wb") as f:
+            ...     with open(f"{d}/dem_image.svg", "w") as f:
             ...         print(diagram, file=f)
 
             >>> with tempfile.TemporaryDirectory() as d:
             ...     diagram = circuit.diagram(type="match-graph-3d")
-            ...     with open(f"{d}/dem_3d_model.gltf", "wb") as f:
+            ...     with open(f"{d}/dem_3d_model.gltf", "w") as f:
             ...         print(diagram, file=f)
         """
     def flattened(

--- a/src/stim/arg_parse.test.cc
+++ b/src/stim/arg_parse.test.cc
@@ -260,23 +260,23 @@ TEST(arg_parse, find_open_file_argument) {
 
     args = {""};
     ASSERT_THROW_MSG(
-        { find_open_file_argument("-arg", nullptr, "r", args.size(), args.data()); }, std::invalid_argument, "Missing");
+        { find_open_file_argument("-arg", nullptr, "rb", args.size(), args.data()); }, std::invalid_argument, "Missing");
     args = {""};
-    ASSERT_EQ(find_open_file_argument("-arg", tmp, "r", args.size(), args.data()), tmp);
+    ASSERT_EQ(find_open_file_argument("-arg", tmp, "rb", args.size(), args.data()), tmp);
 
     args = {"", "-arg"};
     ASSERT_THROW_MSG(
-        { find_open_file_argument("-arg", nullptr, "r", args.size(), args.data()); }, std::invalid_argument, "empty");
+        { find_open_file_argument("-arg", nullptr, "rb", args.size(), args.data()); }, std::invalid_argument, "empty");
     args = {"", "-arg"};
     ASSERT_THROW_MSG(
-        { find_open_file_argument("-arg", tmp, "r", args.size(), args.data()); }, std::invalid_argument, "empty");
+        { find_open_file_argument("-arg", tmp, "rb", args.size(), args.data()); }, std::invalid_argument, "empty");
 
     RaiiTempNamedFile f;
     FILE *f2 = fdopen(f.descriptor, "w");
     putc('x', f2);
     fclose(f2);
     args = {"", "-arg", f.path.data()};
-    f2 = find_open_file_argument("-arg", nullptr, "r", args.size(), args.data());
+    f2 = find_open_file_argument("-arg", nullptr, "rb", args.size(), args.data());
     ASSERT_NE(f2, nullptr);
     ASSERT_EQ(getc(f2), 'x');
     fclose(f2);
@@ -284,7 +284,7 @@ TEST(arg_parse, find_open_file_argument) {
     remove(f.path.data());
     args = {"", "-arg", f.path.data()};
     ASSERT_THROW_MSG(
-        { find_open_file_argument("-arg", nullptr, "r", args.size(), args.data()); },
+        { find_open_file_argument("-arg", nullptr, "rb", args.size(), args.data()); },
         std::invalid_argument,
         "Failed to open");
     f2 = find_open_file_argument("-arg", nullptr, "w", args.size(), args.data());

--- a/src/stim/arg_parse.test.cc
+++ b/src/stim/arg_parse.test.cc
@@ -272,7 +272,7 @@ TEST(arg_parse, find_open_file_argument) {
         { find_open_file_argument("-arg", tmp, "rb", args.size(), args.data()); }, std::invalid_argument, "empty");
 
     RaiiTempNamedFile f;
-    FILE *f2 = fdopen(f.descriptor, "w");
+    FILE *f2 = fdopen(f.descriptor, "wb");
     putc('x', f2);
     fclose(f2);
     args = {"", "-arg", f.path.data()};
@@ -287,7 +287,7 @@ TEST(arg_parse, find_open_file_argument) {
         { find_open_file_argument("-arg", nullptr, "rb", args.size(), args.data()); },
         std::invalid_argument,
         "Failed to open");
-    f2 = find_open_file_argument("-arg", nullptr, "w", args.size(), args.data());
+    f2 = find_open_file_argument("-arg", nullptr, "wb", args.size(), args.data());
     fclose(f2);
 
     fclose(tmp);

--- a/src/stim/circuit/circuit.h
+++ b/src/stim/circuit/circuit.h
@@ -341,11 +341,11 @@ bool read_until_next_line_arg(int &c, SOURCE read_char, bool space_required = tr
         return true;
     }
     if (space_required) {
-        if (c != ' ' && c != '#' && c != '\t' && c != '\n' && c != '{' && c != EOF) {
+        if (c != ' ' && c != '#' && c != '\t' && c != '\n' && c != '\r' && c != '{' && c != EOF) {
             throw std::invalid_argument("Targets must be separated by spacing.");
         }
     }
-    while (c == ' ' || c == '\t') {
+    while (c == ' ' || c == '\t' || c == '\r') {
         c = read_char();
     }
     if (c == '#') {

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -1012,7 +1012,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
         [](pybind11::object &obj) {
             try {
                 auto path = pybind11::cast<std::string>(obj);
-                RaiiFile f(path.data(), "r");
+                RaiiFile f(path.data(), "rb");
                 return Circuit::from_file(f.f);
             } catch (pybind11::cast_error &ex) {
             }
@@ -1020,7 +1020,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
             auto py_path = pybind11::module::import("pathlib").attr("Path");
             if (pybind11::isinstance(obj, py_path)) {
                 auto path = pybind11::cast<std::string>(pybind11::str(obj));
-                RaiiFile f(path.data(), "r");
+                RaiiFile f(path.data(), "rb");
                 return Circuit::from_file(f.f);
             }
 

--- a/src/stim/circuit/circuit.test.cc
+++ b/src/stim/circuit/circuit.test.cc
@@ -1430,3 +1430,7 @@ TEST(circuit, equality) {
     ASSERT_FALSE(b != Circuit(b));
     ASSERT_FALSE(c != Circuit(c));
 }
+
+TEST(circuit, parse_windows_newlines) {
+    ASSERT_EQ(Circuit("H 0\r\nCX 0 1\r\n"), Circuit("H 0\nCX 0 1\n"));
+}

--- a/src/stim/cmd/command_analyze_errors.cc
+++ b/src/stim/cmd/command_analyze_errors.cc
@@ -52,7 +52,7 @@ int stim::command_analyze_errors(int argc, const char **argv) {
             find_float_argument("--approximate_disjoint_errors", 0, 0, 1, argc, argv);
     }
 
-    FILE *in = find_open_file_argument("--in", stdin, "r", argc, argv);
+    FILE *in = find_open_file_argument("--in", stdin, "rb", argc, argv);
     auto out_stream = find_output_stream_argument("--out", true, argc, argv);
     std::ostream &out = out_stream.stream();
     auto circuit = Circuit::from_file(in);

--- a/src/stim/cmd/command_detect.cc
+++ b/src/stim/cmd/command_detect.cc
@@ -46,7 +46,7 @@ int stim::command_detect(int argc, const char **argv) {
         prepend_observables = true;
     }
 
-    RaiiFile in(find_open_file_argument("--in", stdin, "r", argc, argv));
+    RaiiFile in(find_open_file_argument("--in", stdin, "rb", argc, argv));
     RaiiFile out(find_open_file_argument("--out", stdout, "w", argc, argv));
     RaiiFile obs_out(find_open_file_argument("--obs_out", stdout, "w", argc, argv));
     if (obs_out.f == stdout) {

--- a/src/stim/cmd/command_detect.cc
+++ b/src/stim/cmd/command_detect.cc
@@ -47,8 +47,8 @@ int stim::command_detect(int argc, const char **argv) {
     }
 
     RaiiFile in(find_open_file_argument("--in", stdin, "rb", argc, argv));
-    RaiiFile out(find_open_file_argument("--out", stdout, "w", argc, argv));
-    RaiiFile obs_out(find_open_file_argument("--obs_out", stdout, "w", argc, argv));
+    RaiiFile out(find_open_file_argument("--out", stdout, "wb", argc, argv));
+    RaiiFile obs_out(find_open_file_argument("--obs_out", stdout, "wb", argc, argv));
     if (obs_out.f == stdout) {
         obs_out.f = nullptr;
     }

--- a/src/stim/cmd/command_diagram.cc
+++ b/src/stim/cmd/command_diagram.cc
@@ -51,7 +51,7 @@ int stim::command_diagram(int argc, const char **argv) {
         "diagram",
         argc,
         argv);
-    RaiiFile in(find_open_file_argument("--in", stdin, "r", argc, argv));
+    RaiiFile in(find_open_file_argument("--in", stdin, "rb", argc, argv));
     auto out_stream = find_output_stream_argument("--out", true, argc, argv);
     auto &out = out_stream.stream();
     int64_t tick = find_int64_argument("--tick", 0, 0, INT64_MAX, argc, argv);

--- a/src/stim/cmd/command_explain_errors.cc
+++ b/src/stim/cmd/command_explain_errors.cc
@@ -23,13 +23,13 @@ using namespace stim;
 int stim::command_explain_errors(int argc, const char **argv) {
     check_for_unknown_arguments({"--dem_filter", "--single", "--out", "--in"}, {}, "explain_errors", argc, argv);
 
-    FILE *in = find_open_file_argument("--in", stdin, "r", argc, argv);
+    FILE *in = find_open_file_argument("--in", stdin, "rb", argc, argv);
     auto out_stream = find_output_stream_argument("--out", true, argc, argv);
     std::unique_ptr<DetectorErrorModel> dem_filter;
     bool single = find_bool_argument("--single", argc, argv);
     bool has_filter = find_argument("--dem_filter", argc, argv) != nullptr;
     if (has_filter) {
-        FILE *filter_file = find_open_file_argument("--dem_filter", stdin, "r", argc, argv);
+        FILE *filter_file = find_open_file_argument("--dem_filter", stdin, "rb", argc, argv);
         dem_filter =
             std::unique_ptr<DetectorErrorModel>(new DetectorErrorModel(DetectorErrorModel::from_file(filter_file)));
         fclose(filter_file);

--- a/src/stim/cmd/command_m2d.cc
+++ b/src/stim/cmd/command_m2d.cc
@@ -53,9 +53,9 @@ int stim::command_m2d(int argc, const char **argv) {
     fclose(circuit_file);
 
     FILE *in = find_open_file_argument("--in", stdin, "rb", argc, argv);
-    FILE *out = find_open_file_argument("--out", stdout, "w", argc, argv);
+    FILE *out = find_open_file_argument("--out", stdout, "wb", argc, argv);
     FILE *sweep_in = find_open_file_argument("--sweep", stdin, "rb", argc, argv);
-    FILE *obs_out = find_open_file_argument("--obs_out", stdout, "w", argc, argv);
+    FILE *obs_out = find_open_file_argument("--obs_out", stdout, "wb", argc, argv);
     if (sweep_in == stdin) {
         sweep_in = nullptr;
     }

--- a/src/stim/cmd/command_m2d.cc
+++ b/src/stim/cmd/command_m2d.cc
@@ -48,13 +48,13 @@ int stim::command_m2d(int argc, const char **argv) {
     const auto &obs_out_format = find_enum_argument("--obs_out_format", "01", format_name_to_enum_map, argc, argv);
     bool append_observables = find_bool_argument("--append_observables", argc, argv);
     bool skip_reference_sample = find_bool_argument("--skip_reference_sample", argc, argv);
-    FILE *circuit_file = find_open_file_argument("--circuit", nullptr, "r", argc, argv);
+    FILE *circuit_file = find_open_file_argument("--circuit", nullptr, "rb", argc, argv);
     auto circuit = Circuit::from_file(circuit_file);
     fclose(circuit_file);
 
-    FILE *in = find_open_file_argument("--in", stdin, "r", argc, argv);
+    FILE *in = find_open_file_argument("--in", stdin, "rb", argc, argv);
     FILE *out = find_open_file_argument("--out", stdout, "w", argc, argv);
-    FILE *sweep_in = find_open_file_argument("--sweep", stdin, "r", argc, argv);
+    FILE *sweep_in = find_open_file_argument("--sweep", stdin, "rb", argc, argv);
     FILE *obs_out = find_open_file_argument("--obs_out", stdout, "w", argc, argv);
     if (sweep_in == stdin) {
         sweep_in = nullptr;

--- a/src/stim/cmd/command_sample.cc
+++ b/src/stim/cmd/command_sample.cc
@@ -40,7 +40,7 @@ int stim::command_sample(int argc, const char **argv) {
         return EXIT_SUCCESS;
     }
     FILE *in = find_open_file_argument("--in", stdin, "rb", argc, argv);
-    FILE *out = find_open_file_argument("--out", stdout, "w", argc, argv);
+    FILE *out = find_open_file_argument("--out", stdout, "wb", argc, argv);
     auto rng = optionally_seeded_rng(argc, argv);
     bool deprecated_frame0 = find_bool_argument("--frame0", argc, argv);
     if (deprecated_frame0) {

--- a/src/stim/cmd/command_sample.cc
+++ b/src/stim/cmd/command_sample.cc
@@ -39,7 +39,7 @@ int stim::command_sample(int argc, const char **argv) {
     if (num_shots == 0) {
         return EXIT_SUCCESS;
     }
-    FILE *in = find_open_file_argument("--in", stdin, "r", argc, argv);
+    FILE *in = find_open_file_argument("--in", stdin, "rb", argc, argv);
     FILE *out = find_open_file_argument("--out", stdout, "w", argc, argv);
     auto rng = optionally_seeded_rng(argc, argv);
     bool deprecated_frame0 = find_bool_argument("--frame0", argc, argv);

--- a/src/stim/cmd/command_sample_dem.cc
+++ b/src/stim/cmd/command_sample_dem.cc
@@ -48,9 +48,9 @@ int stim::command_sample_dem(int argc, const char **argv) {
     uint64_t num_shots = find_int64_argument("--shots", 1, 0, INT64_MAX, argc, argv);
 
     RaiiFile in(find_open_file_argument("--in", stdin, "rb", argc, argv));
-    RaiiFile out(find_open_file_argument("--out", stdout, "w", argc, argv));
-    RaiiFile obs_out(find_open_file_argument("--obs_out", stdout, "w", argc, argv));
-    RaiiFile err_out(find_open_file_argument("--err_out", stdout, "w", argc, argv));
+    RaiiFile out(find_open_file_argument("--out", stdout, "wb", argc, argv));
+    RaiiFile obs_out(find_open_file_argument("--obs_out", stdout, "wb", argc, argv));
+    RaiiFile err_out(find_open_file_argument("--err_out", stdout, "wb", argc, argv));
     RaiiFile err_in(find_open_file_argument("--replay_err_in", stdin, "rb", argc, argv));
     if (obs_out.f == stdout) {
         obs_out.f = nullptr;

--- a/src/stim/cmd/command_sample_dem.cc
+++ b/src/stim/cmd/command_sample_dem.cc
@@ -47,11 +47,11 @@ int stim::command_sample_dem(int argc, const char **argv) {
     const auto &err_in_format = find_enum_argument("--replay_err_in_format", "01", format_name_to_enum_map, argc, argv);
     uint64_t num_shots = find_int64_argument("--shots", 1, 0, INT64_MAX, argc, argv);
 
-    RaiiFile in(find_open_file_argument("--in", stdin, "r", argc, argv));
+    RaiiFile in(find_open_file_argument("--in", stdin, "rb", argc, argv));
     RaiiFile out(find_open_file_argument("--out", stdout, "w", argc, argv));
     RaiiFile obs_out(find_open_file_argument("--obs_out", stdout, "w", argc, argv));
     RaiiFile err_out(find_open_file_argument("--err_out", stdout, "w", argc, argv));
-    RaiiFile err_in(find_open_file_argument("--replay_err_in", stdin, "r", argc, argv));
+    RaiiFile err_in(find_open_file_argument("--replay_err_in", stdin, "rb", argc, argv));
     if (obs_out.f == stdout) {
         obs_out.f = nullptr;
     }

--- a/src/stim/dem/detector_error_model.pybind.cc
+++ b/src/stim/dem/detector_error_model.pybind.cc
@@ -836,7 +836,7 @@ void stim_pybind::pybind_detector_error_model_methods(
         [](pybind11::object &obj) {
             try {
                 auto path = pybind11::cast<std::string>(obj);
-                RaiiFile f(path.data(), "r");
+                RaiiFile f(path.data(), "rb");
                 return DetectorErrorModel::from_file(f.f);
             } catch (pybind11::cast_error &ex) {
             }
@@ -844,7 +844,7 @@ void stim_pybind::pybind_detector_error_model_methods(
             auto py_path = pybind11::module::import("pathlib").attr("Path");
             if (pybind11::isinstance(obj, py_path)) {
                 auto path = pybind11::cast<std::string>(pybind11::str(obj));
-                RaiiFile f(path.data(), "r");
+                RaiiFile f(path.data(), "rb");
                 return DetectorErrorModel::from_file(f.f);
             }
 

--- a/src/stim/dem/detector_error_model.pybind.cc
+++ b/src/stim/dem/detector_error_model.pybind.cc
@@ -1152,12 +1152,12 @@ void stim_pybind::pybind_detector_error_model_methods(
 
                 >>> with tempfile.TemporaryDirectory() as d:
                 ...     diagram = circuit.diagram(type="match-graph-svg")
-                ...     with open(f"{d}/dem_image.svg", "w") as f:
+                ...     with open(f"{d}/dem_image.svg", "wb") as f:
                 ...         print(diagram, file=f)
 
                 >>> with tempfile.TemporaryDirectory() as d:
                 ...     diagram = circuit.diagram(type="match-graph-3d")
-                ...     with open(f"{d}/dem_3d_model.gltf", "w") as f:
+                ...     with open(f"{d}/dem_3d_model.gltf", "wb") as f:
                 ...         print(diagram, file=f)
         )DOC")
             .data());

--- a/src/stim/dem/detector_error_model.pybind.cc
+++ b/src/stim/dem/detector_error_model.pybind.cc
@@ -1152,12 +1152,12 @@ void stim_pybind::pybind_detector_error_model_methods(
 
                 >>> with tempfile.TemporaryDirectory() as d:
                 ...     diagram = circuit.diagram(type="match-graph-svg")
-                ...     with open(f"{d}/dem_image.svg", "wb") as f:
+                ...     with open(f"{d}/dem_image.svg", "w") as f:
                 ...         print(diagram, file=f)
 
                 >>> with tempfile.TemporaryDirectory() as d:
                 ...     diagram = circuit.diagram(type="match-graph-3d")
-                ...     with open(f"{d}/dem_3d_model.gltf", "wb") as f:
+                ...     with open(f"{d}/dem_3d_model.gltf", "w") as f:
                 ...         print(diagram, file=f)
         )DOC")
             .data());

--- a/src/stim/dem/detector_error_model.test.cc
+++ b/src/stim/dem/detector_error_model.test.cc
@@ -873,3 +873,8 @@ TEST(detector_error_model, flattened) {
         detector(25, 20, 30, 40) D10
     )DEM"));
 }
+
+TEST(detector_error_model, parse_windows_newlines) {
+    ASSERT_EQ(DetectorErrorModel("error(0.125) D0\r\ndetector(5) D10\r\n"),
+              DetectorErrorModel("error(0.125) D0\r\ndetector(5) D10\r\n"));
+}

--- a/src/stim/diagram/graph/match_graph_3d_drawer.test.cc
+++ b/src/stim/diagram/graph/match_graph_3d_drawer.test.cc
@@ -34,7 +34,7 @@ void expect_graph_diagram_is_identical_to_saved_file(const DetectorErrorModel &d
     auto actual = actual_ss.str();
 
     auto path = resolve_test_file(key);
-    FILE *f = fopen(path.c_str(), "r");
+    FILE *f = fopen(path.c_str(), "rb");
     auto expected = rewind_read_close(f);
 
     if (expected != actual) {

--- a/src/stim/diagram/graph/match_graph_svg_drawer.test.cc
+++ b/src/stim/diagram/graph/match_graph_svg_drawer.test.cc
@@ -34,7 +34,7 @@ void expect_graph_svg_diagram_is_identical_to_saved_file(const DetectorErrorMode
     auto actual = actual_ss.str();
 
     auto path = resolve_test_file(key);
-    FILE *f = fopen(path.c_str(), "r");
+    FILE *f = fopen(path.c_str(), "rb");
     auto expected = rewind_read_close(f);
 
     if (expected != actual) {

--- a/src/stim/diagram/timeline/timeline_3d_drawer.test.cc
+++ b/src/stim/diagram/timeline/timeline_3d_drawer.test.cc
@@ -33,7 +33,7 @@ void expect_diagram_is_identical_to_saved_file(const Circuit &circuit, std::stri
     auto actual = actual_ss.str();
 
     auto path = resolve_test_file(key);
-    FILE *f = fopen(path.c_str(), "r");
+    FILE *f = fopen(path.c_str(), "rb");
     auto expected = rewind_read_close(f);
 
     if (expected != actual) {

--- a/src/stim/diagram/timeline/timeline_svg_drawer.test.cc
+++ b/src/stim/diagram/timeline/timeline_svg_drawer.test.cc
@@ -31,7 +31,7 @@ void expect_svg_diagram_is_identical_to_saved_file(const Circuit &circuit, std::
     DiagramTimelineSvgDrawer::make_diagram_write_to(circuit, ss);
     auto actual = ss.str();
     auto path = resolve_test_file(key);
-    FILE *f = fopen(path.c_str(), "r");
+    FILE *f = fopen(path.c_str(), "rb");
     auto expected = rewind_read_close(f);
 
     if (expected != actual) {

--- a/src/stim/io/measure_record_reader.test.cc
+++ b/src/stim/io/measure_record_reader.test.cc
@@ -721,14 +721,14 @@ TEST(MeasureRecordReader, read_file_data_into_shot_table_vs_write_table) {
             f, num_shots, bits_per_shot, simd_bits<MAX_BITWORD_WIDTH>(0), expected_transposed, format, 'M', 'M', 0);
         fclose(f);
 
-        f = fopen(tmp.path.c_str(), "r");
+        f = fopen(tmp.path.c_str(), "rb");
         simd_bit_table<MAX_BITWORD_WIDTH> output(num_shots, bits_per_shot);
         read_file_data_into_shot_table(f, num_shots, bits_per_shot, format, 'M', output, true);
         ASSERT_EQ(getc(f), EOF) << format_data.second.name << ", not transposed";
         fclose(f);
         ASSERT_EQ(output, expected) << format_data.second.name << ", not transposed";
 
-        f = fopen(tmp.path.c_str(), "r");
+        f = fopen(tmp.path.c_str(), "rb");
         simd_bit_table<MAX_BITWORD_WIDTH> output_transposed(bits_per_shot, num_shots);
         read_file_data_into_shot_table(f, num_shots, bits_per_shot, format, 'M', output_transposed, false);
         ASSERT_EQ(getc(f), EOF) << format_data.second.name << ", yes transposed";

--- a/src/stim/io/measure_record_reader.test.cc
+++ b/src/stim/io/measure_record_reader.test.cc
@@ -716,7 +716,7 @@ TEST(MeasureRecordReader, read_file_data_into_shot_table_vs_write_table) {
         simd_bit_table<MAX_BITWORD_WIDTH> expected_transposed = expected.transposed();
 
         RaiiTempNamedFile tmp;
-        FILE *f = fopen(tmp.path.c_str(), "w");
+        FILE *f = fopen(tmp.path.c_str(), "wb");
         write_table_data(
             f, num_shots, bits_per_shot, simd_bits<MAX_BITWORD_WIDTH>(0), expected_transposed, format, 'M', 'M', 0);
         fclose(f);

--- a/src/stim/io/read_write.pybind.cc
+++ b/src/stim/io/read_write.pybind.cc
@@ -46,7 +46,7 @@ pybind11::object read_shot_data_file(
     size_t num_bytes_per_shot = (num_bits_per_shot + 7) / 8;
     size_t num_shots = 0;
     {
-        RaiiFile f(path, "r");
+        RaiiFile f(path, "rb");
         auto reader = MeasureRecordReader::make(f.f, parsed_format, nm, nd, no);
 
         simd_bits<MAX_BITWORD_WIDTH> buffer(num_bits_per_shot);

--- a/src/stim/io/read_write.pybind.cc
+++ b/src/stim/io/read_write.pybind.cc
@@ -118,7 +118,7 @@ void write_shot_data_file(
     simd_bit_table<MAX_BITWORD_WIDTH> buffer =
         numpy_array_to_transposed_simd_table(data, num_bits_per_shot, &num_shots);
 
-    RaiiFile f(path, "w");
+    RaiiFile f(path, "wb");
     simd_bits<MAX_BITWORD_WIDTH> unused(0);
     write_table_data(
         f.f,

--- a/src/stim/io/read_write.pybind.cc
+++ b/src/stim/io/read_write.pybind.cc
@@ -78,7 +78,7 @@ pybind11::object read_shot_data_file(
         size_t t = 0;
         for (size_t s = 0; s < num_shots; s++) {
             for (size_t k = 0; k < num_bits_per_shot; k++) {
-                auto bi = (s * num_bytes_per_shot + k) / 8;
+                auto bi = s * num_bytes_per_shot + k / 8;
                 buffer[t++] = (full_buffer[bi] >> (k % 8)) & 1;
             }
         }

--- a/src/stim/io/read_write.pybind.cc
+++ b/src/stim/io/read_write.pybind.cc
@@ -74,11 +74,11 @@ pybind11::object read_shot_data_file(
             buffer,
             free_when_done);
     } else {
-        bool *buffer = new bool[num_bits_per_shot];
+        bool *buffer = new bool[num_bits_per_shot * num_shots];
         size_t t = 0;
         for (size_t s = 0; s < num_shots; s++) {
             for (size_t k = 0; k < num_bits_per_shot; k++) {
-                auto bi = (s * num_bytes_per_shot + (k / 8));
+                auto bi = (s * num_bytes_per_shot + k) / 8;
                 buffer[t++] = (full_buffer[bi] >> (k % 8)) & 1;
             }
         }

--- a/src/stim/io/read_write_pytest.py
+++ b/src/stim/io/read_write_pytest.py
@@ -172,3 +172,30 @@ def test_write_shot_data_file_01():
         )
         with open(path) as f:
             assert f.read() == '0001110011000\n0000000000000\n'
+
+
+def test_read_data_file_partial_b8():
+    with tempfile.TemporaryDirectory() as d:
+        path = pathlib.Path(d) / 'tmp.b8'
+        with open(path, 'wb') as f:
+            f.write(b'\0' * 273)
+        with pytest.raises(ValueError, match="middle of record"):
+            stim.read_shot_data_file(
+                path=str(path),
+                format="b8",
+                num_detectors=2185,
+                num_observables=0,
+            )
+
+
+def test_read_data_file_big_b8():
+    with tempfile.TemporaryDirectory() as d:
+        path = pathlib.Path(d) / 'tmp.b8'
+        with open(path, 'wb') as f:
+            f.write(b'\0' * 274000)
+        stim.read_shot_data_file(
+            path=str(path),
+            format="b8",
+            num_detectors=2185,
+            num_observables=0,
+        )

--- a/src/stim/io/read_write_pytest.py
+++ b/src/stim/io/read_write_pytest.py
@@ -199,3 +199,20 @@ def test_read_data_file_big_b8():
             num_detectors=2185,
             num_observables=0,
         )
+
+
+def test_read_01_shots():
+    with tempfile.TemporaryDirectory() as d:
+        path = pathlib.Path(d) / 'shots'
+        with open(path, 'w') as f:
+            print("0000", file=f)
+            print("0101", file=f)
+
+        read = stim.read_shot_data_file(
+            path=str(path),
+            format='01',
+            num_measurements=4)
+        np.testing.assert_array_equal(
+            read,
+            [[0, 0, 0, 0], [0, 1, 0, 1]]
+        )

--- a/src/stim/py/compiled_detector_sampler.pybind.cc
+++ b/src/stim/py/compiled_detector_sampler.pybind.cc
@@ -73,8 +73,8 @@ void CompiledDetectorSampler::sample_write(
     const char *obs_out_filepath,
     const std::string &obs_out_format) {
     auto f = format_to_enum(format);
-    RaiiFile out(filepath.data(), "w");
-    RaiiFile obs_out(obs_out_filepath, "w");
+    RaiiFile out(filepath.data(), "wb");
+    RaiiFile obs_out(obs_out_filepath, "wb");
     auto parsed_obs_out_format = format_to_enum(obs_out_format);
     detector_samples_out(
         circuit,

--- a/src/stim/py/compiled_measurement_sampler.pybind.cc
+++ b/src/stim/py/compiled_measurement_sampler.pybind.cc
@@ -41,7 +41,7 @@ pybind11::object CompiledMeasurementSampler::sample_to_numpy(size_t num_shots, b
 void CompiledMeasurementSampler::sample_write(
     size_t num_samples, const std::string &filepath, const std::string &format) {
     auto f = format_to_enum(format);
-    FILE *out = fopen(filepath.data(), "w");
+    FILE *out = fopen(filepath.data(), "wb");
     if (out == nullptr) {
         throw std::invalid_argument("Failed to open '" + filepath + "' to write.");
     }

--- a/src/stim/simulators/dem_sampler.pybind.cc
+++ b/src/stim/simulators/dem_sampler.pybind.cc
@@ -277,9 +277,9 @@ void stim_pybind::pybind_dem_sampler_methods(pybind11::module &m, pybind11::clas
            const std::string &err_out_format,
            pybind11::object &replay_err_in_file,
            const std::string &replay_err_in_format) {
-            RaiiFile fd = optional_py_path_to_raii_file(det_out_file, "w");
-            RaiiFile fo = optional_py_path_to_raii_file(obs_out_file, "w");
-            RaiiFile feo = optional_py_path_to_raii_file(err_out_file, "w");
+            RaiiFile fd = optional_py_path_to_raii_file(det_out_file, "wb");
+            RaiiFile fo = optional_py_path_to_raii_file(obs_out_file, "wb");
+            RaiiFile feo = optional_py_path_to_raii_file(err_out_file, "wb");
             RaiiFile fei = optional_py_path_to_raii_file(replay_err_in_file, "rb");
             self.sample_write(
                 shots,

--- a/src/stim/simulators/dem_sampler.pybind.cc
+++ b/src/stim/simulators/dem_sampler.pybind.cc
@@ -280,7 +280,7 @@ void stim_pybind::pybind_dem_sampler_methods(pybind11::module &m, pybind11::clas
             RaiiFile fd = optional_py_path_to_raii_file(det_out_file, "w");
             RaiiFile fo = optional_py_path_to_raii_file(obs_out_file, "w");
             RaiiFile feo = optional_py_path_to_raii_file(err_out_file, "w");
-            RaiiFile fei = optional_py_path_to_raii_file(replay_err_in_file, "r");
+            RaiiFile fei = optional_py_path_to_raii_file(replay_err_in_file, "rb");
             self.sample_write(
                 shots,
                 fd.f,

--- a/src/stim/simulators/measurements_to_detection_events.pybind.cc
+++ b/src/stim/simulators/measurements_to_detection_events.pybind.cc
@@ -269,7 +269,7 @@ void stim_pybind::pybind_compiled_measurements_to_detection_events_converter_met
                 ...    DETECTOR rec[-1]
                 ... ''').compile_m2d_converter()
                 >>> with tempfile.TemporaryDirectory() as d:
-                ...    with open(f"{d}/measurements.01", "wb") as f:
+                ...    with open(f"{d}/measurements.01", "w") as f:
                 ...        print("0", file=f)
                 ...        print("1", file=f)
                 ...    converter.convert_file(

--- a/src/stim/simulators/measurements_to_detection_events.pybind.cc
+++ b/src/stim/simulators/measurements_to_detection_events.pybind.cc
@@ -62,9 +62,9 @@ void CompiledMeasurementsToDetectionEventsConverter::convert_file(
     auto format_sweep_bits = format_to_enum(sweep_bits_format);
     auto format_out = format_to_enum(detection_events_format);
     RaiiFile file_in(measurements_filepath.data(), "rb");
-    RaiiFile obs_out(obs_out_filepath, "w");
+    RaiiFile obs_out(obs_out_filepath, "wb");
     RaiiFile sweep_bits_in(sweep_bits_filepath, "rb");
-    RaiiFile detections_out(detection_events_filepath.data(), "w");
+    RaiiFile detections_out(detection_events_filepath.data(), "wb");
     auto parsed_obs_out_format = format_to_enum(obs_out_format);
 
     stim::stream_measurements_to_detection_events_helper(
@@ -269,7 +269,7 @@ void stim_pybind::pybind_compiled_measurements_to_detection_events_converter_met
                 ...    DETECTOR rec[-1]
                 ... ''').compile_m2d_converter()
                 >>> with tempfile.TemporaryDirectory() as d:
-                ...    with open(f"{d}/measurements.01", "w") as f:
+                ...    with open(f"{d}/measurements.01", "wb") as f:
                 ...        print("0", file=f)
                 ...        print("1", file=f)
                 ...    converter.convert_file(

--- a/src/stim/simulators/measurements_to_detection_events.pybind.cc
+++ b/src/stim/simulators/measurements_to_detection_events.pybind.cc
@@ -61,9 +61,9 @@ void CompiledMeasurementsToDetectionEventsConverter::convert_file(
     auto format_in = format_to_enum(measurements_format);
     auto format_sweep_bits = format_to_enum(sweep_bits_format);
     auto format_out = format_to_enum(detection_events_format);
-    RaiiFile file_in(measurements_filepath.data(), "r");
+    RaiiFile file_in(measurements_filepath.data(), "rb");
     RaiiFile obs_out(obs_out_filepath, "w");
-    RaiiFile sweep_bits_in(sweep_bits_filepath, "r");
+    RaiiFile sweep_bits_in(sweep_bits_filepath, "rb");
     RaiiFile detections_out(detection_events_filepath.data(), "w");
     auto parsed_obs_out_format = format_to_enum(obs_out_format);
 
@@ -277,7 +277,7 @@ void stim_pybind::pybind_compiled_measurements_to_detection_events_converter_met
                 ...        detection_events_filepath=f"{d}/detections.01",
                 ...        append_observables=False,
                 ...    )
-                ...    with open(f"{d}/detections.01", "r") as f:
+                ...    with open(f"{d}/detections.01") as f:
                 ...        print(f.read(), end="")
                 1
                 0

--- a/src/stim/simulators/measurements_to_detection_events_test.py
+++ b/src/stim/simulators/measurements_to_detection_events_test.py
@@ -39,7 +39,7 @@ def test_convert_file_without_sweep_bits():
             append_observables=False,
         )
 
-        with open(f"{d}/detections.01", "r") as f:
+        with open(f"{d}/detections.01") as f:
             assert f.read() == "1\n0\n"
 
     with tempfile.TemporaryDirectory() as d:
@@ -64,7 +64,7 @@ def test_convert_file_without_sweep_bits():
             append_observables=True,
         )
 
-        with open(f"{d}/detections.dets", "r") as f:
+        with open(f"{d}/detections.dets") as f:
             assert f.read() == "shot D0 L0\nshot\nshot\nshot D0 L0\n"
 
         converter.convert_file(
@@ -78,9 +78,9 @@ def test_convert_file_without_sweep_bits():
             obs_out_format="hits",
         )
 
-        with open(f"{d}/detections.dets", "r") as f:
+        with open(f"{d}/detections.dets") as f:
             assert f.read() == "shot D0\nshot\nshot\nshot D0\n"
-        with open(f"{d}/obs.hits", "r") as f:
+        with open(f"{d}/obs.hits") as f:
             assert f.read() == "0\n\n\n0\n"
 
 

--- a/src/stim/test_util.test.cc
+++ b/src/stim/test_util.test.cc
@@ -28,7 +28,7 @@ std::string resolve_test_file(const std::string &name) {
     };
     for (const auto &prefix : prefixes) {
         std::string full_path = prefix + name;
-        FILE *f = fopen(full_path.c_str(), "r");
+        FILE *f = fopen(full_path.c_str(), "rb");
         if (f != nullptr) {
             fclose(f);
             return full_path;
@@ -75,7 +75,7 @@ RaiiTempNamedFile::~RaiiTempNamedFile() {
 }
 
 std::string RaiiTempNamedFile::read_contents() {
-    FILE *f = fopen(path.c_str(), "r");
+    FILE *f = fopen(path.c_str(), "rb");
     if (f == nullptr) {
         throw std::runtime_error("Failed to open temp named file " + path);
     }

--- a/src/stim/test_util.test.cc
+++ b/src/stim/test_util.test.cc
@@ -92,7 +92,7 @@ std::string RaiiTempNamedFile::read_contents() {
 }
 
 void RaiiTempNamedFile::write_contents(const std::string &contents) {
-    FILE *f = fopen(path.c_str(), "w");
+    FILE *f = fopen(path.c_str(), "wb");
     if (f == nullptr) {
         throw std::runtime_error("Failed to open temp named file " + path);
     }


### PR DESCRIPTION
- `read_shot_data_file` had a segfault due to miscalculating buffer size and also offsets
- Files were being opened in `"r"` mode instead of `"rb"`, resulting in lost bytes on windows due to conversion from `\r\n` to `\n`
- Files were being opened in `"w"` mode instead of `"wb"`, resulting in potential extra bytes on windows due to conversion from `\n` to `\r\n`
- Fix `\r` character not being treated as whitespace when parsing

Fixes https://github.com/quantumlib/Stim/issues/377
