### PR TITLE
Fix slice start assertions not being conditional on non-zero length

### DIFF
--- a/src/stim/circuit/circuit.cc
+++ b/src/stim/circuit/circuit.cc
@@ -1004,8 +1004,8 @@ size_t Circuit::count_sweep_bits() const {
 }
 
 Circuit Circuit::py_get_slice(int64_t start, int64_t step, int64_t slice_length) const {
-    assert(start >= 0);
     assert(slice_length >= 0);
+    assert(slice_length == 0 || start >= 0);
     Circuit result;
     for (size_t k = 0; k < (size_t)slice_length; k++) {
         const auto &op = operations[start + step * k];

--- a/src/stim/circuit/circuit_pybind_test.py
+++ b/src/stim/circuit/circuit_pybind_test.py
@@ -967,3 +967,10 @@ def test_circuit_inverse():
         CX 0 2 0 1
         S_DAG 1 0
     """)
+
+
+def test_circuit_slice_reverse():
+    c = stim.Circuit()
+    assert c[::-1] == stim.Circuit()
+    c = stim.Circuit("X 1\nY 2\nZ 3")
+    assert c[::-1] == stim.Circuit("Z 3\nY 2\nX 1")

--- a/src/stim/dem/detector_error_model.cc
+++ b/src/stim/dem/detector_error_model.cc
@@ -768,8 +768,8 @@ uint64_t DetectorErrorModel::count_observables() const {
 }
 
 DetectorErrorModel DetectorErrorModel::py_get_slice(int64_t start, int64_t step, int64_t slice_length) const {
-    assert(start >= 0);
     assert(slice_length >= 0);
+    assert(slice_length == 0 || start >= 0);
     DetectorErrorModel result;
     for (size_t k = 0; k < (size_t)slice_length; k++) {
         const auto &op = instructions[start + step * k];

--- a/src/stim/stabilizers/pauli_string.cc
+++ b/src/stim/stabilizers/pauli_string.cc
@@ -150,7 +150,8 @@ uint8_t PauliString::py_get_item(int64_t index) const {
 }
 
 PauliString PauliString::py_get_slice(int64_t start, int64_t step, int64_t slice_length) const {
-    assert(start >= 0);
+    assert(slice_length >= 0);
+    assert(slice_length == 0 || start >= 0);
     return PauliString::from_func(false, slice_length, [&](size_t i) {
         int j = start + i * step;
         return "_XZY"[xs[j] + zs[j] * 2];


### PR DESCRIPTION
This was causing crashes in debug builds for `stim.Circuit()[::-1]`