### PR TITLE
Remove 'u8' prefixes from strings

### DIFF
--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -152,7 +152,7 @@ pybind11::class_<Circuit> stim_pybind::pybind_circuit(pybind11::module &m) {
     auto c = pybind11::class_<Circuit>(
         m,
         "Circuit",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             A mutable stabilizer circuit.
 
             Examples:
@@ -228,7 +228,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
             return self;
         }),
         pybind11::arg("stim_program_text") = "",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Creates a stim.Circuit.
 
             Args:
@@ -249,7 +249,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
     c.def_property_readonly(
         "num_measurements",
         &Circuit::count_measurements,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Counts the number of bits produced when sampling the circuit's measurements.
 
             Examples:
@@ -268,7 +268,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
     c.def_property_readonly(
         "num_detectors",
         &Circuit::count_detectors,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Counts the number of bits produced when sampling the circuit's detectors.
 
             Examples:
@@ -290,7 +290,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
     c.def_property_readonly(
         "num_observables",
         &Circuit::count_observables,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Counts the number of logical observables defined by the circuit.
 
             This is one more than the largest index that appears as an argument to an
@@ -311,7 +311,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
     c.def_property_readonly(
         "num_qubits",
         &Circuit::count_qubits,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Counts the number of qubits used when simulating the circuit.
 
             This is always one more than the largest qubit index used by the circuit.
@@ -335,7 +335,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
     c.def_property_readonly(
         "num_sweep_bits",
         &Circuit::count_sweep_bits,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the number of sweep bits needed to completely configure the circuit.
 
             This is always one more than the largest sweep bit index used by the circuit.
@@ -360,7 +360,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
         pybind11::kw_only(),
         pybind11::arg("skip_reference_sample") = false,
         pybind11::arg("seed") = pybind11::none(),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns an object that can quickly batch sample measurements from the circuit.
 
             Args:
@@ -421,7 +421,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
         &py_init_compiled_measurements_to_detection_events_converter,
         pybind11::kw_only(),
         pybind11::arg("skip_reference_sample") = false,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Creates a measurement-to-detection-event converter for the given circuit.
 
             The converter uses a noiseless reference sample, collected from the circuit
@@ -465,7 +465,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
         &py_init_compiled_detector_sampler,
         pybind11::kw_only(),
         pybind11::arg("seed") = pybind11::none(),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns an object that can batch sample detection events from the circuit.
 
             Args:
@@ -511,7 +511,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
     c.def(
         "clear",
         &Circuit::clear,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Clears the contents of the circuit.
 
             Examples:
@@ -568,7 +568,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
             });
             return result;
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             [DEPRECATED]
 
             Returns a list of tuples encoding the contents of the circuit.
@@ -600,7 +600,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
         "__add__",
         &Circuit::operator+,
         pybind11::arg("second"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Creates a circuit by appending two circuits.
 
             Examples:
@@ -625,7 +625,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
         "__iadd__",
         &Circuit::operator+=,
         pybind11::arg("second"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Appends a circuit into the receiving circuit (mutating it).
 
             Examples:
@@ -651,7 +651,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
         "__imul__",
         &Circuit::operator*=,
         pybind11::arg("repetitions"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Mutates the circuit by putting its contents into a REPEAT block.
 
             Special case: if the repetition count is 0, the circuit is cleared.
@@ -681,7 +681,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
         "__mul__",
         &Circuit::operator*,
         pybind11::arg("repetitions"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Repeats the circuit using a REPEAT block.
 
             Has special cases for 0 repetitions and 1 repetitions.
@@ -715,7 +715,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
         "__rmul__",
         &Circuit::operator*,
         pybind11::arg("repetitions"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Repeats the circuit using a REPEAT block.
 
             Has special cases for 0 repetitions and 1 repetitions.
@@ -753,7 +753,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
             pybind11::arg("targets") = pybind11::make_tuple(),
             pybind11::arg("arg") = pybind11::none(),
             k == 0 ? "[DEPRECATED] use stim.Circuit.append instead"
-                   : clean_doc_string(u8R"DOC(
+                   : clean_doc_string(R"DOC(
                 Appends an operation into the circuit.
                 @overload def append(self, name: str, targets: Union[int, stim.GateTarget, Iterable[Union[int, stim.GateTarget]]], arg: Union[float, Iterable[float]]) -> None:
                 @overload def append(self, name: Union[stim.CircuitOperation, stim.CircuitRepeatBlock]) -> None:
@@ -815,7 +815,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
             self.append_from_text(text);
         },
         pybind11::arg("stim_program_text"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Appends operations described by a STIM format program into the circuit.
 
             Examples:
@@ -855,7 +855,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
             Circuit copy = self;
             return copy;
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a copy of the circuit. An independent circuit with the same contents.
 
             Examples:
@@ -917,7 +917,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
         pybind11::arg("before_round_data_depolarization") = 0.0,
         pybind11::arg("before_measure_flip_probability") = 0.0,
         pybind11::arg("after_reset_flip_probability") = 0.0,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Generates common circuits.
 
             The generated circuits can include configurable noise.
@@ -1035,7 +1035,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
                 "Don't know how to read from " + pybind11::cast<std::string>(pybind11::str(obj)));
         },
         pybind11::arg("file"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def from_file(file: Union[io.TextIOBase, str, pathlib.Path]) -> stim.Circuit:
             Reads a stim circuit from a file.
 
@@ -1111,7 +1111,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
                 "Don't know how to write to " + pybind11::cast<std::string>(pybind11::str(obj)));
         },
         pybind11::arg("file"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def to_file(self, file: Union[io.TextIOBase, str, pathlib.Path]) -> None:
             Writes the stim circuit to a file.
 
@@ -1150,7 +1150,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
         [](const Circuit &self) {
             return self.operations.size();
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the number of top-level instructions and blocks in the circuit.
 
             Instructions inside of blocks are not included in this count.
@@ -1201,7 +1201,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
             return pybind11::cast(CircuitInstruction(*op.gate, targets, args));
         },
         pybind11::arg("index_or_slice"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns copies of instructions from the circuit.
             @overload def __getitem__(self, index_or_slice: int) -> Union[stim.CircuitInstruction, stim.CircuitRepeatBlock]:
             @overload def __getitem__(self, index_or_slice: slice) -> stim.Circuit:
@@ -1269,7 +1269,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
         pybind11::arg("approximate_disjoint_errors") = false,
         pybind11::arg("ignore_decomposition_failures") = false,
         pybind11::arg("block_decomposition_from_introducing_remnant_edges") = false,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a stim.DetectorErrorModel describing the error processes in the circuit.
 
             Args:
@@ -1369,7 +1369,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
         pybind11::arg("other"),
         pybind11::kw_only(),
         pybind11::arg("atol"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Checks if a circuit is approximately equal to another circuit.
 
             Two circuits are approximately equal if they are equal up to slight
@@ -1431,7 +1431,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
             }));
         },
         pybind11::arg("only") = pybind11::none(),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the coordinate metadata of detectors in the circuit.
 
             Args:
@@ -1467,7 +1467,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
     c.def(
         "get_final_qubit_coordinates",
         &Circuit::get_final_qubit_coords,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the coordinate metadata of qubits in the circuit.
 
             If a qubit's coordinates are specified multiple times, only the last specified
@@ -1502,7 +1502,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
         pybind11::kw_only(),
         pybind11::arg("ignore_ungraphlike_errors") = true,
         pybind11::arg("canonicalize_circuit_errors") = false,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Finds a minimum set of graphlike errors to produce an undetected logical error.
 
             A "graphlike error" is an error that creates at most two detection events
@@ -1577,7 +1577,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
         pybind11::arg("dont_explore_edges_with_degree_above"),
         pybind11::arg("dont_explore_edges_increasing_symptom_degree"),
         pybind11::arg("canonicalize_circuit_errors") = false,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Searches for small sets of errors that form an undetectable logical error.
 
             THIS IS A HEURISTIC METHOD. It does not guarantee that it will find errors of
@@ -1679,7 +1679,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
         pybind11::kw_only(),
         pybind11::arg("dem_filter") = pybind11::none(),
         pybind11::arg("reduce_to_one_representative_error") = false,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Explains how detector error model errors are produced by circuit errors.
 
             Args:
@@ -1735,7 +1735,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
     c.def(
         "without_noise",
         &Circuit::without_noise,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a copy of the circuit with all noise processes removed.
 
             Pure noise instructions, such as X_ERROR and DEPOLARIZE2, are not
@@ -1765,7 +1765,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
     c.def(
         "flattened",
         &Circuit::flattened,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Creates an equivalent circuit without REPEAT or SHIFT_COORDS.
 
             Returns:
@@ -1806,7 +1806,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
     c.def(
         "with_inlined_feedback",
         &circuit_with_inlined_feedback,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a circuit without feedback with rewritten detectors/observables.
 
             When a feedback operation affects the expected parity of a detector or
@@ -1863,7 +1863,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
     c.def(
         "inverse",
         &Circuit::inverse,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a circuit that applies the same operations but inverted and in reverse.
 
             If circuit starts with QUBIT_COORDS instructions, the returned circuit will
@@ -1921,7 +1921,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
         pybind11::kw_only(),
         pybind11::arg("tick") = pybind11::none(),
         pybind11::arg("filter_coords") = pybind11::none(),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @overload def diagram(self, *, type: 'Literal["timeline-text"]') -> 'stim._DiagramHelper':
             @overload def diagram(self, *, type: 'Literal["timeline-svg"]', tick: Union[None, int, range] = None) -> 'stim._DiagramHelper':
             @overload def diagram(self, *, type: 'Literal["timeline-3d"]') -> 'stim._DiagramHelper':

--- a/src/stim/circuit/circuit_gate_target.pybind.cc
+++ b/src/stim/circuit/circuit_gate_target.pybind.cc
@@ -41,7 +41,7 @@ pybind11::class_<stim::GateTarget> stim_pybind::pybind_circuit_gate_target(pybin
     return pybind11::class_<GateTarget>(
         m,
         "GateTarget",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Represents a gate target, like `0` or `rec[-1]`, from a circuit.
 
             Examples:
@@ -61,7 +61,7 @@ void stim_pybind::pybind_circuit_gate_target_methods(pybind11::module &m, pybind
     c.def(
         pybind11::init(&obj_to_gate_target),
         pybind11::arg("value"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Initializes a `stim.GateTarget`.
 
             Args:
@@ -72,7 +72,7 @@ void stim_pybind::pybind_circuit_gate_target_methods(pybind11::module &m, pybind
     c.def_property_readonly(
         "value",
         &GateTarget::value,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             The numeric part of the target.
 
             This is non-negative integer for qubit targets, and a negative integer for
@@ -83,7 +83,7 @@ void stim_pybind::pybind_circuit_gate_target_methods(pybind11::module &m, pybind
     c.def_property_readonly(
         "is_qubit_target",
         &GateTarget::is_qubit_target,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns whether or not this is a (possibly inverted) qubit target.
 
             For example, `5` on its own in a stim circuit is a raw qubit target.
@@ -93,7 +93,7 @@ void stim_pybind::pybind_circuit_gate_target_methods(pybind11::module &m, pybind
     c.def_property_readonly(
         "is_x_target",
         &GateTarget::is_x_target,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns whether or not this is a (possibly inverted) X pauli target.
 
             For example, `X5` in a stim circuit is a X Pauli target. The value returned by
@@ -104,7 +104,7 @@ void stim_pybind::pybind_circuit_gate_target_methods(pybind11::module &m, pybind
     c.def_property_readonly(
         "is_y_target",
         &GateTarget::is_y_target,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns whether or not this is a (possibly inverted) Y pauli target.
 
             For example, `Y5` in a stim circuit is a Y Pauli target. The value returned by
@@ -115,7 +115,7 @@ void stim_pybind::pybind_circuit_gate_target_methods(pybind11::module &m, pybind
     c.def_property_readonly(
         "is_z_target",
         &GateTarget::is_z_target,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns whether or not this is a (possibly inverted) Z pauli target.
 
             For example, `Z5` in a stim circuit is a Z Pauli target. The value returned by
@@ -126,7 +126,7 @@ void stim_pybind::pybind_circuit_gate_target_methods(pybind11::module &m, pybind
     c.def_property_readonly(
         "is_inverted_result_target",
         &GateTarget::is_inverted_result_target,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns whether or not this is an inverted target.
 
             Inverted targets include inverted qubit targets `stim.target_inv(5)`
@@ -138,7 +138,7 @@ void stim_pybind::pybind_circuit_gate_target_methods(pybind11::module &m, pybind
     c.def_property_readonly(
         "is_measurement_record_target",
         &GateTarget::is_measurement_record_target,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns whether or not this is a measurement record target.
 
             The value returned by `stim.target_rec(-5)`, which would be `rec[-5]` in a
@@ -149,7 +149,7 @@ void stim_pybind::pybind_circuit_gate_target_methods(pybind11::module &m, pybind
     c.def_property_readonly(
         "is_combiner",
         &GateTarget::is_combiner,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns whether or not this is a `stim.target_combiner()`.
         )DOC")
             .data());
@@ -157,7 +157,7 @@ void stim_pybind::pybind_circuit_gate_target_methods(pybind11::module &m, pybind
     c.def_property_readonly(
         "is_sweep_bit_target",
         &GateTarget::is_sweep_bit_target,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns whether or not this is a sweep bit target.
 
             For example, `sweep[5]` in a circuit file is a sweep target, and the value

--- a/src/stim/circuit/circuit_instruction.pybind.cc
+++ b/src/stim/circuit/circuit_instruction.pybind.cc
@@ -84,7 +84,7 @@ pybind11::class_<CircuitInstruction> stim_pybind::pybind_circuit_instruction(pyb
     return pybind11::class_<CircuitInstruction>(
         m,
         "CircuitInstruction",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             An instruction, like `H 0 1` or `CNOT rec[-1] 5`, from a circuit.
 
             Examples:
@@ -109,7 +109,7 @@ void stim_pybind::pybind_circuit_instruction_methods(pybind11::module &m, pybind
         pybind11::arg("name"),
         pybind11::arg("targets"),
         pybind11::arg("gate_args") = std::make_tuple(),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Initializes a `stim.CircuitInstruction`.
 
             Args:
@@ -126,7 +126,7 @@ void stim_pybind::pybind_circuit_instruction_methods(pybind11::module &m, pybind
     c.def_property_readonly(
         "name",
         &CircuitInstruction::name,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             The name of the instruction (e.g. `H` or `X_ERROR` or `DETECTOR`).
         )DOC")
             .data());
@@ -134,7 +134,7 @@ void stim_pybind::pybind_circuit_instruction_methods(pybind11::module &m, pybind
     c.def(
         "targets_copy",
         &CircuitInstruction::targets_copy,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a copy of the targets of the instruction.
         )DOC")
             .data());
@@ -142,7 +142,7 @@ void stim_pybind::pybind_circuit_instruction_methods(pybind11::module &m, pybind
     c.def(
         "gate_args_copy",
         &CircuitInstruction::gate_args_copy,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the gate's arguments (numbers parameterizing the instruction).
 
             For noisy gates this typically a list of probabilities.

--- a/src/stim/circuit/circuit_repeat_block.pybind.cc
+++ b/src/stim/circuit/circuit_repeat_block.pybind.cc
@@ -46,7 +46,7 @@ pybind11::class_<CircuitRepeatBlock> stim_pybind::pybind_circuit_repeat_block(py
     return pybind11::class_<CircuitRepeatBlock>(
         m,
         "CircuitRepeatBlock",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             A REPEAT block from a circuit.
 
             Examples:
@@ -75,7 +75,7 @@ void stim_pybind::pybind_circuit_repeat_block_methods(pybind11::module &m, pybin
         pybind11::init<uint64_t, Circuit>(),
         pybind11::arg("repeat_count"),
         pybind11::arg("body"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Initializes a `stim.CircuitRepeatBlock`.
 
             Args:
@@ -87,7 +87,7 @@ void stim_pybind::pybind_circuit_repeat_block_methods(pybind11::module &m, pybin
     c.def_readonly(
         "repeat_count",
         &CircuitRepeatBlock::repeat_count,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             The repetition count of the repeat block.
 
             Examples:
@@ -108,7 +108,7 @@ void stim_pybind::pybind_circuit_repeat_block_methods(pybind11::module &m, pybin
     c.def(
         "body_copy",
         &CircuitRepeatBlock::body_copy,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a copy of the body of the repeat block.
 
             (Making a copy is enforced to make it clear that editing the result won't change

--- a/src/stim/cmd/command_diagram.pybind.cc
+++ b/src/stim/cmd/command_diagram.pybind.cc
@@ -32,7 +32,7 @@ pybind11::class_<DiagramHelper> stim_pybind::pybind_diagram(pybind11::module &m)
     auto c = pybind11::class_<DiagramHelper>(
         m,
         "_DiagramHelper",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             A helper class for displaying diagrams in IPython notebooks.
 
             To write the diagram's contents to a file (for example, to write an

--- a/src/stim/dem/detector_error_model.pybind.cc
+++ b/src/stim/dem/detector_error_model.pybind.cc
@@ -75,7 +75,7 @@ pybind11::class_<stim::DetectorErrorModel> stim_pybind::pybind_detector_error_mo
     auto c = pybind11::class_<DetectorErrorModel>(
         m,
         "DetectorErrorModel",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             An error model built out of independent error mechanics.
 
             Error mechanisms are described in terms of the visible detection events and the
@@ -124,7 +124,7 @@ void stim_pybind::pybind_detector_error_model_methods(
             return self;
         }),
         pybind11::arg("detector_error_model_text") = "",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Creates a stim.DetectorErrorModel.
 
             Args:
@@ -143,7 +143,7 @@ void stim_pybind::pybind_detector_error_model_methods(
     c.def_property_readonly(
         "num_detectors",
         &DetectorErrorModel::count_detectors,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Counts the number of detectors (e.g. `D2`) in the error model.
 
             Detector indices are assumed to be contiguous from 0 up to whatever the maximum
@@ -179,7 +179,7 @@ void stim_pybind::pybind_detector_error_model_methods(
     c.def_property_readonly(
         "num_errors",
         &DetectorErrorModel::count_errors,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Counts the number of errors (e.g. `error(0.1) D0`) in the error model.
 
             Error instructions inside repeat blocks count once per repetition.
@@ -203,7 +203,7 @@ void stim_pybind::pybind_detector_error_model_methods(
     c.def_property_readonly(
         "num_observables",
         &DetectorErrorModel::count_observables,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Counts the number of frame changes (e.g. `L2`) in the error model.
 
             Observable indices are assumed to be contiguous from 0 up to whatever the
@@ -230,7 +230,7 @@ void stim_pybind::pybind_detector_error_model_methods(
     c.def(
         "clear",
         &DetectorErrorModel::clear,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Clears the contents of the detector error model.
 
             Examples:
@@ -250,14 +250,14 @@ void stim_pybind::pybind_detector_error_model_methods(
     c.def(
         "__str__",
         &DetectorErrorModel::str,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the contents of a detector error model file (.dem) encoding the model.
         )DOC")
             .data());
     c.def(
         "__repr__",
         &detector_error_model_repr,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns valid python code evaluating to an equivalent `stim.DetectorErrorModel`.
         )DOC")
             .data());
@@ -267,7 +267,7 @@ void stim_pybind::pybind_detector_error_model_methods(
         [](DetectorErrorModel &self) -> DetectorErrorModel {
             return self;
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a copy of the detector error model.
 
             The copy is an independent detector error model with the same contents.
@@ -289,7 +289,7 @@ void stim_pybind::pybind_detector_error_model_methods(
         [](const DetectorErrorModel &self) -> size_t {
             return self.instructions.size();
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the number of top-level instructions/blocks in the detector error model.
 
             Instructions inside of blocks are not included in this count.
@@ -334,7 +334,7 @@ void stim_pybind::pybind_detector_error_model_methods(
             return pybind11::cast(result);
         },
         pybind11::arg("index_or_slice"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns copies of instructions from the detector error model.
             @overload def __getitem__(self, index_or_slice: int) -> Union[stim.DemInstruction, stim.DemRepeatBlock]:
             @overload def __getitem__(self, index_or_slice: slice) -> stim.DetectorErrorModel:
@@ -385,7 +385,7 @@ void stim_pybind::pybind_detector_error_model_methods(
         pybind11::arg("other"),
         pybind11::kw_only(),
         pybind11::arg("atol"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Checks if detector error models are approximately equal.
 
             Two detector error model are approximately equal if they are equal up to slight
@@ -490,7 +490,7 @@ void stim_pybind::pybind_detector_error_model_methods(
         pybind11::arg("instruction"),
         pybind11::arg("parens_arguments") = pybind11::none(),
         pybind11::arg("targets") = pybind11::make_tuple(),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Appends an instruction to the detector error model.
 
             Args:
@@ -556,7 +556,7 @@ void stim_pybind::pybind_detector_error_model_methods(
         "__imul__",
         &DetectorErrorModel::operator*=,
         pybind11::arg("repetitions"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Mutates the detector error model by putting its contents into a repeat block.
 
             Special case: if the repetition count is 0, the model is cleared.
@@ -588,7 +588,7 @@ void stim_pybind::pybind_detector_error_model_methods(
             }));
         },
         pybind11::arg("only") = pybind11::none(),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the coordinate metadata of detectors in the detector error model.
 
             Args:
@@ -620,7 +620,7 @@ void stim_pybind::pybind_detector_error_model_methods(
         "__add__",
         &DetectorErrorModel::operator+,
         pybind11::arg("second"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Creates a detector error model by appending two models.
 
             Examples:
@@ -643,7 +643,7 @@ void stim_pybind::pybind_detector_error_model_methods(
         "__iadd__",
         &DetectorErrorModel::operator+=,
         pybind11::arg("second"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Appends a detector error model into the receiving model (mutating it).
 
             Examples:
@@ -667,7 +667,7 @@ void stim_pybind::pybind_detector_error_model_methods(
         "__mul__",
         &DetectorErrorModel::operator*,
         pybind11::arg("repetitions"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Repeats the detector error model using a repeat block.
 
             Has special cases for 0 repetitions and 1 repetitions.
@@ -701,7 +701,7 @@ void stim_pybind::pybind_detector_error_model_methods(
         "__rmul__",
         &DetectorErrorModel::operator*,
         pybind11::arg("repetitions"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Repeats the detector error model using a repeat block.
 
             Has special cases for 0 repetitions and 1 repetitions.
@@ -743,7 +743,7 @@ void stim_pybind::pybind_detector_error_model_methods(
         "shortest_graphlike_error",
         &shortest_graphlike_undetectable_logical_error,
         pybind11::arg("ignore_ungraphlike_errors") = true,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Finds a minimum set of graphlike errors to produce an undetected logical error.
 
             Note that this method does not pay attention to error probabilities (other than
@@ -858,7 +858,7 @@ void stim_pybind::pybind_detector_error_model_methods(
                 "Don't know how to read from " + pybind11::cast<std::string>(pybind11::str(obj)));
         },
         pybind11::arg("file"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def from_file(file: Union[io.TextIOBase, str, pathlib.Path]) -> stim.DetectorErrorModel:
             Reads a detector error model from a file.
 
@@ -934,7 +934,7 @@ void stim_pybind::pybind_detector_error_model_methods(
                 "Don't know how to write to " + pybind11::cast<std::string>(pybind11::str(obj)));
         },
         pybind11::arg("file"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def to_file(self, file: Union[io.TextIOBase, str, pathlib.Path]) -> None:
             Writes the detector error model to a file.
 
@@ -975,7 +975,7 @@ void stim_pybind::pybind_detector_error_model_methods(
         },
         pybind11::kw_only(),
         pybind11::arg("seed") = pybind11::none(),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a CompiledDemSampler that can batch sample from detector error models.
 
             Args:
@@ -1038,7 +1038,7 @@ void stim_pybind::pybind_detector_error_model_methods(
     c.def(
         "flattened",
         &DetectorErrorModel::flattened,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the detector error model without repeat or detector_shift instructions.
 
             Returns:
@@ -1071,7 +1071,7 @@ void stim_pybind::pybind_detector_error_model_methods(
     c.def(
         "rounded",
         &DetectorErrorModel::rounded,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Creates an equivalent detector error model but with rounded error probabilities.
 
             Args:
@@ -1110,7 +1110,7 @@ void stim_pybind::pybind_detector_error_model_methods(
         "diagram",
         &dem_diagram,
         pybind11::arg("type"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @overload def diagram(self, type: 'Literal["match-graph-svg"]') -> 'stim._DiagramHelper':
             @overload def diagram(self, type: 'Literal["match-graph-3d"]') -> 'stim._DiagramHelper':
             @overload def diagram(self, type: 'Literal["match-graph-3d-html"]') -> 'stim._DiagramHelper':

--- a/src/stim/dem/detector_error_model_instruction.pybind.cc
+++ b/src/stim/dem/detector_error_model_instruction.pybind.cc
@@ -88,7 +88,7 @@ pybind11::class_<ExposedDemInstruction> stim_pybind::pybind_detector_error_model
     return pybind11::class_<ExposedDemInstruction>(
         m,
         "DemInstruction",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             An instruction from a detector error model.
 
             Examples:
@@ -158,7 +158,7 @@ void stim_pybind::pybind_detector_error_model_instruction_methods(
         pybind11::arg("type"),
         pybind11::arg("args"),
         pybind11::arg("targets"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Creates a stim.DemInstruction.
 
             Args:
@@ -186,7 +186,7 @@ void stim_pybind::pybind_detector_error_model_instruction_methods(
     c.def(
         "targets_copy",
         &ExposedDemInstruction::targets_copy,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def targets_copy(self) -> List[Union[int, stim.DemTarget]]:
             Returns a copy of the instruction's targets.
 
@@ -197,7 +197,7 @@ void stim_pybind::pybind_detector_error_model_instruction_methods(
     c.def_property_readonly(
         "type",
         &ExposedDemInstruction::type_name,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             The name of the instruction type (e.g. "error" or "shift_detectors").
         )DOC")
             .data());

--- a/src/stim/dem/detector_error_model_repeat_block.pybind.cc
+++ b/src/stim/dem/detector_error_model_repeat_block.pybind.cc
@@ -25,7 +25,7 @@ pybind11::class_<ExposedDemRepeatBlock> stim_pybind::pybind_detector_error_model
     return pybind11::class_<ExposedDemRepeatBlock>(
         m,
         "DemRepeatBlock",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             A repeat block from a detector error model.
 
             Examples:
@@ -51,7 +51,7 @@ void stim_pybind::pybind_detector_error_model_repeat_block_methods(
         pybind11::init<uint64_t, DetectorErrorModel>(),
         pybind11::arg("repeat_count"),
         pybind11::arg("block"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Creates a stim.DemRepeatBlock.
 
             Args:
@@ -76,7 +76,7 @@ void stim_pybind::pybind_detector_error_model_repeat_block_methods(
     c.def(
         "body_copy",
         &ExposedDemRepeatBlock::body_copy,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a copy of the block's body, as a stim.DetectorErrorModel.
         )DOC")
             .data());

--- a/src/stim/dem/detector_error_model_target.pybind.cc
+++ b/src/stim/dem/detector_error_model_target.pybind.cc
@@ -31,7 +31,7 @@ void stim_pybind::pybind_detector_error_model_target_methods(
         "target_relative_detector_id",
         &ExposedDemTarget::relative_detector_id,
         pybind11::arg("index"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a relative detector id (e.g. "D5" in a .dem file).
 
             Args:
@@ -56,7 +56,7 @@ void stim_pybind::pybind_detector_error_model_target_methods(
         "target_logical_observable_id",
         &ExposedDemTarget::observable_id,
         pybind11::arg("index"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a logical observable id identifying a frame change.
 
             Args:
@@ -81,7 +81,7 @@ void stim_pybind::pybind_detector_error_model_target_methods(
     m.def(
         "target_separator",
         &ExposedDemTarget::separator,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a target separator (e.g. "^" in a .dem file).
 
             Examples:
@@ -106,7 +106,7 @@ void stim_pybind::pybind_detector_error_model_target_methods(
         "relative_detector_id",
         &ExposedDemTarget::relative_detector_id,
         pybind11::arg("index"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a relative detector id (e.g. "D5" in a .dem file).
 
             Args:
@@ -132,7 +132,7 @@ void stim_pybind::pybind_detector_error_model_target_methods(
         "logical_observable_id",
         &ExposedDemTarget::observable_id,
         pybind11::arg("index"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a logical observable id identifying a frame change.
 
             Args:
@@ -157,7 +157,7 @@ void stim_pybind::pybind_detector_error_model_target_methods(
     c.def_static(
         "separator",
         &ExposedDemTarget::separator,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a target separator (e.g. "^" in a .dem file).
 
             Examples:
@@ -183,7 +183,7 @@ void stim_pybind::pybind_detector_error_model_target_methods(
     c.def(
         "is_relative_detector_id",
         &ExposedDemTarget::is_relative_detector_id,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Determines if the detector error model target is a relative detector id target.
 
             In a detector error model file, detectors are prefixed by `D`. For
@@ -194,7 +194,7 @@ void stim_pybind::pybind_detector_error_model_target_methods(
     c.def(
         "is_logical_observable_id",
         &ExposedDemTarget::is_observable_id,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Determines if the detector error model target is a logical observable id target.
 
             In a detector error model file, observable targets are prefixed by `L`. For
@@ -205,7 +205,7 @@ void stim_pybind::pybind_detector_error_model_target_methods(
     c.def_property_readonly(
         "val",
         &ExposedDemTarget::val,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the target's integer value.
 
             Example:
@@ -221,7 +221,7 @@ void stim_pybind::pybind_detector_error_model_target_methods(
     c.def(
         "is_separator",
         &ExposedDemTarget::is_separator,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Determines if the detector error model target is a separator.
 
             Separates separate the components of a suggested decompositions within an error.

--- a/src/stim/diagram/gate_data_svg.cc
+++ b/src/stim/diagram/gate_data_svg.cc
@@ -13,13 +13,13 @@ std::map<std::string, SvgGateData> SvgGateData::make_gate_data_map() {
     result.insert({"H", {1, "H", "", "", "white", "black"}});
     result.insert({"H_XY", {1, "H", "XY", "", "white", "black"}});
 
-    result.insert({"SQRT_X", {1, u8"√X", "", "", "white", "black"}});
-    result.insert({"SQRT_Y", {1, u8"√Y", "", "", "white", "black"}});
+    result.insert({"SQRT_X", {1, "√X", "", "", "white", "black"}});
+    result.insert({"SQRT_Y", {1, "√Y", "", "", "white", "black"}});
     result.insert({"S", {1, "S", "", "", "white", "black"}});
 
-    result.insert({"SQRT_X_DAG", {1, u8"√X", "", u8"†", "white", "black"}});
-    result.insert({"SQRT_Y_DAG", {1, u8"√Y", "", u8"†", "white", "black"}});
-    result.insert({"S_DAG", {1, "S", "", u8"†", "white", "black"}});
+    result.insert({"SQRT_X_DAG", {1, "√X", "", "†", "white", "black"}});
+    result.insert({"SQRT_Y_DAG", {1, "√Y", "", "†", "white", "black"}});
+    result.insert({"S_DAG", {1, "S", "", "†", "white", "black"}});
 
     result.insert({"MX", {1, "M", "X", "", "black", "white"}});
     result.insert({"MY", {1, "M", "Y", "", "black", "white"}});
@@ -49,13 +49,13 @@ std::map<std::string, SvgGateData> SvgGateData::make_gate_data_map() {
     result.insert({"MPP[Y]", {1, "MPP", "Y", "", "black", "white"}});
     result.insert({"MPP[Z]", {1, "MPP", "Z", "", "black", "white"}});
 
-    result.insert({"SQRT_XX", {1, u8"√XX", "", "", "white", "black"}});
-    result.insert({"SQRT_YY", {1, u8"√YY", "", "", "white", "black"}});
-    result.insert({"SQRT_ZZ", {1, u8"√ZZ", "", "", "white", "black"}});
+    result.insert({"SQRT_XX", {1, "√XX", "", "", "white", "black"}});
+    result.insert({"SQRT_YY", {1, "√YY", "", "", "white", "black"}});
+    result.insert({"SQRT_ZZ", {1, "√ZZ", "", "", "white", "black"}});
 
-    result.insert({"SQRT_XX_DAG", {1, u8"√XX", "", u8"†", "white", "black"}});
-    result.insert({"SQRT_YY_DAG", {1, u8"√YY", "", u8"†", "white", "black"}});
-    result.insert({"SQRT_ZZ_DAG", {1, u8"√ZZ", "", u8"†", "white", "black"}});
+    result.insert({"SQRT_XX_DAG", {1, "√XX", "", "†", "white", "black"}});
+    result.insert({"SQRT_YY_DAG", {1, "√YY", "", "†", "white", "black"}});
+    result.insert({"SQRT_ZZ_DAG", {1, "√ZZ", "", "†", "white", "black"}});
 
     result.insert({"I", {1, "I", "", "", "white", "black"}});
     result.insert({"C_XYZ", {1, "C", "XYZ", "", "white", "black"}});

--- a/src/stim/io/read_write.pybind.cc
+++ b/src/stim/io/read_write.pybind.cc
@@ -162,7 +162,7 @@ void stim_pybind::pybind_read_write(pybind11::module &m) {
         pybind11::arg("num_observables") = pybind11::none(),
         pybind11::arg("bit_packed") = false,
         pybind11::arg("bit_pack") = false,  // Legacy argument for backwards compat.
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Reads shot data, such as measurement samples, from a file.
             @signature def read_shot_data_file(*, path: Union[str, pathlib.Path], format: Union[str, 'Literal["01", "b8", "r8", "ptb64", "hits", "dets"]'], bit_packed: bool = False, num_measurements: int = 0, num_detectors: int = 0, num_observables: int = 0) -> np.ndarray:
 
@@ -222,7 +222,7 @@ void stim_pybind::pybind_read_write(pybind11::module &m) {
         pybind11::arg("num_measurements") = pybind11::none(),
         pybind11::arg("num_detectors") = pybind11::none(),
         pybind11::arg("num_observables") = pybind11::none(),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Writes shot data, such as measurement samples, to a file.
             @signature def write_shot_data_file(*, data: np.ndarray, path: Union[str, pathlib.Path], format: str, num_measurements: int = 0, num_detectors: int = 0, num_observables: int = 0) -> None:
 

--- a/src/stim/py/compiled_detector_sampler.pybind.cc
+++ b/src/stim/py/compiled_detector_sampler.pybind.cc
@@ -113,7 +113,7 @@ void stim_pybind::pybind_compiled_detector_sampler_methods(
         pybind11::arg("circuit"),
         pybind11::kw_only(),
         pybind11::arg("seed") = pybind11::none(),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Creates an object that can sample the detection events from a circuit.
 
             Args:
@@ -177,7 +177,7 @@ void stim_pybind::pybind_compiled_detector_sampler_methods(
         pybind11::arg("append_observables") = false,
         pybind11::arg("separate_observables") = false,
         pybind11::arg("bit_packed") = false,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a numpy array containing a batch of detector samples from the circuit.
             @overload def sample(self, shots: int, *, prepend_observables: bool = False, append_observables: bool = False, bit_packed: bool = False) -> np.ndarray:
             @overload def sample(self, shots: int, *, separate_observables: Literal[True], bit_packed: bool = False) -> Tuple[np.ndarray, np.ndarray]:
@@ -257,7 +257,7 @@ void stim_pybind::pybind_compiled_detector_sampler_methods(
         pybind11::kw_only(),
         pybind11::arg("prepend_observables") = false,
         pybind11::arg("append_observables") = false,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             [DEPRECATED] Use sampler.sample(..., bit_packed=True) instead.
 
             Returns a numpy array containing bit packed detector samples from the circuit.
@@ -292,7 +292,7 @@ void stim_pybind::pybind_compiled_detector_sampler_methods(
         pybind11::arg("append_observables") = false,
         pybind11::arg("obs_out_filepath") = nullptr,
         pybind11::arg("obs_out_format") = "01",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Samples detection events from the circuit and writes them to a file.
 
             Args:

--- a/src/stim/py/compiled_measurement_sampler.pybind.cc
+++ b/src/stim/py/compiled_measurement_sampler.pybind.cc
@@ -81,7 +81,7 @@ void stim_pybind::pybind_compiled_measurement_sampler_methods(
         pybind11::kw_only(),
         pybind11::arg("skip_reference_sample") = false,
         pybind11::arg("seed") = pybind11::none(),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Creates a measurement sampler for the given circuit.
 
             The sampler uses a noiseless reference sample, collected from the circuit using
@@ -153,7 +153,7 @@ void stim_pybind::pybind_compiled_measurement_sampler_methods(
         pybind11::arg("shots"),
         pybind11::kw_only(),
         pybind11::arg("bit_packed") = false,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Samples a batch of measurement samples from the circuit.
 
             Args:
@@ -193,7 +193,7 @@ void stim_pybind::pybind_compiled_measurement_sampler_methods(
             return self.sample_to_numpy(shots, true);
         },
         pybind11::arg("shots"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             [DEPRECATED] Use sampler.sample(..., bit_packed=True) instead.
 
             Samples a bit packed batch of measurement samples from the circuit.
@@ -227,7 +227,7 @@ void stim_pybind::pybind_compiled_measurement_sampler_methods(
         pybind11::kw_only(),
         pybind11::arg("filepath"),
         pybind11::arg("format") = "01",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Samples measurements from the circuit and writes them to a file.
 
             Examples:

--- a/src/stim/py/stim.pybind.cc
+++ b/src/stim/py/stim.pybind.cc
@@ -130,7 +130,7 @@ void top_level(pybind11::module &m) {
         "target_rec",
         &target_rec,
         pybind11::arg("lookback_index"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a measurement record target with the given lookback.
 
             Measurement record targets are used to refer back to the measurement record;
@@ -161,7 +161,7 @@ void top_level(pybind11::module &m) {
         "target_inv",
         &target_inv,
         pybind11::arg("qubit_index"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a target flagged as inverted.
 
             Inverted targets are used to indicate measurement results should be flipped.
@@ -186,7 +186,7 @@ void top_level(pybind11::module &m) {
     m.def(
         "target_combiner",
         &GateTarget::combiner,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a target combiner that can be used to build Pauli products.
 
             Examples:
@@ -211,7 +211,7 @@ void top_level(pybind11::module &m) {
         &target_x,
         pybind11::arg("qubit_index"),
         pybind11::arg("invert") = false,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a Pauli X target that can be passed into `stim.Circuit.append`.
 
             Args:
@@ -241,7 +241,7 @@ void top_level(pybind11::module &m) {
         &target_y,
         pybind11::arg("qubit_index"),
         pybind11::arg("invert") = false,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a Pauli Y target that can be passed into `stim.Circuit.append`.
 
             Args:
@@ -271,7 +271,7 @@ void top_level(pybind11::module &m) {
         &target_z,
         pybind11::arg("qubit_index"),
         pybind11::arg("invert") = false,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a Pauli Z target that can be passed into `stim.Circuit.append`.
 
             Args:
@@ -300,7 +300,7 @@ void top_level(pybind11::module &m) {
         "target_sweep_bit",
         &target_sweep_bit,
         pybind11::arg("sweep_bit_index"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a sweep bit target that can be passed into `stim.Circuit.append`.
 
             Args:
@@ -322,7 +322,7 @@ void top_level(pybind11::module &m) {
         &stim_main,
         pybind11::kw_only(),
         pybind11::arg("command_line_args"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Runs the command line tool version of stim on the given arguments.
 
             Note that by default any input will be read from stdin, any output

--- a/src/stim/simulators/dem_sampler.pybind.cc
+++ b/src/stim/simulators/dem_sampler.pybind.cc
@@ -78,7 +78,7 @@ pybind11::class_<DemSampler> stim_pybind::pybind_dem_sampler(pybind11::module &m
     return pybind11::class_<DemSampler>(
         m,
         "CompiledDemSampler",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             A helper class for efficiently sampler from a detector error model.
 
             Examples:
@@ -119,7 +119,7 @@ void stim_pybind::pybind_dem_sampler_methods(pybind11::module &m, pybind11::clas
         pybind11::arg("bit_packed") = false,
         pybind11::arg("return_errors") = false,
         pybind11::arg("recorded_errors_to_replay") = pybind11::none(),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def sample(self, shots: int, *, bit_packed: bool = False, return_errors: bool = False, recorded_errors_to_replay: Optional[np.ndarray] = None) -> Tuple[np.ndarray, np.ndarray, Optional[np.ndarray]]:
             Samples the detector error model's error mechanisms to produce sample data.
 
@@ -302,7 +302,7 @@ void stim_pybind::pybind_dem_sampler_methods(pybind11::module &m, pybind11::clas
         pybind11::arg("err_out_format") = "01",
         pybind11::arg("replay_err_in_file") = pybind11::none(),
         pybind11::arg("replay_err_in_format") = "01",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def sample_write(self, shots: int, *, det_out_file: Union[None, str, pathlib.Path], det_out_format: str = "01", obs_out_file: Union[None, str, pathlib.Path], obs_out_format: str = "01", err_out_file: Union[None, str, pathlib.Path] = None, err_out_format: str = "01", replay_err_in_file: Union[None, str, pathlib.Path] = None, replay_err_in_format: str = "01") -> None:
             Samples the detector error model and writes the results to disk.
 

--- a/src/stim/simulators/matched_error.pybind.cc
+++ b/src/stim/simulators/matched_error.pybind.cc
@@ -137,7 +137,7 @@ pybind11::class_<CircuitErrorLocationStackFrame> stim_pybind::pybind_circuit_err
     return pybind11::class_<CircuitErrorLocationStackFrame>(
         m,
         "CircuitErrorLocationStackFrame",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Describes the location of an instruction being executed within a
             circuit or loop, distinguishing between separate loop iterations.
 
@@ -152,7 +152,7 @@ void stim_pybind::pybind_circuit_error_location_stack_frame_methods(
     c.def_readonly(
         "instruction_offset",
         &CircuitErrorLocationStackFrame::instruction_offset,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             The index of the instruction within the circuit, or within the
             instruction's parent REPEAT block. This is slightly different
             from the line number, because blank lines and commented lines
@@ -164,7 +164,7 @@ void stim_pybind::pybind_circuit_error_location_stack_frame_methods(
     c.def_readonly(
         "iteration_index",
         &CircuitErrorLocationStackFrame::iteration_index,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Disambiguates which iteration of the loop containing this instruction
             is being referred to. If the instruction isn't in a REPEAT block, this
             field defaults to 0.
@@ -174,7 +174,7 @@ void stim_pybind::pybind_circuit_error_location_stack_frame_methods(
     c.def_readonly(
         "instruction_repetitions_arg",
         &CircuitErrorLocationStackFrame::instruction_repetitions_arg,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             If the instruction being referred to is a REPEAT block,
             this is the repetition count of that REPEAT block. Otherwise
             this field defaults to 0.
@@ -201,7 +201,7 @@ void stim_pybind::pybind_circuit_error_location_stack_frame_methods(
         pybind11::arg("instruction_offset"),
         pybind11::arg("iteration_index"),
         pybind11::arg("instruction_repetitions_arg"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Creates a stim.CircuitErrorLocationStackFrame.
         )DOC")
             .data());
@@ -213,7 +213,7 @@ pybind11::class_<GateTargetWithCoords> stim_pybind::pybind_gate_target_with_coor
     return pybind11::class_<GateTargetWithCoords>(
         m,
         "GateTargetWithCoords",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             A gate target with associated coordinate information.
 
             For example, if the gate target is a qubit from a circuit with
@@ -233,7 +233,7 @@ void stim_pybind::pybind_gate_target_with_coords_methods(
     c.def_readonly(
         "gate_target",
         &GateTargetWithCoords::gate_target,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the actual gate target as a `stim.GateTarget`.
         )DOC")
             .data());
@@ -241,7 +241,7 @@ void stim_pybind::pybind_gate_target_with_coords_methods(
     c.def_readonly(
         "coords",
         &GateTargetWithCoords::coords,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the associated coordinate information as a list of flaots.
 
             If there is no coordinate information, returns an empty list.
@@ -262,7 +262,7 @@ void stim_pybind::pybind_gate_target_with_coords_methods(
         pybind11::kw_only(),
         pybind11::arg("gate_target"),
         pybind11::arg("coords"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Creates a stim.GateTargetWithCoords.
         )DOC")
             .data());
@@ -273,7 +273,7 @@ pybind11::class_<DemTargetWithCoords> stim_pybind::pybind_dem_target_with_coords
     return pybind11::class_<DemTargetWithCoords>(
         m,
         "DemTargetWithCoords",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             A detector error model instruction target with associated coords.
 
             It is also guaranteed that, if the type of the DEM target is a
@@ -299,7 +299,7 @@ void stim_pybind::pybind_dem_target_with_coords_methods(
         [](const DemTargetWithCoords &self) -> ExposedDemTarget {
             return ExposedDemTarget(self.dem_target);
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the actual DEM target as a `stim.DemTarget`.
         )DOC")
             .data());
@@ -307,7 +307,7 @@ void stim_pybind::pybind_dem_target_with_coords_methods(
     c.def_readonly(
         "coords",
         &DemTargetWithCoords::coords,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the associated coordinate information as a list of flaots.
 
             If there is no coordinate information, returns an empty list.
@@ -329,7 +329,7 @@ void stim_pybind::pybind_dem_target_with_coords_methods(
         pybind11::kw_only(),
         pybind11::arg("dem_target"),
         pybind11::arg("coords"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Creates a stim.DemTargetWithCoords.
         )DOC")
             .data());
@@ -340,7 +340,7 @@ pybind11::class_<FlippedMeasurement> stim_pybind::pybind_flipped_measurement(pyb
     return pybind11::class_<FlippedMeasurement>(
         m,
         "FlippedMeasurement",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Describes a measurement that was flipped.
 
             Gives the measurement's index in the measurement record, and also
@@ -353,7 +353,7 @@ void stim_pybind::pybind_flipped_measurement_methods(
     c.def_readonly(
         "record_index",
         &FlippedMeasurement::measurement_record_index,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             The measurement record index of the flipped measurement.
             For example, the fifth measurement in a circuit has a measurement
             record index of 4.
@@ -363,7 +363,7 @@ void stim_pybind::pybind_flipped_measurement_methods(
     c.def_readonly(
         "observable",
         &FlippedMeasurement::measured_observable,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the observable of the flipped measurement.
 
             For example, an `MX 5` measurement will have the observable X5.
@@ -388,7 +388,7 @@ void stim_pybind::pybind_flipped_measurement_methods(
         pybind11::kw_only(),
         pybind11::arg("record_index"),
         pybind11::arg("observable"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Creates a stim.FlippedMeasurement.
         )DOC")
             .data());
@@ -401,7 +401,7 @@ pybind11::class_<CircuitTargetsInsideInstruction> stim_pybind::pybind_circuit_ta
     return pybind11::class_<CircuitTargetsInsideInstruction>(
         m,
         "CircuitTargetsInsideInstruction",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Describes a range of targets within a circuit instruction.
         )DOC")
             .data());
@@ -417,7 +417,7 @@ void stim_pybind::pybind_circuit_targets_inside_instruction_methods(
             }
             return pybind11::str(self.gate->name);
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the name of the gate / instruction that was being executed.
             @signature def gate(self) -> Optional[str]:
         )DOC")
@@ -426,7 +426,7 @@ void stim_pybind::pybind_circuit_targets_inside_instruction_methods(
     c.def_readonly(
         "target_range_start",
         &CircuitTargetsInsideInstruction::target_range_start,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the inclusive start of the range of targets that were executing
             within the gate / instruction.
         )DOC")
@@ -435,7 +435,7 @@ void stim_pybind::pybind_circuit_targets_inside_instruction_methods(
     c.def_readonly(
         "target_range_end",
         &CircuitTargetsInsideInstruction::target_range_end,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the exclusive end of the range of targets that were executing
             within the gate / instruction.
         )DOC")
@@ -444,7 +444,7 @@ void stim_pybind::pybind_circuit_targets_inside_instruction_methods(
     c.def_readonly(
         "args",
         &CircuitTargetsInsideInstruction::args,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns parens arguments of the gate / instruction that was being executed.
         )DOC")
             .data());
@@ -452,7 +452,7 @@ void stim_pybind::pybind_circuit_targets_inside_instruction_methods(
     c.def_readonly(
         "targets_in_range",
         &CircuitTargetsInsideInstruction::targets_in_range,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the subset of targets of the gate/instruction that were being executed.
 
             Includes coordinate data with the targets.
@@ -479,7 +479,7 @@ void stim_pybind::pybind_circuit_targets_inside_instruction_methods(
         pybind11::arg("target_range_start"),
         pybind11::arg("target_range_end"),
         pybind11::arg("targets_in_range"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Creates a stim.CircuitTargetsInsideInstruction.
         )DOC")
             .data());
@@ -491,7 +491,7 @@ pybind11::class_<CircuitErrorLocation> stim_pybind::pybind_circuit_error_locatio
     return pybind11::class_<CircuitErrorLocation>(
         m,
         "CircuitErrorLocation",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Describes the location of an error mechanism from a stim circuit.
         )DOC")
             .data());
@@ -501,7 +501,7 @@ void stim_pybind::pybind_circuit_error_location_methods(
     c.def_readonly(
         "tick_offset",
         &CircuitErrorLocation::tick_offset,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             The number of TICKs that executed before the error mechanism being discussed,
             including TICKs that occurred multiple times during loops.
         )DOC")
@@ -510,7 +510,7 @@ void stim_pybind::pybind_circuit_error_location_methods(
     c.def_readonly(
         "flipped_pauli_product",
         &CircuitErrorLocation::flipped_pauli_product,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             The Pauli errors that the error mechanism applied to qubits.
             When the error is a measurement error, this will be an empty list.
         )DOC")
@@ -524,7 +524,7 @@ void stim_pybind::pybind_circuit_error_location_methods(
             }
             return pybind11::cast(self.flipped_measurement);
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             The measurement that was flipped by the error mechanism.
             If the error isn't a measurement error, this will be None.
             @signature def flipped_measurement(self) -> Optional[stim.FlippedMeasurement]:
@@ -534,7 +534,7 @@ void stim_pybind::pybind_circuit_error_location_methods(
     c.def_readonly(
         "instruction_targets",
         &CircuitErrorLocation::instruction_targets,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Within the error instruction, which may have hundreds of
             targets, which specific targets were being executed to
             produce the error.
@@ -544,7 +544,7 @@ void stim_pybind::pybind_circuit_error_location_methods(
     c.def_readonly(
         "stack_frames",
         &CircuitErrorLocation::stack_frames,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Where in the circuit's execution does the error mechanism occur,
             accounting for things like nested loops that iterate multiple times.
         )DOC")
@@ -581,7 +581,7 @@ void stim_pybind::pybind_circuit_error_location_methods(
         pybind11::arg("flipped_measurement"),
         pybind11::arg("instruction_targets"),
         pybind11::arg("stack_frames"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Creates a stim.CircuitErrorLocation.
         )DOC")
             .data());
@@ -593,7 +593,7 @@ pybind11::class_<ExplainedError> stim_pybind::pybind_explained_error(pybind11::m
     return pybind11::class_<ExplainedError>(
         m,
         "ExplainedError",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Describes the location of an error mechanism from a stim circuit.
         )DOC")
             .data());
@@ -602,7 +602,7 @@ void stim_pybind::pybind_explained_error_methods(pybind11::module &m, pybind11::
     c.def_readonly(
         "dem_error_terms",
         &ExplainedError::dem_error_terms,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             The detectors and observables flipped by this error mechanism.
         )DOC")
             .data());
@@ -610,7 +610,7 @@ void stim_pybind::pybind_explained_error_methods(pybind11::module &m, pybind11::
     c.def_readonly(
         "circuit_error_locations",
         &ExplainedError::circuit_error_locations,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             The locations of circuit errors that produce the symptoms in dem_error_terms.
 
             Note: if this list contains a single entry, it may be because a result
@@ -642,7 +642,7 @@ void stim_pybind::pybind_explained_error_methods(pybind11::module &m, pybind11::
         pybind11::kw_only(),
         pybind11::arg("dem_error_terms"),
         pybind11::arg("circuit_error_locations"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Creates a stim.ExplainedError.
         )DOC")
             .data());

--- a/src/stim/simulators/measurements_to_detection_events.pybind.cc
+++ b/src/stim/simulators/measurements_to_detection_events.pybind.cc
@@ -175,7 +175,7 @@ void stim_pybind::pybind_compiled_measurements_to_detection_events_converter_met
         pybind11::arg("circuit"),
         pybind11::kw_only(),
         pybind11::arg("skip_reference_sample") = false,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Creates a measurement-to-detection-events converter for the given circuit.
 
             The converter uses a noiseless reference sample, collected from the circuit
@@ -228,7 +228,7 @@ void stim_pybind::pybind_compiled_measurements_to_detection_events_converter_met
         pybind11::arg("append_observables") = false,
         pybind11::arg("obs_out_filepath") = nullptr,
         pybind11::arg("obs_out_format") = "01",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Reads measurement data from a file and writes detection events to another file.
 
             Args:
@@ -293,7 +293,7 @@ void stim_pybind::pybind_compiled_measurements_to_detection_events_converter_met
         pybind11::arg("separate_observables") = pybind11::none(),
         pybind11::arg("append_observables") = pybind11::none(),
         pybind11::arg("bit_pack_result") = false,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Converts measurement data into detection event data.
             @overload def convert(self, *, measurements: np.ndarray, sweep_bits: Optional[np.ndarray] = None, append_observables: bool = False, bit_pack_result: bool = False) -> np.ndarray:
             @overload def convert(self, *, measurements: np.ndarray, sweep_bits: Optional[np.ndarray] = None, separate_observables: 'Literal[True]', append_observables: bool = False, bit_pack_result: bool = False) -> Tuple[np.ndarray, np.ndarray]:

--- a/src/stim/simulators/tableau_simulator.pybind.cc
+++ b/src/stim/simulators/tableau_simulator.pybind.cc
@@ -134,7 +134,7 @@ pybind11::class_<TableauSimulator> stim_pybind::pybind_tableau_simulator(pybind1
     return pybind11::class_<TableauSimulator>(
         m,
         "TableauSimulator",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             A stabilizer circuit simulator that tracks an inverse stabilizer tableau.
 
             Supports interactive usage, where gates and measurements are applied on demand.
@@ -172,7 +172,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         pybind11::init(&create_tableau_simulator),
         pybind11::kw_only(),
         pybind11::arg("seed") = pybind11::none(),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def __init__(self, *, seed: Optional[int] = None) -> None:
             Initializes a stim.TableauSimulator.
 
@@ -223,7 +223,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self) {
             return self.inv_state;
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a copy of the internal state of the simulator as a stim.Tableau.
 
             Returns:
@@ -287,7 +287,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         },
         pybind11::kw_only(),
         pybind11::arg("endian") = "little",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def state_vector(self, *, endian: str = 'little') -> np.ndarray[np.complex64]:
             Returns a wavefunction for the simulator's current state.
 
@@ -345,7 +345,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
             }
             return result;
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a standardized list of the simulator's current stabilizer generators.
 
             Two simulators have the same canonical stabilizers if and only if their current
@@ -399,7 +399,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](const TableauSimulator &self) {
             return self.measurement_record.storage;
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a copy of the record of all measurements performed by the simulator.
 
             Examples:
@@ -428,7 +428,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         "do",
         &do_obj,
         pybind11::arg("circuit_or_pauli_string"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies a circuit or pauli string to the simulator's state.
             @signature def do(self, circuit_or_pauli_string: Union[stim.Circuit, stim.PauliString, stim.CircuitInstruction, stim.CircuitRepeatBlock]) -> None:
 
@@ -461,7 +461,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
             self.paulis(pauli_string.value);
         },
         pybind11::arg("pauli_string"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies the paulis from a pauli string to the simulator's state.
 
             Args:
@@ -482,7 +482,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
             self.expand_do_circuit(circuit);
         },
         pybind11::arg("circuit"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies a circuit to the simulator's state.
 
             Args:
@@ -523,7 +523,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         },
         pybind11::arg("tableau"),
         pybind11::arg("targets"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies a custom tableau operation to qubits in the simulator.
 
             Note that this method has to compute the inverse of the tableau, because the
@@ -568,7 +568,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.H_XZ(args_to_targets(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies a Hadamard gate to the simulator's state.
 
             Args:
@@ -581,7 +581,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.H_XZ(args_to_targets(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies a Hadamard gate to the simulator's state.
 
             Args:
@@ -594,7 +594,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.C_XYZ(args_to_targets(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies a C_XYZ gate to the simulator's state.
 
             Args:
@@ -607,7 +607,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.C_ZYX(args_to_targets(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies a C_ZYX gate to the simulator's state.
 
             Args:
@@ -620,7 +620,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.H_XY(args_to_targets(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies an operation that swaps the X and Y axes to the simulator's state.
 
             Args:
@@ -633,7 +633,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.H_YZ(args_to_targets(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies an operation that swaps the Y and Z axes to the simulator's state.
 
             Args:
@@ -646,7 +646,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.X(args_to_targets(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies a Pauli X gate to the simulator's state.
 
             Args:
@@ -659,7 +659,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.Y(args_to_targets(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies a Pauli Y gate to the simulator's state.
 
             Args:
@@ -672,7 +672,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args targets) {
             self.Z(args_to_targets(self, targets));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies a Pauli Z gate to the simulator's state.
 
             Args:
@@ -685,7 +685,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.SQRT_Z(args_to_targets(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies a SQRT_Z gate to the simulator's state.
 
             Args:
@@ -698,7 +698,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.SQRT_Z_DAG(args_to_targets(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies a SQRT_Z_DAG gate to the simulator's state.
 
             Args:
@@ -711,7 +711,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.SQRT_X(args_to_targets(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies a SQRT_X gate to the simulator's state.
 
             Args:
@@ -724,7 +724,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.SQRT_X_DAG(args_to_targets(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies a SQRT_X_DAG gate to the simulator's state.
 
             Args:
@@ -737,7 +737,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.SQRT_Y(args_to_targets(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies a SQRT_Y gate to the simulator's state.
 
             Args:
@@ -750,7 +750,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.SQRT_Y_DAG(args_to_targets(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies a SQRT_Y_DAG gate to the simulator's state.
 
             Args:
@@ -763,7 +763,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.SWAP(args_to_target_pairs(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies a swap gate to the simulator's state.
 
             Args:
@@ -778,7 +778,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.ISWAP(args_to_target_pairs(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies an ISWAP gate to the simulator's state.
 
             Args:
@@ -793,7 +793,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.ISWAP_DAG(args_to_target_pairs(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies an ISWAP_DAG gate to the simulator's state.
 
             Args:
@@ -808,7 +808,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.ZCX(args_to_target_pairs(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies a controlled X gate to the simulator's state.
 
             Args:
@@ -823,7 +823,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.ZCX(args_to_target_pairs(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies a controlled X gate to the simulator's state.
 
             Args:
@@ -838,7 +838,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.ZCX(args_to_target_pairs(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies a controlled X gate to the simulator's state.
 
             Args:
@@ -853,7 +853,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.ZCZ(args_to_target_pairs(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies a controlled Z gate to the simulator's state.
 
             Args:
@@ -868,7 +868,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.ZCZ(args_to_target_pairs(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies a controlled Z gate to the simulator's state.
 
             Args:
@@ -883,7 +883,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.ZCY(args_to_target_pairs(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies a controlled Y gate to the simulator's state.
 
             Args:
@@ -898,7 +898,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.ZCY(args_to_target_pairs(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies a controlled Y gate to the simulator's state.
 
             Args:
@@ -913,7 +913,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.XCX(args_to_target_pairs(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies an X-controlled X gate to the simulator's state.
 
             Args:
@@ -928,7 +928,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.XCY(args_to_target_pairs(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies an X-controlled Y gate to the simulator's state.
 
             Args:
@@ -943,7 +943,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.XCZ(args_to_target_pairs(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies an X-controlled Z gate to the simulator's state.
 
             Args:
@@ -958,7 +958,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.YCX(args_to_target_pairs(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies a Y-controlled X gate to the simulator's state.
 
             Args:
@@ -973,7 +973,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.YCY(args_to_target_pairs(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies a Y-controlled Y gate to the simulator's state.
 
             Args:
@@ -988,7 +988,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.YCZ(args_to_target_pairs(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Applies a Y-controlled Z gate to the simulator's state.
 
             Args:
@@ -1003,7 +1003,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.reset_z(args_to_targets(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Resets qubits to the |0> state.
 
             Args:
@@ -1024,7 +1024,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.reset_x(args_to_targets(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Resets qubits to the |+> state.
 
             Args:
@@ -1044,7 +1044,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.reset_y(args_to_targets(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Resets qubits to the |i> state.
 
             Args:
@@ -1064,7 +1064,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](TableauSimulator &self, pybind11::args args) {
             self.reset_z(args_to_targets(self, args));
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Resets qubits to the |0> state.
 
             Args:
@@ -1087,7 +1087,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
             return self.peek_x(target);
         },
         pybind11::arg("target"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the expected value of a qubit's X observable.
 
             Because the simulator's state is always a stabilizer state, the expectation will
@@ -1126,7 +1126,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
             return self.peek_y(target);
         },
         pybind11::arg("target"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the expected value of a qubit's Y observable.
 
             Because the simulator's state is always a stabilizer state, the expectation will
@@ -1165,7 +1165,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
             return self.peek_z(target);
         },
         pybind11::arg("target"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the expected value of a qubit's Z observable.
 
             Because the simulator's state is always a stabilizer state, the expectation will
@@ -1204,7 +1204,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
             return PyPauliString(self.peek_bloch(target));
         },
         pybind11::arg("target"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the state of the qubit as a single-qubit stim.PauliString stabilizer.
 
             This is a non-physical operation. It reports information about the qubit without
@@ -1259,7 +1259,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
             return self.peek_observable_expectation(observable.value);
         },
         pybind11::arg("observable"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Determines the expected value of an observable.
 
             Because the simulator's state is always a stabilizer state, the expectation will
@@ -1316,7 +1316,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         pybind11::arg("observable"),
         pybind11::kw_only(),
         pybind11::arg("flip_probability") = 0.0,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Measures an pauli string observable, as if by an MPP instruction.
 
             Args:
@@ -1358,7 +1358,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
             return (bool)self.measurement_record.storage.back();
         },
         pybind11::arg("target"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Measures a single qubit.
 
             Unlike the other methods on TableauSimulator, this one does not broadcast
@@ -1383,7 +1383,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
             auto e = self.measurement_record.storage.end();
             return std::vector<bool>(e - converted_args.targets.size(), e);
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Measures multiple qubits.
 
             Args:
@@ -1403,7 +1403,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         pybind11::arg("targets"),
         pybind11::kw_only(),
         pybind11::arg("desired_value"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def postselect_x(self, targets: Union[int, Iterable[int]], *, desired_value: bool) -> None:
             Postselects qubits in the X basis, or raises an exception.
 
@@ -1434,7 +1434,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         pybind11::arg("targets"),
         pybind11::kw_only(),
         pybind11::arg("desired_value"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def postselect_y(self, targets: Union[int, Iterable[int]], *, desired_value: bool) -> None:
             Postselects qubits in the Y basis, or raises an exception.
 
@@ -1465,7 +1465,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         pybind11::arg("targets"),
         pybind11::kw_only(),
         pybind11::arg("desired_value"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def postselect_z(self, targets: Union[int, Iterable[int]], *, desired_value: bool) -> None:
             Postselects qubits in the Z basis, or raises an exception.
 
@@ -1492,7 +1492,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         [](const TableauSimulator &self) -> size_t {
             return self.inv_state.num_qubits;
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the number of qubits currently being tracked by the simulator.
 
             Note that the number of qubits being tracked will implicitly increase if qubits
@@ -1516,7 +1516,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
             self.set_num_qubits(new_num_qubits);
         },
         pybind11::arg("new_num_qubits"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Resizes the simulator's internal state.
 
             This forces the simulator's internal state to track exactly the qubits whose
@@ -1558,7 +1558,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
             self.inv_state = new_inverse_tableau;
         },
         pybind11::arg("new_inverse_tableau"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Overwrites the simulator's internal state with the given inverse tableau.
 
             The inverse tableau specifies how Pauli product observables of qubits at the
@@ -1602,7 +1602,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         pybind11::kw_only(),
         pybind11::arg("copy_rng") = false,
         pybind11::arg("seed") = pybind11::none(),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def copy(self, *, copy_rng: bool = False, seed: Optional[int] = None) -> stim.TableauSimulator:
             Returns a simulator with the same internal state, except perhaps its prng.
 
@@ -1685,7 +1685,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
             return pybind11::make_tuple(result.first, PyPauliString(result.second));
         },
         pybind11::arg("target"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Measures a qubit and returns the result as well as its Pauli kickback (if any).
 
             The "Pauli kickback" of a stabilizer circuit measurement is a set of Pauli
@@ -1757,7 +1757,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         pybind11::kw_only(),
         pybind11::arg("allow_redundant") = false,
         pybind11::arg("allow_underconstrained") = false,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def set_state_from_stabilizers(self, stabilizers: Iterable[stim.PauliString], *, allow_redundant: bool = False, allow_underconstrained: bool = False) -> None:
             Sets the tableau simulator's state to a state satisfying the given stabilizers.
 
@@ -1867,7 +1867,7 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
         pybind11::arg("state_vector"),
         pybind11::kw_only(),
         pybind11::arg("endian"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def set_state_from_state_vector(self, state_vector: Iterable[float], *, endian: str) -> None:
             Sets the simulator's state to a superposition specified by an amplitude vector.
 

--- a/src/stim/stabilizers/pauli_string.pybind.cc
+++ b/src/stim/stabilizers/pauli_string.pybind.cc
@@ -449,7 +449,7 @@ pybind11::class_<PyPauliString> stim_pybind::pybind_pauli_string(pybind11::modul
     return pybind11::class_<PyPauliString>(
         m,
         "PauliString",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             A signed Pauli tensor product (e.g. "+X \u2297 X \u2297 X" or "-Y \u2297 Z".
 
             Represents a collection of Pauli operations (I, X, Y, Z) applied pairwise to a
@@ -472,7 +472,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
             return result;
         }),
         pybind11::arg("num_qubits"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Creates an identity Pauli string over the given number of qubits.
 
             Examples:
@@ -489,7 +489,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
     c.def(
         pybind11::init(&PyPauliString::from_text),
         pybind11::arg("text"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Creates a stim.PauliString from a text string.
 
             The string can optionally start with a sign ('+', '-', 'i', '+i', or '-i').
@@ -523,7 +523,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
             return copy;
         }),
         pybind11::arg("copy"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Creates a copy of a stim.PauliString.
 
             Examples:
@@ -557,7 +557,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
                 false);
         }),
         pybind11::arg("pauli_indices"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Creates a stim.PauliString from a list of integer pauli indices.
 
             The indexing scheme that is used is:
@@ -586,7 +586,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
         pybind11::arg("num_qubits"),
         pybind11::kw_only(),
         pybind11::arg("allow_imaginary") = false,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Samples a uniformly random Hermitian Pauli string.
 
             Args:
@@ -619,7 +619,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
         [](const PyPauliString &self) {
             return Tableau::from_pauli_string(self.value);
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Creates a Tableau equivalent to this Pauli string.
 
             The tableau represents a Clifford operation that multiplies qubits
@@ -667,7 +667,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
         &PyPauliString::to_unitary_matrix,
         pybind11::kw_only(),
         pybind11::arg("endian"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def to_unitary_matrix(self, *, endian: str) -> np.ndarray[np.complex64]:
             Converts the pauli string into a unitary matrix.
 
@@ -698,7 +698,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
         pybind11::arg("matrix"),
         pybind11::kw_only(),
         pybind11::arg("endian") = "little",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def from_unitary_matrix(matrix: Iterable[Iterable[float]], *, endian: str = 'little') -> stim.PauliString:
             Creates a stim.PauliString from the unitary matrix of a Pauli group member.
 
@@ -742,7 +742,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
             return self.value.ref().commutes(other.value.ref());
         },
         pybind11::arg("other"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Determines if two Pauli strings commute or not.
 
             Two Pauli strings commute if they have an even number of matched
@@ -803,7 +803,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
                 throw std::invalid_argument("new_sign not in [1, -1, 1, 1j]");
             }
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             The sign of the Pauli string. Can be +1, -1, 1j, or -1j.
 
             Examples:
@@ -827,7 +827,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
         [](const PyPauliString &self) {
             return self.value.num_qubits;
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the length the pauli string; the number of qubits it operates on.
         )DOC")
             .data());
@@ -838,7 +838,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
             return std::make_tuple(std::complex<float>(1, 0), self * other);
         },
         pybind11::arg("other"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
              [DEPRECATED] Use multiplication (__mul__ or *) instead.
         )DOC")
             .data());
@@ -846,7 +846,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
     c.def(
         pybind11::self + pybind11::self,
         pybind11::arg("rhs"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the tensor product of two Pauli strings.
 
             Concatenates the Pauli strings and multiplies their signs.
@@ -871,7 +871,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
     c.def(
         pybind11::self += pybind11::self,
         pybind11::arg("rhs"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Performs an inplace tensor product.
 
             Concatenates the given Pauli string onto the receiving string and multiplies
@@ -899,7 +899,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
     c.def(
         pybind11::self * pybind11::object(),
         pybind11::arg("rhs"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Right-multiplies the Pauli string.
 
             Can multiply by another Pauli string, a complex unit, or a tensor power.
@@ -959,7 +959,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
             return self * lhs;
         },
         pybind11::arg("lhs"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Left-multiplies the Pauli string.
 
             Can multiply by another Pauli string, a complex unit, or a tensor power.
@@ -1012,7 +1012,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
     c.def(
         pybind11::self *= pybind11::object(),
         pybind11::arg("rhs"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Inplace right-multiplies the Pauli string.
 
             Can multiply by another Pauli string, a complex unit, or a tensor power.
@@ -1060,7 +1060,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
         &PyPauliString::operator/=,
         pybind11::is_operator(),
         pybind11::arg("rhs"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Inplace divides the Pauli string by a complex unit.
 
             Args:
@@ -1087,7 +1087,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
         &PyPauliString::operator/,
         pybind11::is_operator(),
         pybind11::arg("rhs"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Divides the Pauli string by a complex unit.
 
             Args:
@@ -1114,7 +1114,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
             result.value.sign ^= 1;
             return result;
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the negation of the pauli string.
 
             Examples:
@@ -1134,7 +1134,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
             PyPauliString copy = self;
             return copy;
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a copy of the pauli string.
 
             The copy is an independent pauli string with the same contents.
@@ -1159,7 +1159,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
         },
         pybind11::kw_only(),
         pybind11::arg("bit_packed") = false,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def to_numpy(self, *, bit_packed: bool = False) -> Tuple[np.ndarray, np.ndarray]:
 
             Decomposes the contents of the pauli string into X bit and Z bit numpy arrays.
@@ -1229,7 +1229,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
         pybind11::arg("zs"),
         pybind11::arg("sign") = +1,
         pybind11::arg("num_qubits") = pybind11::none(),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def from_numpy(*, xs: np.ndarray, zs: np.ndarray, sign: Union[int, float, complex] = +1, num_qubits: Optional[int] = None) -> stim.PauliString:
 
             Creates a pauli string from X bit and Z bit numpy arrays, using the encoding:
@@ -1282,7 +1282,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
             PyPauliString copy = self;
             return copy;
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a pauli string with the same contents.
 
             Examples:
@@ -1336,7 +1336,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
         },
         pybind11::arg("index"),
         pybind11::arg("new_pauli"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
            Mutates an entry in the pauli string using the encoding 0=I, 1=X, 2=Y, 3=Z.
 
            Args:
@@ -1377,7 +1377,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
             }
         },
         pybind11::arg("index_or_slice"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns an individual Pauli or Pauli string slice from the pauli string.
             @overload def __getitem__(self, index_or_slice: int) -> int:
             @overload def __getitem__(self, index_or_slice: slice) -> stim.PauliString:

--- a/src/stim/stabilizers/tableau.pybind.cc
+++ b/src/stim/stabilizers/tableau.pybind.cc
@@ -118,7 +118,7 @@ pybind11::class_<Tableau> stim_pybind::pybind_tableau(pybind11::module &m) {
     return pybind11::class_<Tableau>(
         m,
         "Tableau",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             A stabilizer tableau.
 
             Represents a Clifford operation by explicitly storing how that operation
@@ -158,7 +158,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
     c.def(
         pybind11::init<size_t>(),
         pybind11::arg("num_qubits"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Creates an identity tableau over the given number of qubits.
 
             Examples:
@@ -182,7 +182,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
             return Tableau::random(num_qubits, *make_py_seeded_rng(pybind11::none()));
         },
         pybind11::arg("num_qubits"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Samples a uniformly random Clifford operation and returns its tableau.
 
             Args:
@@ -210,7 +210,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
         pybind11::arg("num_qubits"),
         pybind11::kw_only(),
         pybind11::arg("unsigned") = false,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns an iterator that iterates over all Tableaus of a given size.
 
             Args:
@@ -267,7 +267,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
         },
         pybind11::kw_only(),
         pybind11::arg("endian"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def to_unitary_matrix(self, *, endian: str) -> np.ndarray[np.complex64]:
             Converts the tableau into a unitary matrix.
 
@@ -317,7 +317,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
         },
         pybind11::kw_only(),
         pybind11::arg("bit_packed") = false,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def to_numpy(self, *, bit_packed: bool = False) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
 
             Decomposes the contents of the tableau into six numpy arrays.
@@ -528,7 +528,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
         pybind11::arg("z2z"),
         pybind11::arg("x_signs") = pybind11::none(),
         pybind11::arg("z_signs") = pybind11::none(),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def from_numpy(self, *, bit_packed: bool = False) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
 
             Creates a tableau from numpy arrays x2x, x2z, z2x, z2z, x_signs, and z_signs.
@@ -627,7 +627,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
         [](const Tableau &self) {
             return PyPauliString(self.to_pauli_string());
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Return a Pauli string equivalent to the tableau.
 
             If the tableau is equivalent to a pauli product, creates
@@ -664,7 +664,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
         },
         pybind11::kw_only(),
         pybind11::arg("method"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def to_circuit(self, *, method: str) -> stim.Circuit:
             Synthesizes a circuit that implements the tableau's Clifford operation.
 
@@ -729,7 +729,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
             return gate.tableau();
         },
         pybind11::arg("name"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the tableau of a named Clifford gate.
 
             Args:
@@ -772,7 +772,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
         "__pow__",
         &Tableau::raised_to,
         pybind11::arg("exponent"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Raises the tableau to an integer power.
 
             Large powers are reached efficiently using repeated squaring.
@@ -806,7 +806,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
         &Tableau::inverse,
         pybind11::kw_only(),
         pybind11::arg("unsigned") = false,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Computes the inverse of the tableau.
 
             The inverse T^-1 of a tableau T is the unique tableau with the property that
@@ -890,7 +890,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
         },
         pybind11::arg("gate"),
         pybind11::arg("targets"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Appends an operation's effect into this tableau, mutating this tableau.
 
             Time cost is O(n*m*m) where n=len(self) and m=len(gate).
@@ -920,7 +920,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
             return self.then(second);
         },
         pybind11::arg("second"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the result of composing two tableaus.
 
             If the tableau T1 represents the Clifford operation with unitary C1,
@@ -952,7 +952,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
             return rhs.then(self);
         },
         pybind11::arg("rhs"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the product of two tableaus.
 
             If the tableau T1 represents the Clifford operation with unitary C1,
@@ -993,7 +993,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
         },
         pybind11::arg("gate"),
         pybind11::arg("targets"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Prepends an operation's effect into this tableau, mutating this tableau.
 
             Time cost is O(n*m*m) where n=len(self) and m=len(gate).
@@ -1020,7 +1020,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
             return PyPauliString(self.xs[target]);
         },
         pybind11::arg("target"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the result of conjugating a Pauli X by the tableau's Clifford operation.
 
             Args:
@@ -1049,7 +1049,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
             return PyPauliString(self.y_output(target));
         },
         pybind11::arg("target"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the result of conjugating a Pauli Y by the tableau's Clifford operation.
 
             Args:
@@ -1078,7 +1078,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
             return PyPauliString(self.zs[target]);
         },
         pybind11::arg("target"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the result of conjugating a Pauli Z by the tableau's Clifford operation.
 
             Args:
@@ -1103,7 +1103,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
         &Tableau::x_output_pauli_xyz,
         pybind11::arg("input_index"),
         pybind11::arg("output_index"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Constant-time version of `tableau.x_output(input_index)[output_index]`
 
             Args:
@@ -1142,7 +1142,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
         &Tableau::y_output_pauli_xyz,
         pybind11::arg("input_index"),
         pybind11::arg("output_index"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Constant-time version of `tableau.y_output(input_index)[output_index]`
 
             Args:
@@ -1181,7 +1181,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
         &Tableau::z_output_pauli_xyz,
         pybind11::arg("input_index"),
         pybind11::arg("output_index"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Constant-time version of `tableau.z_output(input_index)[output_index]`
 
             Args:
@@ -1220,7 +1220,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
         &Tableau::inverse_x_output_pauli_xyz,
         pybind11::arg("input_index"),
         pybind11::arg("output_index"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Constant-time version of `tableau.inverse().x_output(input_index)[output_index]`
 
             Args:
@@ -1259,7 +1259,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
         &Tableau::inverse_y_output_pauli_xyz,
         pybind11::arg("input_index"),
         pybind11::arg("output_index"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Constant-time version of `tableau.inverse().y_output(input_index)[output_index]`
 
             Args:
@@ -1298,7 +1298,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
         &Tableau::inverse_z_output_pauli_xyz,
         pybind11::arg("input_index"),
         pybind11::arg("output_index"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Constant-time version of `tableau.inverse().z_output(input_index)[output_index]`
 
             Args:
@@ -1340,7 +1340,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
         pybind11::arg("input_index"),
         pybind11::kw_only(),
         pybind11::arg("unsigned") = false,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Conjugates a single-qubit X Pauli generator by the inverse of the tableau.
 
             A faster version of `tableau.inverse(unsigned).x_output(input_index)`.
@@ -1379,7 +1379,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
         pybind11::arg("input_index"),
         pybind11::kw_only(),
         pybind11::arg("unsigned") = false,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Conjugates a single-qubit Y Pauli generator by the inverse of the tableau.
 
             A faster version of `tableau.inverse(unsigned).y_output(input_index)`.
@@ -1418,7 +1418,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
         pybind11::arg("input_index"),
         pybind11::kw_only(),
         pybind11::arg("unsigned") = false,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Conjugates a single-qubit Z Pauli generator by the inverse of the tableau.
 
             A faster version of `tableau.inverse(unsigned).z_output(input_index)`.
@@ -1457,7 +1457,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
             Tableau copy = self;
             return copy;
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns a copy of the tableau. An independent tableau with the same contents.
 
             Examples:
@@ -1510,7 +1510,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
         pybind11::kw_only(),
         pybind11::arg("xs"),
         pybind11::arg("zs"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Creates a tableau from the given outputs for each generator.
 
             Verifies that the tableau is well formed.
@@ -1569,7 +1569,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
         pybind11::arg("matrix"),
         pybind11::kw_only(),
         pybind11::arg("endian"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def from_unitary_matrix(matrix: Iterable[Iterable[float]], *, endian: str = 'little') -> stim.Tableau:
             Creates a tableau from the unitary matrix of a Clifford operation.
 
@@ -1633,7 +1633,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
         pybind11::arg("ignore_noise") = false,
         pybind11::arg("ignore_measurement") = false,
         pybind11::arg("ignore_reset") = false,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def from_circuit(circuit: stim.Circuit, *, ignore_noise: bool = False, ignore_measurement: bool = False, ignore_reset: bool = False) -> stim.Tableau:
             Converts a circuit into an equivalent stabilizer tableau.
 
@@ -1710,7 +1710,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
             return result;
         },
         pybind11::arg("pauli_string"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
              Returns the conjugation of a PauliString by the Tableau's Clifford operation.
 
              The conjugation of P by C is equal to C**-1 * P * C. If P is a Pauli product
@@ -1735,7 +1735,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
     c.def(
         pybind11::self + pybind11::self,
         pybind11::arg("rhs"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the direct sum (diagonal concatenation) of two Tableaus.
 
             Args:
@@ -1761,7 +1761,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
     c.def(
         pybind11::self += pybind11::self,
         pybind11::arg("rhs"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Performs an inplace direct sum (diagonal concatenation).
 
             Args:
@@ -1855,7 +1855,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
         pybind11::kw_only(),
         pybind11::arg("allow_redundant") = false,
         pybind11::arg("allow_underconstrained") = false,
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def from_stabilizers(stabilizers: Iterable[stim.PauliString], *, allow_redundant: bool = False, allow_underconstrained: bool = False) -> stim.Tableau:
             Creates a tableau representing a state with the given stabilizers.
 
@@ -1957,7 +1957,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
         pybind11::arg("state_vector"),
         pybind11::kw_only(),
         pybind11::arg("endian"),
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def from_state_vector(self, state_vector: Iterable[float], *, endian: str) -> stim.Tableau:
             Creates a tableau representing the stabilizer state of the given state vector.
 
@@ -2049,7 +2049,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
         },
         pybind11::kw_only(),
         pybind11::arg("endian") = "little",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             @signature def to_state_vector(self, *, endian: str = 'little') -> np.ndarray[np.complex64]:
             Returns the state vector produced by applying the tableau to the |0..0> state.
 

--- a/src/stim/stabilizers/tableau_iter.pybind.cc
+++ b/src/stim/stabilizers/tableau_iter.pybind.cc
@@ -23,7 +23,7 @@ pybind11::class_<TableauIterator> stim_pybind::pybind_tableau_iter(pybind11::mod
     auto c = pybind11::class_<TableauIterator>(
         m,
         "TableauIterator",
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Iterates over all stabilizer tableaus of a specified size.
 
             Examples:
@@ -46,7 +46,7 @@ void stim_pybind::pybind_tableau_iter_methods(pybind11::module &m, pybind11::cla
             TableauIterator copy = self;
             return copy;
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns an independent copy of the tableau iterator.
 
             Since for-loops and loop-comprehensions call `iter` on things they
@@ -63,7 +63,7 @@ void stim_pybind::pybind_tableau_iter_methods(pybind11::module &m, pybind11::cla
             }
             return self.result;
         },
-        clean_doc_string(u8R"DOC(
+        clean_doc_string(R"DOC(
             Returns the next iterated tableau.
         )DOC")
             .data());


### PR DESCRIPTION
- Was breaking compatibility with -std=C++20
- Doesn't appear to have been doing anything anyways, in terms of what ends up in memory