### PR TITLE
Add time-slice-svg and time+detector-slice-svg diagrams

### DIFF
--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -1210,6 +1210,7 @@ def diagram(
     self,
     *,
     type: 'Literal["timeline-svg"]',
+    tick: Union[None, int, range] = None,
 ) -> 'stim._DiagramHelper':
     pass
 @overload
@@ -1261,7 +1262,25 @@ def diagram(
     self,
     *,
     type: 'Literal["detector-slice-svg"]',
-    tick: int,
+    tick: Union[int, range],
+    filter_coords: Optional[Iterable[Iterable[float]]] = None,
+) -> 'stim._DiagramHelper':
+    pass
+@overload
+def diagram(
+    self,
+    *,
+    type: 'Literal["time-slice-svg"]',
+    tick: Union[int, range],
+    filter_coords: Optional[Iterable[Iterable[float]]] = None,
+) -> 'stim._DiagramHelper':
+    pass
+@overload
+def diagram(
+    self,
+    *,
+    type: 'Literal["time+detector-slice-svg"]',
+    tick: Union[int, range],
     filter_coords: Optional[Iterable[Iterable[float]]] = None,
 ) -> 'stim._DiagramHelper':
     pass
@@ -1269,7 +1288,7 @@ def diagram(
     self,
     type: str = 'timeline-text',
     *,
-    tick: Optional[int] = None,
+    tick: Union[None, int, range] = None,
     filter_coords: Optional[Iterable[Iterable[float]]] = None,
 ) -> 'stim._DiagramHelper':
     """Returns a diagram of the circuit, from a variety of options.
@@ -1310,10 +1329,24 @@ def diagram(
             "match-graph-3d-html": Same 3d model as 'match-graph-3d' but
                 embedded into an HTML web page containing an interactive
                 THREE.js viewer for the 3d model.
-        tick: Required for detector slice diagrams. Specifies which TICK
-            instruction to slice at. Note that the first TICK in the
-            circuit is tick=1. The value tick=0 refers to the very start
-            of the circuit.
+            "time-slice-svg": An SVG image of the operations applied
+                between two TICK instructions in the circuit, with the
+                operations laid out in 2d.
+            "time+detector-slice-svg": A combination of time-slice-svg
+                and detector-slice-svg, with the operations overlaid
+                over the detector slices taken from the TICK after the
+                operations were applied.
+        tick: Required for detector and time slice diagrams. Specifies
+            which TICK instruction, or range of TICK instructions, to
+            slice at. Note that the first TICK instruction in the
+            circuit corresponds tick=1. The value tick=0 refers to the
+            very start of the circuit.
+
+            Passing `range(A, B)` for a detector slice will show the
+            slices for ticks A through B including A but excluding B.
+
+            Passing `range(A, B)` for a time slice will show the
+            operations between tick A and tick B.
         filter_coords: A set of acceptable coordinate prefixes. For
             detector slice diagrams, only detectors whose coordinates
             begin with one of these filters will be included.
@@ -1332,7 +1365,7 @@ def diagram(
         ...     CNOT 0 1 1 2
         ... ''')
 
-        >>> print(circuit.diagram(type="timeline-text"))
+        >>> print(circuit.diagram())
         q0: -H-@---
                |
         q1: ---X-@-
@@ -1347,7 +1380,7 @@ def diagram(
         ...     DETECTOR rec[-1] rec[-2]
         ... ''')
 
-        >>> print(circuit.diagram(type="detector-slice-text", tick=1))
+        >>> print(circuit.diagram("detector-slice-text", tick=1))
         q0: -Z:D0-
              |
         q1: -Z:D0-

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -726,6 +726,7 @@ class Circuit:
         self,
         *,
         type: 'Literal["timeline-svg"]',
+        tick: Union[None, int, range] = None,
     ) -> 'stim._DiagramHelper':
         pass
     @overload
@@ -777,7 +778,25 @@ class Circuit:
         self,
         *,
         type: 'Literal["detector-slice-svg"]',
-        tick: int,
+        tick: Union[int, range],
+        filter_coords: Optional[Iterable[Iterable[float]]] = None,
+    ) -> 'stim._DiagramHelper':
+        pass
+    @overload
+    def diagram(
+        self,
+        *,
+        type: 'Literal["time-slice-svg"]',
+        tick: Union[int, range],
+        filter_coords: Optional[Iterable[Iterable[float]]] = None,
+    ) -> 'stim._DiagramHelper':
+        pass
+    @overload
+    def diagram(
+        self,
+        *,
+        type: 'Literal["time+detector-slice-svg"]',
+        tick: Union[int, range],
         filter_coords: Optional[Iterable[Iterable[float]]] = None,
     ) -> 'stim._DiagramHelper':
         pass
@@ -785,7 +804,7 @@ class Circuit:
         self,
         type: str = 'timeline-text',
         *,
-        tick: Optional[int] = None,
+        tick: Union[None, int, range] = None,
         filter_coords: Optional[Iterable[Iterable[float]]] = None,
     ) -> 'stim._DiagramHelper':
         """Returns a diagram of the circuit, from a variety of options.
@@ -826,10 +845,24 @@ class Circuit:
                 "match-graph-3d-html": Same 3d model as 'match-graph-3d' but
                     embedded into an HTML web page containing an interactive
                     THREE.js viewer for the 3d model.
-            tick: Required for detector slice diagrams. Specifies which TICK
-                instruction to slice at. Note that the first TICK in the
-                circuit is tick=1. The value tick=0 refers to the very start
-                of the circuit.
+                "time-slice-svg": An SVG image of the operations applied
+                    between two TICK instructions in the circuit, with the
+                    operations laid out in 2d.
+                "time+detector-slice-svg": A combination of time-slice-svg
+                    and detector-slice-svg, with the operations overlaid
+                    over the detector slices taken from the TICK after the
+                    operations were applied.
+            tick: Required for detector and time slice diagrams. Specifies
+                which TICK instruction, or range of TICK instructions, to
+                slice at. Note that the first TICK instruction in the
+                circuit corresponds tick=1. The value tick=0 refers to the
+                very start of the circuit.
+
+                Passing `range(A, B)` for a detector slice will show the
+                slices for ticks A through B including A but excluding B.
+
+                Passing `range(A, B)` for a time slice will show the
+                operations between tick A and tick B.
             filter_coords: A set of acceptable coordinate prefixes. For
                 detector slice diagrams, only detectors whose coordinates
                 begin with one of these filters will be included.
@@ -848,7 +881,7 @@ class Circuit:
             ...     CNOT 0 1 1 2
             ... ''')
 
-            >>> print(circuit.diagram(type="timeline-text"))
+            >>> print(circuit.diagram())
             q0: -H-@---
                    |
             q1: ---X-@-
@@ -863,7 +896,7 @@ class Circuit:
             ...     DETECTOR rec[-1] rec[-2]
             ... ''')
 
-            >>> print(circuit.diagram(type="detector-slice-text", tick=1))
+            >>> print(circuit.diagram("detector-slice-text", tick=1))
             q0: -Z:D0-
                  |
             q1: -Z:D0-

--- a/doc/usage_command_line.md
+++ b/doc/usage_command_line.md
@@ -561,7 +561,7 @@ SYNOPSIS
         [--in filepath] \
         [--out filepath] \
         [--remove_noise] \
-        [--tick int] \
+        [--tick int | int:int] \
         --type name
 
 DESCRIPTION
@@ -614,13 +614,17 @@ OPTIONS
 
 
     --tick
-        Specifies that the diagram should apply to a specific TICK of the
-        input circuit.
+        Specifies that the diagram should apply to a specific TICK or range
+        of TICKS from the input circuit.
 
-        In detector-slice diagrams, `--tick` identifies which TICK is the
-        instant at which the time slice is taken. Note that `--tick=0` is
-        the very beginning of the circuit and `--tick=1` is the instant of
-        the first TICK instruction.
+        To specify a single tick, pass an integer like `--tick=5`.
+        To specify a range, pass two integers separated by a colon like
+        `--tick=start:end`. Note that the range is half open.
+
+        In detector and time slice diagrams, `--tick` identifies which ticks
+        to include in the diagram. Note that `--tick=0` is the very
+        beginning of the circuit and `--tick=1` is the instant of the first
+        TICK instruction.
 
 
     --type
@@ -693,6 +697,18 @@ OPTIONS
             measurement layer and a reset layer will produce the
             usual diagram of a surface code. Uses the Pauli color convention
             XYZ=RGB.
+
+            INPUT MUST BE A CIRCUIT.
+
+        "time-slice-svg": An SVG image of the operations that a circuit
+            applies during the specified tick or range of ticks.
+
+            INPUT MUST BE A CIRCUIT.
+
+        "time+detector-slice-svg": An SVG image of the operations that a
+            circuit applies during the specified tick or range of ticks,
+            combined with the detector slices after those operations are
+            applied.
 
             INPUT MUST BE A CIRCUIT.
 

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -726,6 +726,7 @@ class Circuit:
         self,
         *,
         type: 'Literal["timeline-svg"]',
+        tick: Union[None, int, range] = None,
     ) -> 'stim._DiagramHelper':
         pass
     @overload
@@ -777,7 +778,25 @@ class Circuit:
         self,
         *,
         type: 'Literal["detector-slice-svg"]',
-        tick: int,
+        tick: Union[int, range],
+        filter_coords: Optional[Iterable[Iterable[float]]] = None,
+    ) -> 'stim._DiagramHelper':
+        pass
+    @overload
+    def diagram(
+        self,
+        *,
+        type: 'Literal["time-slice-svg"]',
+        tick: Union[int, range],
+        filter_coords: Optional[Iterable[Iterable[float]]] = None,
+    ) -> 'stim._DiagramHelper':
+        pass
+    @overload
+    def diagram(
+        self,
+        *,
+        type: 'Literal["time+detector-slice-svg"]',
+        tick: Union[int, range],
         filter_coords: Optional[Iterable[Iterable[float]]] = None,
     ) -> 'stim._DiagramHelper':
         pass
@@ -785,7 +804,7 @@ class Circuit:
         self,
         type: str = 'timeline-text',
         *,
-        tick: Optional[int] = None,
+        tick: Union[None, int, range] = None,
         filter_coords: Optional[Iterable[Iterable[float]]] = None,
     ) -> 'stim._DiagramHelper':
         """Returns a diagram of the circuit, from a variety of options.
@@ -826,10 +845,24 @@ class Circuit:
                 "match-graph-3d-html": Same 3d model as 'match-graph-3d' but
                     embedded into an HTML web page containing an interactive
                     THREE.js viewer for the 3d model.
-            tick: Required for detector slice diagrams. Specifies which TICK
-                instruction to slice at. Note that the first TICK in the
-                circuit is tick=1. The value tick=0 refers to the very start
-                of the circuit.
+                "time-slice-svg": An SVG image of the operations applied
+                    between two TICK instructions in the circuit, with the
+                    operations laid out in 2d.
+                "time+detector-slice-svg": A combination of time-slice-svg
+                    and detector-slice-svg, with the operations overlaid
+                    over the detector slices taken from the TICK after the
+                    operations were applied.
+            tick: Required for detector and time slice diagrams. Specifies
+                which TICK instruction, or range of TICK instructions, to
+                slice at. Note that the first TICK instruction in the
+                circuit corresponds tick=1. The value tick=0 refers to the
+                very start of the circuit.
+
+                Passing `range(A, B)` for a detector slice will show the
+                slices for ticks A through B including A but excluding B.
+
+                Passing `range(A, B)` for a time slice will show the
+                operations between tick A and tick B.
             filter_coords: A set of acceptable coordinate prefixes. For
                 detector slice diagrams, only detectors whose coordinates
                 begin with one of these filters will be included.
@@ -848,7 +881,7 @@ class Circuit:
             ...     CNOT 0 1 1 2
             ... ''')
 
-            >>> print(circuit.diagram(type="timeline-text"))
+            >>> print(circuit.diagram())
             q0: -H-@---
                    |
             q1: ---X-@-
@@ -863,7 +896,7 @@ class Circuit:
             ...     DETECTOR rec[-1] rec[-2]
             ... ''')
 
-            >>> print(circuit.diagram(type="detector-slice-text", tick=1))
+            >>> print(circuit.diagram("detector-slice-text", tick=1))
             q0: -Z:D0-
                  |
             q1: -Z:D0-

--- a/src/stim/arg_parse.cc
+++ b/src/stim/arg_parse.cc
@@ -408,8 +408,27 @@ double stim::parse_exact_double_from_string(const std::string &text) {
     char *end = nullptr;
     const char *c = text.c_str();
     double d = strtod(c, &end);
-    if (isspace(*c) || end == c || end != c + text.size() || std::isinf(d) || std::isnan(d)) {
-        throw std::invalid_argument("Not an exact double: '" + text + "'");
+    if (text.size() > 0 && !isspace(*c)) {
+        if (end == c + text.size() && !std::isinf(d) && !std::isnan(d)) {
+            return d;
+        }
     }
-    return d;
+    throw std::invalid_argument("Not an exact double: '" + text + "'");
+}
+
+uint64_t stim::parse_exact_uint64_t_from_string(const std::string &text) {
+    char *end = nullptr;
+    const char *c = text.c_str();
+    auto v = strtoull(c, &end, 10);
+    if (end == c + text.size()) {
+        // strtoull silently accepts spaces and negative signs and overflowing
+        // values. The only guaranteed way I've found to ensure it actually
+        // worked is to recreate the string and check that it's the sam.e
+        std::stringstream ss;
+        ss << v;
+        if (ss.str() == text) {
+            return v;
+        }
+    }
+    throw std::invalid_argument("Not an integer that can be stored in a uint64_t: '" + text + "'");
 }

--- a/src/stim/arg_parse.h
+++ b/src/stim/arg_parse.h
@@ -263,6 +263,7 @@ ostream_else_cout find_output_stream_argument(const char *name, bool default_std
 std::vector<std::string> split(char splitter, const std::string &text);
 
 double parse_exact_double_from_string(const std::string &text);
+uint64_t parse_exact_uint64_t_from_string(const std::string &text);
 
 }  // namespace stim
 

--- a/src/stim/arg_parse.test.cc
+++ b/src/stim/arg_parse.test.cc
@@ -324,3 +324,25 @@ TEST(arg_parse, parse_exact_double_from_string) {
     ASSERT_EQ(parse_exact_double_from_string("1.5"), 1.5);
     ASSERT_EQ(parse_exact_double_from_string("-1.5"), -1.5);
 }
+
+TEST(arg_parse, parse_exact_uint64_t_from_string) {
+    ASSERT_THROW({ parse_exact_uint64_t_from_string(""); }, std::invalid_argument);
+    ASSERT_THROW({ parse_exact_uint64_t_from_string("a"); }, std::invalid_argument);
+    ASSERT_THROW({ parse_exact_uint64_t_from_string(" 1"); }, std::invalid_argument);
+    ASSERT_THROW({ parse_exact_uint64_t_from_string("\t1"); }, std::invalid_argument);
+    ASSERT_THROW({ parse_exact_uint64_t_from_string("1 "); }, std::invalid_argument);
+    ASSERT_THROW({ parse_exact_uint64_t_from_string("banana"); }, std::invalid_argument);
+    ASSERT_THROW({ parse_exact_uint64_t_from_string("1.2.3"); }, std::invalid_argument);
+    ASSERT_THROW({ parse_exact_uint64_t_from_string("INFINITY"); }, std::invalid_argument);
+    ASSERT_THROW({ parse_exact_uint64_t_from_string("inf"); }, std::invalid_argument);
+    ASSERT_THROW({ parse_exact_uint64_t_from_string("nan"); }, std::invalid_argument);
+    ASSERT_THROW({ parse_exact_uint64_t_from_string("1e3"); }, std::invalid_argument);
+    ASSERT_THROW({ parse_exact_uint64_t_from_string("1.5"); }, std::invalid_argument);
+    ASSERT_THROW({ parse_exact_uint64_t_from_string("-1"); }, std::invalid_argument);
+    ASSERT_THROW({ parse_exact_uint64_t_from_string("18446744073709551616"); }, std::invalid_argument);
+
+    ASSERT_EQ(parse_exact_uint64_t_from_string("0"), 0);
+    ASSERT_EQ(parse_exact_uint64_t_from_string("1"), 1);
+    ASSERT_EQ(parse_exact_uint64_t_from_string("2"), 2);
+    ASSERT_EQ(parse_exact_uint64_t_from_string("18446744073709551615"), UINT64_MAX);
+}

--- a/src/stim/circuit/circuit.cc
+++ b/src/stim/circuit/circuit.cc
@@ -1177,7 +1177,8 @@ Circuit Circuit::inverse() const {
                 op.str() + "' instruction.");
         } else if (op.gate->id == gate_name_to_id("QUBIT_COORDS")) {
             if (k > skip_reversing) {
-                throw std::invalid_argument("Inverting QUBIT_COORDS is not implemented except at the start of the circuit.");
+                throw std::invalid_argument(
+                    "Inverting QUBIT_COORDS is not implemented except at the start of the circuit.");
             }
             skip_reversing++;
             result.safe_append(op);

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -1865,15 +1865,17 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
         pybind11::arg("filter_coords") = pybind11::none(),
         clean_doc_string(u8R"DOC(
             @overload def diagram(self, *, type: 'Literal["timeline-text"]') -> 'stim._DiagramHelper':
-            @overload def diagram(self, *, type: 'Literal["timeline-svg"]') -> 'stim._DiagramHelper':
+            @overload def diagram(self, *, type: 'Literal["timeline-svg"]', tick: Union[None, int, range] = None) -> 'stim._DiagramHelper':
             @overload def diagram(self, *, type: 'Literal["timeline-3d"]') -> 'stim._DiagramHelper':
             @overload def diagram(self, *, type: 'Literal["timeline-3d-html"]') -> 'stim._DiagramHelper':
             @overload def diagram(self, *, type: 'Literal["match-graph-svg"]') -> 'stim._DiagramHelper':
             @overload def diagram(self, *, type: 'Literal["match-graph-3d"]') -> 'stim._DiagramHelper':
             @overload def diagram(self, *, type: 'Literal["match-graph-3d-html"]') -> 'stim._DiagramHelper':
             @overload def diagram(self, *, type: 'Literal["detector-slice-text"]', tick: int, filter_coords: Optional[Iterable[Iterable[float]]] = None) -> 'stim._DiagramHelper':
-            @overload def diagram(self, *, type: 'Literal["detector-slice-svg"]', tick: int, filter_coords: Optional[Iterable[Iterable[float]]] = None) -> 'stim._DiagramHelper':
-            @signature def diagram(self, type: str = 'timeline-text', *, tick: Optional[int] = None, filter_coords: Optional[Iterable[Iterable[float]]] = None) -> 'stim._DiagramHelper':
+            @overload def diagram(self, *, type: 'Literal["detector-slice-svg"]', tick: Union[int, range], filter_coords: Optional[Iterable[Iterable[float]]] = None) -> 'stim._DiagramHelper':
+            @overload def diagram(self, *, type: 'Literal["time-slice-svg"]', tick: Union[int, range], filter_coords: Optional[Iterable[Iterable[float]]] = None) -> 'stim._DiagramHelper':
+            @overload def diagram(self, *, type: 'Literal["time+detector-slice-svg"]', tick: Union[int, range], filter_coords: Optional[Iterable[Iterable[float]]] = None) -> 'stim._DiagramHelper':
+            @signature def diagram(self, type: str = 'timeline-text', *, tick: Union[None, int, range] = None, filter_coords: Optional[Iterable[Iterable[float]]] = None) -> 'stim._DiagramHelper':
             Returns a diagram of the circuit, from a variety of options.
 
             Args:
@@ -1912,10 +1914,24 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
                     "match-graph-3d-html": Same 3d model as 'match-graph-3d' but
                         embedded into an HTML web page containing an interactive
                         THREE.js viewer for the 3d model.
-                tick: Required for detector slice diagrams. Specifies which TICK
-                    instruction to slice at. Note that the first TICK in the
-                    circuit is tick=1. The value tick=0 refers to the very start
-                    of the circuit.
+                    "time-slice-svg": An SVG image of the operations applied
+                        between two TICK instructions in the circuit, with the
+                        operations laid out in 2d.
+                    "time+detector-slice-svg": A combination of time-slice-svg
+                        and detector-slice-svg, with the operations overlaid
+                        over the detector slices taken from the TICK after the
+                        operations were applied.
+                tick: Required for detector and time slice diagrams. Specifies
+                    which TICK instruction, or range of TICK instructions, to
+                    slice at. Note that the first TICK instruction in the
+                    circuit corresponds tick=1. The value tick=0 refers to the
+                    very start of the circuit.
+
+                    Passing `range(A, B)` for a detector slice will show the
+                    slices for ticks A through B including A but excluding B.
+
+                    Passing `range(A, B)` for a time slice will show the
+                    operations between tick A and tick B.
                 filter_coords: A set of acceptable coordinate prefixes. For
                     detector slice diagrams, only detectors whose coordinates
                     begin with one of these filters will be included.
@@ -1934,7 +1950,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
                 ...     CNOT 0 1 1 2
                 ... ''')
 
-                >>> print(circuit.diagram(type="timeline-text"))
+                >>> print(circuit.diagram())
                 q0: -H-@---
                        |
                 q1: ---X-@-
@@ -1949,7 +1965,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
                 ...     DETECTOR rec[-1] rec[-2]
                 ... ''')
 
-                >>> print(circuit.diagram(type="detector-slice-text", tick=1))
+                >>> print(circuit.diagram("detector-slice-text", tick=1))
                 q0: -Z:D0-
                      |
                 q1: -Z:D0-

--- a/src/stim/circuit/circuit.test.cc
+++ b/src/stim/circuit/circuit.test.cc
@@ -1512,12 +1512,12 @@ TEST(circuit, inverse) {
             S 0
         )CIRCUIT"));
 
-    ASSERT_THROW({Circuit("X_ERROR(0.125) 0").inverse();}, std::invalid_argument);
-    ASSERT_THROW({Circuit("M(0.125) 0").inverse();}, std::invalid_argument);
-    ASSERT_THROW({Circuit("M 0").inverse();}, std::invalid_argument);
-    ASSERT_THROW({Circuit("R 0").inverse();}, std::invalid_argument);
-    ASSERT_THROW({Circuit("MR 0").inverse();}, std::invalid_argument);
-    ASSERT_THROW({Circuit("MPP X0*X1").inverse();}, std::invalid_argument);
-    ASSERT_THROW({Circuit("DETECTOR").inverse();}, std::invalid_argument);
-    ASSERT_THROW({Circuit("OBSERVABLE_INCLUDE").inverse();}, std::invalid_argument);
+    ASSERT_THROW({ Circuit("X_ERROR(0.125) 0").inverse(); }, std::invalid_argument);
+    ASSERT_THROW({ Circuit("M(0.125) 0").inverse(); }, std::invalid_argument);
+    ASSERT_THROW({ Circuit("M 0").inverse(); }, std::invalid_argument);
+    ASSERT_THROW({ Circuit("R 0").inverse(); }, std::invalid_argument);
+    ASSERT_THROW({ Circuit("MR 0").inverse(); }, std::invalid_argument);
+    ASSERT_THROW({ Circuit("MPP X0*X1").inverse(); }, std::invalid_argument);
+    ASSERT_THROW({ Circuit("DETECTOR").inverse(); }, std::invalid_argument);
+    ASSERT_THROW({ Circuit("OBSERVABLE_INCLUDE").inverse(); }, std::invalid_argument);
 }

--- a/src/stim/circuit/circuit_pybind_test.py
+++ b/src/stim/circuit/circuit_pybind_test.py
@@ -951,6 +951,7 @@ q2: ------
 
     assert c.diagram() is not None
     assert c.diagram("timeline-svg") is not None
+    assert c.diagram("timeline-svg", tick=5) is not None
     assert c.diagram(type="timeline-svg") is not None
     assert c.diagram(type="timeline-3d") is not None
     assert c.diagram(type="timeline-3d-html") is not None
@@ -959,6 +960,13 @@ q2: ------
     assert c.diagram(type="match-graph-3d-html") is not None
     assert c.diagram(type="detector-slice-svg", tick=1) is not None
     assert c.diagram(type="detector-slice-text", tick=1) is not None
+    assert c.diagram(type="time-slice-svg", tick=1) is not None
+    assert c.diagram(type="time+detector-slice-svg", tick=1) is not None
+    assert c.diagram(type="time+detector-slice-svg", tick=range(1, 3)) is not None
+    with pytest.raises(ValueError, match="step"):
+        assert c.diagram(type="time+detector-slice-svg", tick=range(1, 3, 2)) is not None
+    with pytest.raises(ValueError, match="stop"):
+        assert c.diagram(type="time+detector-slice-svg", tick=range(3, 3)) is not None
 
 
 def test_circuit_inverse():

--- a/src/stim/cmd/command_diagram.cc
+++ b/src/stim/cmd/command_diagram.cc
@@ -33,6 +33,8 @@ enum DiagramTypes {
     TIMELINE_SVG,
     TIMELINE_3D,
     TIMELINE_3D_HTML,
+    TIME_SLICE_SVG,
+    TIME_SLICE_PLUS_DETECTOR_SLICE_SVG,
     MATCH_GRAPH_SVG,
     MATCH_GRAPH_3D,
     MATCH_GRAPH_3D_HTML,
@@ -57,12 +59,36 @@ int stim::command_diagram(int argc, const char **argv) {
     RaiiFile in(find_open_file_argument("--in", stdin, "rb", argc, argv));
     auto out_stream = find_output_stream_argument("--out", true, argc, argv);
     auto &out = out_stream.stream();
-    int64_t tick = find_int64_argument("--tick", 0, 0, INT64_MAX, argc, argv);
+
+    bool has_tick_arg = false;
+    uint64_t tick = 0;
+    uint64_t tick_start = 0;
+    uint64_t tick_num = 1;
+    if (find_argument("--tick", argc, argv) != nullptr) {
+        has_tick_arg = true;
+        std::string tick_str = find_argument("--tick", argc, argv);
+        auto t = tick_str.find(':');
+        if (t != 0 && t != std::string::npos) {
+            tick_start = parse_exact_uint64_t_from_string(tick_str.substr(0, t));
+            uint64_t tick_end = parse_exact_uint64_t_from_string(tick_str.substr(t + 1));
+            if (tick_end <= tick_start) {
+                throw std::invalid_argument("tick_end <= tick_start");
+            }
+            tick_num = tick_end - tick_start;
+            tick = tick_start;
+        } else {
+            tick = find_int64_argument("--tick", 0, 0, INT64_MAX, argc, argv);
+            tick_num = 1;
+            tick_start = tick;
+        }
+    }
     std::map<std::string, DiagramTypes> diagram_types{
         {"timeline-text", TIMELINE_TEXT},
         {"timeline-svg", TIMELINE_SVG},
         {"timeline-3d", TIMELINE_3D},
         {"timeline-3d-html", TIMELINE_3D_HTML},
+        {"time-slice-svg", TIME_SLICE_SVG},
+        {"time+detector-slice-svg", TIME_SLICE_PLUS_DETECTOR_SLICE_SVG},
         {"match-graph-svg", MATCH_GRAPH_SVG},
         {"match-graph-3d", MATCH_GRAPH_3D},
         {"match-graph-3d-html", MATCH_GRAPH_3D_HTML},
@@ -124,7 +150,20 @@ int stim::command_diagram(int argc, const char **argv) {
         }
         case TIMELINE_SVG: {
             auto circuit = read_circuit();
-            DiagramTimelineSvgDrawer::make_diagram_write_to(circuit, out);
+            auto coord_filter = read_coords();
+            DiagramTimelineSvgDrawer::make_diagram_write_to(circuit, out, tick_start, tick_num, SVG_MODE_TIMELINE, coord_filter);
+            break;
+        }
+        case TIME_SLICE_SVG: {
+            auto circuit = read_circuit();
+            auto coord_filter = read_coords();
+            DiagramTimelineSvgDrawer::make_diagram_write_to(circuit, out, tick_start, tick_num, SVG_MODE_TIME_SLICE, coord_filter);
+            break;
+        }
+        case TIME_SLICE_PLUS_DETECTOR_SLICE_SVG: {
+            auto circuit = read_circuit();
+            auto coord_filter = read_coords();
+            DiagramTimelineSvgDrawer::make_diagram_write_to(circuit, out, tick_start, tick_num, SVG_MODE_TIME_DETECTOR_SLICE, coord_filter);
             break;
         }
         case TIMELINE_3D: {
@@ -157,21 +196,21 @@ int stim::command_diagram(int argc, const char **argv) {
             break;
         }
         case DETECTOR_SLICE_TEXT: {
-            if (tick == -1) {
+            if (!has_tick_arg) {
                 throw std::invalid_argument("Must specify --tick=# with --type=detector-slice-text");
             }
             auto coord_filter = read_coords();
             auto circuit = read_circuit();
-            out << DetectorSliceSet::from_circuit_tick(circuit, (uint64_t)tick, coord_filter);
+            out << DetectorSliceSet::from_circuit_ticks(circuit, (uint64_t)tick, 1, coord_filter);
             break;
         }
         case DETECTOR_SLICE_SVG: {
-            if (tick == -1) {
+            if (!has_tick_arg) {
                 throw std::invalid_argument("Must specify --tick=# with --type=detector-slice-svg");
             }
             auto coord_filter = read_coords();
             auto circuit = read_circuit();
-            DetectorSliceSet::from_circuit_tick(circuit, (uint64_t)tick, coord_filter).write_svg_diagram_to(out);
+            DetectorSliceSet::from_circuit_ticks(circuit, tick_start, tick_num, coord_filter).write_svg_diagram_to(out);
             break;
         }
         default: {
@@ -260,17 +299,21 @@ SubCommandHelp stim::command_diagram_help() {
 
     result.flags.push_back(SubCommandHelpFlag{
         "--tick",
-        "int",
+        "int | int:int",
         "none",
-        {"[none]", "int"},
+        {"[none]", "int", "int-int"},
         clean_doc_string(R"PARAGRAPH(
-            Specifies that the diagram should apply to a specific TICK of the
-            input circuit.
+            Specifies that the diagram should apply to a specific TICK or range
+            of TICKS from the input circuit.
 
-            In detector-slice diagrams, `--tick` identifies which TICK is the
-            instant at which the time slice is taken. Note that `--tick=0` is
-            the very beginning of the circuit and `--tick=1` is the instant of
-            the first TICK instruction.
+            To specify a single tick, pass an integer like `--tick=5`.
+            To specify a range, pass two integers separated by a colon like
+            `--tick=start:end`. Note that the range is half open.
+
+            In detector and time slice diagrams, `--tick` identifies which ticks
+            to include in the diagram. Note that `--tick=0` is the very
+            beginning of the circuit and `--tick=1` is the instant of the first
+            TICK instruction.
         )PARAGRAPH"),
     });
 
@@ -372,6 +415,18 @@ SubCommandHelp stim::command_diagram_help() {
                 measurement layer and a reset layer will produce the
                 usual diagram of a surface code. Uses the Pauli color convention
                 XYZ=RGB.
+
+                INPUT MUST BE A CIRCUIT.
+
+            "time-slice-svg": An SVG image of the operations that a circuit
+                applies during the specified tick or range of ticks.
+
+                INPUT MUST BE A CIRCUIT.
+
+            "time+detector-slice-svg": An SVG image of the operations that a
+                circuit applies during the specified tick or range of ticks,
+                combined with the detector slices after those operations are
+                applied.
 
                 INPUT MUST BE A CIRCUIT.
         )PARAGRAPH"),

--- a/src/stim/cmd/command_diagram.test.cc
+++ b/src/stim/cmd/command_diagram.test.cc
@@ -105,25 +105,31 @@ TEST(command_diagram, run_captured_stim_main_works_various_arguments) {
         "match-graph-svg",
         "match-graph-3d",
         "match-graph-3d-html",
-        "detector-slice-txt",
+        "detector-slice-text",
         "detector-slice-svg",
+        "time-slice-svg",
+        "time+detector-slice-svg",
     };
-    ASSERT_NE(
-        "",
-        run_captured_stim_main(
-            {
-                "diagram",
-                "--type",
-                "timeline-svg",
-                "--tick",
-                "1",
-            },
-            R"input(
+    for (const auto &type : diagram_types) {
+        auto actual = run_captured_stim_main(
+                {
+                    "diagram",
+                    "--type",
+                    type.c_str(),
+                    "--tick",
+                    "1:2",
+                },
+                R"input(
             H 0
             CNOT 0 1
             X_ERROR(0.125) 0
             TICK
             M 0 1
             DETECTOR(1, 2, 3) rec[-1] rec[-2]
-        )input"));
+        )input");
+        if (actual.find("[stderr") != std::string::npos) {
+            EXPECT_TRUE(false) << actual;
+        }
+        EXPECT_NE(actual, "") << type;
+    }
 }

--- a/src/stim/diagram/circuit_timeline_helper.cc
+++ b/src/stim/diagram/circuit_timeline_helper.cc
@@ -25,9 +25,15 @@ void CircuitTimelineHelper::do_repeat_block(const Circuit &circuit, const Operat
     };
     cur_loop_nesting.push_back(loop_data);
 
-    start_repeat_callback(loop_data);
-    do_circuit(body);
-    end_repeat_callback(loop_data);
+    if (unroll_loops) {
+        for (size_t k = 0; k < loop_data.num_repetitions; k++) {
+            do_circuit(body);
+        }
+    } else {
+        start_repeat_callback(loop_data);
+        do_circuit(body);
+        end_repeat_callback(loop_data);
+    }
 
     cur_loop_nesting.pop_back();
     skip_loop_iterations(loop_data, loop_data.num_repetitions - 1);

--- a/src/stim/diagram/circuit_timeline_helper.cc
+++ b/src/stim/diagram/circuit_timeline_helper.cc
@@ -5,12 +5,22 @@
 using namespace stim;
 using namespace stim_draw_internal;
 
+void CircuitTimelineHelper::skip_loop_iterations(CircuitTimelineLoopData loop_data, uint64_t skipped_reps) {
+    if (loop_data.num_repetitions > 0) {
+        vec_pad_add_mul(cur_coord_shift, loop_data.shift_per_iteration, skipped_reps);
+        measure_offset += loop_data.measurements_per_iteration * skipped_reps;
+        detector_offset += loop_data.detectors_per_iteration * skipped_reps;
+        num_ticks_seen += loop_data.ticks_per_iteration * skipped_reps;
+    }
+}
+
 void CircuitTimelineHelper::do_repeat_block(const Circuit &circuit, const Operation &op) {
     const auto &body = op_data_block_body(circuit, op.target_data);
     CircuitTimelineLoopData loop_data{
         op_data_rep_count(op.target_data),
         body.count_measurements(),
         body.count_detectors(),
+        body.count_ticks(),
         body.final_coord_shift(),
     };
     cur_loop_nesting.push_back(loop_data);
@@ -20,10 +30,7 @@ void CircuitTimelineHelper::do_repeat_block(const Circuit &circuit, const Operat
     end_repeat_callback(loop_data);
 
     cur_loop_nesting.pop_back();
-    uint64_t skipped_reps = loop_data.num_repetitions - 1;
-    vec_pad_add_mul(cur_coord_shift, loop_data.shift_per_iteration, skipped_reps);
-    measure_offset += loop_data.measurements_per_iteration * skipped_reps;
-    detector_offset += loop_data.detectors_per_iteration * skipped_reps;
+    skip_loop_iterations(loop_data, loop_data.num_repetitions - 1);
 }
 
 void CircuitTimelineHelper::do_atomic_operation(
@@ -181,6 +188,7 @@ void CircuitTimelineHelper::do_next_operation(const Circuit &circuit, const Oper
     } else if (op.gate->id == gate_name_to_id("QUBIT_COORDS")) {
         do_qubit_coords(op);
     } else if (op.gate->id == gate_name_to_id("TICK")) {
+        num_ticks_seen += 1;
         do_atomic_operation(op.gate, {}, {});
     } else if (op.gate->flags & GATE_TARGETS_PAIRS) {
         do_two_qubit_gate(op);

--- a/src/stim/diagram/circuit_timeline_helper.h
+++ b/src/stim/diagram/circuit_timeline_helper.h
@@ -53,6 +53,7 @@ struct CircuitTimelineHelper {
     uint64_t measure_offset = 0;
     uint64_t detector_offset = 0;
     uint64_t num_ticks_seen = 0;
+    bool unroll_loops = false;
     std::vector<double> coord_workspace;
     std::vector<uint64_t> u64_workspace;
     std::vector<stim::GateTarget> targets_workspace;

--- a/src/stim/diagram/circuit_timeline_helper.h
+++ b/src/stim/diagram/circuit_timeline_helper.h
@@ -28,6 +28,7 @@ struct CircuitTimelineLoopData {
     uint64_t num_repetitions;
     uint64_t measurements_per_iteration;
     uint64_t detectors_per_iteration;
+    uint64_t ticks_per_iteration;
     std::vector<double> shift_per_iteration;
 };
 
@@ -51,6 +52,7 @@ struct CircuitTimelineHelper {
     std::vector<double> cur_coord_shift;
     uint64_t measure_offset = 0;
     uint64_t detector_offset = 0;
+    uint64_t num_ticks_seen = 0;
     std::vector<double> coord_workspace;
     std::vector<uint64_t> u64_workspace;
     std::vector<stim::GateTarget> targets_workspace;
@@ -65,6 +67,7 @@ struct CircuitTimelineHelper {
 
     stim::GateTarget rec_to_qubit(const stim::GateTarget &target);
     stim::GateTarget pick_pseudo_target_representing_measurements(const stim::Operation &op);
+    void skip_loop_iterations(CircuitTimelineLoopData loop_data, uint64_t skipped_reps);
     void do_record_measure_result(uint32_t target_qubit);
     void do_repeat_block(const stim::Circuit &circuit, const stim::Operation &op);
     void do_next_operation(const stim::Circuit &circuit, const stim::Operation &op);

--- a/src/stim/diagram/detector_slice/detector_slice_set.cc
+++ b/src/stim/diagram/detector_slice/detector_slice_set.cc
@@ -75,7 +75,7 @@ bool DetectorSliceSetComputer::process_op_rev(const Circuit &parent, const Opera
 DetectorSliceSetComputer::DetectorSliceSetComputer(
     const Circuit &circuit,
     uint64_t first_yield_tick,
-    size_t num_yield_ticks)
+    uint64_t num_yield_ticks)
     : analyzer(circuit.count_detectors(), circuit.count_qubits(), false, true, true, 1, false, false),
       first_yield_tick(first_yield_tick),
       num_yield_ticks(num_yield_ticks) {

--- a/src/stim/diagram/detector_slice/detector_slice_set.cc
+++ b/src/stim/diagram/detector_slice/detector_slice_set.cc
@@ -18,13 +18,11 @@ struct DetectorSliceSetComputer {
     uint64_t tick_cur;
     uint64_t first_yield_tick;
     uint64_t num_yield_ticks;
-    ConstPointerRange<std::vector<double>> coord_filter;
     std::function<void(void)> on_tick_callback;
     DetectorSliceSetComputer(
         const Circuit &circuit,
         uint64_t first_yield_tick,
-        uint64_t num_yield_ticks,
-        ConstPointerRange<std::vector<double>> coord_filter);
+        uint64_t num_yield_ticks);
     bool process_block_rev(const Circuit &block);
     bool process_op_rev(const Circuit &parent, const Operation &op);
     bool process_tick();
@@ -77,12 +75,10 @@ bool DetectorSliceSetComputer::process_op_rev(const Circuit &parent, const Opera
 DetectorSliceSetComputer::DetectorSliceSetComputer(
     const Circuit &circuit,
     uint64_t first_yield_tick,
-    size_t num_yield_ticks,
-    ConstPointerRange<std::vector<double>> coord_filter)
+    size_t num_yield_ticks)
     : analyzer(circuit.count_detectors(), circuit.count_qubits(), false, true, true, 1, false, false),
       first_yield_tick(first_yield_tick),
-      num_yield_ticks(num_yield_ticks),
-      coord_filter(coord_filter) {
+      num_yield_ticks(num_yield_ticks) {
     tick_cur = circuit.count_ticks() + 1;  // +1 because of artificial TICKs at start and end.
     analyzer.accumulate_errors = false;
 }
@@ -169,9 +165,9 @@ std::set<uint64_t> DetectorSliceSet::used_qubits() const {
 DetectorSliceSet DetectorSliceSet::from_circuit_ticks(
     const stim::Circuit &circuit,
     uint64_t start_tick,
-    size_t num_ticks,
+    uint64_t num_ticks,
     ConstPointerRange<std::vector<double>> coord_filter) {
-    DetectorSliceSetComputer helper(circuit, start_tick, num_ticks, coord_filter);
+    DetectorSliceSetComputer helper(circuit, start_tick, num_ticks);
     size_t num_qubits = helper.analyzer.xs.size();
 
     std::set<DemTarget> xs;

--- a/src/stim/diagram/detector_slice/detector_slice_set.h
+++ b/src/stim/diagram/detector_slice/detector_slice_set.h
@@ -27,9 +27,11 @@ namespace stim_draw_internal {
 
 struct DetectorSliceSet {
     uint64_t num_qubits;
+    uint64_t min_tick;
+    uint64_t num_ticks;
     std::map<uint64_t, std::vector<double>> coordinates;
     std::map<uint64_t, std::vector<double>> detector_coordinates;
-    std::map<stim::DemTarget, std::vector<stim::GateTarget>> slices;
+    std::map<std::pair<uint64_t, stim::DemTarget>, std::vector<stim::GateTarget>> slices;
 
     /// Args:
     ///     circuit: The circuit to make a detector slice diagram from.
@@ -38,14 +40,19 @@ struct DetectorSliceSet {
     ///         forth.
     ///     coord_filter: Detectors that fail to match these coordinates
     ///         are excluded.
-    static DetectorSliceSet from_circuit_tick(
-        const stim::Circuit &circuit, uint64_t tick_index, stim::ConstPointerRange<std::vector<double>> coord_filter);
+    static DetectorSliceSet from_circuit_ticks(
+        const stim::Circuit &circuit,
+        uint64_t start_tick,
+        size_t num_ticks,
+        stim::ConstPointerRange<std::vector<double>> coord_filter);
 
     std::set<uint64_t> used_qubits() const;
     std::string str() const;
 
     void write_text_diagram_to(std::ostream &out) const;
     void write_svg_diagram_to(std::ostream &out) const;
+    void write_svg_contents_to(
+        std::ostream &out, const std::function<Coord<2>(uint64_t tick, uint32_t qubit)> &coords, size_t scale) const;
 };
 
 struct FlattenedCoords {

--- a/src/stim/diagram/detector_slice/detector_slice_set.h
+++ b/src/stim/diagram/detector_slice/detector_slice_set.h
@@ -43,7 +43,7 @@ struct DetectorSliceSet {
     static DetectorSliceSet from_circuit_ticks(
         const stim::Circuit &circuit,
         uint64_t start_tick,
-        size_t num_ticks,
+        uint64_t num_ticks,
         stim::ConstPointerRange<std::vector<double>> coord_filter);
 
     std::set<uint64_t> used_qubits() const;

--- a/src/stim/diagram/detector_slice/detector_slice_set.test.cc
+++ b/src/stim/diagram/detector_slice/detector_slice_set.test.cc
@@ -21,13 +21,14 @@
 #include "stim/gen/circuit_gen_params.h"
 #include "stim/gen/gen_rep_code.h"
 #include "stim/gen/gen_surface_code.h"
+#include "stim/test_util.test.h"
 
 using namespace stim;
 using namespace stim_draw_internal;
 
 TEST(detector_slice_set, from_circuit) {
     std::vector<double> empty_filter;
-    auto slice_set = DetectorSliceSet::from_circuit_tick(
+    auto slice_set = DetectorSliceSet::from_circuit_ticks(
         stim::Circuit(R"CIRCUIT(
         QUBIT_COORDS(3, 5) 1
         R 0
@@ -52,13 +53,14 @@ TEST(detector_slice_set, from_circuit) {
         }
 )CIRCUIT"),
         2,
+        1,
         {&empty_filter});
     ASSERT_EQ(slice_set.coordinates, (std::map<uint64_t, std::vector<double>>{{1, {3, 5}}}));
     ASSERT_EQ(
         slice_set.slices,
-        (std::map<stim::DemTarget, std::vector<stim::GateTarget>>{
-            {DemTarget::relative_detector_id(1), {GateTarget::x(0), GateTarget::z(1)}},
-            {DemTarget::relative_detector_id(2), {GateTarget::z(1)}},
+        (std::map<std::pair<uint64_t, stim::DemTarget>, std::vector<stim::GateTarget>>{
+            {{2, DemTarget::relative_detector_id(1)}, {GateTarget::x(0), GateTarget::z(1)}},
+            {{2, DemTarget::relative_detector_id(2)}, {GateTarget::z(1)}},
         }));
 }
 
@@ -87,22 +89,42 @@ TEST(detector_slice_set, big_loop_seeking) {
 
     uint64_t inner = 10 * 100 * 1000 + 1;
     std::vector<double> empty_filter;
-    auto slice_set = DetectorSliceSet::from_circuit_tick(circuit, inner * 10000ULL * 50ULL + 2ULL, {&empty_filter});
+    auto slice_set = DetectorSliceSet::from_circuit_ticks(circuit, inner * 10000ULL * 50ULL + 2ULL, 1, {&empty_filter});
     ASSERT_EQ(slice_set.coordinates, (std::map<uint64_t, std::vector<double>>{}));
     ASSERT_EQ(
         slice_set.slices,
-        (std::map<stim::DemTarget, std::vector<stim::GateTarget>>{
-            {DemTarget::relative_detector_id(inner * 10000ULL * 50ULL + 1ULL), {GateTarget::y(0)}},
+        (std::map<std::pair<uint64_t, stim::DemTarget>, std::vector<stim::GateTarget>>{
+            {{inner * 10000ULL * 50ULL + 2ULL, DemTarget::relative_detector_id(inner * 10000ULL * 50ULL + 1ULL)},
+             {GateTarget::y(0)}},
         }));
 
-    slice_set = DetectorSliceSet::from_circuit_tick(
-        circuit, inner * 10000ULL * 25ULL + 1000ULL * 100ULL * 10ULL + 1ULL, {&empty_filter});
+    slice_set = DetectorSliceSet::from_circuit_ticks(
+        circuit, inner * 10000ULL * 25ULL + 1000ULL * 100ULL * 10ULL + 1ULL, 1, {&empty_filter});
     ASSERT_EQ(slice_set.coordinates, (std::map<uint64_t, std::vector<double>>{}));
     ASSERT_EQ(
         slice_set.slices,
-        (std::map<stim::DemTarget, std::vector<stim::GateTarget>>{
-            {DemTarget::relative_detector_id(inner * 10000ULL * 25ULL + 1000ULL * 100ULL * 10ULL), {GateTarget::x(1)}},
-            {DemTarget::observable_id(5), {GateTarget::x(1)}},
+        (std::map<std::pair<uint64_t, stim::DemTarget>, std::vector<stim::GateTarget>>{
+            {{inner * 10000ULL * 25ULL + 1000ULL * 100ULL * 10ULL + 1ULL,
+              DemTarget::relative_detector_id(inner * 10000ULL * 25ULL + 1000ULL * 100ULL * 10ULL)},
+             {GateTarget::x(1)}},
+            {{inner * 10000ULL * 25ULL + 1000ULL * 100ULL * 10ULL + 1ULL, DemTarget::observable_id(5)},
+             {GateTarget::x(1)}},
+        }));
+
+    slice_set = DetectorSliceSet::from_circuit_ticks(
+        circuit, inner * 10000ULL * 25ULL + 1000ULL * 100ULL * 10ULL + 1ULL, 2, {&empty_filter});
+    ASSERT_EQ(slice_set.coordinates, (std::map<uint64_t, std::vector<double>>{}));
+    ASSERT_EQ(
+        slice_set.slices,
+        (std::map<std::pair<uint64_t, stim::DemTarget>, std::vector<stim::GateTarget>>{
+            {{inner * 10000ULL * 25ULL + 1000ULL * 100ULL * 10ULL + 1ULL,
+              DemTarget::relative_detector_id(inner * 10000ULL * 25ULL + 1000ULL * 100ULL * 10ULL)},
+             {GateTarget::x(1)}},
+            {{inner * 10000ULL * 25ULL + 1000ULL * 100ULL * 10ULL + 1ULL, DemTarget::observable_id(5)},
+             {GateTarget::x(1)}},
+            {{inner * 10000ULL * 25ULL + 1000ULL * 100ULL * 10ULL + 2ULL,
+              DemTarget::relative_detector_id(inner * 10000ULL * 25ULL + 1000ULL * 100ULL * 10ULL + 1ULL)},
+             {GateTarget::y(0)}},
         }));
 }
 
@@ -110,7 +132,7 @@ TEST(detector_slice_set_text_diagram, repetition_code) {
     std::vector<double> empty_filter;
     CircuitGenParameters params(10, 5, "memory");
     auto circuit = generate_rep_code_circuit(params).circuit;
-    auto slice_set = DetectorSliceSet::from_circuit_tick(circuit, 9, {&empty_filter});
+    auto slice_set = DetectorSliceSet::from_circuit_ticks(circuit, 9, 1, {&empty_filter});
     ASSERT_EQ(slice_set.slices.size(), circuit.count_qubits());
     ASSERT_EQ("\n" + slice_set.str() + "\n", R"DIAGRAM(
 q0: --------Z:D12----------------------------
@@ -132,7 +154,7 @@ q7: -Z:D11-----------------------Z:D15-------
 q8: -----------------------------Z:D15--Z:L0-
 )DIAGRAM");
 
-    ASSERT_EQ("\n" + DetectorSliceSet::from_circuit_tick(circuit, 11, {&empty_filter}).str() + "\n", R"DIAGRAM(
+    ASSERT_EQ("\n" + DetectorSliceSet::from_circuit_ticks(circuit, 11, 1, {&empty_filter}).str() + "\n", R"DIAGRAM(
 q0: --------Z:D16-
             |
 q1: -Z:D12--Z:D16-
@@ -157,7 +179,7 @@ TEST(detector_slice_set_text_diagram, surface_code) {
     std::vector<double> empty_filter;
     CircuitGenParameters params(10, 2, "unrotated_memory_z");
     auto circuit = generate_surface_code_circuit(params).circuit;
-    auto slice_set = DetectorSliceSet::from_circuit_tick(circuit, 11, {&empty_filter});
+    auto slice_set = DetectorSliceSet::from_circuit_ticks(circuit, 11, 1, {&empty_filter});
     ASSERT_EQ(slice_set.slices.size(), circuit.count_qubits());
     ASSERT_EQ("\n" + slice_set.str() + "\n", R"DIAGRAM(
 q0:(0, 0) -X:D2--Z:D3--------------------------------Z:L0-
@@ -184,45 +206,8 @@ TEST(detector_slice_set_svg_diagram, surface_code) {
     std::vector<double> empty_filter;
     CircuitGenParameters params(10, 2, "rotated_memory_z");
     auto circuit = generate_surface_code_circuit(params).circuit;
-    auto slice_set = DetectorSliceSet::from_circuit_tick(circuit, 8, {&empty_filter});
+    auto slice_set = DetectorSliceSet::from_circuit_ticks(circuit, 8, 1, {&empty_filter});
     std::stringstream ss;
     slice_set.write_svg_diagram_to(ss);
-    ASSERT_EQ(
-        "\n" + ss.str() + "\n",
-        u8R"SVG(
-<svg viewBox="0 0 77.2548 122.51" xmlns="http://www.w3.org/2000/svg">
-<path d="M38.6274,16 61.2548,38.6274 16,38.6274 Z" stroke="none" fill-opacity="0.75" fill="#AAAAAA" />
-<defs>
-<radialGradient id="xgrad"><stop offset="50%" stop-color="#FF4444" stop-opacity="1"/><stop offset="100%" stop-color="#AAAAAA" stop-opacity="0"/></radialGradient>
-<radialGradient id="ygrad"><stop offset="50%" stop-color="#40FF40" stop-opacity="1"/><stop offset="100%" stop-color="#AAAAAA" stop-opacity="0"/></radialGradient>
-<radialGradient id="zgrad"><stop offset="50%" stop-color="#4848FF" stop-opacity="1"/><stop offset="100%" stop-color="#AAAAAA" stop-opacity="0"/></radialGradient>
-</defs>
-<clipPath id="clip0"><path d="M38.6274,16 61.2548,38.6274 16,38.6274 Z" /></clipPath>
-<circle clip-path="url(#clip0)" cx="16" cy="38.6274" r="20" stroke="none" fill="url('#xgrad')"/>
-<circle clip-path="url(#clip0)" cx="38.6274" cy="16" r="20" stroke="none" fill="url('#zgrad')"/>
-<circle clip-path="url(#clip0)" cx="61.2548" cy="38.6274" r="20" stroke="none" fill="url('#xgrad')"/>
-<path d="M38.6274,16 61.2548,38.6274 16,38.6274 Z" stroke="black" fill="none" />
-<path d="M16,38.6274 61.2548,38.6274 38.6274,61.2548 61.2548,83.8822 16,83.8822 Z" stroke="none" fill-opacity="0.75" fill="#4848FF" />
-<path d="M16,38.6274 61.2548,38.6274 38.6274,61.2548 61.2548,83.8822 16,83.8822 Z" stroke="black" fill="none" />
-<path d="M16,83.8822 61.2548,83.8822 38.6274,106.51 Z" stroke="none" fill-opacity="0.75" fill="#AAAAAA" />
-<clipPath id="clip1"><path d="M16,83.8822 61.2548,83.8822 38.6274,106.51 Z" /></clipPath>
-<circle clip-path="url(#clip1)" cx="16" cy="83.8822" r="20" stroke="none" fill="url('#xgrad')"/>
-<circle clip-path="url(#clip1)" cx="61.2548" cy="83.8822" r="20" stroke="none" fill="url('#xgrad')"/>
-<circle clip-path="url(#clip1)" cx="38.6274" cy="106.51" r="20" stroke="none" fill="url('#zgrad')"/>
-<path d="M16,83.8822 61.2548,83.8822 38.6274,106.51 Z" stroke="black" fill="none" />
-<path d="M32.6274,16 a 6 6 0 0 0 12 0 a 6 6 0 0 0 -12 0" stroke="none" fill-opacity="1" fill="#4848FF" />
-<path d="M32.6274,16 a 6 6 0 0 0 12 0 a 6 6 0 0 0 -12 0" stroke="black" fill="none" />
-<path d="M32.6274,61.2548 a 6 6 0 0 0 12 0 a 6 6 0 0 0 -12 0" stroke="none" fill-opacity="1" fill="#4848FF" />
-<path d="M32.6274,61.2548 a 6 6 0 0 0 12 0 a 6 6 0 0 0 -12 0" stroke="black" fill="none" />
-<path d="M32.6274,106.51 a 6 6 0 0 0 12 0 a 6 6 0 0 0 -12 0" stroke="none" fill-opacity="1" fill="#4848FF" />
-<path d="M32.6274,106.51 a 6 6 0 0 0 12 0 a 6 6 0 0 0 -12 0" stroke="black" fill="none" />
-<circle cx="16" cy="38.6274" r="2" stroke="none" fill="black" />
-<circle cx="38.6274" cy="16" r="2" stroke="none" fill="black" />
-<circle cx="61.2548" cy="38.6274" r="2" stroke="none" fill="black" />
-<circle cx="16" cy="83.8822" r="2" stroke="none" fill="black" />
-<circle cx="38.6274" cy="61.2548" r="2" stroke="none" fill="black" />
-<circle cx="61.2548" cy="83.8822" r="2" stroke="none" fill="black" />
-<circle cx="38.6274" cy="106.51" r="2" stroke="none" fill="black" />
-</svg>
-)SVG");
+    expect_string_is_identical_to_saved_file(ss.str(), "rotated_memory_z_detector_slice.svg");
 }

--- a/src/stim/diagram/gate_data_svg.cc
+++ b/src/stim/diagram/gate_data_svg.cc
@@ -5,68 +5,68 @@ using namespace stim_draw_internal;
 std::map<std::string, SvgGateData> SvgGateData::make_gate_data_map() {
     std::map<std::string, SvgGateData> result;
 
-    result.insert({"X", {1, "X", "", "", "white"}});
-    result.insert({"Y", {1, "Y", "", "", "white"}});
-    result.insert({"Z", {1, "Z", "", "", "white"}});
+    result.insert({"X", {1, "X", "", "", "white", "black"}});
+    result.insert({"Y", {1, "Y", "", "", "white", "black"}});
+    result.insert({"Z", {1, "Z", "", "", "white", "black"}});
 
-    result.insert({"H_YZ", {1, "H", "YZ", "", "white"}});
-    result.insert({"H", {1, "H", "", "", "white"}});
-    result.insert({"H_XY", {1, "H", "XY", "", "white"}});
+    result.insert({"H_YZ", {1, "H", "YZ", "", "white", "black"}});
+    result.insert({"H", {1, "H", "", "", "white", "black"}});
+    result.insert({"H_XY", {1, "H", "XY", "", "white", "black"}});
 
-    result.insert({"SQRT_X", {1, u8"√X", "", "", "white"}});
-    result.insert({"SQRT_Y", {1, u8"√Y", "", "", "white"}});
-    result.insert({"S", {1, "S", "", "", "white"}});
+    result.insert({"SQRT_X", {1, u8"√X", "", "", "white", "black"}});
+    result.insert({"SQRT_Y", {1, u8"√Y", "", "", "white", "black"}});
+    result.insert({"S", {1, "S", "", "", "white", "black"}});
 
-    result.insert({"SQRT_X_DAG", {1, u8"√X", "", u8"†", "white"}});
-    result.insert({"SQRT_Y_DAG", {1, u8"√Y", "", u8"†", "white"}});
-    result.insert({"S_DAG", {1, "S", "", u8"†", "white"}});
+    result.insert({"SQRT_X_DAG", {1, u8"√X", "", u8"†", "white", "black"}});
+    result.insert({"SQRT_Y_DAG", {1, u8"√Y", "", u8"†", "white", "black"}});
+    result.insert({"S_DAG", {1, "S", "", u8"†", "white", "black"}});
 
-    result.insert({"MX", {1, "M", "X", "", "white"}});
-    result.insert({"MY", {1, "M", "Y", "", "white"}});
-    result.insert({"M", {1, "M", "", "", "white"}});
+    result.insert({"MX", {1, "M", "X", "", "black", "white"}});
+    result.insert({"MY", {1, "M", "Y", "", "black", "white"}});
+    result.insert({"M", {1, "M", "", "", "black", "white"}});
 
-    result.insert({"RX", {1, "R", "X", "", "white"}});
-    result.insert({"RY", {1, "R", "Y", "", "white"}});
-    result.insert({"R", {1, "R", "", "", "white"}});
+    result.insert({"RX", {1, "R", "X", "", "black", "white"}});
+    result.insert({"RY", {1, "R", "Y", "", "black", "white"}});
+    result.insert({"R", {1, "R", "", "", "black", "white"}});
 
-    result.insert({"MRX", {1, "MR", "X", "", "white"}});
-    result.insert({"MRY", {1, "MR", "Y", "", "white"}});
-    result.insert({"MR", {1, "MR", "", "", "white"}});
+    result.insert({"MRX", {1, "MR", "X", "", "black", "white"}});
+    result.insert({"MRY", {1, "MR", "Y", "", "black", "white"}});
+    result.insert({"MR", {1, "MR", "", "", "black", "white"}});
 
-    result.insert({"X_ERROR", {1, "ERR", "X", "", "pink"}});
-    result.insert({"Y_ERROR", {1, "ERR", "Y", "", "pink"}});
-    result.insert({"Z_ERROR", {1, "ERR", "Z", "", "pink"}});
+    result.insert({"X_ERROR", {1, "ERR", "X", "", "pink", "black"}});
+    result.insert({"Y_ERROR", {1, "ERR", "Y", "", "pink", "black"}});
+    result.insert({"Z_ERROR", {1, "ERR", "Z", "", "pink", "black"}});
 
-    result.insert({"E[X]", {1, "E", "X", "", "pink"}});
-    result.insert({"E[Y]", {1, "E", "Y", "", "pink"}});
-    result.insert({"E[Z]", {1, "E", "Z", "", "pink"}});
+    result.insert({"E[X]", {1, "E", "X", "", "pink", "black"}});
+    result.insert({"E[Y]", {1, "E", "Y", "", "pink", "black"}});
+    result.insert({"E[Z]", {1, "E", "Z", "", "pink", "black"}});
 
-    result.insert({"ELSE_CORRELATED_ERROR[X]", {1, "EE", "X", "", "pink"}});
-    result.insert({"ELSE_CORRELATED_ERROR[Y]", {1, "EE", "Y", "", "pink"}});
-    result.insert({"ELSE_CORRELATED_ERROR[Z]", {1, "EE", "Z", "", "pink"}});
+    result.insert({"ELSE_CORRELATED_ERROR[X]", {1, "EE", "X", "", "pink", "black"}});
+    result.insert({"ELSE_CORRELATED_ERROR[Y]", {1, "EE", "Y", "", "pink", "black"}});
+    result.insert({"ELSE_CORRELATED_ERROR[Z]", {1, "EE", "Z", "", "pink", "black"}});
 
-    result.insert({"MPP[X]", {1, "MPP", "X", "", "white"}});
-    result.insert({"MPP[Y]", {1, "MPP", "Y", "", "white"}});
-    result.insert({"MPP[Z]", {1, "MPP", "Z", "", "white"}});
+    result.insert({"MPP[X]", {1, "MPP", "X", "", "black", "white"}});
+    result.insert({"MPP[Y]", {1, "MPP", "Y", "", "black", "white"}});
+    result.insert({"MPP[Z]", {1, "MPP", "Z", "", "black", "white"}});
 
-    result.insert({"SQRT_XX", {1, u8"√XX", "", "", "white"}});
-    result.insert({"SQRT_YY", {1, u8"√YY", "", "", "white"}});
-    result.insert({"SQRT_ZZ", {1, u8"√ZZ", "", "", "white"}});
+    result.insert({"SQRT_XX", {1, u8"√XX", "", "", "white", "black"}});
+    result.insert({"SQRT_YY", {1, u8"√YY", "", "", "white", "black"}});
+    result.insert({"SQRT_ZZ", {1, u8"√ZZ", "", "", "white", "black"}});
 
-    result.insert({"SQRT_XX_DAG", {1, u8"√XX", "", u8"†", "white"}});
-    result.insert({"SQRT_YY_DAG", {1, u8"√YY", "", u8"†", "white"}});
-    result.insert({"SQRT_ZZ_DAG", {1, u8"√ZZ", "", u8"†", "white"}});
+    result.insert({"SQRT_XX_DAG", {1, u8"√XX", "", u8"†", "white", "black"}});
+    result.insert({"SQRT_YY_DAG", {1, u8"√YY", "", u8"†", "white", "black"}});
+    result.insert({"SQRT_ZZ_DAG", {1, u8"√ZZ", "", u8"†", "white", "black"}});
 
-    result.insert({"I", {1, "I", "", "", "white"}});
-    result.insert({"C_XYZ", {1, "C", "XYZ", "", "white"}});
-    result.insert({"C_ZYX", {1, "C", "ZYX", "", "white"}});
+    result.insert({"I", {1, "I", "", "", "white", "black"}});
+    result.insert({"C_XYZ", {1, "C", "XYZ", "", "white", "black"}});
+    result.insert({"C_ZYX", {1, "C", "ZYX", "", "white", "black"}});
 
-    result.insert({"DEPOLARIZE1", {1, "DEP", "1", "", "pink"}});
-    result.insert({"DEPOLARIZE2", {1, "DEP", "2", "", "pink"}});
+    result.insert({"DEPOLARIZE1", {1, "DEP", "1", "", "pink", "black"}});
+    result.insert({"DEPOLARIZE2", {1, "DEP", "2", "", "pink", "black"}});
 
-    result.insert({"PAULI_CHANNEL_1", {4, "PAULI_CHANNEL_1", "", "", "pink"}});
-    result.insert({"PAULI_CHANNEL_2[0]", {16, "PAULI_CHANNEL_2", "0", "", "pink"}});
-    result.insert({"PAULI_CHANNEL_2[1]", {16, "PAULI_CHANNEL_2", "1", "", "pink"}});
+    result.insert({"PAULI_CHANNEL_1", {4, "PAULI_CHANNEL_1", "", "", "pink", "black"}});
+    result.insert({"PAULI_CHANNEL_2[0]", {16, "PAULI_CHANNEL_2", "0", "", "pink", "black"}});
+    result.insert({"PAULI_CHANNEL_2[1]", {16, "PAULI_CHANNEL_2", "1", "", "pink", "black"}});
 
     return result;
 }

--- a/src/stim/diagram/gate_data_svg.h
+++ b/src/stim/diagram/gate_data_svg.h
@@ -28,6 +28,7 @@ struct SvgGateData {
     std::string subscript;
     std::string superscript;
     std::string fill;
+    std::string text_color;
 
     static std::map<std::string, SvgGateData> make_gate_data_map();
 };

--- a/src/stim/diagram/graph/match_graph_3d_drawer.test.cc
+++ b/src/stim/diagram/graph/match_graph_3d_drawer.test.cc
@@ -27,31 +27,12 @@
 using namespace stim;
 using namespace stim_draw_internal;
 
-void expect_graph_diagram_is_identical_to_saved_file(const DetectorErrorModel &dem, std::string key) {
+void expect_graph_diagram_is_identical_to_saved_file(const DetectorErrorModel &dem, const std::string &key) {
     auto diagram = dem_match_graph_to_basic_3d_diagram(dem);
     std::stringstream actual_ss;
     diagram.to_gltf_scene().to_json().write(actual_ss);
     auto actual = actual_ss.str();
-
-    auto path = resolve_test_file(key);
-    FILE *f = fopen(path.c_str(), "rb");
-    auto expected = rewind_read_close(f);
-
-    if (expected != actual) {
-        auto dot = key.rfind('.');
-        std::string new_path;
-        if (dot == std::string::npos) {
-            new_path = path + ".new";
-        } else {
-            dot += path.size() - key.size();
-            new_path = path.substr(0, dot) + ".new" + path.substr(dot);
-        }
-        std::ofstream out;
-        out.open(new_path);
-        out << actual;
-        out.close();
-        EXPECT_TRUE(false) << "Diagram didn't agree. key=" << key;
-    }
+    expect_string_is_identical_to_saved_file(actual_ss.str(), key);
 }
 
 TEST(match_graph_drawer_3d, repetition_code) {

--- a/src/stim/diagram/graph/match_graph_svg_drawer.test.cc
+++ b/src/stim/diagram/graph/match_graph_svg_drawer.test.cc
@@ -28,30 +28,11 @@
 using namespace stim;
 using namespace stim_draw_internal;
 
-void expect_graph_svg_diagram_is_identical_to_saved_file(const DetectorErrorModel &dem, std::string key) {
+void expect_graph_svg_diagram_is_identical_to_saved_file(const DetectorErrorModel &dem, const std::string &key) {
     std::stringstream actual_ss;
     dem_match_graph_to_svg_diagram_write_to(dem, actual_ss);
     auto actual = actual_ss.str();
-
-    auto path = resolve_test_file(key);
-    FILE *f = fopen(path.c_str(), "rb");
-    auto expected = rewind_read_close(f);
-
-    if (expected != actual) {
-        auto dot = key.rfind('.');
-        std::string new_path;
-        if (dot == std::string::npos) {
-            new_path = path + ".new";
-        } else {
-            dot += path.size() - key.size();
-            new_path = path.substr(0, dot) + ".new" + path.substr(dot);
-        }
-        std::ofstream out;
-        out.open(new_path);
-        out << actual;
-        out.close();
-        EXPECT_TRUE(false) << "Diagram didn't agree. key=" << key;
-    }
+    expect_string_is_identical_to_saved_file(actual_ss.str(), key);
 }
 
 TEST(match_graph_drawer_svg, repetition_code) {

--- a/src/stim/diagram/timeline/timeline_3d_drawer.test.cc
+++ b/src/stim/diagram/timeline/timeline_3d_drawer.test.cc
@@ -26,7 +26,7 @@
 using namespace stim;
 using namespace stim_draw_internal;
 
-void expect_diagram_is_identical_to_saved_file(const Circuit &circuit, std::string key) {
+void expect_diagram_is_identical_to_saved_file(const Circuit &circuit, const std::string &key) {
     auto diagram = DiagramTimeline3DDrawer::circuit_to_basic_3d_diagram(circuit);
     std::stringstream actual_ss;
     diagram.to_gltf_scene().to_json().write(actual_ss);

--- a/src/stim/diagram/timeline/timeline_svg_drawer.cc
+++ b/src/stim/diagram/timeline/timeline_svg_drawer.cc
@@ -741,6 +741,7 @@ void DiagramTimelineSvgDrawer::make_diagram_write_to(
     obj.min_tick = tick_slice_start;
     obj.max_tick = tick_slice_start + tick_slice_num - 1;
     obj.mode = mode;
+    obj.resolver.unroll_loops = mode != SVG_MODE_TIMELINE;
     obj.resolver.resolved_op_callback = [&](const ResolvedTimelineOperation &op) {
         obj.do_resolved_operation(op);
     };

--- a/src/stim/simulators/tableau_simulator.test.cc
+++ b/src/stim/simulators/tableau_simulator.test.cc
@@ -2106,9 +2106,9 @@ TEST(TableauSimulator, measure_pauli_string) {
 
     ASSERT_TRUE(sim.measure_pauli_string(PauliString::from_str("XX"), 1.0));
 
-    ASSERT_THROW({sim.measure_pauli_string(PauliString::from_str(""), -0.5);}, std::invalid_argument);
-    ASSERT_THROW({sim.measure_pauli_string(PauliString::from_str(""), 2.5);}, std::invalid_argument);
-    ASSERT_THROW({sim.measure_pauli_string(PauliString::from_str(""), NAN);}, std::invalid_argument);
+    ASSERT_THROW({ sim.measure_pauli_string(PauliString::from_str(""), -0.5); }, std::invalid_argument);
+    ASSERT_THROW({ sim.measure_pauli_string(PauliString::from_str(""), 2.5); }, std::invalid_argument);
+    ASSERT_THROW({ sim.measure_pauli_string(PauliString::from_str(""), NAN); }, std::invalid_argument);
 
     ASSERT_FALSE(sim.measure_pauli_string(PauliString::from_str("+"), 0.0));
     ASSERT_TRUE(sim.measure_pauli_string(PauliString::from_str("+"), 1.0));
@@ -2117,9 +2117,8 @@ TEST(TableauSimulator, measure_pauli_string) {
     ASSERT_FALSE(sim.measure_pauli_string(PauliString::from_str("____________Z"), 0.0));
     ASSERT_EQ(sim.inv_state.num_qubits, 13);
 
-    ASSERT_EQ(sim.measurement_record.storage, (std::vector<bool>{
-        0, 1, 1, 0, 1, 0, 0, 1, 0, 0, 0, b, b, !b, !b, 1, 0, 1, 1, 0, 0
-    }));
+    ASSERT_EQ(sim.measurement_record.storage, (std::vector<bool>{0, 1, 1,  0,  1, 0, 0, 1, 0, 0, 0,
+                                                                 b, b, !b, !b, 1, 0, 1, 1, 0, 0}));
 
     size_t t = 0;
     for (size_t k = 0; k < 10000; k++) {

--- a/src/stim/test_util.test.cc
+++ b/src/stim/test_util.test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <fstream>
 #include "stim/test_util.test.h"
 
 #include "stim/probability_util.h"
@@ -34,7 +35,37 @@ std::string resolve_test_file(const std::string &name) {
             return full_path;
         }
     }
+    for (const auto &prefix : prefixes) {
+        std::string full_path = prefix + name;
+        FILE *f = fopen(full_path.c_str(), "wb");
+        if (f != nullptr) {
+            fclose(f);
+            return full_path;
+        }
+    }
     throw std::invalid_argument("Run tests from the repo root so they can find the testdata/ directory.");
+}
+
+void expect_string_is_identical_to_saved_file(const std::string &actual, const std::string &key) {
+    auto path = resolve_test_file(key);
+    FILE *f = fopen(path.c_str(), "rb");
+    auto expected = rewind_read_close(f);
+
+    if (expected != actual) {
+        auto dot = key.rfind('.');
+        std::string new_path;
+        if (dot == std::string::npos) {
+            new_path = path + ".new";
+        } else {
+            dot += path.size() - key.size();
+            new_path = path.substr(0, dot) + ".new" + path.substr(dot);
+        }
+        std::ofstream out;
+        out.open(new_path);
+        out << actual;
+        out.close();
+        EXPECT_TRUE(false) << "Diagram didn't agree. key=" << key;
+    }
 }
 
 std::mt19937_64 &SHARED_TEST_RNG() {

--- a/src/stim/test_util.test.h
+++ b/src/stim/test_util.test.h
@@ -28,6 +28,7 @@ std::mt19937_64 &SHARED_TEST_RNG();
 std::string rewind_read_close(FILE *f);
 
 std::string resolve_test_file(const std::string &name);
+void expect_string_is_identical_to_saved_file(const std::string &actual, const std::string &key);
 
 struct RaiiTempNamedFile {
     int descriptor;

--- a/testdata/classical_feedback.svg
+++ b/testdata/classical_feedback.svg
@@ -5,8 +5,8 @@
 <text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="128">q1</text>
 <path d="M64,192 L224,192 " stroke="black"/>
 <text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="192">q2</text>
-<rect x="80" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="64">M</text>
+<rect x="80" y="48" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="64" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="96" y="44">rec[0]</text>
 <rect x="80" y="112" width="96" height="32" stroke="black" fill="lightgray"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="128" y="128">X<tspan baseline-shift="super" font-size="10">rec[0]</tspan></text>

--- a/testdata/collapsing.svg
+++ b/testdata/collapsing.svg
@@ -7,71 +7,71 @@
 <text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="192">q2</text>
 <path d="M64,256 L608,256 " stroke="black"/>
 <text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="256">q3</text>
-<rect x="80" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="64">R</text>
-<rect x="80" y="112" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="128">R<tspan baseline-shift="sub" font-size="10">X</tspan></text>
-<rect x="80" y="176" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="192">R<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
-<rect x="80" y="240" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="256">R</text>
-<rect x="144" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="160" y="64">M</text>
+<rect x="80" y="48" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="64" fill="white">R</text>
+<rect x="80" y="112" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="128" fill="white">R<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<rect x="80" y="176" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="192" fill="white">R<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
+<rect x="80" y="240" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="256" fill="white">R</text>
+<rect x="144" y="48" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="160" y="64" fill="white">M</text>
 <text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="160" y="84">0.001</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="160" y="44">rec[0]</text>
-<rect x="144" y="112" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="160" y="128">M</text>
+<rect x="144" y="112" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="160" y="128" fill="white">M</text>
 <text dominant-baseline="hanging" text-anchor="middle" font-family="monospace" font-size="10" stroke="red" x="160" y="148">0.001</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="160" y="108">rec[1]</text>
-<rect x="208" y="112" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="128">MR</text>
+<rect x="208" y="112" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="128" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="224" y="108">rec[2]</text>
-<rect x="208" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="64">MR</text>
+<rect x="208" y="48" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="64" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="224" y="44">rec[3]</text>
-<rect x="272" y="112" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="128">MR<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<rect x="272" y="112" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="128" fill="white">MR<tspan baseline-shift="sub" font-size="10">X</tspan></text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="288" y="108">rec[4]</text>
-<rect x="272" y="176" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="192">MR<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<rect x="272" y="176" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="192" fill="white">MR<tspan baseline-shift="sub" font-size="10">X</tspan></text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="288" y="172">rec[5]</text>
-<rect x="272" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="64">MR<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
+<rect x="272" y="48" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="64" fill="white">MR<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="288" y="44">rec[6]</text>
-<rect x="272" y="240" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="256">MR<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
+<rect x="272" y="240" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="256" fill="white">MR<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="288" y="236">rec[7]</text>
-<rect x="336" y="112" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="128">MR<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
+<rect x="336" y="112" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="128" fill="white">MR<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="352" y="108">rec[8]</text>
-<rect x="336" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="64">MR</text>
+<rect x="336" y="48" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="64" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="352" y="44">rec[9]</text>
-<rect x="400" y="112" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="128">M<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<rect x="400" y="112" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="128" fill="white">M<tspan baseline-shift="sub" font-size="10">X</tspan></text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="416" y="108">rec[10]</text>
-<rect x="400" y="176" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="192">M<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
+<rect x="400" y="176" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="192" fill="white">M<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="416" y="172">rec[11]</text>
-<rect x="400" y="240" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="256">M</text>
+<rect x="400" y="240" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="416" y="256" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="416" y="236">rec[12]</text>
 <path d="M480,64 L480,192 " stroke="black"/>
-<rect x="464" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="480" y="64">MPP<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<rect x="464" y="48" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="480" y="64" fill="white">MPP<tspan baseline-shift="sub" font-size="10">X</tspan></text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="480" y="44">rec[13]</text>
-<rect x="464" y="176" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="480" y="192">MPP<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
-<rect x="464" y="240" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="480" y="256">MPP<tspan baseline-shift="sub" font-size="10">Z</tspan></text>
+<rect x="464" y="176" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="480" y="192" fill="white">MPP<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
+<rect x="464" y="240" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="480" y="256" fill="white">MPP<tspan baseline-shift="sub" font-size="10">Z</tspan></text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="480" y="236">rec[14]</text>
-<rect x="528" y="112" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="544" y="128">MPP<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<rect x="528" y="112" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="544" y="128" fill="white">MPP<tspan baseline-shift="sub" font-size="10">X</tspan></text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="544" y="108">rec[15]</text>
 <path d="M544,192 L544,256 " stroke="black"/>
-<rect x="528" y="176" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="544" y="192">MPP<tspan baseline-shift="sub" font-size="10">Z</tspan></text>
+<rect x="528" y="176" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="544" y="192" fill="white">MPP<tspan baseline-shift="sub" font-size="10">Z</tspan></text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="544" y="172">rec[16]</text>
-<rect x="528" y="240" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="544" y="256">MPP<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
+<rect x="528" y="240" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="544" y="256" fill="white">MPP<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
 </svg>

--- a/testdata/detector_pseudo_targets.svg
+++ b/testdata/detector_pseudo_targets.svg
@@ -11,31 +11,31 @@
 <text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="320">q4</text>
 <path d="M64,384 L992,384 " stroke="black"/>
 <text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="384">q5</text>
-<rect x="80" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="64">M</text>
+<rect x="80" y="48" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="64" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="96" y="44">rec[0]</text>
-<rect x="80" y="112" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="128">M</text>
+<rect x="80" y="112" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="128" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="96" y="108">rec[1]</text>
-<rect x="80" y="176" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="192">M</text>
+<rect x="80" y="176" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="192" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="96" y="172">rec[2]</text>
-<rect x="80" y="240" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="256">M</text>
+<rect x="80" y="240" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="256" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="96" y="236">rec[3]</text>
-<rect x="80" y="304" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="320">M</text>
+<rect x="80" y="304" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="320" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="96" y="300">rec[4]</text>
-<rect x="80" y="368" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="384">M</text>
+<rect x="80" y="368" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="384" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="96" y="364">rec[5]</text>
 <path d="M168,32 L160,32 L160,448 L168,448 " stroke="black" fill="none"/>
 <text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="164" y="444">REP100</text>
-<rect x="208" y="112" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="128">M</text>
+<rect x="208" y="112" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="224" y="128" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="224" y="108">rec[6+iter*2]</text>
-<rect x="208" y="176" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="192">M</text>
+<rect x="208" y="176" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="224" y="192" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="224" y="172">rec[7+iter*2]</text>
 <path d="M280,32 L288,32 L288,448 L280,448 " stroke="black" fill="none"/>
 <rect x="336" y="176" width="160" height="32" stroke="black" fill="lightgray"/>

--- a/testdata/lattice_surgery_cnot.svg
+++ b/testdata/lattice_surgery_cnot.svg
@@ -5,22 +5,22 @@
 <text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="128">q1</text>
 <path d="M64,192 L544,192 " stroke="black"/>
 <text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="192">q2</text>
-<rect x="80" y="176" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="192">R</text>
+<rect x="80" y="176" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="192" fill="white">R</text>
 <path d="M160,128 L160,192 " stroke="black"/>
-<rect x="144" y="112" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="160" y="128">MPP<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<rect x="144" y="112" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="160" y="128" fill="white">MPP<tspan baseline-shift="sub" font-size="10">X</tspan></text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="160" y="108">rec[0]</text>
-<rect x="144" y="176" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="160" y="192">MPP<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<rect x="144" y="176" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="160" y="192" fill="white">MPP<tspan baseline-shift="sub" font-size="10">X</tspan></text>
 <path d="M224,64 L224,192 " stroke="black"/>
-<rect x="208" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="224" y="64">MPP<tspan baseline-shift="sub" font-size="10">Z</tspan></text>
+<rect x="208" y="48" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="224" y="64" fill="white">MPP<tspan baseline-shift="sub" font-size="10">Z</tspan></text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="224" y="44">rec[1]</text>
-<rect x="208" y="176" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="224" y="192">MPP<tspan baseline-shift="sub" font-size="10">Z</tspan></text>
-<rect x="272" y="176" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="192">M<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<rect x="208" y="176" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="224" y="192" fill="white">MPP<tspan baseline-shift="sub" font-size="10">Z</tspan></text>
+<rect x="272" y="176" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="192" fill="white">M<tspan baseline-shift="sub" font-size="10">X</tspan></text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="288" y="172">rec[2]</text>
 <rect x="272" y="48" width="96" height="32" stroke="black" fill="lightgray"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="320" y="64">Z<tspan baseline-shift="super" font-size="10">rec[0]</tspan></text>

--- a/testdata/measurement_looping.svg
+++ b/testdata/measurement_looping.svg
@@ -9,28 +9,28 @@
 <text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="256">q3</text>
 <path d="M64,320 L736,320 " stroke="black"/>
 <text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="320">q4</text>
-<rect x="80" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="64">M</text>
+<rect x="80" y="48" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="64" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="96" y="44">rec[0]</text>
 <path d="M168,32 L160,32 L160,384 L168,384 " stroke="black" fill="none"/>
 <text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="164" y="380">REP100</text>
-<rect x="208" y="112" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="128">M</text>
+<rect x="208" y="112" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="224" y="128" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="224" y="108">rec[1+iter*13]</text>
 <path d="M296,36 L288,36 L288,380 L296,380 " stroke="black" fill="none"/>
 <text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="292" y="376">REP5</text>
-<rect x="336" y="176" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="192">M</text>
+<rect x="336" y="176" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="192" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="352" y="172">rec[2+iter*13+iter2]</text>
 <path d="M408,36 L416,36 L416,380 L408,380 " stroke="black" fill="none"/>
 <path d="M488,36 L480,36 L480,380 L488,380 " stroke="black" fill="none"/>
 <text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="484" y="376">REP7</text>
 <path d="M544,256 L544,320 " stroke="black"/>
-<rect x="528" y="240" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="544" y="256">MPP<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<rect x="528" y="240" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="544" y="256" fill="white">MPP<tspan baseline-shift="sub" font-size="10">X</tspan></text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="544" y="236">rec[7+iter*13+iter2]</text>
-<rect x="528" y="304" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="544" y="320">MPP<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
+<rect x="528" y="304" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="544" y="320" fill="white">MPP<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
 <path d="M600,36 L608,36 L608,380 L600,380 " stroke="black" fill="none"/>
 <path d="M664,32 L672,32 L672,384 L664,384 " stroke="black" fill="none"/>
 </svg>

--- a/testdata/repeat.svg
+++ b/testdata/repeat.svg
@@ -8,25 +8,25 @@
 <path d="M64,256 L608,256 " stroke="black"/>
 <text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="256">q3</text>
 <rect x="80" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="64">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="64">H</text>
 <rect x="80" y="112" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="128">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="128">H</text>
 <rect x="80" y="176" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="192">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="192">H</text>
 <path d="M168,32 L160,32 L160,320 L168,320 " stroke="black" fill="none"/>
 <text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="164" y="316">REP5</text>
-<rect x="208" y="176" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="192">R<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<rect x="208" y="176" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="192" fill="white">R<tspan baseline-shift="sub" font-size="10">X</tspan></text>
 <path d="M296,36 L288,36 L288,316 L296,316 " stroke="black" fill="none"/>
 <text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="292" y="312">REP100</text>
 <rect x="336" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="64">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="64">H</text>
 <rect x="336" y="112" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="128">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="128">H</text>
 <rect x="336" y="240" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="256">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="256">H</text>
 <rect x="400" y="240" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="256">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="416" y="256">H</text>
 <path d="M472,36 L480,36 L480,316 L472,316 " stroke="black" fill="none"/>
 <path d="M536,32 L544,32 L544,320 L536,320 " stroke="black" fill="none"/>
 </svg>

--- a/testdata/repetition_code.svg
+++ b/testdata/repetition_code.svg
@@ -9,16 +9,16 @@
 <text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="256">q3</text>
 <path d="M64,320 L1568,320 " stroke="black"/>
 <text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="320">q4</text>
-<rect x="80" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="64">R</text>
-<rect x="80" y="112" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="128">R</text>
-<rect x="80" y="176" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="192">R</text>
-<rect x="80" y="240" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="256">R</text>
-<rect x="80" y="304" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="320">R</text>
+<rect x="80" y="48" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="64" fill="white">R</text>
+<rect x="80" y="112" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="128" fill="white">R</text>
+<rect x="80" y="176" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="192" fill="white">R</text>
+<rect x="80" y="240" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="256" fill="white">R</text>
+<rect x="80" y="304" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="320" fill="white">R</text>
 <path d="M160,64 L160,128 " stroke="black"/>
 <circle cx="160" cy="64" r="8" stroke="none" fill="black"/>
 <circle cx="160" cy="128" r="8" stroke="black" fill="white"/>
@@ -35,11 +35,11 @@
 <circle cx="224" cy="320" r="8" stroke="none" fill="black"/>
 <circle cx="224" cy="256" r="8" stroke="black" fill="white"/>
 <path d="M216,256 L232,256 M224,248 L224,264 " stroke="black"/>
-<rect x="272" y="112" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="128">MR</text>
+<rect x="272" y="112" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="128" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="288" y="108">rec[0]</text>
-<rect x="272" y="240" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="256">MR</text>
+<rect x="272" y="240" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="256" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="288" y="236">rec[1]</text>
 <rect x="336" y="112" width="160" height="32" stroke="black" fill="lightgray"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="128">DETECTOR</text>
@@ -69,11 +69,11 @@
 <circle cx="736" cy="320" r="8" stroke="none" fill="black"/>
 <circle cx="736" cy="256" r="8" stroke="black" fill="white"/>
 <path d="M728,256 L744,256 M736,248 L736,264 " stroke="black"/>
-<rect x="784" y="112" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="800" y="128">MR</text>
+<rect x="784" y="112" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="800" y="128" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="800" y="108">rec[2+iter*2]</text>
-<rect x="784" y="240" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="800" y="256">MR</text>
+<rect x="784" y="240" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="800" y="256" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="800" y="236">rec[3+iter*2]</text>
 <rect x="848" y="112" width="224" height="32" stroke="black" fill="lightgray"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="960" y="128">DETECTOR</text>
@@ -86,14 +86,14 @@
 <path d="M772,40 L772,32 L1084,32 L1084,40 " stroke="black" fill="none"/>
 <path d="M772,376 L772,384 L1084,384 L1084,376 " stroke="black" fill="none"/>
 <path d="M1112,32 L1120,32 L1120,384 L1112,384 " stroke="black" fill="none"/>
-<rect x="1168" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1184" y="64">M</text>
+<rect x="1168" y="48" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1184" y="64" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="1184" y="44">rec[20]</text>
-<rect x="1168" y="176" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1184" y="192">M</text>
+<rect x="1168" y="176" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1184" y="192" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="1184" y="172">rec[21]</text>
-<rect x="1168" y="304" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1184" y="320">M</text>
+<rect x="1168" y="304" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1184" y="320" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="1184" y="300">rec[22]</text>
 <rect x="1232" y="48" width="288" height="32" stroke="black" fill="lightgray"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1376" y="64">DETECTOR</text>

--- a/testdata/rotated_memory_z_detector_slice.svg
+++ b/testdata/rotated_memory_z_detector_slice.svg
@@ -1,0 +1,34 @@
+<svg viewBox="0 0 77.2548 122.51" xmlns="http://www.w3.org/2000/svg">
+<path d="M38.6274,16 61.2548,38.6274 16,38.6274 Z" stroke="none" fill-opacity="0.75" fill="#AAAAAA" />
+<defs>
+<radialGradient id="xgrad"><stop offset="50%" stop-color="#FF4444" stop-opacity="1"/><stop offset="100%" stop-color="#AAAAAA" stop-opacity="0"/></radialGradient>
+<radialGradient id="ygrad"><stop offset="50%" stop-color="#40FF40" stop-opacity="1"/><stop offset="100%" stop-color="#AAAAAA" stop-opacity="0"/></radialGradient>
+<radialGradient id="zgrad"><stop offset="50%" stop-color="#4848FF" stop-opacity="1"/><stop offset="100%" stop-color="#AAAAAA" stop-opacity="0"/></radialGradient>
+</defs>
+<clipPath id="clip0"><path d="M38.6274,16 61.2548,38.6274 16,38.6274 Z" /></clipPath>
+<circle clip-path="url(#clip0)" cx="16" cy="38.6274" r="20" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip0)" cx="38.6274" cy="16" r="20" stroke="none" fill="url('#zgrad')"/>
+<circle clip-path="url(#clip0)" cx="61.2548" cy="38.6274" r="20" stroke="none" fill="url('#xgrad')"/>
+<path d="M38.6274,16 61.2548,38.6274 16,38.6274 Z" stroke="black" fill="none" />
+<path d="M16,38.6274 61.2548,38.6274 38.6274,61.2548 61.2548,83.8822 16,83.8822 Z" stroke="none" fill-opacity="0.75" fill="#4848FF" />
+<path d="M16,38.6274 61.2548,38.6274 38.6274,61.2548 61.2548,83.8822 16,83.8822 Z" stroke="black" fill="none" />
+<path d="M16,83.8822 61.2548,83.8822 38.6274,106.51 Z" stroke="none" fill-opacity="0.75" fill="#AAAAAA" />
+<clipPath id="clip1"><path d="M16,83.8822 61.2548,83.8822 38.6274,106.51 Z" /></clipPath>
+<circle clip-path="url(#clip1)" cx="16" cy="83.8822" r="20" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip1)" cx="61.2548" cy="83.8822" r="20" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip1)" cx="38.6274" cy="106.51" r="20" stroke="none" fill="url('#zgrad')"/>
+<path d="M16,83.8822 61.2548,83.8822 38.6274,106.51 Z" stroke="black" fill="none" />
+<path d="M32.6274,16 a 6 6 0 0 0 12 0 a 6 6 0 0 0 -12 0" stroke="none" fill-opacity="1" fill="#4848FF" />
+<path d="M32.6274,16 a 6 6 0 0 0 12 0 a 6 6 0 0 0 -12 0" stroke="black" fill="none" />
+<path d="M32.6274,61.2548 a 6 6 0 0 0 12 0 a 6 6 0 0 0 -12 0" stroke="none" fill-opacity="1" fill="#4848FF" />
+<path d="M32.6274,61.2548 a 6 6 0 0 0 12 0 a 6 6 0 0 0 -12 0" stroke="black" fill="none" />
+<path d="M32.6274,106.51 a 6 6 0 0 0 12 0 a 6 6 0 0 0 -12 0" stroke="none" fill-opacity="1" fill="#4848FF" />
+<path d="M32.6274,106.51 a 6 6 0 0 0 12 0 a 6 6 0 0 0 -12 0" stroke="black" fill="none" />
+<circle cx="16" cy="38.6274" r="2" stroke="none" fill="black" />
+<circle cx="38.6274" cy="16" r="2" stroke="none" fill="black" />
+<circle cx="61.2548" cy="38.6274" r="2" stroke="none" fill="black" />
+<circle cx="16" cy="83.8822" r="2" stroke="none" fill="black" />
+<circle cx="38.6274" cy="61.2548" r="2" stroke="none" fill="black" />
+<circle cx="61.2548" cy="83.8822" r="2" stroke="none" fill="black" />
+<circle cx="38.6274" cy="106.51" r="2" stroke="none" fill="black" />
+</svg>

--- a/testdata/single_qubits_gates.svg
+++ b/testdata/single_qubits_gates.svg
@@ -8,27 +8,27 @@
 <path d="M64,256 L480,256 " stroke="black"/>
 <text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="256">q3</text>
 <rect x="80" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="64">I</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="64">I</text>
 <rect x="80" y="112" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="128">X</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="128">X</text>
 <rect x="80" y="176" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="192">Y</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="192">Y</text>
 <rect x="80" y="240" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="256">Z</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="256">Z</text>
 <rect x="144" y="48" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="160" y="64">C<tspan baseline-shift="sub" font-size="10">XYZ</tspan></text>
 <rect x="144" y="112" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="160" y="128">C<tspan baseline-shift="sub" font-size="10">ZYX</tspan></text>
 <rect x="144" y="176" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="160" y="192">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="160" y="192">H</text>
 <rect x="144" y="240" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="160" y="256">H<tspan baseline-shift="sub" font-size="10">XY</tspan></text>
 <rect x="208" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="64">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="224" y="64">H</text>
 <rect x="208" y="112" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="128">H<tspan baseline-shift="sub" font-size="10">YZ</tspan></text>
 <rect x="208" y="176" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="192">S</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="224" y="192">S</text>
 <rect x="208" y="240" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="256">√X</text>
 <rect x="272" y="48" width="32" height="32" stroke="black" fill="white"/>
@@ -38,15 +38,15 @@
 <rect x="272" y="176" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="192">√Y<tspan baseline-shift="super" font-size="10">†</tspan></text>
 <rect x="272" y="240" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="256">S</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="288" y="256">S</text>
 <rect x="336" y="48" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="64">S<tspan baseline-shift="super" font-size="10">†</tspan></text>
 <rect x="336" y="112" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="128">S<tspan baseline-shift="super" font-size="10">†</tspan></text>
 <rect x="336" y="176" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="192">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="192">H</text>
 <rect x="400" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="64">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="416" y="64">H</text>
 <rect x="400" y="240" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="256">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="416" y="256">H</text>
 </svg>

--- a/testdata/surface_code.svg
+++ b/testdata/surface_code.svg
@@ -99,70 +99,70 @@
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="192" y="1536">COORDS(3,4)</text>
 <rect x="80" y="1584" width="224" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="192" y="1600">COORDS(4,4)</text>
-<rect x="336" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="64">R</text>
-<rect x="336" y="176" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="192">R</text>
-<rect x="336" y="304" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="320">R</text>
-<rect x="336" y="432" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="448">R</text>
-<rect x="336" y="560" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="576">R</text>
-<rect x="336" y="688" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="704">R</text>
-<rect x="336" y="816" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="832">R</text>
-<rect x="336" y="944" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="960">R</text>
-<rect x="336" y="1072" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="1088">R</text>
-<rect x="336" y="1200" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="1216">R</text>
-<rect x="336" y="1328" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="1344">R</text>
-<rect x="336" y="1456" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="1472">R</text>
-<rect x="336" y="1584" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="1600">R</text>
-<rect x="336" y="112" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="128">R</text>
-<rect x="336" y="240" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="256">R</text>
-<rect x="336" y="368" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="384">R</text>
-<rect x="336" y="496" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="512">R</text>
-<rect x="336" y="624" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="640">R</text>
-<rect x="336" y="752" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="768">R</text>
-<rect x="336" y="880" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="896">R</text>
-<rect x="336" y="1008" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="1024">R</text>
-<rect x="336" y="1136" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="1152">R</text>
-<rect x="336" y="1264" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="1280">R</text>
-<rect x="336" y="1392" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="1408">R</text>
-<rect x="336" y="1520" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="1536">R</text>
+<rect x="336" y="48" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="64" fill="white">R</text>
+<rect x="336" y="176" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="192" fill="white">R</text>
+<rect x="336" y="304" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="320" fill="white">R</text>
+<rect x="336" y="432" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="448" fill="white">R</text>
+<rect x="336" y="560" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="576" fill="white">R</text>
+<rect x="336" y="688" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="704" fill="white">R</text>
+<rect x="336" y="816" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="832" fill="white">R</text>
+<rect x="336" y="944" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="960" fill="white">R</text>
+<rect x="336" y="1072" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="1088" fill="white">R</text>
+<rect x="336" y="1200" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="1216" fill="white">R</text>
+<rect x="336" y="1328" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="1344" fill="white">R</text>
+<rect x="336" y="1456" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="1472" fill="white">R</text>
+<rect x="336" y="1584" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="1600" fill="white">R</text>
+<rect x="336" y="112" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="128" fill="white">R</text>
+<rect x="336" y="240" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="256" fill="white">R</text>
+<rect x="336" y="368" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="384" fill="white">R</text>
+<rect x="336" y="496" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="512" fill="white">R</text>
+<rect x="336" y="624" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="640" fill="white">R</text>
+<rect x="336" y="752" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="768" fill="white">R</text>
+<rect x="336" y="880" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="896" fill="white">R</text>
+<rect x="336" y="1008" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="1024" fill="white">R</text>
+<rect x="336" y="1136" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="1152" fill="white">R</text>
+<rect x="336" y="1264" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="1280" fill="white">R</text>
+<rect x="336" y="1392" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="1408" fill="white">R</text>
+<rect x="336" y="1520" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="352" y="1536" fill="white">R</text>
 <path d="M68,40 L68,32 L380,32 L380,40 " stroke="black" fill="none"/>
 <path d="M68,1656 L68,1664 L380,1664 L380,1656 " stroke="black" fill="none"/>
 <rect x="400" y="112" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="128">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="416" y="128">H</text>
 <rect x="400" y="240" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="256">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="416" y="256">H</text>
 <rect x="400" y="752" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="768">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="416" y="768">H</text>
 <rect x="400" y="880" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="896">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="416" y="896">H</text>
 <rect x="400" y="1392" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="1408">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="416" y="1408">H</text>
 <rect x="400" y="1520" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="1536">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="416" y="1536">H</text>
 <path d="M480,128 L480,192 " stroke="black"/>
 <circle cx="480" cy="128" r="8" stroke="none" fill="black"/>
 <circle cx="480" cy="192" r="8" stroke="black" fill="white"/>
@@ -328,52 +328,52 @@
 <circle cx="1184" cy="1280" r="8" stroke="black" fill="white"/>
 <path d="M1176,1280 L1192,1280 M1184,1272 L1184,1288 " stroke="black"/>
 <rect x="1232" y="112" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1248" y="128">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1248" y="128">H</text>
 <rect x="1232" y="240" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1248" y="256">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1248" y="256">H</text>
 <rect x="1232" y="752" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1248" y="768">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1248" y="768">H</text>
 <rect x="1232" y="880" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1248" y="896">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1248" y="896">H</text>
 <rect x="1232" y="1392" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1248" y="1408">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1248" y="1408">H</text>
 <rect x="1232" y="1520" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1248" y="1536">H</text>
-<rect x="1296" y="112" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1312" y="128">MR</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1248" y="1536">H</text>
+<rect x="1296" y="112" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1312" y="128" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="1312" y="108">rec[0]</text>
-<rect x="1296" y="240" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1312" y="256">MR</text>
+<rect x="1296" y="240" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1312" y="256" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="1312" y="236">rec[1]</text>
-<rect x="1296" y="368" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1312" y="384">MR</text>
+<rect x="1296" y="368" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1312" y="384" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="1312" y="364">rec[2]</text>
-<rect x="1296" y="496" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1312" y="512">MR</text>
+<rect x="1296" y="496" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1312" y="512" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="1312" y="492">rec[3]</text>
-<rect x="1296" y="624" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1312" y="640">MR</text>
+<rect x="1296" y="624" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1312" y="640" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="1312" y="620">rec[4]</text>
-<rect x="1296" y="752" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1312" y="768">MR</text>
+<rect x="1296" y="752" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1312" y="768" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="1312" y="748">rec[5]</text>
-<rect x="1296" y="880" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1312" y="896">MR</text>
+<rect x="1296" y="880" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1312" y="896" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="1312" y="876">rec[6]</text>
-<rect x="1296" y="1008" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1312" y="1024">MR</text>
+<rect x="1296" y="1008" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1312" y="1024" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="1312" y="1004">rec[7]</text>
-<rect x="1296" y="1136" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1312" y="1152">MR</text>
+<rect x="1296" y="1136" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1312" y="1152" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="1312" y="1132">rec[8]</text>
-<rect x="1296" y="1264" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1312" y="1280">MR</text>
+<rect x="1296" y="1264" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1312" y="1280" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="1312" y="1260">rec[9]</text>
-<rect x="1296" y="1392" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1312" y="1408">MR</text>
+<rect x="1296" y="1392" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1312" y="1408" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="1312" y="1388">rec[10]</text>
-<rect x="1296" y="1520" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1312" y="1536">MR</text>
+<rect x="1296" y="1520" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1312" y="1536" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="1312" y="1516">rec[11]</text>
 <rect x="1360" y="368" width="224" height="32" stroke="black" fill="lightgray"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1472" y="384">DETECTOR</text>
@@ -404,17 +404,17 @@
 <path d="M1640,32 L1632,32 L1632,1664 L1640,1664 " stroke="black" fill="none"/>
 <text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="1636" y="1660">REP9</text>
 <rect x="1744" y="112" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1760" y="128">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1760" y="128">H</text>
 <rect x="1744" y="240" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1760" y="256">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1760" y="256">H</text>
 <rect x="1744" y="752" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1760" y="768">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1760" y="768">H</text>
 <rect x="1744" y="880" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1760" y="896">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1760" y="896">H</text>
 <rect x="1744" y="1392" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1760" y="1408">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1760" y="1408">H</text>
 <rect x="1744" y="1520" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1760" y="1536">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1760" y="1536">H</text>
 <path d="M1824,128 L1824,192 " stroke="black"/>
 <circle cx="1824" cy="128" r="8" stroke="none" fill="black"/>
 <circle cx="1824" cy="192" r="8" stroke="black" fill="white"/>
@@ -580,52 +580,52 @@
 <circle cx="2528" cy="1280" r="8" stroke="black" fill="white"/>
 <path d="M2520,1280 L2536,1280 M2528,1272 L2528,1288 " stroke="black"/>
 <rect x="2576" y="112" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2592" y="128">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="2592" y="128">H</text>
 <rect x="2576" y="240" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2592" y="256">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="2592" y="256">H</text>
 <rect x="2576" y="752" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2592" y="768">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="2592" y="768">H</text>
 <rect x="2576" y="880" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2592" y="896">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="2592" y="896">H</text>
 <rect x="2576" y="1392" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2592" y="1408">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="2592" y="1408">H</text>
 <rect x="2576" y="1520" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2592" y="1536">H</text>
-<rect x="2640" y="112" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2656" y="128">MR</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="2592" y="1536">H</text>
+<rect x="2640" y="112" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2656" y="128" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="2656" y="108">rec[12+iter*12]</text>
-<rect x="2640" y="240" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2656" y="256">MR</text>
+<rect x="2640" y="240" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2656" y="256" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="2656" y="236">rec[13+iter*12]</text>
-<rect x="2640" y="368" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2656" y="384">MR</text>
+<rect x="2640" y="368" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2656" y="384" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="2656" y="364">rec[14+iter*12]</text>
-<rect x="2640" y="496" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2656" y="512">MR</text>
+<rect x="2640" y="496" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2656" y="512" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="2656" y="492">rec[15+iter*12]</text>
-<rect x="2640" y="624" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2656" y="640">MR</text>
+<rect x="2640" y="624" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2656" y="640" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="2656" y="620">rec[16+iter*12]</text>
-<rect x="2640" y="752" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2656" y="768">MR</text>
+<rect x="2640" y="752" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2656" y="768" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="2656" y="748">rec[17+iter*12]</text>
-<rect x="2640" y="880" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2656" y="896">MR</text>
+<rect x="2640" y="880" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2656" y="896" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="2656" y="876">rec[18+iter*12]</text>
-<rect x="2640" y="1008" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2656" y="1024">MR</text>
+<rect x="2640" y="1008" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2656" y="1024" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="2656" y="1004">rec[19+iter*12]</text>
-<rect x="2640" y="1136" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2656" y="1152">MR</text>
+<rect x="2640" y="1136" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2656" y="1152" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="2656" y="1132">rec[20+iter*12]</text>
-<rect x="2640" y="1264" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2656" y="1280">MR</text>
+<rect x="2640" y="1264" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2656" y="1280" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="2656" y="1260">rec[21+iter*12]</text>
-<rect x="2640" y="1392" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2656" y="1408">MR</text>
+<rect x="2640" y="1392" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2656" y="1408" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="2656" y="1388">rec[22+iter*12]</text>
-<rect x="2640" y="1520" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2656" y="1536">MR</text>
+<rect x="2640" y="1520" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2656" y="1536" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="2656" y="1516">rec[23+iter*12]</text>
 <rect x="2704" y="112" width="224" height="32" stroke="black" fill="lightgray"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="2816" y="128">DETECTOR</text>
@@ -678,44 +678,44 @@
 <path d="M2628,40 L2628,32 L2940,32 L2940,40 " stroke="black" fill="none"/>
 <path d="M2628,1656 L2628,1664 L2940,1664 L2940,1656 " stroke="black" fill="none"/>
 <path d="M2968,32 L2976,32 L2976,1664 L2968,1664 " stroke="black" fill="none"/>
-<rect x="3024" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="3040" y="64">M</text>
+<rect x="3024" y="48" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="3040" y="64" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="3040" y="44">rec[120]</text>
-<rect x="3024" y="176" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="3040" y="192">M</text>
+<rect x="3024" y="176" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="3040" y="192" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="3040" y="172">rec[121]</text>
-<rect x="3024" y="304" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="3040" y="320">M</text>
+<rect x="3024" y="304" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="3040" y="320" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="3040" y="300">rec[122]</text>
-<rect x="3024" y="432" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="3040" y="448">M</text>
+<rect x="3024" y="432" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="3040" y="448" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="3040" y="428">rec[123]</text>
-<rect x="3024" y="560" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="3040" y="576">M</text>
+<rect x="3024" y="560" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="3040" y="576" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="3040" y="556">rec[124]</text>
-<rect x="3024" y="688" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="3040" y="704">M</text>
+<rect x="3024" y="688" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="3040" y="704" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="3040" y="684">rec[125]</text>
-<rect x="3024" y="816" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="3040" y="832">M</text>
+<rect x="3024" y="816" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="3040" y="832" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="3040" y="812">rec[126]</text>
-<rect x="3024" y="944" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="3040" y="960">M</text>
+<rect x="3024" y="944" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="3040" y="960" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="3040" y="940">rec[127]</text>
-<rect x="3024" y="1072" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="3040" y="1088">M</text>
+<rect x="3024" y="1072" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="3040" y="1088" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="3040" y="1068">rec[128]</text>
-<rect x="3024" y="1200" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="3040" y="1216">M</text>
+<rect x="3024" y="1200" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="3040" y="1216" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="3040" y="1196">rec[129]</text>
-<rect x="3024" y="1328" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="3040" y="1344">M</text>
+<rect x="3024" y="1328" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="3040" y="1344" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="3040" y="1324">rec[130]</text>
-<rect x="3024" y="1456" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="3040" y="1472">M</text>
+<rect x="3024" y="1456" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="3040" y="1472" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="3040" y="1452">rec[131]</text>
-<rect x="3024" y="1584" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="3040" y="1600">M</text>
+<rect x="3024" y="1584" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="3040" y="1600" fill="white">M</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="3040" y="1580">rec[132]</text>
 <rect x="3024" y="368" width="352" height="32" stroke="black" fill="lightgray"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="3200" y="384">DETECTOR</text>

--- a/testdata/surface_code_time_detector_slice.svg
+++ b/testdata/surface_code_time_detector_slice.svg
@@ -747,6 +747,18 @@
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="601.6" y="1251.2" fill="white">MR</text>
 <rect x="713.6" y="1235.2" width="32" height="32" stroke="black" fill="black"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="729.6" y="1251.2" fill="white">MR</text>
+<rect x="1043.2" y="979.2" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1059.2" y="995.2">H</text>
+<rect x="1171.2" y="979.2" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1187.2" y="995.2">H</text>
+<rect x="1043.2" y="1107.2" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1059.2" y="1123.2">H</text>
+<rect x="1171.2" y="1107.2" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1187.2" y="1123.2">H</text>
+<rect x="1043.2" y="1235.2" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1059.2" y="1251.2">H</text>
+<rect x="1171.2" y="1235.2" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1187.2" y="1251.2">H</text>
 <rect x="0" y="0" width="416" height="416" stroke="black" fill="none"/>
 <rect x="0" y="457.6" width="416" height="416" stroke="black" fill="none"/>
 <rect x="0" y="915.2" width="416" height="416" stroke="black" fill="none"/>

--- a/testdata/surface_code_time_detector_slice.svg
+++ b/testdata/surface_code_time_detector_slice.svg
@@ -1,0 +1,761 @@
+<svg viewBox="0 0 1788.8 1331.2"  version="1.1" xmlns="http://www.w3.org/2000/svg">
+<path d="M80,80 144,80 208,80 144,144 Z" stroke="none" fill-opacity="0.75" fill="#FF4444" />
+<path d="M80,80 144,80 208,80 144,144 Z" stroke="black" fill="none" />
+<path d="M144,144 144,208 208,208 144,272 80,208 Z" stroke="none" fill-opacity="0.75" fill="#FF4444" />
+<path d="M144,144 144,208 208,208 144,272 80,208 Z" stroke="black" fill="none" />
+<path d="M144,272 208,336 144,336 80,336 Z" stroke="none" fill-opacity="0.75" fill="#FF4444" />
+<path d="M144,272 208,336 144,336 80,336 Z" stroke="black" fill="none" />
+<path d="M537.6,80 601.6,80 665.6,80 601.6,144 Z" stroke="none" fill-opacity="0.75" fill="#AAAAAA" />
+<defs>
+<radialGradient id="xgrad"><stop offset="50%" stop-color="#FF4444" stop-opacity="1"/><stop offset="100%" stop-color="#AAAAAA" stop-opacity="0"/></radialGradient>
+<radialGradient id="ygrad"><stop offset="50%" stop-color="#40FF40" stop-opacity="1"/><stop offset="100%" stop-color="#AAAAAA" stop-opacity="0"/></radialGradient>
+<radialGradient id="zgrad"><stop offset="50%" stop-color="#4848FF" stop-opacity="1"/><stop offset="100%" stop-color="#AAAAAA" stop-opacity="0"/></radialGradient>
+</defs>
+<clipPath id="clip0"><path d="M537.6,80 601.6,80 665.6,80 601.6,144 Z" /></clipPath>
+<circle clip-path="url(#clip0)" cx="537.6" cy="80" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip0)" cx="601.6" cy="80" r="43" stroke="none" fill="url('#zgrad')"/>
+<circle clip-path="url(#clip0)" cx="665.6" cy="80" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip0)" cx="601.6" cy="144" r="43" stroke="none" fill="url('#xgrad')"/>
+<path d="M537.6,80 601.6,80 665.6,80 601.6,144 Z" stroke="black" fill="none" />
+<path d="M601.6,144 601.6,208 665.6,208 601.6,272 537.6,208 Z" stroke="none" fill-opacity="0.75" fill="#AAAAAA" />
+<clipPath id="clip1"><path d="M601.6,144 601.6,208 665.6,208 601.6,272 537.6,208 Z" /></clipPath>
+<circle clip-path="url(#clip1)" cx="601.6" cy="144" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip1)" cx="537.6" cy="208" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip1)" cx="601.6" cy="208" r="43" stroke="none" fill="url('#zgrad')"/>
+<circle clip-path="url(#clip1)" cx="665.6" cy="208" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip1)" cx="601.6" cy="272" r="43" stroke="none" fill="url('#xgrad')"/>
+<path d="M601.6,144 601.6,208 665.6,208 601.6,272 537.6,208 Z" stroke="black" fill="none" />
+<path d="M601.6,272 665.6,336 601.6,336 537.6,336 Z" stroke="none" fill-opacity="0.75" fill="#AAAAAA" />
+<clipPath id="clip2"><path d="M601.6,272 665.6,336 601.6,336 537.6,336 Z" /></clipPath>
+<circle clip-path="url(#clip2)" cx="601.6" cy="272" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip2)" cx="537.6" cy="336" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip2)" cx="601.6" cy="336" r="43" stroke="none" fill="url('#zgrad')"/>
+<circle clip-path="url(#clip2)" cx="665.6" cy="336" r="43" stroke="none" fill="url('#xgrad')"/>
+<path d="M601.6,272 665.6,336 601.6,336 537.6,336 Z" stroke="black" fill="none" />
+<path d="M995.2,80 1059.2,80 1123.2,80 1059.2,144 Z" stroke="none" fill-opacity="0.75" fill="#AAAAAA" />
+<clipPath id="clip3"><path d="M995.2,80 1059.2,80 1123.2,80 1059.2,144 Z" /></clipPath>
+<circle clip-path="url(#clip3)" cx="995.2" cy="80" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip3)" cx="1059.2" cy="80" r="43" stroke="none" fill="url('#zgrad')"/>
+<circle clip-path="url(#clip3)" cx="1123.2" cy="80" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip3)" cx="1059.2" cy="144" r="43" stroke="none" fill="url('#xgrad')"/>
+<path d="M995.2,80 1059.2,80 1123.2,80 1059.2,144 Z" stroke="black" fill="none" />
+<path d="M1059.2,144 1059.2,208 1123.2,208 1059.2,272 995.2,208 Z" stroke="none" fill-opacity="0.75" fill="#AAAAAA" />
+<clipPath id="clip4"><path d="M1059.2,144 1059.2,208 1123.2,208 1059.2,272 995.2,208 Z" /></clipPath>
+<circle clip-path="url(#clip4)" cx="1059.2" cy="144" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip4)" cx="995.2" cy="208" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip4)" cx="1059.2" cy="208" r="43" stroke="none" fill="url('#zgrad')"/>
+<circle clip-path="url(#clip4)" cx="1123.2" cy="208" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip4)" cx="1059.2" cy="272" r="43" stroke="none" fill="url('#xgrad')"/>
+<path d="M1059.2,144 1059.2,208 1123.2,208 1059.2,272 995.2,208 Z" stroke="black" fill="none" />
+<path d="M1059.2,272 1123.2,336 1059.2,336 995.2,336 Z" stroke="none" fill-opacity="0.75" fill="#AAAAAA" />
+<clipPath id="clip5"><path d="M1059.2,272 1123.2,336 1059.2,336 995.2,336 Z" /></clipPath>
+<circle clip-path="url(#clip5)" cx="1059.2" cy="272" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip5)" cx="995.2" cy="336" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip5)" cx="1059.2" cy="336" r="43" stroke="none" fill="url('#zgrad')"/>
+<circle clip-path="url(#clip5)" cx="1123.2" cy="336" r="43" stroke="none" fill="url('#xgrad')"/>
+<path d="M1059.2,272 1123.2,336 1059.2,336 995.2,336 Z" stroke="black" fill="none" />
+<path d="M1452.8,80 1516.8,80 1580.8,80 1516.8,144 Z" stroke="none" fill-opacity="0.75" fill="#FF4444" />
+<path d="M1452.8,80 1516.8,80 1580.8,80 1516.8,144 Z" stroke="black" fill="none" />
+<path d="M1516.8,144 1516.8,208 1580.8,208 1516.8,272 1452.8,208 Z" stroke="none" fill-opacity="0.75" fill="#FF4444" />
+<path d="M1516.8,144 1516.8,208 1580.8,208 1516.8,272 1452.8,208 Z" stroke="black" fill="none" />
+<path d="M1516.8,272 1580.8,336 1516.8,336 1452.8,336 Z" stroke="none" fill-opacity="0.75" fill="#FF4444" />
+<path d="M1516.8,272 1580.8,336 1516.8,336 1452.8,336 Z" stroke="black" fill="none" />
+<path d="M80,537.6 144,537.6 144,601.6 80,601.6 Z" stroke="none" fill-opacity="0.75" fill="#FF4444" />
+<path d="M80,537.6 144,537.6 144,601.6 80,601.6 Z" stroke="black" fill="none" />
+<path d="M80,665.6 80,601.6 144,601.6 144,665.6 144,729.6 80,729.6 Z" stroke="none" fill-opacity="0.75" fill="#FF4444" />
+<path d="M80,665.6 80,601.6 144,601.6 144,665.6 144,729.6 80,729.6 Z" stroke="black" fill="none" />
+<path d="M80,729.6 144,729.6 144,793.6 80,793.6 Z" stroke="none" fill-opacity="0.75" fill="#FF4444" />
+<path d="M80,729.6 144,729.6 144,793.6 80,793.6 Z" stroke="black" fill="none" />
+<path d="M537.6,537.6 601.6,537.6 537.6,601.6 Z" stroke="none" fill-opacity="0.75" fill="#FF4444" />
+<path d="M537.6,537.6 601.6,537.6 537.6,601.6 Z" stroke="black" fill="none" />
+<path d="M601.6,601.6 601.6,665.6 537.6,729.6 537.6,665.6 Z" stroke="none" fill-opacity="0.75" fill="#FF4444" />
+<path d="M601.6,601.6 601.6,665.6 537.6,729.6 537.6,665.6 Z" stroke="black" fill="none" />
+<path d="M601.6,729.6 601.6,793.6 537.6,793.6 Z" stroke="none" fill-opacity="0.75" fill="#FF4444" />
+<path d="M601.6,729.6 601.6,793.6 537.6,793.6 Z" stroke="black" fill="none" />
+<path d="M601.6,537.6 665.6,537.6 601.6,601.6 Z" stroke="none" fill-opacity="0.75" fill="#FF4444" />
+<path d="M601.6,537.6 665.6,537.6 601.6,601.6 Z" stroke="black" fill="none" />
+<path d="M665.6,601.6 665.6,665.6 601.6,729.6 601.6,665.6 Z" stroke="none" fill-opacity="0.75" fill="#FF4444" />
+<path d="M665.6,601.6 665.6,665.6 601.6,729.6 601.6,665.6 Z" stroke="black" fill="none" />
+<path d="M665.6,729.6 665.6,793.6 601.6,793.6 Z" stroke="none" fill-opacity="0.75" fill="#FF4444" />
+<path d="M665.6,729.6 665.6,793.6 601.6,793.6 Z" stroke="black" fill="none" />
+<path d="M1059.2,537.6 1123.2,537.6 1123.2,601.6 1059.2,601.6 Z" stroke="none" fill-opacity="0.75" fill="#FF4444" />
+<path d="M1059.2,537.6 1123.2,537.6 1123.2,601.6 1059.2,601.6 Z" stroke="black" fill="none" />
+<path d="M1059.2,665.6 1059.2,601.6 1123.2,601.6 1123.2,665.6 1123.2,729.6 1059.2,729.6 Z" stroke="none" fill-opacity="0.75" fill="#FF4444" />
+<path d="M1059.2,665.6 1059.2,601.6 1123.2,601.6 1123.2,665.6 1123.2,729.6 1059.2,729.6 Z" stroke="black" fill="none" />
+<path d="M1059.2,729.6 1123.2,729.6 1123.2,793.6 1059.2,793.6 Z" stroke="none" fill-opacity="0.75" fill="#FF4444" />
+<path d="M1059.2,729.6 1123.2,729.6 1123.2,793.6 1059.2,793.6 Z" stroke="black" fill="none" />
+<path d="M1452.8,537.6 1516.8,537.6 1580.8,537.6 1516.8,601.6 Z" stroke="none" fill-opacity="0.75" fill="#FF4444" />
+<path d="M1452.8,537.6 1516.8,537.6 1580.8,537.6 1516.8,601.6 Z" stroke="black" fill="none" />
+<path d="M1516.8,601.6 1516.8,665.6 1580.8,665.6 1516.8,729.6 1452.8,665.6 Z" stroke="none" fill-opacity="0.75" fill="#FF4444" />
+<path d="M1516.8,601.6 1516.8,665.6 1580.8,665.6 1516.8,729.6 1452.8,665.6 Z" stroke="black" fill="none" />
+<path d="M1516.8,729.6 1580.8,793.6 1516.8,793.6 1452.8,793.6 Z" stroke="none" fill-opacity="0.75" fill="#FF4444" />
+<path d="M1516.8,729.6 1580.8,793.6 1516.8,793.6 1452.8,793.6 Z" stroke="black" fill="none" />
+<path d="M80,995.2 144,995.2 208,995.2 144,1059.2 Z" stroke="none" fill-opacity="0.75" fill="#AAAAAA" />
+<clipPath id="clip6"><path d="M80,995.2 144,995.2 208,995.2 144,1059.2 Z" /></clipPath>
+<circle clip-path="url(#clip6)" cx="80" cy="995.2" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip6)" cx="144" cy="995.2" r="43" stroke="none" fill="url('#zgrad')"/>
+<circle clip-path="url(#clip6)" cx="208" cy="995.2" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip6)" cx="144" cy="1059.2" r="43" stroke="none" fill="url('#xgrad')"/>
+<path d="M80,995.2 144,995.2 208,995.2 144,1059.2 Z" stroke="black" fill="none" />
+<path d="M144,1059.2 144,1123.2 208,1123.2 144,1187.2 80,1123.2 Z" stroke="none" fill-opacity="0.75" fill="#AAAAAA" />
+<clipPath id="clip7"><path d="M144,1059.2 144,1123.2 208,1123.2 144,1187.2 80,1123.2 Z" /></clipPath>
+<circle clip-path="url(#clip7)" cx="144" cy="1059.2" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip7)" cx="80" cy="1123.2" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip7)" cx="144" cy="1123.2" r="43" stroke="none" fill="url('#zgrad')"/>
+<circle clip-path="url(#clip7)" cx="208" cy="1123.2" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip7)" cx="144" cy="1187.2" r="43" stroke="none" fill="url('#xgrad')"/>
+<path d="M144,1059.2 144,1123.2 208,1123.2 144,1187.2 80,1123.2 Z" stroke="black" fill="none" />
+<path d="M144,1187.2 208,1251.2 144,1251.2 80,1251.2 Z" stroke="none" fill-opacity="0.75" fill="#AAAAAA" />
+<clipPath id="clip8"><path d="M144,1187.2 208,1251.2 144,1251.2 80,1251.2 Z" /></clipPath>
+<circle clip-path="url(#clip8)" cx="144" cy="1187.2" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip8)" cx="80" cy="1251.2" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip8)" cx="144" cy="1251.2" r="43" stroke="none" fill="url('#zgrad')"/>
+<circle clip-path="url(#clip8)" cx="208" cy="1251.2" r="43" stroke="none" fill="url('#xgrad')"/>
+<path d="M144,1187.2 208,1251.2 144,1251.2 80,1251.2 Z" stroke="black" fill="none" />
+<path d="M537.6,995.2 601.6,995.2 665.6,995.2 601.6,1059.2 Z" stroke="none" fill-opacity="0.75" fill="#AAAAAA" />
+<clipPath id="clip9"><path d="M537.6,995.2 601.6,995.2 665.6,995.2 601.6,1059.2 Z" /></clipPath>
+<circle clip-path="url(#clip9)" cx="537.6" cy="995.2" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip9)" cx="601.6" cy="995.2" r="43" stroke="none" fill="url('#zgrad')"/>
+<circle clip-path="url(#clip9)" cx="665.6" cy="995.2" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip9)" cx="601.6" cy="1059.2" r="43" stroke="none" fill="url('#xgrad')"/>
+<path d="M537.6,995.2 601.6,995.2 665.6,995.2 601.6,1059.2 Z" stroke="black" fill="none" />
+<path d="M601.6,1059.2 601.6,1123.2 665.6,1123.2 601.6,1187.2 537.6,1123.2 Z" stroke="none" fill-opacity="0.75" fill="#AAAAAA" />
+<clipPath id="clip10"><path d="M601.6,1059.2 601.6,1123.2 665.6,1123.2 601.6,1187.2 537.6,1123.2 Z" /></clipPath>
+<circle clip-path="url(#clip10)" cx="601.6" cy="1059.2" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip10)" cx="537.6" cy="1123.2" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip10)" cx="601.6" cy="1123.2" r="43" stroke="none" fill="url('#zgrad')"/>
+<circle clip-path="url(#clip10)" cx="665.6" cy="1123.2" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip10)" cx="601.6" cy="1187.2" r="43" stroke="none" fill="url('#xgrad')"/>
+<path d="M601.6,1059.2 601.6,1123.2 665.6,1123.2 601.6,1187.2 537.6,1123.2 Z" stroke="black" fill="none" />
+<path d="M601.6,1187.2 665.6,1251.2 601.6,1251.2 537.6,1251.2 Z" stroke="none" fill-opacity="0.75" fill="#AAAAAA" />
+<clipPath id="clip11"><path d="M601.6,1187.2 665.6,1251.2 601.6,1251.2 537.6,1251.2 Z" /></clipPath>
+<circle clip-path="url(#clip11)" cx="601.6" cy="1187.2" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip11)" cx="537.6" cy="1251.2" r="43" stroke="none" fill="url('#xgrad')"/>
+<circle clip-path="url(#clip11)" cx="601.6" cy="1251.2" r="43" stroke="none" fill="url('#zgrad')"/>
+<circle clip-path="url(#clip11)" cx="665.6" cy="1251.2" r="43" stroke="none" fill="url('#xgrad')"/>
+<path d="M601.6,1187.2 665.6,1251.2 601.6,1251.2 537.6,1251.2 Z" stroke="black" fill="none" />
+<path d="M995.2,995.2 1059.2,995.2 1123.2,995.2 1059.2,1059.2 Z" stroke="none" fill-opacity="0.75" fill="#FF4444" />
+<path d="M995.2,995.2 1059.2,995.2 1123.2,995.2 1059.2,1059.2 Z" stroke="black" fill="none" />
+<path d="M1059.2,1059.2 1059.2,1123.2 1123.2,1123.2 1059.2,1187.2 995.2,1123.2 Z" stroke="none" fill-opacity="0.75" fill="#FF4444" />
+<path d="M1059.2,1059.2 1059.2,1123.2 1123.2,1123.2 1059.2,1187.2 995.2,1123.2 Z" stroke="black" fill="none" />
+<path d="M1059.2,1187.2 1123.2,1251.2 1059.2,1251.2 995.2,1251.2 Z" stroke="none" fill-opacity="0.75" fill="#FF4444" />
+<path d="M1059.2,1187.2 1123.2,1251.2 1059.2,1251.2 995.2,1251.2 Z" stroke="black" fill="none" />
+<path d="M144,537.6 C 163.2 550.4, 188.8 550.4, 208 537.6 C 188.8 524.8, 163.2 524.8, 144 537.6" stroke="none" fill-opacity="1" fill="#FF4444" />
+<path d="M144,537.6 C 163.2 550.4, 188.8 550.4, 208 537.6 C 188.8 524.8, 163.2 524.8, 144 537.6" stroke="black" fill="none" />
+<path d="M144,665.6 C 163.2 678.4, 188.8 678.4, 208 665.6 C 188.8 652.8, 163.2 652.8, 144 665.6" stroke="none" fill-opacity="1" fill="#FF4444" />
+<path d="M144,665.6 C 163.2 678.4, 188.8 678.4, 208 665.6 C 188.8 652.8, 163.2 652.8, 144 665.6" stroke="black" fill="none" />
+<path d="M144,793.6 C 163.2 806.4, 188.8 806.4, 208 793.6 C 188.8 780.8, 163.2 780.8, 144 793.6" stroke="none" fill-opacity="1" fill="#FF4444" />
+<path d="M144,793.6 C 163.2 806.4, 188.8 806.4, 208 793.6 C 188.8 780.8, 163.2 780.8, 144 793.6" stroke="black" fill="none" />
+<path d="M995.2,537.6 C 1014.4 550.4, 1040 550.4, 1059.2 537.6 C 1040 524.8, 1014.4 524.8, 995.2 537.6" stroke="none" fill-opacity="1" fill="#FF4444" />
+<path d="M995.2,537.6 C 1014.4 550.4, 1040 550.4, 1059.2 537.6 C 1040 524.8, 1014.4 524.8, 995.2 537.6" stroke="black" fill="none" />
+<path d="M995.2,665.6 C 1014.4 678.4, 1040 678.4, 1059.2 665.6 C 1040 652.8, 1014.4 652.8, 995.2 665.6" stroke="none" fill-opacity="1" fill="#FF4444" />
+<path d="M995.2,665.6 C 1014.4 678.4, 1040 678.4, 1059.2 665.6 C 1040 652.8, 1014.4 652.8, 995.2 665.6" stroke="black" fill="none" />
+<path d="M995.2,793.6 C 1014.4 806.4, 1040 806.4, 1059.2 793.6 C 1040 780.8, 1014.4 780.8, 995.2 793.6" stroke="none" fill-opacity="1" fill="#FF4444" />
+<path d="M995.2,793.6 C 1014.4 806.4, 1040 806.4, 1059.2 793.6 C 1040 780.8, 1014.4 780.8, 995.2 793.6" stroke="black" fill="none" />
+<path d="M1035.2,80 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="none" fill-opacity="1" fill="#4848FF" />
+<path d="M1035.2,80 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="black" fill="none" />
+<path d="M1035.2,208 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="none" fill-opacity="1" fill="#4848FF" />
+<path d="M1035.2,208 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="black" fill="none" />
+<path d="M1035.2,336 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="none" fill-opacity="1" fill="#4848FF" />
+<path d="M1035.2,336 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="black" fill="none" />
+<path d="M1492.8,80 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="none" fill-opacity="1" fill="#FF4444" />
+<path d="M1492.8,80 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="black" fill="none" />
+<path d="M1492.8,208 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="none" fill-opacity="1" fill="#FF4444" />
+<path d="M1492.8,208 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="black" fill="none" />
+<path d="M1492.8,336 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="none" fill-opacity="1" fill="#FF4444" />
+<path d="M1492.8,336 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="black" fill="none" />
+<path d="M1492.8,537.6 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="none" fill-opacity="1" fill="#FF4444" />
+<path d="M1492.8,537.6 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="black" fill="none" />
+<path d="M1492.8,665.6 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="none" fill-opacity="1" fill="#FF4444" />
+<path d="M1492.8,665.6 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="black" fill="none" />
+<path d="M1492.8,793.6 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="none" fill-opacity="1" fill="#FF4444" />
+<path d="M1492.8,793.6 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="black" fill="none" />
+<path d="M120,995.2 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="none" fill-opacity="1" fill="#4848FF" />
+<path d="M120,995.2 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="black" fill="none" />
+<path d="M120,1123.2 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="none" fill-opacity="1" fill="#4848FF" />
+<path d="M120,1123.2 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="black" fill="none" />
+<path d="M120,1251.2 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="none" fill-opacity="1" fill="#4848FF" />
+<path d="M120,1251.2 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="black" fill="none" />
+<path d="M577.6,995.2 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="none" fill-opacity="1" fill="#4848FF" />
+<path d="M577.6,995.2 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="black" fill="none" />
+<path d="M577.6,1123.2 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="none" fill-opacity="1" fill="#4848FF" />
+<path d="M577.6,1123.2 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="black" fill="none" />
+<path d="M577.6,1251.2 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="none" fill-opacity="1" fill="#4848FF" />
+<path d="M577.6,1251.2 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="black" fill="none" />
+<path d="M1035.2,995.2 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="none" fill-opacity="1" fill="#FF4444" />
+<path d="M1035.2,995.2 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="black" fill="none" />
+<path d="M1035.2,1123.2 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="none" fill-opacity="1" fill="#FF4444" />
+<path d="M1035.2,1123.2 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="black" fill="none" />
+<path d="M1035.2,1251.2 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="none" fill-opacity="1" fill="#FF4444" />
+<path d="M1035.2,1251.2 a 24 24 0 0 0 48 0 a 24 24 0 0 0 -48 0" stroke="black" fill="none" />
+<circle cx="80" cy="80" r="2" stroke="none" fill="black"/>
+<circle cx="144" cy="80" r="2" stroke="none" fill="black"/>
+<circle cx="208" cy="80" r="2" stroke="none" fill="black"/>
+<circle cx="272" cy="80" r="2" stroke="none" fill="black"/>
+<circle cx="336" cy="80" r="2" stroke="none" fill="black"/>
+<circle cx="80" cy="144" r="2" stroke="none" fill="black"/>
+<circle cx="144" cy="144" r="2" stroke="none" fill="black"/>
+<circle cx="208" cy="144" r="2" stroke="none" fill="black"/>
+<circle cx="272" cy="144" r="2" stroke="none" fill="black"/>
+<circle cx="336" cy="144" r="2" stroke="none" fill="black"/>
+<circle cx="80" cy="208" r="2" stroke="none" fill="black"/>
+<circle cx="144" cy="208" r="2" stroke="none" fill="black"/>
+<circle cx="208" cy="208" r="2" stroke="none" fill="black"/>
+<circle cx="272" cy="208" r="2" stroke="none" fill="black"/>
+<circle cx="336" cy="208" r="2" stroke="none" fill="black"/>
+<circle cx="80" cy="272" r="2" stroke="none" fill="black"/>
+<circle cx="144" cy="272" r="2" stroke="none" fill="black"/>
+<circle cx="208" cy="272" r="2" stroke="none" fill="black"/>
+<circle cx="272" cy="272" r="2" stroke="none" fill="black"/>
+<circle cx="336" cy="272" r="2" stroke="none" fill="black"/>
+<circle cx="80" cy="336" r="2" stroke="none" fill="black"/>
+<circle cx="144" cy="336" r="2" stroke="none" fill="black"/>
+<circle cx="208" cy="336" r="2" stroke="none" fill="black"/>
+<circle cx="272" cy="336" r="2" stroke="none" fill="black"/>
+<circle cx="336" cy="336" r="2" stroke="none" fill="black"/>
+<circle cx="80" cy="537.6" r="2" stroke="none" fill="black"/>
+<circle cx="144" cy="537.6" r="2" stroke="none" fill="black"/>
+<circle cx="208" cy="537.6" r="2" stroke="none" fill="black"/>
+<circle cx="272" cy="537.6" r="2" stroke="none" fill="black"/>
+<circle cx="336" cy="537.6" r="2" stroke="none" fill="black"/>
+<circle cx="80" cy="601.6" r="2" stroke="none" fill="black"/>
+<circle cx="144" cy="601.6" r="2" stroke="none" fill="black"/>
+<circle cx="208" cy="601.6" r="2" stroke="none" fill="black"/>
+<circle cx="272" cy="601.6" r="2" stroke="none" fill="black"/>
+<circle cx="336" cy="601.6" r="2" stroke="none" fill="black"/>
+<circle cx="80" cy="665.6" r="2" stroke="none" fill="black"/>
+<circle cx="144" cy="665.6" r="2" stroke="none" fill="black"/>
+<circle cx="208" cy="665.6" r="2" stroke="none" fill="black"/>
+<circle cx="272" cy="665.6" r="2" stroke="none" fill="black"/>
+<circle cx="336" cy="665.6" r="2" stroke="none" fill="black"/>
+<circle cx="80" cy="729.6" r="2" stroke="none" fill="black"/>
+<circle cx="144" cy="729.6" r="2" stroke="none" fill="black"/>
+<circle cx="208" cy="729.6" r="2" stroke="none" fill="black"/>
+<circle cx="272" cy="729.6" r="2" stroke="none" fill="black"/>
+<circle cx="336" cy="729.6" r="2" stroke="none" fill="black"/>
+<circle cx="80" cy="793.6" r="2" stroke="none" fill="black"/>
+<circle cx="144" cy="793.6" r="2" stroke="none" fill="black"/>
+<circle cx="208" cy="793.6" r="2" stroke="none" fill="black"/>
+<circle cx="272" cy="793.6" r="2" stroke="none" fill="black"/>
+<circle cx="336" cy="793.6" r="2" stroke="none" fill="black"/>
+<circle cx="80" cy="995.2" r="2" stroke="none" fill="black"/>
+<circle cx="144" cy="995.2" r="2" stroke="none" fill="black"/>
+<circle cx="208" cy="995.2" r="2" stroke="none" fill="black"/>
+<circle cx="272" cy="995.2" r="2" stroke="none" fill="black"/>
+<circle cx="336" cy="995.2" r="2" stroke="none" fill="black"/>
+<circle cx="80" cy="1059.2" r="2" stroke="none" fill="black"/>
+<circle cx="144" cy="1059.2" r="2" stroke="none" fill="black"/>
+<circle cx="208" cy="1059.2" r="2" stroke="none" fill="black"/>
+<circle cx="272" cy="1059.2" r="2" stroke="none" fill="black"/>
+<circle cx="336" cy="1059.2" r="2" stroke="none" fill="black"/>
+<circle cx="80" cy="1123.2" r="2" stroke="none" fill="black"/>
+<circle cx="144" cy="1123.2" r="2" stroke="none" fill="black"/>
+<circle cx="208" cy="1123.2" r="2" stroke="none" fill="black"/>
+<circle cx="272" cy="1123.2" r="2" stroke="none" fill="black"/>
+<circle cx="336" cy="1123.2" r="2" stroke="none" fill="black"/>
+<circle cx="80" cy="1187.2" r="2" stroke="none" fill="black"/>
+<circle cx="144" cy="1187.2" r="2" stroke="none" fill="black"/>
+<circle cx="208" cy="1187.2" r="2" stroke="none" fill="black"/>
+<circle cx="272" cy="1187.2" r="2" stroke="none" fill="black"/>
+<circle cx="336" cy="1187.2" r="2" stroke="none" fill="black"/>
+<circle cx="80" cy="1251.2" r="2" stroke="none" fill="black"/>
+<circle cx="144" cy="1251.2" r="2" stroke="none" fill="black"/>
+<circle cx="208" cy="1251.2" r="2" stroke="none" fill="black"/>
+<circle cx="272" cy="1251.2" r="2" stroke="none" fill="black"/>
+<circle cx="336" cy="1251.2" r="2" stroke="none" fill="black"/>
+<circle cx="537.6" cy="80" r="2" stroke="none" fill="black"/>
+<circle cx="601.6" cy="80" r="2" stroke="none" fill="black"/>
+<circle cx="665.6" cy="80" r="2" stroke="none" fill="black"/>
+<circle cx="729.6" cy="80" r="2" stroke="none" fill="black"/>
+<circle cx="793.6" cy="80" r="2" stroke="none" fill="black"/>
+<circle cx="537.6" cy="144" r="2" stroke="none" fill="black"/>
+<circle cx="601.6" cy="144" r="2" stroke="none" fill="black"/>
+<circle cx="665.6" cy="144" r="2" stroke="none" fill="black"/>
+<circle cx="729.6" cy="144" r="2" stroke="none" fill="black"/>
+<circle cx="793.6" cy="144" r="2" stroke="none" fill="black"/>
+<circle cx="537.6" cy="208" r="2" stroke="none" fill="black"/>
+<circle cx="601.6" cy="208" r="2" stroke="none" fill="black"/>
+<circle cx="665.6" cy="208" r="2" stroke="none" fill="black"/>
+<circle cx="729.6" cy="208" r="2" stroke="none" fill="black"/>
+<circle cx="793.6" cy="208" r="2" stroke="none" fill="black"/>
+<circle cx="537.6" cy="272" r="2" stroke="none" fill="black"/>
+<circle cx="601.6" cy="272" r="2" stroke="none" fill="black"/>
+<circle cx="665.6" cy="272" r="2" stroke="none" fill="black"/>
+<circle cx="729.6" cy="272" r="2" stroke="none" fill="black"/>
+<circle cx="793.6" cy="272" r="2" stroke="none" fill="black"/>
+<circle cx="537.6" cy="336" r="2" stroke="none" fill="black"/>
+<circle cx="601.6" cy="336" r="2" stroke="none" fill="black"/>
+<circle cx="665.6" cy="336" r="2" stroke="none" fill="black"/>
+<circle cx="729.6" cy="336" r="2" stroke="none" fill="black"/>
+<circle cx="793.6" cy="336" r="2" stroke="none" fill="black"/>
+<circle cx="537.6" cy="537.6" r="2" stroke="none" fill="black"/>
+<circle cx="601.6" cy="537.6" r="2" stroke="none" fill="black"/>
+<circle cx="665.6" cy="537.6" r="2" stroke="none" fill="black"/>
+<circle cx="729.6" cy="537.6" r="2" stroke="none" fill="black"/>
+<circle cx="793.6" cy="537.6" r="2" stroke="none" fill="black"/>
+<circle cx="537.6" cy="601.6" r="2" stroke="none" fill="black"/>
+<circle cx="601.6" cy="601.6" r="2" stroke="none" fill="black"/>
+<circle cx="665.6" cy="601.6" r="2" stroke="none" fill="black"/>
+<circle cx="729.6" cy="601.6" r="2" stroke="none" fill="black"/>
+<circle cx="793.6" cy="601.6" r="2" stroke="none" fill="black"/>
+<circle cx="537.6" cy="665.6" r="2" stroke="none" fill="black"/>
+<circle cx="601.6" cy="665.6" r="2" stroke="none" fill="black"/>
+<circle cx="665.6" cy="665.6" r="2" stroke="none" fill="black"/>
+<circle cx="729.6" cy="665.6" r="2" stroke="none" fill="black"/>
+<circle cx="793.6" cy="665.6" r="2" stroke="none" fill="black"/>
+<circle cx="537.6" cy="729.6" r="2" stroke="none" fill="black"/>
+<circle cx="601.6" cy="729.6" r="2" stroke="none" fill="black"/>
+<circle cx="665.6" cy="729.6" r="2" stroke="none" fill="black"/>
+<circle cx="729.6" cy="729.6" r="2" stroke="none" fill="black"/>
+<circle cx="793.6" cy="729.6" r="2" stroke="none" fill="black"/>
+<circle cx="537.6" cy="793.6" r="2" stroke="none" fill="black"/>
+<circle cx="601.6" cy="793.6" r="2" stroke="none" fill="black"/>
+<circle cx="665.6" cy="793.6" r="2" stroke="none" fill="black"/>
+<circle cx="729.6" cy="793.6" r="2" stroke="none" fill="black"/>
+<circle cx="793.6" cy="793.6" r="2" stroke="none" fill="black"/>
+<circle cx="537.6" cy="995.2" r="2" stroke="none" fill="black"/>
+<circle cx="601.6" cy="995.2" r="2" stroke="none" fill="black"/>
+<circle cx="665.6" cy="995.2" r="2" stroke="none" fill="black"/>
+<circle cx="729.6" cy="995.2" r="2" stroke="none" fill="black"/>
+<circle cx="793.6" cy="995.2" r="2" stroke="none" fill="black"/>
+<circle cx="537.6" cy="1059.2" r="2" stroke="none" fill="black"/>
+<circle cx="601.6" cy="1059.2" r="2" stroke="none" fill="black"/>
+<circle cx="665.6" cy="1059.2" r="2" stroke="none" fill="black"/>
+<circle cx="729.6" cy="1059.2" r="2" stroke="none" fill="black"/>
+<circle cx="793.6" cy="1059.2" r="2" stroke="none" fill="black"/>
+<circle cx="537.6" cy="1123.2" r="2" stroke="none" fill="black"/>
+<circle cx="601.6" cy="1123.2" r="2" stroke="none" fill="black"/>
+<circle cx="665.6" cy="1123.2" r="2" stroke="none" fill="black"/>
+<circle cx="729.6" cy="1123.2" r="2" stroke="none" fill="black"/>
+<circle cx="793.6" cy="1123.2" r="2" stroke="none" fill="black"/>
+<circle cx="537.6" cy="1187.2" r="2" stroke="none" fill="black"/>
+<circle cx="601.6" cy="1187.2" r="2" stroke="none" fill="black"/>
+<circle cx="665.6" cy="1187.2" r="2" stroke="none" fill="black"/>
+<circle cx="729.6" cy="1187.2" r="2" stroke="none" fill="black"/>
+<circle cx="793.6" cy="1187.2" r="2" stroke="none" fill="black"/>
+<circle cx="537.6" cy="1251.2" r="2" stroke="none" fill="black"/>
+<circle cx="601.6" cy="1251.2" r="2" stroke="none" fill="black"/>
+<circle cx="665.6" cy="1251.2" r="2" stroke="none" fill="black"/>
+<circle cx="729.6" cy="1251.2" r="2" stroke="none" fill="black"/>
+<circle cx="793.6" cy="1251.2" r="2" stroke="none" fill="black"/>
+<circle cx="995.2" cy="80" r="2" stroke="none" fill="black"/>
+<circle cx="1059.2" cy="80" r="2" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="80" r="2" stroke="none" fill="black"/>
+<circle cx="1187.2" cy="80" r="2" stroke="none" fill="black"/>
+<circle cx="1251.2" cy="80" r="2" stroke="none" fill="black"/>
+<circle cx="995.2" cy="144" r="2" stroke="none" fill="black"/>
+<circle cx="1059.2" cy="144" r="2" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="144" r="2" stroke="none" fill="black"/>
+<circle cx="1187.2" cy="144" r="2" stroke="none" fill="black"/>
+<circle cx="1251.2" cy="144" r="2" stroke="none" fill="black"/>
+<circle cx="995.2" cy="208" r="2" stroke="none" fill="black"/>
+<circle cx="1059.2" cy="208" r="2" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="208" r="2" stroke="none" fill="black"/>
+<circle cx="1187.2" cy="208" r="2" stroke="none" fill="black"/>
+<circle cx="1251.2" cy="208" r="2" stroke="none" fill="black"/>
+<circle cx="995.2" cy="272" r="2" stroke="none" fill="black"/>
+<circle cx="1059.2" cy="272" r="2" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="272" r="2" stroke="none" fill="black"/>
+<circle cx="1187.2" cy="272" r="2" stroke="none" fill="black"/>
+<circle cx="1251.2" cy="272" r="2" stroke="none" fill="black"/>
+<circle cx="995.2" cy="336" r="2" stroke="none" fill="black"/>
+<circle cx="1059.2" cy="336" r="2" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="336" r="2" stroke="none" fill="black"/>
+<circle cx="1187.2" cy="336" r="2" stroke="none" fill="black"/>
+<circle cx="1251.2" cy="336" r="2" stroke="none" fill="black"/>
+<circle cx="995.2" cy="537.6" r="2" stroke="none" fill="black"/>
+<circle cx="1059.2" cy="537.6" r="2" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="537.6" r="2" stroke="none" fill="black"/>
+<circle cx="1187.2" cy="537.6" r="2" stroke="none" fill="black"/>
+<circle cx="1251.2" cy="537.6" r="2" stroke="none" fill="black"/>
+<circle cx="995.2" cy="601.6" r="2" stroke="none" fill="black"/>
+<circle cx="1059.2" cy="601.6" r="2" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="601.6" r="2" stroke="none" fill="black"/>
+<circle cx="1187.2" cy="601.6" r="2" stroke="none" fill="black"/>
+<circle cx="1251.2" cy="601.6" r="2" stroke="none" fill="black"/>
+<circle cx="995.2" cy="665.6" r="2" stroke="none" fill="black"/>
+<circle cx="1059.2" cy="665.6" r="2" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="665.6" r="2" stroke="none" fill="black"/>
+<circle cx="1187.2" cy="665.6" r="2" stroke="none" fill="black"/>
+<circle cx="1251.2" cy="665.6" r="2" stroke="none" fill="black"/>
+<circle cx="995.2" cy="729.6" r="2" stroke="none" fill="black"/>
+<circle cx="1059.2" cy="729.6" r="2" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="729.6" r="2" stroke="none" fill="black"/>
+<circle cx="1187.2" cy="729.6" r="2" stroke="none" fill="black"/>
+<circle cx="1251.2" cy="729.6" r="2" stroke="none" fill="black"/>
+<circle cx="995.2" cy="793.6" r="2" stroke="none" fill="black"/>
+<circle cx="1059.2" cy="793.6" r="2" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="793.6" r="2" stroke="none" fill="black"/>
+<circle cx="1187.2" cy="793.6" r="2" stroke="none" fill="black"/>
+<circle cx="1251.2" cy="793.6" r="2" stroke="none" fill="black"/>
+<circle cx="995.2" cy="995.2" r="2" stroke="none" fill="black"/>
+<circle cx="1059.2" cy="995.2" r="2" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="995.2" r="2" stroke="none" fill="black"/>
+<circle cx="1187.2" cy="995.2" r="2" stroke="none" fill="black"/>
+<circle cx="1251.2" cy="995.2" r="2" stroke="none" fill="black"/>
+<circle cx="995.2" cy="1059.2" r="2" stroke="none" fill="black"/>
+<circle cx="1059.2" cy="1059.2" r="2" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="1059.2" r="2" stroke="none" fill="black"/>
+<circle cx="1187.2" cy="1059.2" r="2" stroke="none" fill="black"/>
+<circle cx="1251.2" cy="1059.2" r="2" stroke="none" fill="black"/>
+<circle cx="995.2" cy="1123.2" r="2" stroke="none" fill="black"/>
+<circle cx="1059.2" cy="1123.2" r="2" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="1123.2" r="2" stroke="none" fill="black"/>
+<circle cx="1187.2" cy="1123.2" r="2" stroke="none" fill="black"/>
+<circle cx="1251.2" cy="1123.2" r="2" stroke="none" fill="black"/>
+<circle cx="995.2" cy="1187.2" r="2" stroke="none" fill="black"/>
+<circle cx="1059.2" cy="1187.2" r="2" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="1187.2" r="2" stroke="none" fill="black"/>
+<circle cx="1187.2" cy="1187.2" r="2" stroke="none" fill="black"/>
+<circle cx="1251.2" cy="1187.2" r="2" stroke="none" fill="black"/>
+<circle cx="995.2" cy="1251.2" r="2" stroke="none" fill="black"/>
+<circle cx="1059.2" cy="1251.2" r="2" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="1251.2" r="2" stroke="none" fill="black"/>
+<circle cx="1187.2" cy="1251.2" r="2" stroke="none" fill="black"/>
+<circle cx="1251.2" cy="1251.2" r="2" stroke="none" fill="black"/>
+<circle cx="1452.8" cy="80" r="2" stroke="none" fill="black"/>
+<circle cx="1516.8" cy="80" r="2" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="80" r="2" stroke="none" fill="black"/>
+<circle cx="1644.8" cy="80" r="2" stroke="none" fill="black"/>
+<circle cx="1708.8" cy="80" r="2" stroke="none" fill="black"/>
+<circle cx="1452.8" cy="144" r="2" stroke="none" fill="black"/>
+<circle cx="1516.8" cy="144" r="2" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="144" r="2" stroke="none" fill="black"/>
+<circle cx="1644.8" cy="144" r="2" stroke="none" fill="black"/>
+<circle cx="1708.8" cy="144" r="2" stroke="none" fill="black"/>
+<circle cx="1452.8" cy="208" r="2" stroke="none" fill="black"/>
+<circle cx="1516.8" cy="208" r="2" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="208" r="2" stroke="none" fill="black"/>
+<circle cx="1644.8" cy="208" r="2" stroke="none" fill="black"/>
+<circle cx="1708.8" cy="208" r="2" stroke="none" fill="black"/>
+<circle cx="1452.8" cy="272" r="2" stroke="none" fill="black"/>
+<circle cx="1516.8" cy="272" r="2" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="272" r="2" stroke="none" fill="black"/>
+<circle cx="1644.8" cy="272" r="2" stroke="none" fill="black"/>
+<circle cx="1708.8" cy="272" r="2" stroke="none" fill="black"/>
+<circle cx="1452.8" cy="336" r="2" stroke="none" fill="black"/>
+<circle cx="1516.8" cy="336" r="2" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="336" r="2" stroke="none" fill="black"/>
+<circle cx="1644.8" cy="336" r="2" stroke="none" fill="black"/>
+<circle cx="1708.8" cy="336" r="2" stroke="none" fill="black"/>
+<circle cx="1452.8" cy="537.6" r="2" stroke="none" fill="black"/>
+<circle cx="1516.8" cy="537.6" r="2" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="537.6" r="2" stroke="none" fill="black"/>
+<circle cx="1644.8" cy="537.6" r="2" stroke="none" fill="black"/>
+<circle cx="1708.8" cy="537.6" r="2" stroke="none" fill="black"/>
+<circle cx="1452.8" cy="601.6" r="2" stroke="none" fill="black"/>
+<circle cx="1516.8" cy="601.6" r="2" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="601.6" r="2" stroke="none" fill="black"/>
+<circle cx="1644.8" cy="601.6" r="2" stroke="none" fill="black"/>
+<circle cx="1708.8" cy="601.6" r="2" stroke="none" fill="black"/>
+<circle cx="1452.8" cy="665.6" r="2" stroke="none" fill="black"/>
+<circle cx="1516.8" cy="665.6" r="2" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="665.6" r="2" stroke="none" fill="black"/>
+<circle cx="1644.8" cy="665.6" r="2" stroke="none" fill="black"/>
+<circle cx="1708.8" cy="665.6" r="2" stroke="none" fill="black"/>
+<circle cx="1452.8" cy="729.6" r="2" stroke="none" fill="black"/>
+<circle cx="1516.8" cy="729.6" r="2" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="729.6" r="2" stroke="none" fill="black"/>
+<circle cx="1644.8" cy="729.6" r="2" stroke="none" fill="black"/>
+<circle cx="1708.8" cy="729.6" r="2" stroke="none" fill="black"/>
+<circle cx="1452.8" cy="793.6" r="2" stroke="none" fill="black"/>
+<circle cx="1516.8" cy="793.6" r="2" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="793.6" r="2" stroke="none" fill="black"/>
+<circle cx="1644.8" cy="793.6" r="2" stroke="none" fill="black"/>
+<circle cx="1708.8" cy="793.6" r="2" stroke="none" fill="black"/>
+<path d="M144,80 L80,80 " stroke="black" stroke-width="3"/>
+<circle cx="144" cy="80" r="8" stroke="none" fill="black"/>
+<circle cx="80" cy="80" r="8" stroke="black" fill="white"/>
+<path d="M72,80 L88,80 M80,72 L80,88 " stroke="black"/>
+<path d="M144,208 L80,208 " stroke="black" stroke-width="3"/>
+<circle cx="144" cy="208" r="8" stroke="none" fill="black"/>
+<circle cx="80" cy="208" r="8" stroke="black" fill="white"/>
+<path d="M72,208 L88,208 M80,200 L80,216 " stroke="black"/>
+<path d="M144,336 L80,336 " stroke="black" stroke-width="3"/>
+<circle cx="144" cy="336" r="8" stroke="none" fill="black"/>
+<circle cx="80" cy="336" r="8" stroke="black" fill="white"/>
+<path d="M72,336 L88,336 M80,328 L80,344 " stroke="black"/>
+<path d="M272,80 L208,80 " stroke="black" stroke-width="3"/>
+<circle cx="272" cy="80" r="8" stroke="none" fill="black"/>
+<circle cx="208" cy="80" r="8" stroke="black" fill="white"/>
+<path d="M200,80 L216,80 M208,72 L208,88 " stroke="black"/>
+<path d="M272,208 L208,208 " stroke="black" stroke-width="3"/>
+<circle cx="272" cy="208" r="8" stroke="none" fill="black"/>
+<circle cx="208" cy="208" r="8" stroke="black" fill="white"/>
+<path d="M200,208 L216,208 M208,200 L208,216 " stroke="black"/>
+<path d="M272,336 L208,336 " stroke="black" stroke-width="3"/>
+<circle cx="272" cy="336" r="8" stroke="none" fill="black"/>
+<circle cx="208" cy="336" r="8" stroke="black" fill="white"/>
+<path d="M200,336 L216,336 M208,328 L208,344 " stroke="black"/>
+<path d="M144,144 L208,144 " stroke="black" stroke-width="3"/>
+<circle cx="144" cy="144" r="8" stroke="none" fill="black"/>
+<circle cx="208" cy="144" r="8" stroke="black" fill="white"/>
+<path d="M200,144 L216,144 M208,136 L208,152 " stroke="black"/>
+<path d="M144,272 L208,272 " stroke="black" stroke-width="3"/>
+<circle cx="144" cy="272" r="8" stroke="none" fill="black"/>
+<circle cx="208" cy="272" r="8" stroke="black" fill="white"/>
+<path d="M200,272 L216,272 M208,264 L208,280 " stroke="black"/>
+<path d="M272,144 L336,144 " stroke="black" stroke-width="3"/>
+<circle cx="272" cy="144" r="8" stroke="none" fill="black"/>
+<circle cx="336" cy="144" r="8" stroke="black" fill="white"/>
+<path d="M328,144 L344,144 M336,136 L336,152 " stroke="black"/>
+<path d="M272,272 L336,272 " stroke="black" stroke-width="3"/>
+<circle cx="272" cy="272" r="8" stroke="none" fill="black"/>
+<circle cx="336" cy="272" r="8" stroke="black" fill="white"/>
+<path d="M328,272 L344,272 M336,264 L336,280 " stroke="black"/>
+<rect x="585.6" y="64" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="601.6" y="80">H</text>
+<rect x="713.6" y="64" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="729.6" y="80">H</text>
+<rect x="585.6" y="192" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="601.6" y="208">H</text>
+<rect x="713.6" y="192" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="729.6" y="208">H</text>
+<rect x="585.6" y="320" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="601.6" y="336">H</text>
+<rect x="713.6" y="320" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="729.6" y="336">H</text>
+<rect x="1043.2" y="64" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1059.2" y="80" fill="white">MR</text>
+<rect x="1171.2" y="64" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1187.2" y="80" fill="white">MR</text>
+<rect x="979.2" y="128" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="995.2" y="144" fill="white">MR</text>
+<rect x="1107.2" y="128" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1123.2" y="144" fill="white">MR</text>
+<rect x="1235.2" y="128" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1251.2" y="144" fill="white">MR</text>
+<rect x="1043.2" y="192" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1059.2" y="208" fill="white">MR</text>
+<rect x="1171.2" y="192" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1187.2" y="208" fill="white">MR</text>
+<rect x="979.2" y="256" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="995.2" y="272" fill="white">MR</text>
+<rect x="1107.2" y="256" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1123.2" y="272" fill="white">MR</text>
+<rect x="1235.2" y="256" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1251.2" y="272" fill="white">MR</text>
+<rect x="1043.2" y="320" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1059.2" y="336" fill="white">MR</text>
+<rect x="1171.2" y="320" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1187.2" y="336" fill="white">MR</text>
+<rect x="1500.8" y="64" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1516.8" y="80">H</text>
+<rect x="1628.8" y="64" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1644.8" y="80">H</text>
+<rect x="1500.8" y="192" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1516.8" y="208">H</text>
+<rect x="1628.8" y="192" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1644.8" y="208">H</text>
+<rect x="1500.8" y="320" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1516.8" y="336">H</text>
+<rect x="1628.8" y="320" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1644.8" y="336">H</text>
+<path d="M144,537.6 L208,537.6 " stroke="black" stroke-width="3"/>
+<circle cx="144" cy="537.6" r="8" stroke="none" fill="black"/>
+<circle cx="208" cy="537.6" r="8" stroke="black" fill="white"/>
+<path d="M200,537.6 L216,537.6 M208,529.6 L208,545.6 " stroke="black"/>
+<path d="M144,665.6 L208,665.6 " stroke="black" stroke-width="3"/>
+<circle cx="144" cy="665.6" r="8" stroke="none" fill="black"/>
+<circle cx="208" cy="665.6" r="8" stroke="black" fill="white"/>
+<path d="M200,665.6 L216,665.6 M208,657.6 L208,673.6 " stroke="black"/>
+<path d="M144,793.6 L208,793.6 " stroke="black" stroke-width="3"/>
+<circle cx="144" cy="793.6" r="8" stroke="none" fill="black"/>
+<circle cx="208" cy="793.6" r="8" stroke="black" fill="white"/>
+<path d="M200,793.6 L216,793.6 M208,785.6 L208,801.6 " stroke="black"/>
+<path d="M272,537.6 L336,537.6 " stroke="black" stroke-width="3"/>
+<circle cx="272" cy="537.6" r="8" stroke="none" fill="black"/>
+<circle cx="336" cy="537.6" r="8" stroke="black" fill="white"/>
+<path d="M328,537.6 L344,537.6 M336,529.6 L336,545.6 " stroke="black"/>
+<path d="M272,665.6 L336,665.6 " stroke="black" stroke-width="3"/>
+<circle cx="272" cy="665.6" r="8" stroke="none" fill="black"/>
+<circle cx="336" cy="665.6" r="8" stroke="black" fill="white"/>
+<path d="M328,665.6 L344,665.6 M336,657.6 L336,673.6 " stroke="black"/>
+<path d="M272,793.6 L336,793.6 " stroke="black" stroke-width="3"/>
+<circle cx="272" cy="793.6" r="8" stroke="none" fill="black"/>
+<circle cx="336" cy="793.6" r="8" stroke="black" fill="white"/>
+<path d="M328,793.6 L344,793.6 M336,785.6 L336,801.6 " stroke="black"/>
+<path d="M144,601.6 L80,601.6 " stroke="black" stroke-width="3"/>
+<circle cx="144" cy="601.6" r="8" stroke="none" fill="black"/>
+<circle cx="80" cy="601.6" r="8" stroke="black" fill="white"/>
+<path d="M72,601.6 L88,601.6 M80,593.6 L80,609.6 " stroke="black"/>
+<path d="M144,729.6 L80,729.6 " stroke="black" stroke-width="3"/>
+<circle cx="144" cy="729.6" r="8" stroke="none" fill="black"/>
+<circle cx="80" cy="729.6" r="8" stroke="black" fill="white"/>
+<path d="M72,729.6 L88,729.6 M80,721.6 L80,737.6 " stroke="black"/>
+<path d="M272,601.6 L208,601.6 " stroke="black" stroke-width="3"/>
+<circle cx="272" cy="601.6" r="8" stroke="none" fill="black"/>
+<circle cx="208" cy="601.6" r="8" stroke="black" fill="white"/>
+<path d="M200,601.6 L216,601.6 M208,593.6 L208,609.6 " stroke="black"/>
+<path d="M272,729.6 L208,729.6 " stroke="black" stroke-width="3"/>
+<circle cx="272" cy="729.6" r="8" stroke="none" fill="black"/>
+<circle cx="208" cy="729.6" r="8" stroke="black" fill="white"/>
+<path d="M200,729.6 L216,729.6 M208,721.6 L208,737.6 " stroke="black"/>
+<path d="M601.6,537.6 L601.6,601.6 " stroke="black" stroke-width="3"/>
+<circle cx="601.6" cy="537.6" r="8" stroke="none" fill="black"/>
+<circle cx="601.6" cy="601.6" r="8" stroke="black" fill="white"/>
+<path d="M593.6,601.6 L609.6,601.6 M601.6,593.6 L601.6,609.6 " stroke="black"/>
+<path d="M601.6,665.6 L601.6,729.6 " stroke="black" stroke-width="3"/>
+<circle cx="601.6" cy="665.6" r="8" stroke="none" fill="black"/>
+<circle cx="601.6" cy="729.6" r="8" stroke="black" fill="white"/>
+<path d="M593.6,729.6 L609.6,729.6 M601.6,721.6 L601.6,737.6 " stroke="black"/>
+<path d="M729.6,537.6 L729.6,601.6 " stroke="black" stroke-width="3"/>
+<circle cx="729.6" cy="537.6" r="8" stroke="none" fill="black"/>
+<circle cx="729.6" cy="601.6" r="8" stroke="black" fill="white"/>
+<path d="M721.6,601.6 L737.6,601.6 M729.6,593.6 L729.6,609.6 " stroke="black"/>
+<path d="M729.6,665.6 L729.6,729.6 " stroke="black" stroke-width="3"/>
+<circle cx="729.6" cy="665.6" r="8" stroke="none" fill="black"/>
+<circle cx="729.6" cy="729.6" r="8" stroke="black" fill="white"/>
+<path d="M721.6,729.6 L737.6,729.6 M729.6,721.6 L729.6,737.6 " stroke="black"/>
+<path d="M537.6,665.6 L537.6,601.6 " stroke="black" stroke-width="3"/>
+<circle cx="537.6" cy="665.6" r="8" stroke="none" fill="black"/>
+<circle cx="537.6" cy="601.6" r="8" stroke="black" fill="white"/>
+<path d="M529.6,601.6 L545.6,601.6 M537.6,593.6 L537.6,609.6 " stroke="black"/>
+<path d="M537.6,793.6 L537.6,729.6 " stroke="black" stroke-width="3"/>
+<circle cx="537.6" cy="793.6" r="8" stroke="none" fill="black"/>
+<circle cx="537.6" cy="729.6" r="8" stroke="black" fill="white"/>
+<path d="M529.6,729.6 L545.6,729.6 M537.6,721.6 L537.6,737.6 " stroke="black"/>
+<path d="M665.6,665.6 L665.6,601.6 " stroke="black" stroke-width="3"/>
+<circle cx="665.6" cy="665.6" r="8" stroke="none" fill="black"/>
+<circle cx="665.6" cy="601.6" r="8" stroke="black" fill="white"/>
+<path d="M657.6,601.6 L673.6,601.6 M665.6,593.6 L665.6,609.6 " stroke="black"/>
+<path d="M665.6,793.6 L665.6,729.6 " stroke="black" stroke-width="3"/>
+<circle cx="665.6" cy="793.6" r="8" stroke="none" fill="black"/>
+<circle cx="665.6" cy="729.6" r="8" stroke="black" fill="white"/>
+<path d="M657.6,729.6 L673.6,729.6 M665.6,721.6 L665.6,737.6 " stroke="black"/>
+<path d="M793.6,665.6 L793.6,601.6 " stroke="black" stroke-width="3"/>
+<circle cx="793.6" cy="665.6" r="8" stroke="none" fill="black"/>
+<circle cx="793.6" cy="601.6" r="8" stroke="black" fill="white"/>
+<path d="M785.6,601.6 L801.6,601.6 M793.6,593.6 L793.6,609.6 " stroke="black"/>
+<path d="M793.6,793.6 L793.6,729.6 " stroke="black" stroke-width="3"/>
+<circle cx="793.6" cy="793.6" r="8" stroke="none" fill="black"/>
+<circle cx="793.6" cy="729.6" r="8" stroke="black" fill="white"/>
+<path d="M785.6,729.6 L801.6,729.6 M793.6,721.6 L793.6,737.6 " stroke="black"/>
+<path d="M1059.2,665.6 L1059.2,601.6 " stroke="black" stroke-width="3"/>
+<circle cx="1059.2" cy="665.6" r="8" stroke="none" fill="black"/>
+<circle cx="1059.2" cy="601.6" r="8" stroke="black" fill="white"/>
+<path d="M1051.2,601.6 L1067.2,601.6 M1059.2,593.6 L1059.2,609.6 " stroke="black"/>
+<path d="M1059.2,793.6 L1059.2,729.6 " stroke="black" stroke-width="3"/>
+<circle cx="1059.2" cy="793.6" r="8" stroke="none" fill="black"/>
+<circle cx="1059.2" cy="729.6" r="8" stroke="black" fill="white"/>
+<path d="M1051.2,729.6 L1067.2,729.6 M1059.2,721.6 L1059.2,737.6 " stroke="black"/>
+<path d="M1187.2,665.6 L1187.2,601.6 " stroke="black" stroke-width="3"/>
+<circle cx="1187.2" cy="665.6" r="8" stroke="none" fill="black"/>
+<circle cx="1187.2" cy="601.6" r="8" stroke="black" fill="white"/>
+<path d="M1179.2,601.6 L1195.2,601.6 M1187.2,593.6 L1187.2,609.6 " stroke="black"/>
+<path d="M1187.2,793.6 L1187.2,729.6 " stroke="black" stroke-width="3"/>
+<circle cx="1187.2" cy="793.6" r="8" stroke="none" fill="black"/>
+<circle cx="1187.2" cy="729.6" r="8" stroke="black" fill="white"/>
+<path d="M1179.2,729.6 L1195.2,729.6 M1187.2,721.6 L1187.2,737.6 " stroke="black"/>
+<path d="M995.2,537.6 L995.2,601.6 " stroke="black" stroke-width="3"/>
+<circle cx="995.2" cy="537.6" r="8" stroke="none" fill="black"/>
+<circle cx="995.2" cy="601.6" r="8" stroke="black" fill="white"/>
+<path d="M987.2,601.6 L1003.2,601.6 M995.2,593.6 L995.2,609.6 " stroke="black"/>
+<path d="M995.2,665.6 L995.2,729.6 " stroke="black" stroke-width="3"/>
+<circle cx="995.2" cy="665.6" r="8" stroke="none" fill="black"/>
+<circle cx="995.2" cy="729.6" r="8" stroke="black" fill="white"/>
+<path d="M987.2,729.6 L1003.2,729.6 M995.2,721.6 L995.2,737.6 " stroke="black"/>
+<path d="M1123.2,537.6 L1123.2,601.6 " stroke="black" stroke-width="3"/>
+<circle cx="1123.2" cy="537.6" r="8" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="601.6" r="8" stroke="black" fill="white"/>
+<path d="M1115.2,601.6 L1131.2,601.6 M1123.2,593.6 L1123.2,609.6 " stroke="black"/>
+<path d="M1123.2,665.6 L1123.2,729.6 " stroke="black" stroke-width="3"/>
+<circle cx="1123.2" cy="665.6" r="8" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="729.6" r="8" stroke="black" fill="white"/>
+<path d="M1115.2,729.6 L1131.2,729.6 M1123.2,721.6 L1123.2,737.6 " stroke="black"/>
+<path d="M1251.2,537.6 L1251.2,601.6 " stroke="black" stroke-width="3"/>
+<circle cx="1251.2" cy="537.6" r="8" stroke="none" fill="black"/>
+<circle cx="1251.2" cy="601.6" r="8" stroke="black" fill="white"/>
+<path d="M1243.2,601.6 L1259.2,601.6 M1251.2,593.6 L1251.2,609.6 " stroke="black"/>
+<path d="M1251.2,665.6 L1251.2,729.6 " stroke="black" stroke-width="3"/>
+<circle cx="1251.2" cy="665.6" r="8" stroke="none" fill="black"/>
+<circle cx="1251.2" cy="729.6" r="8" stroke="black" fill="white"/>
+<path d="M1243.2,729.6 L1259.2,729.6 M1251.2,721.6 L1251.2,737.6 " stroke="black"/>
+<path d="M1516.8,537.6 L1452.8,537.6 " stroke="black" stroke-width="3"/>
+<circle cx="1516.8" cy="537.6" r="8" stroke="none" fill="black"/>
+<circle cx="1452.8" cy="537.6" r="8" stroke="black" fill="white"/>
+<path d="M1444.8,537.6 L1460.8,537.6 M1452.8,529.6 L1452.8,545.6 " stroke="black"/>
+<path d="M1516.8,665.6 L1452.8,665.6 " stroke="black" stroke-width="3"/>
+<circle cx="1516.8" cy="665.6" r="8" stroke="none" fill="black"/>
+<circle cx="1452.8" cy="665.6" r="8" stroke="black" fill="white"/>
+<path d="M1444.8,665.6 L1460.8,665.6 M1452.8,657.6 L1452.8,673.6 " stroke="black"/>
+<path d="M1516.8,793.6 L1452.8,793.6 " stroke="black" stroke-width="3"/>
+<circle cx="1516.8" cy="793.6" r="8" stroke="none" fill="black"/>
+<circle cx="1452.8" cy="793.6" r="8" stroke="black" fill="white"/>
+<path d="M1444.8,793.6 L1460.8,793.6 M1452.8,785.6 L1452.8,801.6 " stroke="black"/>
+<path d="M1644.8,537.6 L1580.8,537.6 " stroke="black" stroke-width="3"/>
+<circle cx="1644.8" cy="537.6" r="8" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="537.6" r="8" stroke="black" fill="white"/>
+<path d="M1572.8,537.6 L1588.8,537.6 M1580.8,529.6 L1580.8,545.6 " stroke="black"/>
+<path d="M1644.8,665.6 L1580.8,665.6 " stroke="black" stroke-width="3"/>
+<circle cx="1644.8" cy="665.6" r="8" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="665.6" r="8" stroke="black" fill="white"/>
+<path d="M1572.8,665.6 L1588.8,665.6 M1580.8,657.6 L1580.8,673.6 " stroke="black"/>
+<path d="M1644.8,793.6 L1580.8,793.6 " stroke="black" stroke-width="3"/>
+<circle cx="1644.8" cy="793.6" r="8" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="793.6" r="8" stroke="black" fill="white"/>
+<path d="M1572.8,793.6 L1588.8,793.6 M1580.8,785.6 L1580.8,801.6 " stroke="black"/>
+<path d="M1516.8,601.6 L1580.8,601.6 " stroke="black" stroke-width="3"/>
+<circle cx="1516.8" cy="601.6" r="8" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="601.6" r="8" stroke="black" fill="white"/>
+<path d="M1572.8,601.6 L1588.8,601.6 M1580.8,593.6 L1580.8,609.6 " stroke="black"/>
+<path d="M1516.8,729.6 L1580.8,729.6 " stroke="black" stroke-width="3"/>
+<circle cx="1516.8" cy="729.6" r="8" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="729.6" r="8" stroke="black" fill="white"/>
+<path d="M1572.8,729.6 L1588.8,729.6 M1580.8,721.6 L1580.8,737.6 " stroke="black"/>
+<path d="M1644.8,601.6 L1708.8,601.6 " stroke="black" stroke-width="3"/>
+<circle cx="1644.8" cy="601.6" r="8" stroke="none" fill="black"/>
+<circle cx="1708.8" cy="601.6" r="8" stroke="black" fill="white"/>
+<path d="M1700.8,601.6 L1716.8,601.6 M1708.8,593.6 L1708.8,609.6 " stroke="black"/>
+<path d="M1644.8,729.6 L1708.8,729.6 " stroke="black" stroke-width="3"/>
+<circle cx="1644.8" cy="729.6" r="8" stroke="none" fill="black"/>
+<circle cx="1708.8" cy="729.6" r="8" stroke="black" fill="white"/>
+<path d="M1700.8,729.6 L1716.8,729.6 M1708.8,721.6 L1708.8,737.6 " stroke="black"/>
+<rect x="128" y="979.2" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="144" y="995.2">H</text>
+<rect x="256" y="979.2" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="272" y="995.2">H</text>
+<rect x="128" y="1107.2" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="144" y="1123.2">H</text>
+<rect x="256" y="1107.2" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="272" y="1123.2">H</text>
+<rect x="128" y="1235.2" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="144" y="1251.2">H</text>
+<rect x="256" y="1235.2" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="272" y="1251.2">H</text>
+<rect x="585.6" y="979.2" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="601.6" y="995.2" fill="white">MR</text>
+<rect x="713.6" y="979.2" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="729.6" y="995.2" fill="white">MR</text>
+<rect x="521.6" y="1043.2" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="537.6" y="1059.2" fill="white">MR</text>
+<rect x="649.6" y="1043.2" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="665.6" y="1059.2" fill="white">MR</text>
+<rect x="777.6" y="1043.2" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="793.6" y="1059.2" fill="white">MR</text>
+<rect x="585.6" y="1107.2" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="601.6" y="1123.2" fill="white">MR</text>
+<rect x="713.6" y="1107.2" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="729.6" y="1123.2" fill="white">MR</text>
+<rect x="521.6" y="1171.2" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="537.6" y="1187.2" fill="white">MR</text>
+<rect x="649.6" y="1171.2" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="665.6" y="1187.2" fill="white">MR</text>
+<rect x="777.6" y="1171.2" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="793.6" y="1187.2" fill="white">MR</text>
+<rect x="585.6" y="1235.2" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="601.6" y="1251.2" fill="white">MR</text>
+<rect x="713.6" y="1235.2" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="729.6" y="1251.2" fill="white">MR</text>
+<rect x="0" y="0" width="416" height="416" stroke="black" fill="none"/>
+<rect x="0" y="457.6" width="416" height="416" stroke="black" fill="none"/>
+<rect x="0" y="915.2" width="416" height="416" stroke="black" fill="none"/>
+<rect x="457.6" y="0" width="416" height="416" stroke="black" fill="none"/>
+<rect x="457.6" y="457.6" width="416" height="416" stroke="black" fill="none"/>
+<rect x="457.6" y="915.2" width="416" height="416" stroke="black" fill="none"/>
+<rect x="915.2" y="0" width="416" height="416" stroke="black" fill="none"/>
+<rect x="915.2" y="457.6" width="416" height="416" stroke="black" fill="none"/>
+<rect x="915.2" y="915.2" width="416" height="416" stroke="black" fill="none"/>
+<rect x="1372.8" y="0" width="416" height="416" stroke="black" fill="none"/>
+<rect x="1372.8" y="457.6" width="416" height="416" stroke="black" fill="none"/>
+</svg>

--- a/testdata/surface_code_time_slice.svg
+++ b/testdata/surface_code_time_slice.svg
@@ -362,6 +362,14 @@
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="735.701" y="1210.38" fill="white">MR</text>
 <rect x="719.701" y="1284.89" width="32" height="32" stroke="black" fill="black"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="735.701" y="1300.89" fill="white">MR</text>
+<rect x="1103.87" y="1013.36" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1119.87" y="1029.36">H</text>
+<rect x="1194.38" y="1103.87" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1210.38" y="1119.87">H</text>
+<rect x="1103.87" y="1194.38" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1119.87" y="1210.38">H</text>
+<rect x="1194.38" y="1284.89" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1210.38" y="1300.89">H</text>
 <rect x="0" y="0" width="431.529" height="431.529" stroke="black" fill="none"/>
 <rect x="0" y="474.682" width="431.529" height="431.529" stroke="black" fill="none"/>
 <rect x="0" y="949.364" width="431.529" height="431.529" stroke="black" fill="none"/>

--- a/testdata/surface_code_time_slice.svg
+++ b/testdata/surface_code_time_slice.svg
@@ -1,0 +1,376 @@
+<svg viewBox="0 0 1855.57 1380.89"  version="1.1" xmlns="http://www.w3.org/2000/svg">
+<circle cx="125.255" cy="125.255" r="2" stroke="none" fill="black"/>
+<circle cx="170.51" cy="80" r="2" stroke="none" fill="black"/>
+<circle cx="215.764" cy="125.255" r="2" stroke="none" fill="black"/>
+<circle cx="306.274" cy="125.255" r="2" stroke="none" fill="black"/>
+<circle cx="125.255" cy="215.764" r="2" stroke="none" fill="black"/>
+<circle cx="170.51" cy="170.51" r="2" stroke="none" fill="black"/>
+<circle cx="215.764" cy="215.764" r="2" stroke="none" fill="black"/>
+<circle cx="261.019" cy="170.51" r="2" stroke="none" fill="black"/>
+<circle cx="306.274" cy="215.764" r="2" stroke="none" fill="black"/>
+<circle cx="351.529" cy="170.51" r="2" stroke="none" fill="black"/>
+<circle cx="80" cy="261.019" r="2" stroke="none" fill="black"/>
+<circle cx="125.255" cy="306.274" r="2" stroke="none" fill="black"/>
+<circle cx="170.51" cy="261.019" r="2" stroke="none" fill="black"/>
+<circle cx="215.764" cy="306.274" r="2" stroke="none" fill="black"/>
+<circle cx="261.019" cy="261.019" r="2" stroke="none" fill="black"/>
+<circle cx="306.274" cy="306.274" r="2" stroke="none" fill="black"/>
+<circle cx="261.019" cy="351.529" r="2" stroke="none" fill="black"/>
+<circle cx="125.255" cy="599.937" r="2" stroke="none" fill="black"/>
+<circle cx="170.51" cy="554.682" r="2" stroke="none" fill="black"/>
+<circle cx="215.764" cy="599.937" r="2" stroke="none" fill="black"/>
+<circle cx="306.274" cy="599.937" r="2" stroke="none" fill="black"/>
+<circle cx="125.255" cy="690.446" r="2" stroke="none" fill="black"/>
+<circle cx="170.51" cy="645.192" r="2" stroke="none" fill="black"/>
+<circle cx="215.764" cy="690.446" r="2" stroke="none" fill="black"/>
+<circle cx="261.019" cy="645.192" r="2" stroke="none" fill="black"/>
+<circle cx="306.274" cy="690.446" r="2" stroke="none" fill="black"/>
+<circle cx="351.529" cy="645.192" r="2" stroke="none" fill="black"/>
+<circle cx="80" cy="735.701" r="2" stroke="none" fill="black"/>
+<circle cx="125.255" cy="780.956" r="2" stroke="none" fill="black"/>
+<circle cx="170.51" cy="735.701" r="2" stroke="none" fill="black"/>
+<circle cx="215.764" cy="780.956" r="2" stroke="none" fill="black"/>
+<circle cx="261.019" cy="735.701" r="2" stroke="none" fill="black"/>
+<circle cx="306.274" cy="780.956" r="2" stroke="none" fill="black"/>
+<circle cx="261.019" cy="826.211" r="2" stroke="none" fill="black"/>
+<circle cx="125.255" cy="1074.62" r="2" stroke="none" fill="black"/>
+<circle cx="170.51" cy="1029.36" r="2" stroke="none" fill="black"/>
+<circle cx="215.764" cy="1074.62" r="2" stroke="none" fill="black"/>
+<circle cx="306.274" cy="1074.62" r="2" stroke="none" fill="black"/>
+<circle cx="125.255" cy="1165.13" r="2" stroke="none" fill="black"/>
+<circle cx="170.51" cy="1119.87" r="2" stroke="none" fill="black"/>
+<circle cx="215.764" cy="1165.13" r="2" stroke="none" fill="black"/>
+<circle cx="261.019" cy="1119.87" r="2" stroke="none" fill="black"/>
+<circle cx="306.274" cy="1165.13" r="2" stroke="none" fill="black"/>
+<circle cx="351.529" cy="1119.87" r="2" stroke="none" fill="black"/>
+<circle cx="80" cy="1210.38" r="2" stroke="none" fill="black"/>
+<circle cx="125.255" cy="1255.64" r="2" stroke="none" fill="black"/>
+<circle cx="170.51" cy="1210.38" r="2" stroke="none" fill="black"/>
+<circle cx="215.764" cy="1255.64" r="2" stroke="none" fill="black"/>
+<circle cx="261.019" cy="1210.38" r="2" stroke="none" fill="black"/>
+<circle cx="306.274" cy="1255.64" r="2" stroke="none" fill="black"/>
+<circle cx="261.019" cy="1300.89" r="2" stroke="none" fill="black"/>
+<circle cx="599.937" cy="125.255" r="2" stroke="none" fill="black"/>
+<circle cx="645.192" cy="80" r="2" stroke="none" fill="black"/>
+<circle cx="690.446" cy="125.255" r="2" stroke="none" fill="black"/>
+<circle cx="780.956" cy="125.255" r="2" stroke="none" fill="black"/>
+<circle cx="599.937" cy="215.764" r="2" stroke="none" fill="black"/>
+<circle cx="645.192" cy="170.51" r="2" stroke="none" fill="black"/>
+<circle cx="690.446" cy="215.764" r="2" stroke="none" fill="black"/>
+<circle cx="735.701" cy="170.51" r="2" stroke="none" fill="black"/>
+<circle cx="780.956" cy="215.764" r="2" stroke="none" fill="black"/>
+<circle cx="826.211" cy="170.51" r="2" stroke="none" fill="black"/>
+<circle cx="554.682" cy="261.019" r="2" stroke="none" fill="black"/>
+<circle cx="599.937" cy="306.274" r="2" stroke="none" fill="black"/>
+<circle cx="645.192" cy="261.019" r="2" stroke="none" fill="black"/>
+<circle cx="690.446" cy="306.274" r="2" stroke="none" fill="black"/>
+<circle cx="735.701" cy="261.019" r="2" stroke="none" fill="black"/>
+<circle cx="780.956" cy="306.274" r="2" stroke="none" fill="black"/>
+<circle cx="735.701" cy="351.529" r="2" stroke="none" fill="black"/>
+<circle cx="599.937" cy="599.937" r="2" stroke="none" fill="black"/>
+<circle cx="645.192" cy="554.682" r="2" stroke="none" fill="black"/>
+<circle cx="690.446" cy="599.937" r="2" stroke="none" fill="black"/>
+<circle cx="780.956" cy="599.937" r="2" stroke="none" fill="black"/>
+<circle cx="599.937" cy="690.446" r="2" stroke="none" fill="black"/>
+<circle cx="645.192" cy="645.192" r="2" stroke="none" fill="black"/>
+<circle cx="690.446" cy="690.446" r="2" stroke="none" fill="black"/>
+<circle cx="735.701" cy="645.192" r="2" stroke="none" fill="black"/>
+<circle cx="780.956" cy="690.446" r="2" stroke="none" fill="black"/>
+<circle cx="826.211" cy="645.192" r="2" stroke="none" fill="black"/>
+<circle cx="554.682" cy="735.701" r="2" stroke="none" fill="black"/>
+<circle cx="599.937" cy="780.956" r="2" stroke="none" fill="black"/>
+<circle cx="645.192" cy="735.701" r="2" stroke="none" fill="black"/>
+<circle cx="690.446" cy="780.956" r="2" stroke="none" fill="black"/>
+<circle cx="735.701" cy="735.701" r="2" stroke="none" fill="black"/>
+<circle cx="780.956" cy="780.956" r="2" stroke="none" fill="black"/>
+<circle cx="735.701" cy="826.211" r="2" stroke="none" fill="black"/>
+<circle cx="599.937" cy="1074.62" r="2" stroke="none" fill="black"/>
+<circle cx="645.192" cy="1029.36" r="2" stroke="none" fill="black"/>
+<circle cx="690.446" cy="1074.62" r="2" stroke="none" fill="black"/>
+<circle cx="780.956" cy="1074.62" r="2" stroke="none" fill="black"/>
+<circle cx="599.937" cy="1165.13" r="2" stroke="none" fill="black"/>
+<circle cx="645.192" cy="1119.87" r="2" stroke="none" fill="black"/>
+<circle cx="690.446" cy="1165.13" r="2" stroke="none" fill="black"/>
+<circle cx="735.701" cy="1119.87" r="2" stroke="none" fill="black"/>
+<circle cx="780.956" cy="1165.13" r="2" stroke="none" fill="black"/>
+<circle cx="826.211" cy="1119.87" r="2" stroke="none" fill="black"/>
+<circle cx="554.682" cy="1210.38" r="2" stroke="none" fill="black"/>
+<circle cx="599.937" cy="1255.64" r="2" stroke="none" fill="black"/>
+<circle cx="645.192" cy="1210.38" r="2" stroke="none" fill="black"/>
+<circle cx="690.446" cy="1255.64" r="2" stroke="none" fill="black"/>
+<circle cx="735.701" cy="1210.38" r="2" stroke="none" fill="black"/>
+<circle cx="780.956" cy="1255.64" r="2" stroke="none" fill="black"/>
+<circle cx="735.701" cy="1300.89" r="2" stroke="none" fill="black"/>
+<circle cx="1074.62" cy="125.255" r="2" stroke="none" fill="black"/>
+<circle cx="1119.87" cy="80" r="2" stroke="none" fill="black"/>
+<circle cx="1165.13" cy="125.255" r="2" stroke="none" fill="black"/>
+<circle cx="1255.64" cy="125.255" r="2" stroke="none" fill="black"/>
+<circle cx="1074.62" cy="215.764" r="2" stroke="none" fill="black"/>
+<circle cx="1119.87" cy="170.51" r="2" stroke="none" fill="black"/>
+<circle cx="1165.13" cy="215.764" r="2" stroke="none" fill="black"/>
+<circle cx="1210.38" cy="170.51" r="2" stroke="none" fill="black"/>
+<circle cx="1255.64" cy="215.764" r="2" stroke="none" fill="black"/>
+<circle cx="1300.89" cy="170.51" r="2" stroke="none" fill="black"/>
+<circle cx="1029.36" cy="261.019" r="2" stroke="none" fill="black"/>
+<circle cx="1074.62" cy="306.274" r="2" stroke="none" fill="black"/>
+<circle cx="1119.87" cy="261.019" r="2" stroke="none" fill="black"/>
+<circle cx="1165.13" cy="306.274" r="2" stroke="none" fill="black"/>
+<circle cx="1210.38" cy="261.019" r="2" stroke="none" fill="black"/>
+<circle cx="1255.64" cy="306.274" r="2" stroke="none" fill="black"/>
+<circle cx="1210.38" cy="351.529" r="2" stroke="none" fill="black"/>
+<circle cx="1074.62" cy="599.937" r="2" stroke="none" fill="black"/>
+<circle cx="1119.87" cy="554.682" r="2" stroke="none" fill="black"/>
+<circle cx="1165.13" cy="599.937" r="2" stroke="none" fill="black"/>
+<circle cx="1255.64" cy="599.937" r="2" stroke="none" fill="black"/>
+<circle cx="1074.62" cy="690.446" r="2" stroke="none" fill="black"/>
+<circle cx="1119.87" cy="645.192" r="2" stroke="none" fill="black"/>
+<circle cx="1165.13" cy="690.446" r="2" stroke="none" fill="black"/>
+<circle cx="1210.38" cy="645.192" r="2" stroke="none" fill="black"/>
+<circle cx="1255.64" cy="690.446" r="2" stroke="none" fill="black"/>
+<circle cx="1300.89" cy="645.192" r="2" stroke="none" fill="black"/>
+<circle cx="1029.36" cy="735.701" r="2" stroke="none" fill="black"/>
+<circle cx="1074.62" cy="780.956" r="2" stroke="none" fill="black"/>
+<circle cx="1119.87" cy="735.701" r="2" stroke="none" fill="black"/>
+<circle cx="1165.13" cy="780.956" r="2" stroke="none" fill="black"/>
+<circle cx="1210.38" cy="735.701" r="2" stroke="none" fill="black"/>
+<circle cx="1255.64" cy="780.956" r="2" stroke="none" fill="black"/>
+<circle cx="1210.38" cy="826.211" r="2" stroke="none" fill="black"/>
+<circle cx="1074.62" cy="1074.62" r="2" stroke="none" fill="black"/>
+<circle cx="1119.87" cy="1029.36" r="2" stroke="none" fill="black"/>
+<circle cx="1165.13" cy="1074.62" r="2" stroke="none" fill="black"/>
+<circle cx="1255.64" cy="1074.62" r="2" stroke="none" fill="black"/>
+<circle cx="1074.62" cy="1165.13" r="2" stroke="none" fill="black"/>
+<circle cx="1119.87" cy="1119.87" r="2" stroke="none" fill="black"/>
+<circle cx="1165.13" cy="1165.13" r="2" stroke="none" fill="black"/>
+<circle cx="1210.38" cy="1119.87" r="2" stroke="none" fill="black"/>
+<circle cx="1255.64" cy="1165.13" r="2" stroke="none" fill="black"/>
+<circle cx="1300.89" cy="1119.87" r="2" stroke="none" fill="black"/>
+<circle cx="1029.36" cy="1210.38" r="2" stroke="none" fill="black"/>
+<circle cx="1074.62" cy="1255.64" r="2" stroke="none" fill="black"/>
+<circle cx="1119.87" cy="1210.38" r="2" stroke="none" fill="black"/>
+<circle cx="1165.13" cy="1255.64" r="2" stroke="none" fill="black"/>
+<circle cx="1210.38" cy="1210.38" r="2" stroke="none" fill="black"/>
+<circle cx="1255.64" cy="1255.64" r="2" stroke="none" fill="black"/>
+<circle cx="1210.38" cy="1300.89" r="2" stroke="none" fill="black"/>
+<circle cx="1549.3" cy="125.255" r="2" stroke="none" fill="black"/>
+<circle cx="1594.56" cy="80" r="2" stroke="none" fill="black"/>
+<circle cx="1639.81" cy="125.255" r="2" stroke="none" fill="black"/>
+<circle cx="1730.32" cy="125.255" r="2" stroke="none" fill="black"/>
+<circle cx="1549.3" cy="215.764" r="2" stroke="none" fill="black"/>
+<circle cx="1594.56" cy="170.51" r="2" stroke="none" fill="black"/>
+<circle cx="1639.81" cy="215.764" r="2" stroke="none" fill="black"/>
+<circle cx="1685.07" cy="170.51" r="2" stroke="none" fill="black"/>
+<circle cx="1730.32" cy="215.764" r="2" stroke="none" fill="black"/>
+<circle cx="1775.57" cy="170.51" r="2" stroke="none" fill="black"/>
+<circle cx="1504.05" cy="261.019" r="2" stroke="none" fill="black"/>
+<circle cx="1549.3" cy="306.274" r="2" stroke="none" fill="black"/>
+<circle cx="1594.56" cy="261.019" r="2" stroke="none" fill="black"/>
+<circle cx="1639.81" cy="306.274" r="2" stroke="none" fill="black"/>
+<circle cx="1685.07" cy="261.019" r="2" stroke="none" fill="black"/>
+<circle cx="1730.32" cy="306.274" r="2" stroke="none" fill="black"/>
+<circle cx="1685.07" cy="351.529" r="2" stroke="none" fill="black"/>
+<circle cx="1549.3" cy="599.937" r="2" stroke="none" fill="black"/>
+<circle cx="1594.56" cy="554.682" r="2" stroke="none" fill="black"/>
+<circle cx="1639.81" cy="599.937" r="2" stroke="none" fill="black"/>
+<circle cx="1730.32" cy="599.937" r="2" stroke="none" fill="black"/>
+<circle cx="1549.3" cy="690.446" r="2" stroke="none" fill="black"/>
+<circle cx="1594.56" cy="645.192" r="2" stroke="none" fill="black"/>
+<circle cx="1639.81" cy="690.446" r="2" stroke="none" fill="black"/>
+<circle cx="1685.07" cy="645.192" r="2" stroke="none" fill="black"/>
+<circle cx="1730.32" cy="690.446" r="2" stroke="none" fill="black"/>
+<circle cx="1775.57" cy="645.192" r="2" stroke="none" fill="black"/>
+<circle cx="1504.05" cy="735.701" r="2" stroke="none" fill="black"/>
+<circle cx="1549.3" cy="780.956" r="2" stroke="none" fill="black"/>
+<circle cx="1594.56" cy="735.701" r="2" stroke="none" fill="black"/>
+<circle cx="1639.81" cy="780.956" r="2" stroke="none" fill="black"/>
+<circle cx="1685.07" cy="735.701" r="2" stroke="none" fill="black"/>
+<circle cx="1730.32" cy="780.956" r="2" stroke="none" fill="black"/>
+<circle cx="1685.07" cy="826.211" r="2" stroke="none" fill="black"/>
+<path d="M170.51,261.019 L125.255,215.764 " stroke="black" stroke-width="3"/>
+<circle cx="170.51" cy="261.019" r="8" stroke="none" fill="black"/>
+<circle cx="125.255" cy="215.764" r="8" stroke="black" fill="white"/>
+<path d="M117.255,215.764 L133.255,215.764 M125.255,207.764 L125.255,223.764 " stroke="black"/>
+<path d="M261.019,170.51 L215.764,125.255 " stroke="black" stroke-width="3"/>
+<circle cx="261.019" cy="170.51" r="8" stroke="none" fill="black"/>
+<circle cx="215.764" cy="125.255" r="8" stroke="black" fill="white"/>
+<path d="M207.764,125.255 L223.764,125.255 M215.764,117.255 L215.764,133.255 " stroke="black"/>
+<path d="M261.019,351.529 L215.764,306.274 " stroke="black" stroke-width="3"/>
+<circle cx="261.019" cy="351.529" r="8" stroke="none" fill="black"/>
+<circle cx="215.764" cy="306.274" r="8" stroke="black" fill="white"/>
+<path d="M207.764,306.274 L223.764,306.274 M215.764,298.274 L215.764,314.274 " stroke="black"/>
+<path d="M125.255,125.255 L170.51,170.51 " stroke="black" stroke-width="3"/>
+<circle cx="125.255" cy="125.255" r="8" stroke="none" fill="black"/>
+<circle cx="170.51" cy="170.51" r="8" stroke="black" fill="white"/>
+<path d="M162.51,170.51 L178.51,170.51 M170.51,162.51 L170.51,178.51 " stroke="black"/>
+<path d="M215.764,215.764 L261.019,261.019 " stroke="black" stroke-width="3"/>
+<circle cx="215.764" cy="215.764" r="8" stroke="none" fill="black"/>
+<circle cx="261.019" cy="261.019" r="8" stroke="black" fill="white"/>
+<path d="M253.019,261.019 L269.019,261.019 M261.019,253.019 L261.019,269.019 " stroke="black"/>
+<path d="M306.274,125.255 L351.529,170.51 " stroke="black" stroke-width="3"/>
+<circle cx="306.274" cy="125.255" r="8" stroke="none" fill="black"/>
+<circle cx="351.529" cy="170.51" r="8" stroke="black" fill="white"/>
+<path d="M343.529,170.51 L359.529,170.51 M351.529,162.51 L351.529,178.51 " stroke="black"/>
+<rect x="629.192" y="64" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="645.192" y="80">H</text>
+<rect x="719.701" y="154.51" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="735.701" y="170.51">H</text>
+<rect x="629.192" y="245.019" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="645.192" y="261.019">H</text>
+<rect x="719.701" y="335.529" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="735.701" y="351.529">H</text>
+<rect x="1103.87" y="64" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1119.87" y="80" fill="white">MR</text>
+<rect x="1103.87" y="154.51" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1119.87" y="170.51" fill="white">MR</text>
+<rect x="1194.38" y="154.51" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1210.38" y="170.51" fill="white">MR</text>
+<rect x="1284.89" y="154.51" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1300.89" y="170.51" fill="white">MR</text>
+<rect x="1013.36" y="245.019" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1029.36" y="261.019" fill="white">MR</text>
+<rect x="1103.87" y="245.019" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1119.87" y="261.019" fill="white">MR</text>
+<rect x="1194.38" y="245.019" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1210.38" y="261.019" fill="white">MR</text>
+<rect x="1194.38" y="335.529" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="1210.38" y="351.529" fill="white">MR</text>
+<rect x="1578.56" y="64" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1594.56" y="80">H</text>
+<rect x="1669.06" y="154.51" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1685.06" y="170.51">H</text>
+<rect x="1578.56" y="245.019" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1594.56" y="261.019">H</text>
+<rect x="1669.06" y="335.529" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1685.06" y="351.529">H</text>
+<path d="M170.51,554.682 L215.764,599.937 " stroke="black" stroke-width="3"/>
+<circle cx="170.51" cy="554.682" r="8" stroke="none" fill="black"/>
+<circle cx="215.764" cy="599.937" r="8" stroke="black" fill="white"/>
+<path d="M207.764,599.937 L223.764,599.937 M215.764,591.937 L215.764,607.937 " stroke="black"/>
+<path d="M170.51,735.701 L215.764,780.956 " stroke="black" stroke-width="3"/>
+<circle cx="170.51" cy="735.701" r="8" stroke="none" fill="black"/>
+<circle cx="215.764" cy="780.956" r="8" stroke="black" fill="white"/>
+<path d="M207.764,780.956 L223.764,780.956 M215.764,772.956 L215.764,788.956 " stroke="black"/>
+<path d="M261.019,645.192 L306.274,690.446 " stroke="black" stroke-width="3"/>
+<circle cx="261.019" cy="645.192" r="8" stroke="none" fill="black"/>
+<circle cx="306.274" cy="690.446" r="8" stroke="black" fill="white"/>
+<path d="M298.274,690.446 L314.274,690.446 M306.274,682.446 L306.274,698.446 " stroke="black"/>
+<path d="M125.255,780.956 L80,735.701 " stroke="black" stroke-width="3"/>
+<circle cx="125.255" cy="780.956" r="8" stroke="none" fill="black"/>
+<circle cx="80" cy="735.701" r="8" stroke="black" fill="white"/>
+<path d="M72,735.701 L88,735.701 M80,727.701 L80,743.701 " stroke="black"/>
+<path d="M215.764,690.446 L170.51,645.192 " stroke="black" stroke-width="3"/>
+<circle cx="215.764" cy="690.446" r="8" stroke="none" fill="black"/>
+<circle cx="170.51" cy="645.192" r="8" stroke="black" fill="white"/>
+<path d="M162.51,645.192 L178.51,645.192 M170.51,637.192 L170.51,653.192 " stroke="black"/>
+<path d="M306.274,780.956 L261.019,735.701 " stroke="black" stroke-width="3"/>
+<circle cx="306.274" cy="780.956" r="8" stroke="none" fill="black"/>
+<circle cx="261.019" cy="735.701" r="8" stroke="black" fill="white"/>
+<path d="M253.019,735.701 L269.019,735.701 M261.019,727.701 L261.019,743.701 " stroke="black"/>
+<path d="M645.192,554.682 L599.937,599.937 " stroke="black" stroke-width="3"/>
+<circle cx="645.192" cy="554.682" r="8" stroke="none" fill="black"/>
+<circle cx="599.937" cy="599.937" r="8" stroke="black" fill="white"/>
+<path d="M591.937,599.937 L607.937,599.937 M599.937,591.937 L599.937,607.937 " stroke="black"/>
+<path d="M645.192,735.701 L599.937,780.956 " stroke="black" stroke-width="3"/>
+<circle cx="645.192" cy="735.701" r="8" stroke="none" fill="black"/>
+<circle cx="599.937" cy="780.956" r="8" stroke="black" fill="white"/>
+<path d="M591.937,780.956 L607.937,780.956 M599.937,772.956 L599.937,788.956 " stroke="black"/>
+<path d="M735.701,645.192 L690.446,690.446 " stroke="black" stroke-width="3"/>
+<circle cx="735.701" cy="645.192" r="8" stroke="none" fill="black"/>
+<circle cx="690.446" cy="690.446" r="8" stroke="black" fill="white"/>
+<path d="M682.446,690.446 L698.446,690.446 M690.446,682.446 L690.446,698.446 " stroke="black"/>
+<path d="M599.937,690.446 L554.682,735.701 " stroke="black" stroke-width="3"/>
+<circle cx="599.937" cy="690.446" r="8" stroke="none" fill="black"/>
+<circle cx="554.682" cy="735.701" r="8" stroke="black" fill="white"/>
+<path d="M546.682,735.701 L562.682,735.701 M554.682,727.701 L554.682,743.701 " stroke="black"/>
+<path d="M690.446,599.937 L645.192,645.192 " stroke="black" stroke-width="3"/>
+<circle cx="690.446" cy="599.937" r="8" stroke="none" fill="black"/>
+<circle cx="645.192" cy="645.192" r="8" stroke="black" fill="white"/>
+<path d="M637.192,645.192 L653.192,645.192 M645.192,637.192 L645.192,653.192 " stroke="black"/>
+<path d="M780.956,690.446 L735.701,735.701 " stroke="black" stroke-width="3"/>
+<circle cx="780.956" cy="690.446" r="8" stroke="none" fill="black"/>
+<circle cx="735.701" cy="735.701" r="8" stroke="black" fill="white"/>
+<path d="M727.701,735.701 L743.701,735.701 M735.701,727.701 L735.701,743.701 " stroke="black"/>
+<path d="M1119.87,735.701 L1165.13,690.446 " stroke="black" stroke-width="3"/>
+<circle cx="1119.87" cy="735.701" r="8" stroke="none" fill="black"/>
+<circle cx="1165.13" cy="690.446" r="8" stroke="black" fill="white"/>
+<path d="M1157.13,690.446 L1173.13,690.446 M1165.13,682.446 L1165.13,698.446 " stroke="black"/>
+<path d="M1210.38,645.192 L1255.64,599.937 " stroke="black" stroke-width="3"/>
+<circle cx="1210.38" cy="645.192" r="8" stroke="none" fill="black"/>
+<circle cx="1255.64" cy="599.937" r="8" stroke="black" fill="white"/>
+<path d="M1247.64,599.937 L1263.64,599.937 M1255.64,591.937 L1255.64,607.937 " stroke="black"/>
+<path d="M1210.38,826.211 L1255.64,780.956 " stroke="black" stroke-width="3"/>
+<circle cx="1210.38" cy="826.211" r="8" stroke="none" fill="black"/>
+<circle cx="1255.64" cy="780.956" r="8" stroke="black" fill="white"/>
+<path d="M1247.64,780.956 L1263.64,780.956 M1255.64,772.956 L1255.64,788.956 " stroke="black"/>
+<path d="M1074.62,690.446 L1119.87,645.192 " stroke="black" stroke-width="3"/>
+<circle cx="1074.62" cy="690.446" r="8" stroke="none" fill="black"/>
+<circle cx="1119.87" cy="645.192" r="8" stroke="black" fill="white"/>
+<path d="M1111.87,645.192 L1127.87,645.192 M1119.87,637.192 L1119.87,653.192 " stroke="black"/>
+<path d="M1165.13,780.956 L1210.38,735.701 " stroke="black" stroke-width="3"/>
+<circle cx="1165.13" cy="780.956" r="8" stroke="none" fill="black"/>
+<circle cx="1210.38" cy="735.701" r="8" stroke="black" fill="white"/>
+<path d="M1202.38,735.701 L1218.38,735.701 M1210.38,727.701 L1210.38,743.701 " stroke="black"/>
+<path d="M1255.64,690.446 L1300.89,645.192 " stroke="black" stroke-width="3"/>
+<circle cx="1255.64" cy="690.446" r="8" stroke="none" fill="black"/>
+<circle cx="1300.89" cy="645.192" r="8" stroke="black" fill="white"/>
+<path d="M1292.89,645.192 L1308.89,645.192 M1300.89,637.192 L1300.89,653.192 " stroke="black"/>
+<path d="M1594.56,735.701 L1549.3,690.446 " stroke="black" stroke-width="3"/>
+<circle cx="1594.56" cy="735.701" r="8" stroke="none" fill="black"/>
+<circle cx="1549.3" cy="690.446" r="8" stroke="black" fill="white"/>
+<path d="M1541.3,690.446 L1557.3,690.446 M1549.3,682.446 L1549.3,698.446 " stroke="black"/>
+<path d="M1685.06,645.192 L1639.81,599.937 " stroke="black" stroke-width="3"/>
+<circle cx="1685.06" cy="645.192" r="8" stroke="none" fill="black"/>
+<circle cx="1639.81" cy="599.937" r="8" stroke="black" fill="white"/>
+<path d="M1631.81,599.937 L1647.81,599.937 M1639.81,591.937 L1639.81,607.937 " stroke="black"/>
+<path d="M1685.06,826.211 L1639.81,780.956 " stroke="black" stroke-width="3"/>
+<circle cx="1685.06" cy="826.211" r="8" stroke="none" fill="black"/>
+<circle cx="1639.81" cy="780.956" r="8" stroke="black" fill="white"/>
+<path d="M1631.81,780.956 L1647.81,780.956 M1639.81,772.956 L1639.81,788.956 " stroke="black"/>
+<path d="M1549.3,599.937 L1594.56,645.192 " stroke="black" stroke-width="3"/>
+<circle cx="1549.3" cy="599.937" r="8" stroke="none" fill="black"/>
+<circle cx="1594.56" cy="645.192" r="8" stroke="black" fill="white"/>
+<path d="M1586.56,645.192 L1602.56,645.192 M1594.56,637.192 L1594.56,653.192 " stroke="black"/>
+<path d="M1639.81,690.446 L1685.06,735.701 " stroke="black" stroke-width="3"/>
+<circle cx="1639.81" cy="690.446" r="8" stroke="none" fill="black"/>
+<circle cx="1685.06" cy="735.701" r="8" stroke="black" fill="white"/>
+<path d="M1677.06,735.701 L1693.06,735.701 M1685.06,727.701 L1685.06,743.701 " stroke="black"/>
+<path d="M1730.32,599.937 L1775.57,645.192 " stroke="black" stroke-width="3"/>
+<circle cx="1730.32" cy="599.937" r="8" stroke="none" fill="black"/>
+<circle cx="1775.57" cy="645.192" r="8" stroke="black" fill="white"/>
+<path d="M1767.57,645.192 L1783.57,645.192 M1775.57,637.192 L1775.57,653.192 " stroke="black"/>
+<rect x="154.51" y="1013.36" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="170.51" y="1029.36">H</text>
+<rect x="245.019" y="1103.87" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="261.019" y="1119.87">H</text>
+<rect x="154.51" y="1194.38" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="170.51" y="1210.38">H</text>
+<rect x="245.019" y="1284.89" width="32" height="32" stroke="black" fill="white"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="261.019" y="1300.89">H</text>
+<rect x="629.192" y="1013.36" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="645.192" y="1029.36" fill="white">MR</text>
+<rect x="629.192" y="1103.87" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="645.192" y="1119.87" fill="white">MR</text>
+<rect x="719.701" y="1103.87" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="735.701" y="1119.87" fill="white">MR</text>
+<rect x="810.211" y="1103.87" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="826.211" y="1119.87" fill="white">MR</text>
+<rect x="538.682" y="1194.38" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="554.682" y="1210.38" fill="white">MR</text>
+<rect x="629.192" y="1194.38" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="645.192" y="1210.38" fill="white">MR</text>
+<rect x="719.701" y="1194.38" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="735.701" y="1210.38" fill="white">MR</text>
+<rect x="719.701" y="1284.89" width="32" height="32" stroke="black" fill="black"/>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="735.701" y="1300.89" fill="white">MR</text>
+<rect x="0" y="0" width="431.529" height="431.529" stroke="black" fill="none"/>
+<rect x="0" y="474.682" width="431.529" height="431.529" stroke="black" fill="none"/>
+<rect x="0" y="949.364" width="431.529" height="431.529" stroke="black" fill="none"/>
+<rect x="474.682" y="0" width="431.529" height="431.529" stroke="black" fill="none"/>
+<rect x="474.682" y="474.682" width="431.529" height="431.529" stroke="black" fill="none"/>
+<rect x="474.682" y="949.364" width="431.529" height="431.529" stroke="black" fill="none"/>
+<rect x="949.364" y="0" width="431.529" height="431.529" stroke="black" fill="none"/>
+<rect x="949.364" y="474.682" width="431.529" height="431.529" stroke="black" fill="none"/>
+<rect x="949.364" y="949.364" width="431.529" height="431.529" stroke="black" fill="none"/>
+<rect x="1424.05" y="0" width="431.529" height="431.529" stroke="black" fill="none"/>
+<rect x="1424.05" y="474.682" width="431.529" height="431.529" stroke="black" fill="none"/>
+</svg>

--- a/testdata/tick.svg
+++ b/testdata/tick.svg
@@ -4,40 +4,40 @@
 <path d="M64,128 L992,128 " stroke="black"/>
 <text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="128">q1</text>
 <rect x="80" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="64">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="64">H</text>
 <rect x="144" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="160" y="64">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="160" y="64">H</text>
 <path d="M68,40 L68,32 L188,32 L188,40 " stroke="black" fill="none"/>
 <path d="M68,184 L68,192 L188,192 L188,184 " stroke="black" fill="none"/>
 <rect x="208" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="64">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="224" y="64">H</text>
 <rect x="208" y="112" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="128">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="224" y="128">H</text>
 <rect x="272" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="64">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="288" y="64">H</text>
 <path d="M360,32 L352,32 L352,192 L360,192 " stroke="black" fill="none"/>
 <text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="356" y="188">REP1</text>
 <rect x="400" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="64">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="416" y="64">H</text>
 <rect x="400" y="112" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="128">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="416" y="128">H</text>
 <rect x="464" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="480" y="64">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="480" y="64">H</text>
 <rect x="528" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="544" y="64">S</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="544" y="64">S</text>
 <path d="M452,40 L452,32 L572,32 L572,40 " stroke="black" fill="none"/>
 <path d="M452,184 L452,192 L572,192 L572,184 " stroke="black" fill="none"/>
 <path d="M600,32 L608,32 L608,192 L600,192 " stroke="black" fill="none"/>
 <rect x="656" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="672" y="64">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="672" y="64">H</text>
 <rect x="720" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="736" y="64">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="736" y="64">H</text>
 <rect x="784" y="48" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="800" y="64">√X</text>
 <path d="M644,40 L644,32 L828,32 L828,40 " stroke="black" fill="none"/>
 <path d="M644,184 L644,192 L828,192 L828,184 " stroke="black" fill="none"/>
 <rect x="848" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="864" y="64">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="864" y="64">H</text>
 <rect x="912" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="928" y="64">H</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="928" y="64">H</text>
 </svg>


### PR DESCRIPTION
- Add ability to specify tick ranges instead of a single tick
- Add ability to filter timeline-svg by tick
- Draw measurement operations in black fill
- Increase font size of single qubit gates in SVG drawings

![image](https://user-images.githubusercontent.com/79941/201464665-990fc516-9087-40ca-8fa3-3693b5bb0cf1.png)

Fixes https://github.com/quantumlib/Stim/issues/389