### PR TITLE
Fix error message with invalid sign value

### DIFF
--- a/src/stim/stabilizers/pauli_string.pybind.cc
+++ b/src/stim/stabilizers/pauli_string.pybind.cc
@@ -800,7 +800,7 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
                 self.value.sign = true;
                 self.imag = true;
             } else {
-                throw std::invalid_argument("new_sign not in [1, -1, 1, 1j]");
+                throw std::invalid_argument("new_sign not in [1, -1, 1j, -1j]");
             }
         },
         clean_doc_string(R"DOC(


### PR DESCRIPTION
Fixes a typo in the error message for `sign` attribute of a PauliString.
The allowable values are [1, -1, 1j, -1j]