### PR TITLE
Add support for circuit instructions to `stim.TableauSimulator.do`

### DIFF
--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -8858,27 +8858,16 @@ def cz(
 # stim.TableauSimulator.do
 
 # (in class stim.TableauSimulator)
-@overload
 def do(
     self,
-    circuit_or_pauli_string: stim.Circuit,
-) -> None:
-    pass
-@overload
-def do(
-    self,
-    circuit_or_pauli_string: stim.PauliString,
-) -> None:
-    pass
-def do(
-    self,
-    circuit_or_pauli_string: object,
+    circuit_or_pauli_string: Union[stim.Circuit, stim.PauliString, stim.CircuitInstruction, stim.CircuitRepeatBlock],
 ) -> None:
     """Applies a circuit or pauli string to the simulator's state.
 
     Args:
-        circuit_or_pauli_string: A stim.Circuit or a stim.PauliString containing
-            operations to apply to the simulator's state.
+        circuit_or_pauli_string: A stim.Circuit, stim.PauliString,
+            stim.CircuitInstruction, or stim.CircuitRepeatBlock
+            with operations to apply to the simulator's state.
 
     Examples:
         >>> import stim

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -6783,27 +6783,16 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
         """
-    @overload
     def do(
         self,
-        circuit_or_pauli_string: stim.Circuit,
-    ) -> None:
-        pass
-    @overload
-    def do(
-        self,
-        circuit_or_pauli_string: stim.PauliString,
-    ) -> None:
-        pass
-    def do(
-        self,
-        circuit_or_pauli_string: object,
+        circuit_or_pauli_string: Union[stim.Circuit, stim.PauliString, stim.CircuitInstruction, stim.CircuitRepeatBlock],
     ) -> None:
         """Applies a circuit or pauli string to the simulator's state.
 
         Args:
-            circuit_or_pauli_string: A stim.Circuit or a stim.PauliString containing
-                operations to apply to the simulator's state.
+            circuit_or_pauli_string: A stim.Circuit, stim.PauliString,
+                stim.CircuitInstruction, or stim.CircuitRepeatBlock
+                with operations to apply to the simulator's state.
 
         Examples:
             >>> import stim

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -6783,27 +6783,16 @@ class TableauSimulator:
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
         """
-    @overload
     def do(
         self,
-        circuit_or_pauli_string: stim.Circuit,
-    ) -> None:
-        pass
-    @overload
-    def do(
-        self,
-        circuit_or_pauli_string: stim.PauliString,
-    ) -> None:
-        pass
-    def do(
-        self,
-        circuit_or_pauli_string: object,
+        circuit_or_pauli_string: Union[stim.Circuit, stim.PauliString, stim.CircuitInstruction, stim.CircuitRepeatBlock],
     ) -> None:
         """Applies a circuit or pauli string to the simulator's state.
 
         Args:
-            circuit_or_pauli_string: A stim.Circuit or a stim.PauliString containing
-                operations to apply to the simulator's state.
+            circuit_or_pauli_string: A stim.Circuit, stim.PauliString,
+                stim.CircuitInstruction, or stim.CircuitRepeatBlock
+                with operations to apply to the simulator's state.
 
         Examples:
             >>> import stim

--- a/src/stim/circuit/gate_target.cc
+++ b/src/stim/circuit/gate_target.cc
@@ -79,6 +79,9 @@ bool GateTarget::is_inverted_result_target() const {
 bool GateTarget::is_measurement_record_target() const {
     return data & TARGET_RECORD_BIT;
 }
+bool GateTarget::has_qubit_value() const {
+    return !(data & (TARGET_RECORD_BIT | TARGET_SWEEP_BIT | TARGET_COMBINER));
+}
 bool GateTarget::is_qubit_target() const {
     return !(data & (TARGET_PAULI_X_BIT | TARGET_PAULI_Z_BIT | TARGET_RECORD_BIT | TARGET_SWEEP_BIT | TARGET_COMBINER));
 }

--- a/src/stim/circuit/gate_target.h
+++ b/src/stim/circuit/gate_target.h
@@ -43,6 +43,7 @@ struct GateTarget {
     static GateTarget sweep_bit(uint32_t index);
     static GateTarget combiner();
 
+    bool has_qubit_value() const;
     bool is_combiner() const;
     bool is_x_target() const;
     bool is_y_target() const;

--- a/src/stim/circuit/gate_target.test.cc
+++ b/src/stim/circuit/gate_target.test.cc
@@ -16,8 +16,6 @@
 
 #include "gtest/gtest.h"
 
-#include "stim/test_util.test.h"
-
 using namespace stim;
 
 TEST(gate_target, xyz) {
@@ -35,6 +33,8 @@ TEST(gate_target, xyz) {
     ASSERT_EQ(t.is_z_target(), false);
     ASSERT_EQ(t.str(), "stim.target_x(5)");
     ASSERT_EQ(t.value(), 5);
+    ASSERT_TRUE(t.has_qubit_value());
+    ASSERT_FALSE(t.is_sweep_bit_target());
 
     t = GateTarget::x(7, true);
     ASSERT_EQ(t.is_combiner(), false);
@@ -46,6 +46,8 @@ TEST(gate_target, xyz) {
     ASSERT_EQ(t.is_z_target(), false);
     ASSERT_EQ(t.str(), "stim.target_x(7, invert=True)");
     ASSERT_EQ(t.value(), 7);
+    ASSERT_TRUE(t.has_qubit_value());
+    ASSERT_FALSE(t.is_sweep_bit_target());
 
     t = GateTarget::y(11, false);
     ASSERT_EQ(t.is_combiner(), false);
@@ -57,6 +59,8 @@ TEST(gate_target, xyz) {
     ASSERT_EQ(t.is_z_target(), false);
     ASSERT_EQ(t.str(), "stim.target_y(11)");
     ASSERT_EQ(t.value(), 11);
+    ASSERT_TRUE(t.has_qubit_value());
+    ASSERT_FALSE(t.is_sweep_bit_target());
 
     t = GateTarget::y(13, true);
     ASSERT_EQ(t.is_combiner(), false);
@@ -68,6 +72,7 @@ TEST(gate_target, xyz) {
     ASSERT_EQ(t.is_z_target(), false);
     ASSERT_EQ(t.str(), "stim.target_y(13, invert=True)");
     ASSERT_EQ(t.value(), 13);
+    ASSERT_FALSE(t.is_sweep_bit_target());
 
     t = GateTarget::z(17, false);
     ASSERT_EQ(t.is_combiner(), false);
@@ -79,6 +84,8 @@ TEST(gate_target, xyz) {
     ASSERT_EQ(t.is_z_target(), true);
     ASSERT_EQ(t.str(), "stim.target_z(17)");
     ASSERT_EQ(t.value(), 17);
+    ASSERT_TRUE(t.has_qubit_value());
+    ASSERT_FALSE(t.is_sweep_bit_target());
 
     t = GateTarget::z(19, true);
     ASSERT_EQ(t.is_combiner(), false);
@@ -91,6 +98,8 @@ TEST(gate_target, xyz) {
     ASSERT_EQ(t.str(), "stim.target_z(19, invert=True)");
     ASSERT_EQ(t.value(), 19);
     ASSERT_EQ(t.qubit_value(), 19);
+    ASSERT_TRUE(t.has_qubit_value());
+    ASSERT_FALSE(t.is_sweep_bit_target());
 }
 
 TEST(gate_target, qubit) {
@@ -107,6 +116,8 @@ TEST(gate_target, qubit) {
     ASSERT_EQ(t.str(), "5");
     ASSERT_EQ(t.value(), 5);
     ASSERT_EQ(t.qubit_value(), 5);
+    ASSERT_TRUE(t.has_qubit_value());
+    ASSERT_FALSE(t.is_sweep_bit_target());
 
     t = GateTarget::qubit(7, true);
     ASSERT_EQ(t.is_combiner(), false);
@@ -118,6 +129,8 @@ TEST(gate_target, qubit) {
     ASSERT_EQ(t.is_z_target(), false);
     ASSERT_EQ(t.str(), "stim.target_inv(7)");
     ASSERT_EQ(t.value(), 7);
+    ASSERT_TRUE(t.has_qubit_value());
+    ASSERT_FALSE(t.is_sweep_bit_target());
 }
 
 TEST(gate_target, record) {
@@ -136,6 +149,23 @@ TEST(gate_target, record) {
     ASSERT_EQ(t.str(), "stim.target_rec(-5)");
     ASSERT_EQ(t.value(), -5);
     ASSERT_EQ(t.qubit_value(), 5);
+    ASSERT_FALSE(t.has_qubit_value());
+    ASSERT_FALSE(t.is_sweep_bit_target());
+}
+
+TEST(gate_target, sweep) {
+    auto t = GateTarget::sweep_bit(5);
+    ASSERT_EQ(t.is_combiner(), false);
+    ASSERT_EQ(t.is_inverted_result_target(), false);
+    ASSERT_EQ(t.is_measurement_record_target(), false);
+    ASSERT_EQ(t.is_qubit_target(), false);
+    ASSERT_EQ(t.is_x_target(), false);
+    ASSERT_EQ(t.is_y_target(), false);
+    ASSERT_EQ(t.is_z_target(), false);
+    ASSERT_EQ(t.str(), "stim.target_sweep_bit(5)");
+    ASSERT_EQ(t.value(), 5);
+    ASSERT_FALSE(t.has_qubit_value());
+    ASSERT_TRUE(t.is_sweep_bit_target());
 }
 
 TEST(gate_target, combiner) {
@@ -149,6 +179,8 @@ TEST(gate_target, combiner) {
     ASSERT_EQ(t.is_z_target(), false);
     ASSERT_EQ(t.str(), "stim.GateTarget.combiner()");
     ASSERT_EQ(t.qubit_value(), 0);
+    ASSERT_FALSE(t.has_qubit_value());
+    ASSERT_FALSE(t.is_sweep_bit_target());
 }
 
 TEST(gate_target, equality) {

--- a/src/stim/simulators/tableau_simulator.h
+++ b/src/stim/simulators/tableau_simulator.h
@@ -143,7 +143,8 @@ struct TableauSimulator {
     /// Runs all of the operations in the given circuit.
     ///
     /// Automatically expands the tableau simulator's state, if needed.
-    void expand_do_circuit(const Circuit &circuit);
+    void expand_do_circuit(const Circuit &circuit, uint64_t reps = 1);
+    void do_operation_ensure_size(const Operation &operation);
 
     void apply_tableau(const Tableau &tableau, const std::vector<size_t> &targets);
 

--- a/src/stim/simulators/tableau_simulator_pybind_test.py
+++ b/src/stim/simulators/tableau_simulator_pybind_test.py
@@ -594,3 +594,29 @@ def test_copy_with_explicit_copy_rng_and_seed():
     s = stim.TableauSimulator()
     with pytest.raises(ValueError, match='seed and copy_rng are incompatible'):
         _ = s.copy(copy_rng=True, seed=0)
+
+
+def test_do_circuit_instruction():
+    s = stim.TableauSimulator()
+    assert s.peek_z(0) == +1
+    s.do(stim.Circuit("X 0")[0])
+    assert s.peek_z(0) == -1
+
+    s.do(stim.Circuit("""
+        REPEAT 100 {
+            CNOT 0 1 1 2 2 3 3 4 4 5 5 6 6 7 7 0
+        }
+    """)[0])
+    assert s.peek_z(0) == +1
+    assert s.peek_z(1) == +1
+    assert s.peek_z(2) == +1
+    assert s.peek_z(3) == -1
+    assert s.peek_z(4) == +1
+    assert s.peek_z(5) == -1
+    assert s.peek_z(6) == +1
+    assert s.peek_z(7) == +1
+
+    s.do(stim.Circuit("X 500")[0])
+    assert s.peek_z(499) == +1
+    assert s.peek_z(500) == -1
+    assert s.peek_z(501) == +1


### PR DESCRIPTION
- Add `GateTarget::has_qubit_value`

Fixes https://github.com/quantumlib/Stim/issues/285