### PR TITLE
Add ability to access group stats in `plot_args_func`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
     - uses: actions/checkout@v1
     - run: |
         cd ..
-        git clone https://github.com/google/googletest.git -b release-1.10.0
+        git clone https://github.com/google/googletest.git -b release-1.12.1
         mkdir googletest/build && cd googletest/build
         cmake .. -DBUILD_GMOCK=OFF
         make
@@ -267,7 +267,7 @@ jobs:
     - uses: actions/checkout@v1
     - run: |
         cd ..
-        git clone https://github.com/google/googletest.git -b release-1.10.0
+        git clone https://github.com/google/googletest.git -b release-1.12.1
         mkdir googletest/build && cd googletest/build
         cmake .. -DBUILD_GMOCK=OFF
         make
@@ -281,7 +281,7 @@ jobs:
     - uses: actions/checkout@v1
     - run: |
         cd ..
-        git clone https://github.com/google/googletest.git -b release-1.10.0
+        git clone https://github.com/google/googletest.git -b release-1.12.1
         mkdir googletest/build && cd googletest/build
         cmake .. -DBUILD_GMOCK=OFF
         make

--- a/glue/sample/src/sinter/_main_plot_test.py
+++ b/glue/sample/src/sinter/_main_plot_test.py
@@ -62,7 +62,7 @@ shots,errors,discards,seconds,decoder,strong_id,json_metadata
                 "--group_func",
                 "decoder",
                 "--plot_args_func",
-                "{'lw': 2}",
+                "{'lw': 2, 'color': 'r' if decoder == 'never' else 'b'}",
             ])
         assert (d / "output.png").exists()
 


### PR DESCRIPTION
- Backwards-compatibly add a 'all stats in group' parameter to the python API version
- Add several more available values to `--plot_args_func` in `sinter plot`