### PR TITLE
Add `--postselected_detectors_predicate` option to sinter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ cmake-build-debug-coverage/*
 # clangd generated files
 compile_commands.json
 .cache/*
+build.ninja
+.ninja_deps
+.ninja_log

--- a/glue/sample/src/sinter/_main_collect.py
+++ b/glue/sample/src/sinter/_main_collect.py
@@ -2,6 +2,7 @@ import argparse
 import math
 import sys
 from typing import Iterator, Any, Tuple, List, Callable, FrozenSet, Optional
+from typing import cast
 
 import numpy as np
 import stim
@@ -9,32 +10,34 @@ import stim
 import sinter
 from sinter._printer import ThrottledProgressPrinter
 from sinter._task import Task
-from sinter._collection import collect, Progress, post_selection_mask_from_4th_coord
+from sinter._collection import collect, Progress, post_selection_mask_from_predicate
 from sinter._decoding_all_built_in_decoders import BUILT_IN_DECODERS
 from sinter._main_combine import ExistingData, CSV_HEADER
 
 
 def iter_file_paths_into_goals(circuit_paths: Iterator[str],
                                metadata_func: Callable,
-                               postselect_4th_coord: bool,
-                               postselected_observables_predicate: Callable[[int, Any], FrozenSet[int]],
+                               postselected_detectors_predicate: Optional[Callable[[int, Any, Tuple[float, ...]], bool]],
+                               postselected_observables_predicate: Callable[[int, Any], bool],
                                ) -> Iterator[Task]:
     for path in circuit_paths:
         with open(path) as f:
             circuit_text = f.read()
         circuit = stim.Circuit(circuit_text)
 
-        if postselect_4th_coord:
-            post_mask = post_selection_mask_from_4th_coord(circuit)
+        metadata = metadata_func(path=path, circuit=circuit)
+        if postselected_detectors_predicate is not None:
+            post_mask = post_selection_mask_from_predicate(circuit, metadata=metadata, postselected_detectors_predicate=postselected_detectors_predicate)
+            if not np.any(post_mask):
+                post_mask = None
         else:
             post_mask = None
-        metadata = metadata_func(path=path, circuit=circuit)
         postselected_observables = [
             k
             for k in range(circuit.num_observables)
             if postselected_observables_predicate(k, metadata)
         ]
-        if postselected_observables:
+        if any(postselected_observables):
             postselected_observables_mask = np.zeros(shape=math.ceil(circuit.num_observables / 8), dtype=np.uint8)
             for k in postselected_observables:
                 postselected_observables_mask[k // 8] |= 1 << (k % 8)
@@ -110,6 +113,21 @@ def parse_args(args: List[str]) -> Any:
                         help='Turns on detector postselection. '
                              'If any detector with a non-zero 4th coordinate fires, the shot is discarded.',
                         action='store_true')
+    parser.add_argument('--postselected_detectors_predicate',
+                        type=str,
+                        default='''False''',
+                        help='Specifies a predicate used to decide which detectors to postselect. '
+                             'When a postselected detector produces a detection event, the shot is discarded instead of being given to the decoder.'
+                             'The number of discarded shots is tracked as a statistic.'
+                             'Available values:\n'
+                             '    index: The unique number identifying the detector, determined by the order of detectors in the circuit file.\n'
+                             '    coords: The coordinate data associated with the detector. An empty tuple, if the circuit file did not specify detector coordinates.\n'
+                             '    metadata: The metadata associated with the task being sampled.\n'
+                             'Expected expression type:\n'
+                             '    Something that can be given to `bool` to get False (do not postselect) or True (yes postselect).\n'
+                             'Examples:\n'
+                             '''    --postselected_detectors_predicate "coords[2] == 0"\n'''
+                             '''    --postselected_observables_predicate "coords[3] < metadata['postselection_level']"\n''')
     parser.add_argument('--postselected_observables_predicate',
                         type=str,
                         default='''False''',
@@ -138,7 +156,7 @@ def parse_args(args: List[str]) -> Any:
     parser.add_argument('--metadata_func',
                         type=str,
                         default="{'path': path}",
-                        help='A python expression that determines whether a case is kept or not.\n'
+                        help='A python expression that associates json metadata with a circuit\'s results.\n'
                              'Set to "auto" to use "sinter.comma_separated_key_values(path)"\n'
                              'Values available to the expression:\n'
                              '    path: Relative path to the circuit file, from the command line arguments.\n'
@@ -150,9 +168,9 @@ def parse_args(args: List[str]) -> Any:
                              '    it in the metadata as well would be redundant. But something like\n'
                              '    decoder version could be usefully added.\n'
                              'Examples:\n'
-                             '''    -metadata_func "{'path': path}"\n'''
-                             '''    -metadata_func "auto"\n'''
-                             '''    -metadata_func "{'n': circuit.num_qubits, 'p': float(path.split('/')[-1].split('.')[0])}"\n'''
+                             '''    --metadata_func "{'path': path}"\n'''
+                             '''    --metadata_func "auto"\n'''
+                             '''    --metadata_func "{'n': circuit.num_qubits, 'p': float(path.split('/')[-1].split('.')[0])}"\n'''
                         )
     a = parser.parse_args(args=args)
     if a.metadata_func == 'auto':
@@ -165,6 +183,18 @@ def parse_args(args: List[str]) -> Any:
         'lambda index, metadata: ' + a.postselected_observables_predicate,
         filename='postselected_observables_predicate:command_line_arg',
         mode='eval'))
+    if a.postselected_detectors_predicate == 'False':
+        if a.postselect_detectors_with_non_zero_4th_coord:
+            a.postselected_detectors_predicate = lambda index, metadata, coords: coords[3]
+        else:
+            a.postselected_detectors_predicate = None
+    else:
+        if a.postselect_detectors_with_non_zero_4th_coord:
+            raise ValueError("Can't specify both --postselect_detectors_with_non_zero_4th_coord and --postselected_detectors_predicate")
+        a.postselected_detectors_predicate = eval(compile(
+            'lambda index, metadata, coords: ' + cast(str, a.postselected_detectors_predicate),
+            filename='postselected_detectors_predicate:command_line_arg',
+            mode='eval'))
     if a.custom_decoders_module_function is not None:
         terms = a.custom_decoders_module_function.split(':')
         if len(terms) != 2:
@@ -206,7 +236,7 @@ def main_collect(*, command_line_args: List[str]):
     iter_tasks = iter_file_paths_into_goals(
         circuit_paths=args.circuits,
         metadata_func=args.metadata_func,
-        postselect_4th_coord=args.postselect_detectors_with_non_zero_4th_coord,
+        postselected_detectors_predicate=args.postselected_detectors_predicate,
         postselected_observables_predicate=args.postselected_observables_predicate,
     )
     num_tasks = len(args.circuits) * len(args.decoders)

--- a/src/stim/diagram/gate_data_svg.cc
+++ b/src/stim/diagram/gate_data_svg.cc
@@ -5,68 +5,68 @@ using namespace stim_draw_internal;
 std::map<std::string, SvgGateData> SvgGateData::make_gate_data_map() {
     std::map<std::string, SvgGateData> result;
 
-    result.insert({"X", {1, "X", "", "", "white", "black"}});
-    result.insert({"Y", {1, "Y", "", "", "white", "black"}});
-    result.insert({"Z", {1, "Z", "", "", "white", "black"}});
+    result.insert({"X", {1, "X", "", "", "white", "black", 0, 10}});
+    result.insert({"Y", {1, "Y", "", "", "white", "black", 0, 10}});
+    result.insert({"Z", {1, "Z", "", "", "white", "black", 0, 10}});
 
-    result.insert({"H_YZ", {1, "H", "YZ", "", "white", "black"}});
-    result.insert({"H", {1, "H", "", "", "white", "black"}});
-    result.insert({"H_XY", {1, "H", "XY", "", "white", "black"}});
+    result.insert({"H_YZ", {1, "H", "YZ", "", "white", "black", 0, 10}});
+    result.insert({"H", {1, "H", "", "", "white", "black", 0, 10}});
+    result.insert({"H_XY", {1, "H", "XY", "", "white", "black", 0, 10}});
 
     result.insert({"SQRT_X", {1, "√X", "", "", "white", "black", 24}});
     result.insert({"SQRT_Y", {1, "√Y", "", "", "white", "black", 24}});
-    result.insert({"S", {1, "S", "", "", "white", "black"}});
+    result.insert({"S", {1, "S", "", "", "white", "black", 0, 10}});
 
-    result.insert({"SQRT_X_DAG", {1, "√X", "", "†", "white", "black"}});
-    result.insert({"SQRT_Y_DAG", {1, "√Y", "", "†", "white", "black"}});
-    result.insert({"S_DAG", {1, "S", "", "†", "white", "black"}});
+    result.insert({"SQRT_X_DAG", {1, "√X", "", "†", "white", "black", 0, 10}});
+    result.insert({"SQRT_Y_DAG", {1, "√Y", "", "†", "white", "black", 0, 10}});
+    result.insert({"S_DAG", {1, "S", "", "†", "white", "black", 0, 10}});
 
     result.insert({"MX", {1, "M", "X", "", "black", "white", 26, 16}});
     result.insert({"MY", {1, "M", "Y", "", "black", "white", 26, 16}});
-    result.insert({"M", {1, "M", "", "", "black", "white"}});
+    result.insert({"M", {1, "M", "", "", "black", "white", 0, 10}});
 
     result.insert({"RX", {1, "R", "X", "", "black", "white", 26, 16}});
     result.insert({"RY", {1, "R", "Y", "", "black", "white", 26, 16}});
-    result.insert({"R", {1, "R", "", "", "black", "white"}});
+    result.insert({"R", {1, "R", "", "", "black", "white", 0, 10}});
 
-    result.insert({"MRX", {1, "MR", "X", "", "black", "white"}});
-    result.insert({"MRY", {1, "MR", "Y", "", "black", "white"}});
-    result.insert({"MR", {1, "MR", "", "", "black", "white"}});
+    result.insert({"MRX", {1, "MR", "X", "", "black", "white", 0, 10}});
+    result.insert({"MRY", {1, "MR", "Y", "", "black", "white", 0, 10}});
+    result.insert({"MR", {1, "MR", "", "", "black", "white", 0, 10}});
 
-    result.insert({"X_ERROR", {1, "ERR", "X", "", "pink", "black"}});
-    result.insert({"Y_ERROR", {1, "ERR", "Y", "", "pink", "black"}});
-    result.insert({"Z_ERROR", {1, "ERR", "Z", "", "pink", "black"}});
+    result.insert({"X_ERROR", {1, "ERR", "X", "", "pink", "black", 0, 10}});
+    result.insert({"Y_ERROR", {1, "ERR", "Y", "", "pink", "black", 0, 10}});
+    result.insert({"Z_ERROR", {1, "ERR", "Z", "", "pink", "black", 0, 10}});
 
-    result.insert({"E[X]", {1, "E", "X", "", "pink", "black"}});
-    result.insert({"E[Y]", {1, "E", "Y", "", "pink", "black"}});
-    result.insert({"E[Z]", {1, "E", "Z", "", "pink", "black"}});
+    result.insert({"E[X]", {1, "E", "X", "", "pink", "black", 0, 10}});
+    result.insert({"E[Y]", {1, "E", "Y", "", "pink", "black", 0, 10}});
+    result.insert({"E[Z]", {1, "E", "Z", "", "pink", "black", 0, 10}});
 
-    result.insert({"ELSE_CORRELATED_ERROR[X]", {1, "EE", "X", "", "pink", "black"}});
-    result.insert({"ELSE_CORRELATED_ERROR[Y]", {1, "EE", "Y", "", "pink", "black"}});
-    result.insert({"ELSE_CORRELATED_ERROR[Z]", {1, "EE", "Z", "", "pink", "black"}});
+    result.insert({"ELSE_CORRELATED_ERROR[X]", {1, "EE", "X", "", "pink", "black", 0, 10}});
+    result.insert({"ELSE_CORRELATED_ERROR[Y]", {1, "EE", "Y", "", "pink", "black", 0, 10}});
+    result.insert({"ELSE_CORRELATED_ERROR[Z]", {1, "EE", "Z", "", "pink", "black", 0, 10}});
 
-    result.insert({"MPP[X]", {1, "MPP", "X", "", "black", "white"}});
-    result.insert({"MPP[Y]", {1, "MPP", "Y", "", "black", "white"}});
-    result.insert({"MPP[Z]", {1, "MPP", "Z", "", "black", "white"}});
+    result.insert({"MPP[X]", {1, "MPP", "X", "", "black", "white", 0, 10}});
+    result.insert({"MPP[Y]", {1, "MPP", "Y", "", "black", "white", 0, 10}});
+    result.insert({"MPP[Z]", {1, "MPP", "Z", "", "black", "white", 0, 10}});
 
-    result.insert({"SQRT_XX", {1, "√XX", "", "", "white", "black"}});
-    result.insert({"SQRT_YY", {1, "√YY", "", "", "white", "black"}});
-    result.insert({"SQRT_ZZ", {1, "√ZZ", "", "", "white", "black"}});
+    result.insert({"SQRT_XX", {1, "√XX", "", "", "white", "black", 0, 10}});
+    result.insert({"SQRT_YY", {1, "√YY", "", "", "white", "black", 0, 10}});
+    result.insert({"SQRT_ZZ", {1, "√ZZ", "", "", "white", "black", 0, 10}});
 
-    result.insert({"SQRT_XX_DAG", {1, "√XX", "", "†", "white", "black"}});
-    result.insert({"SQRT_YY_DAG", {1, "√YY", "", "†", "white", "black"}});
-    result.insert({"SQRT_ZZ_DAG", {1, "√ZZ", "", "†", "white", "black"}});
+    result.insert({"SQRT_XX_DAG", {1, "√XX", "", "†", "white", "black", 0, 10}});
+    result.insert({"SQRT_YY_DAG", {1, "√YY", "", "†", "white", "black", 0, 10}});
+    result.insert({"SQRT_ZZ_DAG", {1, "√ZZ", "", "†", "white", "black", 0, 10}});
 
-    result.insert({"I", {1, "I", "", "", "white", "black"}});
-    result.insert({"C_XYZ", {1, "C", "XYZ", "", "white", "black"}});
-    result.insert({"C_ZYX", {1, "C", "ZYX", "", "white", "black"}});
+    result.insert({"I", {1, "I", "", "", "white", "black", 0, 10}});
+    result.insert({"C_XYZ", {1, "C", "XYZ", "", "white", "black", 0, 10}});
+    result.insert({"C_ZYX", {1, "C", "ZYX", "", "white", "black", 0, 10}});
 
-    result.insert({"DEPOLARIZE1", {1, "DEP", "1", "", "pink", "black"}});
-    result.insert({"DEPOLARIZE2", {1, "DEP", "2", "", "pink", "black"}});
+    result.insert({"DEPOLARIZE1", {1, "DEP", "1", "", "pink", "black", 0, 10}});
+    result.insert({"DEPOLARIZE2", {1, "DEP", "2", "", "pink", "black", 0, 10}});
 
-    result.insert({"PAULI_CHANNEL_1", {4, "PAULI_CHANNEL_1", "", "", "pink", "black"}});
-    result.insert({"PAULI_CHANNEL_2[0]", {16, "PAULI_CHANNEL_2", "0", "", "pink", "black"}});
-    result.insert({"PAULI_CHANNEL_2[1]", {16, "PAULI_CHANNEL_2", "1", "", "pink", "black"}});
+    result.insert({"PAULI_CHANNEL_1", {4, "PAULI_CHANNEL_1", "", "", "pink", "black", 0, 10}});
+    result.insert({"PAULI_CHANNEL_2[0]", {16, "PAULI_CHANNEL_2", "0", "", "pink", "black", 0, 10}});
+    result.insert({"PAULI_CHANNEL_2[1]", {16, "PAULI_CHANNEL_2", "1", "", "pink", "black", 0, 10}});
 
     return result;
 }

--- a/src/stim/diagram/gate_data_svg.cc
+++ b/src/stim/diagram/gate_data_svg.cc
@@ -13,20 +13,20 @@ std::map<std::string, SvgGateData> SvgGateData::make_gate_data_map() {
     result.insert({"H", {1, "H", "", "", "white", "black"}});
     result.insert({"H_XY", {1, "H", "XY", "", "white", "black"}});
 
-    result.insert({"SQRT_X", {1, "√X", "", "", "white", "black"}});
-    result.insert({"SQRT_Y", {1, "√Y", "", "", "white", "black"}});
+    result.insert({"SQRT_X", {1, "√X", "", "", "white", "black", 24}});
+    result.insert({"SQRT_Y", {1, "√Y", "", "", "white", "black", 24}});
     result.insert({"S", {1, "S", "", "", "white", "black"}});
 
     result.insert({"SQRT_X_DAG", {1, "√X", "", "†", "white", "black"}});
     result.insert({"SQRT_Y_DAG", {1, "√Y", "", "†", "white", "black"}});
     result.insert({"S_DAG", {1, "S", "", "†", "white", "black"}});
 
-    result.insert({"MX", {1, "M", "X", "", "black", "white"}});
-    result.insert({"MY", {1, "M", "Y", "", "black", "white"}});
+    result.insert({"MX", {1, "M", "X", "", "black", "white", 26, 16}});
+    result.insert({"MY", {1, "M", "Y", "", "black", "white", 26, 16}});
     result.insert({"M", {1, "M", "", "", "black", "white"}});
 
-    result.insert({"RX", {1, "R", "X", "", "black", "white"}});
-    result.insert({"RY", {1, "R", "Y", "", "black", "white"}});
+    result.insert({"RX", {1, "R", "X", "", "black", "white", 26, 16}});
+    result.insert({"RY", {1, "R", "Y", "", "black", "white", 26, 16}});
     result.insert({"R", {1, "R", "", "", "black", "white"}});
 
     result.insert({"MRX", {1, "MR", "X", "", "black", "white"}});

--- a/src/stim/diagram/gate_data_svg.h
+++ b/src/stim/diagram/gate_data_svg.h
@@ -29,6 +29,8 @@ struct SvgGateData {
     std::string superscript;
     std::string fill;
     std::string text_color;
+    size_t font_size = 0;
+    size_t sub_font_size = 10;
 
     static std::map<std::string, SvgGateData> make_gate_data_map();
 };

--- a/src/stim/diagram/gate_data_svg.h
+++ b/src/stim/diagram/gate_data_svg.h
@@ -29,8 +29,8 @@ struct SvgGateData {
     std::string superscript;
     std::string fill;
     std::string text_color;
-    size_t font_size = 0;
-    size_t sub_font_size = 10;
+    size_t font_size;
+    size_t sub_font_size;
 
     static std::map<std::string, SvgGateData> make_gate_data_map();
 };

--- a/src/stim/diagram/timeline/timeline_svg_drawer.cc
+++ b/src/stim/diagram/timeline/timeline_svg_drawer.cc
@@ -70,7 +70,7 @@ void DiagramTimelineSvgDrawer::do_feedback(
     draw_annotated_gate(
         c.xyz[0],
         c.xyz[1],
-        SvgGateData{(uint16_t)(mode == SVG_MODE_TIMELINE ? 2 : 1), gate, "", exponent.str(), "lightgray", "black"},
+        SvgGateData{(uint16_t)(mode == SVG_MODE_TIMELINE ? 2 : 1), gate, "", exponent.str(), "lightgray", "black", 0, 10},
         {});
 }
 
@@ -597,7 +597,7 @@ void DiagramTimelineSvgDrawer::do_qubit_coords(const ResolvedTimelineOperation &
     ss << "COORDS";
     write_coords(ss, op.args);
     auto c = q2xy(target.qubit_value());
-    draw_annotated_gate(c.xyz[0], c.xyz[1], SvgGateData{(uint16_t)(2 + op.args.size()), ss.str(), "", "", "white", "black"}, {});
+    draw_annotated_gate(c.xyz[0], c.xyz[1], SvgGateData{(uint16_t)(2 + op.args.size()), ss.str(), "", "", "white", "black", 0, 10}, {});
 }
 
 void DiagramTimelineSvgDrawer::do_detector(const ResolvedTimelineOperation &op) {
@@ -611,7 +611,7 @@ void DiagramTimelineSvgDrawer::do_detector(const ResolvedTimelineOperation &op) 
 
     auto c = q2xy(pseudo_target.qubit_value());
     auto span = (uint16_t)(1 + std::max(std::max(op.targets.size(), op.args.size()), (size_t)2));
-    draw_annotated_gate(c.xyz[0], c.xyz[1], SvgGateData{span, "DETECTOR", "", "", "lightgray", "black"}, {});
+    draw_annotated_gate(c.xyz[0], c.xyz[1], SvgGateData{span, "DETECTOR", "", "", "lightgray", "black", 0, 10}, {});
     c.xyz[0] += (span - 1) * GATE_PITCH * 0.5f;
 
     if (!op.args.empty()) {
@@ -661,7 +661,7 @@ void DiagramTimelineSvgDrawer::do_observable_include(const ResolvedTimelineOpera
     auto span = (uint16_t)(1 + std::max(std::max(op.targets.size(), op.args.size()), (size_t)2));
     std::stringstream ss;
     ss << "OBS_INCLUDE(" << op.args[0] << ")";
-    draw_annotated_gate(c.xyz[0], c.xyz[1], SvgGateData{span, ss.str(), "", "", "lightgray", "black"}, {});
+    draw_annotated_gate(c.xyz[0], c.xyz[1], SvgGateData{span, ss.str(), "", "", "lightgray", "black", 0, 10}, {});
     c.xyz[0] += (span - 1) * GATE_PITCH * 0.5f;
 
     svg_out << "<text";

--- a/src/stim/diagram/timeline/timeline_svg_drawer.cc
+++ b/src/stim/diagram/timeline/timeline_svg_drawer.cc
@@ -14,6 +14,7 @@ constexpr uint16_t CIRCUIT_START_X = 32;
 constexpr uint16_t CIRCUIT_START_Y = 32;
 constexpr uint16_t GATE_PITCH = 64;
 constexpr uint16_t GATE_RADIUS = 16;
+constexpr uint16_t CONTROL_RADIUS = 12;
 constexpr float SLICE_WINDOW_GAP = 1.1f;
 
 template <typename T>
@@ -77,23 +78,23 @@ void DiagramTimelineSvgDrawer::draw_x_control(float cx, float cy) {
     svg_out << "<circle";
     write_key_val(svg_out, "cx", cx);
     write_key_val(svg_out, "cy", cy);
-    write_key_val(svg_out, "r", 8);
+    write_key_val(svg_out, "r", CONTROL_RADIUS);
     write_key_val(svg_out, "stroke", "black");
     write_key_val(svg_out, "fill", "white");
     svg_out << "/>\n";
 
     svg_out << "<path d=\"";
-    svg_out << "M" << cx - 8 << "," << cy << " ";
-    svg_out << "L" << cx + 8 << "," << cy << " ";
-    svg_out << "M" << cx << "," << cy - 8 << " ";
-    svg_out << "L" << cx << "," << cy + 8 << " ";
+    svg_out << "M" << cx - CONTROL_RADIUS << "," << cy << " ";
+    svg_out << "L" << cx + CONTROL_RADIUS << "," << cy << " ";
+    svg_out << "M" << cx << "," << cy - CONTROL_RADIUS << " ";
+    svg_out << "L" << cx << "," << cy + CONTROL_RADIUS << " ";
     svg_out << "\"";
     write_key_val(svg_out, "stroke", "black");
     svg_out << "/>\n";
 }
 
 void DiagramTimelineSvgDrawer::draw_y_control(float cx, float cy) {
-    float r = 10;
+    float r = CONTROL_RADIUS * 1.4;
     float r_sin = r * sqrtf(3) * 0.5;
     float r_cos = r * 0.5;
     svg_out << "<path d=\"";
@@ -111,18 +112,19 @@ void DiagramTimelineSvgDrawer::draw_z_control(float cx, float cy) {
     svg_out << "<circle";
     write_key_val(svg_out, "cx", cx);
     write_key_val(svg_out, "cy", cy);
-    write_key_val(svg_out, "r", 8);
+    write_key_val(svg_out, "r", CONTROL_RADIUS);
     write_key_val(svg_out, "stroke", "none");
     write_key_val(svg_out, "fill", "black");
     svg_out << "/>\n";
 }
 
 void DiagramTimelineSvgDrawer::draw_swap_control(float cx, float cy) {
+    float r = CONTROL_RADIUS / 2.0f;
     svg_out << "<path d=\"";
-    svg_out << "M" << cx - 4 << "," << cy - 4 << " ";
-    svg_out << "L" << cx + 4 << "," << cy + 4 << " ";
-    svg_out << "M" << cx + 4 << "," << cy - 4 << " ";
-    svg_out << "L" << cx - 4 << "," << cy + 4 << " ";
+    svg_out << "M" << cx - r << "," << cy - r << " ";
+    svg_out << "L" << cx + r << "," << cy + r << " ";
+    svg_out << "M" << cx + r << "," << cy - r << " ";
+    svg_out << "L" << cx - r << "," << cy + r << " ";
     svg_out << "\"";
     write_key_val(svg_out, "stroke", "black");
     svg_out << "/>\n";
@@ -132,7 +134,7 @@ void DiagramTimelineSvgDrawer::draw_iswap_control(float cx, float cy, bool inver
     svg_out << "<circle";
     write_key_val(svg_out, "cx", cx);
     write_key_val(svg_out, "cy", cy);
-    write_key_val(svg_out, "r", 8);
+    write_key_val(svg_out, "r", CONTROL_RADIUS);
     write_key_val(svg_out, "stroke", "none");
     write_key_val(svg_out, "fill", "gray");
     svg_out << "/>\n";
@@ -141,10 +143,10 @@ void DiagramTimelineSvgDrawer::draw_iswap_control(float cx, float cy, bool inver
 
     if (inverse) {
         svg_out << "<path d=\"";
-        svg_out << "M" << cx + 4 << "," << cy - 10 << " ";
-        svg_out << "L" << cx + 12 << "," << cy - 10 << " ";
-        svg_out << "M" << cx + 8 << "," << cy - 14 << " ";
-        svg_out << "L" << cx + 8 << "," << cy - 2 << " ";
+        svg_out << "M" << cx + CONTROL_RADIUS - 4 << "," << cy - CONTROL_RADIUS - 2 << " ";
+        svg_out << "L" << cx + CONTROL_RADIUS + 4 << "," << cy - CONTROL_RADIUS - 2 << " ";
+        svg_out << "M" << cx + CONTROL_RADIUS << "," << cy - CONTROL_RADIUS - 6 << " ";
+        svg_out << "L" << cx + CONTROL_RADIUS << "," << cy - 2 << " ";
         svg_out << "\"";
         write_key_val(svg_out, "stroke", "black");
         svg_out << "/>\n";
@@ -181,7 +183,7 @@ void DiagramTimelineSvgDrawer::draw_annotated_gate(
     write_key_val(svg_out, "dominant-baseline", "central");
     write_key_val(svg_out, "text-anchor", "middle");
     write_key_val(svg_out, "font-family", "monospace");
-    write_key_val(svg_out, "font-size", n == 1 ? 30 : n >= 4 && data.span == 1 ? 12 : 16);
+    write_key_val(svg_out, "font-size", data.font_size != 0 ? data.font_size : n == 1 ? 30 : n >= 4 && data.span == 1 ? 12 : 16);
     write_key_val(svg_out, "x", cx);
     write_key_val(svg_out, "y", cy);
     if (data.text_color != "black") {
@@ -192,7 +194,7 @@ void DiagramTimelineSvgDrawer::draw_annotated_gate(
     if (data.superscript[0] != '\0') {
         svg_out << "<tspan";
         write_key_val(svg_out, "baseline-shift", "super");
-        write_key_val(svg_out, "font-size", "10");
+        write_key_val(svg_out, "font-size", data.sub_font_size);
         svg_out << ">";
         svg_out << data.superscript;
         svg_out << "</tspan>";
@@ -200,7 +202,7 @@ void DiagramTimelineSvgDrawer::draw_annotated_gate(
     if (data.subscript[0] != '\0') {
         svg_out << "<tspan";
         write_key_val(svg_out, "baseline-shift", "sub");
-        write_key_val(svg_out, "font-size", 10);
+        write_key_val(svg_out, "font-size", data.sub_font_size);
         svg_out << ">";
         svg_out << data.subscript;
         svg_out << "</tspan>";
@@ -212,7 +214,7 @@ void DiagramTimelineSvgDrawer::draw_annotated_gate(
         write_key_val(svg_out, "dominant-baseline", "hanging");
         write_key_val(svg_out, "text-anchor", "middle");
         write_key_val(svg_out, "font-family", "monospace");
-        write_key_val(svg_out, "font-size", 10);
+        write_key_val(svg_out, "font-size", data.sub_font_size);
         write_key_val(svg_out, "stroke", "red");
         write_key_val(svg_out, "x", cx);
         write_key_val(svg_out, "y", cy + GATE_RADIUS + 4);
@@ -423,7 +425,7 @@ void DiagramTimelineSvgDrawer::reserve_drawing_room_for_targets(ConstPointerRang
             }
             svg_out << "\"";
             write_key_val(svg_out, "stroke", "black");
-            write_key_val(svg_out, "stroke-width", "3");
+            write_key_val(svg_out, "stroke-width", "5");
             svg_out << "/>\n";
         }
 

--- a/testdata/collapsing.svg
+++ b/testdata/collapsing.svg
@@ -10,9 +10,9 @@
 <rect x="80" y="48" width="32" height="32" stroke="black" fill="black"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="64" fill="white">R</text>
 <rect x="80" y="112" width="32" height="32" stroke="black" fill="black"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="128" fill="white">R<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="26" x="96" y="128" fill="white">R<tspan baseline-shift="sub" font-size="16">X</tspan></text>
 <rect x="80" y="176" width="32" height="32" stroke="black" fill="black"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="96" y="192" fill="white">R<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="26" x="96" y="192" fill="white">R<tspan baseline-shift="sub" font-size="16">Y</tspan></text>
 <rect x="80" y="240" width="32" height="32" stroke="black" fill="black"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="256" fill="white">R</text>
 <rect x="144" y="48" width="32" height="32" stroke="black" fill="black"/>
@@ -48,10 +48,10 @@
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="64" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="352" y="44">rec[9]</text>
 <rect x="400" y="112" width="32" height="32" stroke="black" fill="black"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="128" fill="white">M<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="26" x="416" y="128" fill="white">M<tspan baseline-shift="sub" font-size="16">X</tspan></text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="416" y="108">rec[10]</text>
 <rect x="400" y="176" width="32" height="32" stroke="black" fill="black"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="416" y="192" fill="white">M<tspan baseline-shift="sub" font-size="10">Y</tspan></text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="26" x="416" y="192" fill="white">M<tspan baseline-shift="sub" font-size="16">Y</tspan></text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="416" y="172">rec[11]</text>
 <rect x="400" y="240" width="32" height="32" stroke="black" fill="black"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="416" y="256" fill="white">M</text>

--- a/testdata/command_diagram_timeline.svg
+++ b/testdata/command_diagram_timeline.svg
@@ -10,9 +10,9 @@
 <rect x="144" y="48" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="160" y="64">H</text>
 <path d="M224,64 L224,128 " stroke="black"/>
-<circle cx="224" cy="64" r="8" stroke="none" fill="black"/>
-<circle cx="224" cy="128" r="8" stroke="black" fill="white"/>
-<path d="M216,128 L232,128 M224,120 L224,136 " stroke="black"/>
+<circle cx="224" cy="64" r="12" stroke="none" fill="black"/>
+<circle cx="224" cy="128" r="12" stroke="black" fill="white"/>
+<path d="M212,128 L236,128 M224,116 L224,140 " stroke="black"/>
 <path d="M132,40 L132,32 L252,32 L252,40 " stroke="black" fill="none"/>
 <path d="M132,184 L132,192 L252,192 L252,184 " stroke="black" fill="none"/>
 <rect x="272" y="48" width="32" height="32" stroke="black" fill="white"/>

--- a/testdata/command_diagram_timeline_tick1.svg
+++ b/testdata/command_diagram_timeline_tick1.svg
@@ -6,9 +6,9 @@
 <rect x="80" y="48" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="64">H</text>
 <path d="M160,64 L160,128 " stroke="black"/>
-<circle cx="160" cy="64" r="8" stroke="none" fill="black"/>
-<circle cx="160" cy="128" r="8" stroke="black" fill="white"/>
-<path d="M152,128 L168,128 M160,120 L160,136 " stroke="black"/>
+<circle cx="160" cy="64" r="12" stroke="none" fill="black"/>
+<circle cx="160" cy="128" r="12" stroke="black" fill="white"/>
+<path d="M148,128 L172,128 M160,116 L160,140 " stroke="black"/>
 <path d="M68,40 L68,32 L188,32 L188,40 " stroke="black" fill="none"/>
 <path d="M68,184 L68,192 L188,192 L188,184 " stroke="black" fill="none"/>
 </svg>

--- a/testdata/command_diagram_timeline_tick1_3.svg
+++ b/testdata/command_diagram_timeline_tick1_3.svg
@@ -6,9 +6,9 @@
 <rect x="80" y="48" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="64">H</text>
 <path d="M160,64 L160,128 " stroke="black"/>
-<circle cx="160" cy="64" r="8" stroke="none" fill="black"/>
-<circle cx="160" cy="128" r="8" stroke="black" fill="white"/>
-<path d="M152,128 L168,128 M160,120 L160,136 " stroke="black"/>
+<circle cx="160" cy="64" r="12" stroke="none" fill="black"/>
+<circle cx="160" cy="128" r="12" stroke="black" fill="white"/>
+<path d="M148,128 L172,128 M160,116 L160,140 " stroke="black"/>
 <path d="M68,40 L68,32 L188,32 L188,40 " stroke="black" fill="none"/>
 <path d="M68,184 L68,192 L188,192 L188,184 " stroke="black" fill="none"/>
 <rect x="208" y="48" width="32" height="32" stroke="black" fill="white"/>

--- a/testdata/lattice_surgery_cnot.svg
+++ b/testdata/lattice_surgery_cnot.svg
@@ -20,7 +20,7 @@
 <rect x="208" y="176" width="32" height="32" stroke="black" fill="black"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="224" y="192" fill="white">MPP<tspan baseline-shift="sub" font-size="10">Z</tspan></text>
 <rect x="272" y="176" width="32" height="32" stroke="black" fill="black"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="192" fill="white">M<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="26" x="288" y="192" fill="white">M<tspan baseline-shift="sub" font-size="16">X</tspan></text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="288" y="172">rec[2]</text>
 <rect x="272" y="48" width="96" height="32" stroke="black" fill="lightgray"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="320" y="64">Z<tspan baseline-shift="super" font-size="10">rec[0]</tspan></text>

--- a/testdata/repeat.svg
+++ b/testdata/repeat.svg
@@ -16,7 +16,7 @@
 <path d="M168,32 L160,32 L160,320 L168,320 " stroke="black" fill="none"/>
 <text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="164" y="316">REP5</text>
 <rect x="208" y="176" width="32" height="32" stroke="black" fill="black"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="192" fill="white">R<tspan baseline-shift="sub" font-size="10">X</tspan></text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="26" x="224" y="192" fill="white">R<tspan baseline-shift="sub" font-size="16">X</tspan></text>
 <path d="M296,36 L288,36 L288,316 L296,316 " stroke="black" fill="none"/>
 <text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="292" y="312">REP100</text>
 <rect x="336" y="48" width="32" height="32" stroke="black" fill="white"/>

--- a/testdata/repetition_code.svg
+++ b/testdata/repetition_code.svg
@@ -20,21 +20,21 @@
 <rect x="80" y="304" width="32" height="32" stroke="black" fill="black"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="96" y="320" fill="white">R</text>
 <path d="M160,64 L160,128 " stroke="black"/>
-<circle cx="160" cy="64" r="8" stroke="none" fill="black"/>
-<circle cx="160" cy="128" r="8" stroke="black" fill="white"/>
-<path d="M152,128 L168,128 M160,120 L160,136 " stroke="black"/>
+<circle cx="160" cy="64" r="12" stroke="none" fill="black"/>
+<circle cx="160" cy="128" r="12" stroke="black" fill="white"/>
+<path d="M148,128 L172,128 M160,116 L160,140 " stroke="black"/>
 <path d="M160,192 L160,256 " stroke="black"/>
-<circle cx="160" cy="192" r="8" stroke="none" fill="black"/>
-<circle cx="160" cy="256" r="8" stroke="black" fill="white"/>
-<path d="M152,256 L168,256 M160,248 L160,264 " stroke="black"/>
+<circle cx="160" cy="192" r="12" stroke="none" fill="black"/>
+<circle cx="160" cy="256" r="12" stroke="black" fill="white"/>
+<path d="M148,256 L172,256 M160,244 L160,268 " stroke="black"/>
 <path d="M224,128 L224,192 " stroke="black"/>
-<circle cx="224" cy="192" r="8" stroke="none" fill="black"/>
-<circle cx="224" cy="128" r="8" stroke="black" fill="white"/>
-<path d="M216,128 L232,128 M224,120 L224,136 " stroke="black"/>
+<circle cx="224" cy="192" r="12" stroke="none" fill="black"/>
+<circle cx="224" cy="128" r="12" stroke="black" fill="white"/>
+<path d="M212,128 L236,128 M224,116 L224,140 " stroke="black"/>
 <path d="M224,256 L224,320 " stroke="black"/>
-<circle cx="224" cy="320" r="8" stroke="none" fill="black"/>
-<circle cx="224" cy="256" r="8" stroke="black" fill="white"/>
-<path d="M216,256 L232,256 M224,248 L224,264 " stroke="black"/>
+<circle cx="224" cy="320" r="12" stroke="none" fill="black"/>
+<circle cx="224" cy="256" r="12" stroke="black" fill="white"/>
+<path d="M212,256 L236,256 M224,244 L224,268 " stroke="black"/>
 <rect x="272" y="112" width="32" height="32" stroke="black" fill="black"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="128" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="288" y="108">rec[0]</text>
@@ -54,21 +54,21 @@
 <path d="M552,32 L544,32 L544,384 L552,384 " stroke="black" fill="none"/>
 <text dominant-baseline="auto" text-anchor="start" font-family="monospace" font-size="12" x="548" y="380">REP9</text>
 <path d="M672,64 L672,128 " stroke="black"/>
-<circle cx="672" cy="64" r="8" stroke="none" fill="black"/>
-<circle cx="672" cy="128" r="8" stroke="black" fill="white"/>
-<path d="M664,128 L680,128 M672,120 L672,136 " stroke="black"/>
+<circle cx="672" cy="64" r="12" stroke="none" fill="black"/>
+<circle cx="672" cy="128" r="12" stroke="black" fill="white"/>
+<path d="M660,128 L684,128 M672,116 L672,140 " stroke="black"/>
 <path d="M672,192 L672,256 " stroke="black"/>
-<circle cx="672" cy="192" r="8" stroke="none" fill="black"/>
-<circle cx="672" cy="256" r="8" stroke="black" fill="white"/>
-<path d="M664,256 L680,256 M672,248 L672,264 " stroke="black"/>
+<circle cx="672" cy="192" r="12" stroke="none" fill="black"/>
+<circle cx="672" cy="256" r="12" stroke="black" fill="white"/>
+<path d="M660,256 L684,256 M672,244 L672,268 " stroke="black"/>
 <path d="M736,128 L736,192 " stroke="black"/>
-<circle cx="736" cy="192" r="8" stroke="none" fill="black"/>
-<circle cx="736" cy="128" r="8" stroke="black" fill="white"/>
-<path d="M728,128 L744,128 M736,120 L736,136 " stroke="black"/>
+<circle cx="736" cy="192" r="12" stroke="none" fill="black"/>
+<circle cx="736" cy="128" r="12" stroke="black" fill="white"/>
+<path d="M724,128 L748,128 M736,116 L736,140 " stroke="black"/>
 <path d="M736,256 L736,320 " stroke="black"/>
-<circle cx="736" cy="320" r="8" stroke="none" fill="black"/>
-<circle cx="736" cy="256" r="8" stroke="black" fill="white"/>
-<path d="M728,256 L744,256 M736,248 L736,264 " stroke="black"/>
+<circle cx="736" cy="320" r="12" stroke="none" fill="black"/>
+<circle cx="736" cy="256" r="12" stroke="black" fill="white"/>
+<path d="M724,256 L748,256 M736,244 L736,268 " stroke="black"/>
 <rect x="784" y="112" width="32" height="32" stroke="black" fill="black"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="800" y="128" fill="white">MR</text>
 <text text-anchor="middle" font-family="monospace" font-size="8" x="800" y="108">rec[2+iter*2]</text>

--- a/testdata/single_qubits_gates.svg
+++ b/testdata/single_qubits_gates.svg
@@ -30,11 +30,11 @@
 <rect x="208" y="176" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="224" y="192">S</text>
 <rect x="208" y="240" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="224" y="256">√X</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="24" x="224" y="256">√X</text>
 <rect x="272" y="48" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="64">√X<tspan baseline-shift="super" font-size="10">†</tspan></text>
 <rect x="272" y="112" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="128">√Y</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="24" x="288" y="128">√Y</text>
 <rect x="272" y="176" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="288" y="192">√Y<tspan baseline-shift="super" font-size="10">†</tspan></text>
 <rect x="272" y="240" width="32" height="32" stroke="black" fill="white"/>

--- a/testdata/surface_code.svg
+++ b/testdata/surface_code.svg
@@ -164,169 +164,169 @@
 <rect x="400" y="1520" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="416" y="1536">H</text>
 <path d="M480,128 L480,192 " stroke="black"/>
-<circle cx="480" cy="128" r="8" stroke="none" fill="black"/>
-<circle cx="480" cy="192" r="8" stroke="black" fill="white"/>
-<path d="M472,192 L488,192 M480,184 L480,200 " stroke="black"/>
+<circle cx="480" cy="128" r="12" stroke="none" fill="black"/>
+<circle cx="480" cy="192" r="12" stroke="black" fill="white"/>
+<path d="M468,192 L492,192 M480,180 L480,204 " stroke="black"/>
 <path d="M480,768 L480,832 " stroke="black"/>
-<circle cx="480" cy="768" r="8" stroke="none" fill="black"/>
-<circle cx="480" cy="832" r="8" stroke="black" fill="white"/>
-<path d="M472,832 L488,832 M480,824 L480,840 " stroke="black"/>
+<circle cx="480" cy="768" r="12" stroke="none" fill="black"/>
+<circle cx="480" cy="832" r="12" stroke="black" fill="white"/>
+<path d="M468,832 L492,832 M480,820 L480,844 " stroke="black"/>
 <path d="M480,1408 L480,1472 " stroke="black"/>
-<circle cx="480" cy="1408" r="8" stroke="none" fill="black"/>
-<circle cx="480" cy="1472" r="8" stroke="black" fill="white"/>
-<path d="M472,1472 L488,1472 M480,1464 L480,1480 " stroke="black"/>
+<circle cx="480" cy="1408" r="12" stroke="none" fill="black"/>
+<circle cx="480" cy="1472" r="12" stroke="black" fill="white"/>
+<path d="M468,1472 L492,1472 M480,1460 L480,1484 " stroke="black"/>
 <path d="M480,256 L480,320 " stroke="black"/>
-<circle cx="480" cy="256" r="8" stroke="none" fill="black"/>
-<circle cx="480" cy="320" r="8" stroke="black" fill="white"/>
-<path d="M472,320 L488,320 M480,312 L480,328 " stroke="black"/>
+<circle cx="480" cy="256" r="12" stroke="none" fill="black"/>
+<circle cx="480" cy="320" r="12" stroke="black" fill="white"/>
+<path d="M468,320 L492,320 M480,308 L480,332 " stroke="black"/>
 <path d="M480,896 L480,960 " stroke="black"/>
-<circle cx="480" cy="896" r="8" stroke="none" fill="black"/>
-<circle cx="480" cy="960" r="8" stroke="black" fill="white"/>
-<path d="M472,960 L488,960 M480,952 L480,968 " stroke="black"/>
+<circle cx="480" cy="896" r="12" stroke="none" fill="black"/>
+<circle cx="480" cy="960" r="12" stroke="black" fill="white"/>
+<path d="M468,960 L492,960 M480,948 L480,972 " stroke="black"/>
 <path d="M480,1536 L480,1600 " stroke="black"/>
-<circle cx="480" cy="1536" r="8" stroke="none" fill="black"/>
-<circle cx="480" cy="1600" r="8" stroke="black" fill="white"/>
-<path d="M472,1600 L488,1600 M480,1592 L480,1608 " stroke="black"/>
+<circle cx="480" cy="1536" r="12" stroke="none" fill="black"/>
+<circle cx="480" cy="1600" r="12" stroke="black" fill="white"/>
+<path d="M468,1600 L492,1600 M480,1588 L480,1612 " stroke="black"/>
 <path d="M480,384 L480,448 " stroke="black"/>
-<circle cx="480" cy="448" r="8" stroke="none" fill="black"/>
-<circle cx="480" cy="384" r="8" stroke="black" fill="white"/>
-<path d="M472,384 L488,384 M480,376 L480,392 " stroke="black"/>
+<circle cx="480" cy="448" r="12" stroke="none" fill="black"/>
+<circle cx="480" cy="384" r="12" stroke="black" fill="white"/>
+<path d="M468,384 L492,384 M480,372 L480,396 " stroke="black"/>
 <path d="M480,1024 L480,1088 " stroke="black"/>
-<circle cx="480" cy="1088" r="8" stroke="none" fill="black"/>
-<circle cx="480" cy="1024" r="8" stroke="black" fill="white"/>
-<path d="M472,1024 L488,1024 M480,1016 L480,1032 " stroke="black"/>
+<circle cx="480" cy="1088" r="12" stroke="none" fill="black"/>
+<circle cx="480" cy="1024" r="12" stroke="black" fill="white"/>
+<path d="M468,1024 L492,1024 M480,1012 L480,1036 " stroke="black"/>
 <path d="M480,512 L480,576 " stroke="black"/>
-<circle cx="480" cy="576" r="8" stroke="none" fill="black"/>
-<circle cx="480" cy="512" r="8" stroke="black" fill="white"/>
-<path d="M472,512 L488,512 M480,504 L480,520 " stroke="black"/>
+<circle cx="480" cy="576" r="12" stroke="none" fill="black"/>
+<circle cx="480" cy="512" r="12" stroke="black" fill="white"/>
+<path d="M468,512 L492,512 M480,500 L480,524 " stroke="black"/>
 <path d="M480,1152 L480,1216 " stroke="black"/>
-<circle cx="480" cy="1216" r="8" stroke="none" fill="black"/>
-<circle cx="480" cy="1152" r="8" stroke="black" fill="white"/>
-<path d="M472,1152 L488,1152 M480,1144 L480,1160 " stroke="black"/>
+<circle cx="480" cy="1216" r="12" stroke="none" fill="black"/>
+<circle cx="480" cy="1152" r="12" stroke="black" fill="white"/>
+<path d="M468,1152 L492,1152 M480,1140 L480,1164 " stroke="black"/>
 <path d="M544,128 L544,448 " stroke="black"/>
-<circle cx="544" cy="128" r="8" stroke="none" fill="black"/>
-<circle cx="544" cy="448" r="8" stroke="black" fill="white"/>
-<path d="M536,448 L552,448 M544,440 L544,456 " stroke="black"/>
+<circle cx="544" cy="128" r="12" stroke="none" fill="black"/>
+<circle cx="544" cy="448" r="12" stroke="black" fill="white"/>
+<path d="M532,448 L556,448 M544,436 L544,460 " stroke="black"/>
 <path d="M544,768 L544,1088 " stroke="black"/>
-<circle cx="544" cy="768" r="8" stroke="none" fill="black"/>
-<circle cx="544" cy="1088" r="8" stroke="black" fill="white"/>
-<path d="M536,1088 L552,1088 M544,1080 L544,1096 " stroke="black"/>
+<circle cx="544" cy="768" r="12" stroke="none" fill="black"/>
+<circle cx="544" cy="1088" r="12" stroke="black" fill="white"/>
+<path d="M532,1088 L556,1088 M544,1076 L544,1100 " stroke="black"/>
 <path d="M608,256 L608,576 " stroke="black"/>
-<circle cx="608" cy="256" r="8" stroke="none" fill="black"/>
-<circle cx="608" cy="576" r="8" stroke="black" fill="white"/>
-<path d="M600,576 L616,576 M608,568 L608,584 " stroke="black"/>
+<circle cx="608" cy="256" r="12" stroke="none" fill="black"/>
+<circle cx="608" cy="576" r="12" stroke="black" fill="white"/>
+<path d="M596,576 L620,576 M608,564 L608,588 " stroke="black"/>
 <path d="M608,896 L608,1216 " stroke="black"/>
-<circle cx="608" cy="896" r="8" stroke="none" fill="black"/>
-<circle cx="608" cy="1216" r="8" stroke="black" fill="white"/>
-<path d="M600,1216 L616,1216 M608,1208 L608,1224 " stroke="black"/>
+<circle cx="608" cy="896" r="12" stroke="none" fill="black"/>
+<circle cx="608" cy="1216" r="12" stroke="black" fill="white"/>
+<path d="M596,1216 L620,1216 M608,1204 L608,1228 " stroke="black"/>
 <path d="M672,384 L672,704 " stroke="black"/>
-<circle cx="672" cy="704" r="8" stroke="none" fill="black"/>
-<circle cx="672" cy="384" r="8" stroke="black" fill="white"/>
-<path d="M664,384 L680,384 M672,376 L672,392 " stroke="black"/>
+<circle cx="672" cy="704" r="12" stroke="none" fill="black"/>
+<circle cx="672" cy="384" r="12" stroke="black" fill="white"/>
+<path d="M660,384 L684,384 M672,372 L672,396 " stroke="black"/>
 <path d="M672,1024 L672,1344 " stroke="black"/>
-<circle cx="672" cy="1344" r="8" stroke="none" fill="black"/>
-<circle cx="672" cy="1024" r="8" stroke="black" fill="white"/>
-<path d="M664,1024 L680,1024 M672,1016 L672,1032 " stroke="black"/>
+<circle cx="672" cy="1344" r="12" stroke="none" fill="black"/>
+<circle cx="672" cy="1024" r="12" stroke="black" fill="white"/>
+<path d="M660,1024 L684,1024 M672,1012 L672,1036 " stroke="black"/>
 <path d="M736,512 L736,832 " stroke="black"/>
-<circle cx="736" cy="832" r="8" stroke="none" fill="black"/>
-<circle cx="736" cy="512" r="8" stroke="black" fill="white"/>
-<path d="M728,512 L744,512 M736,504 L736,520 " stroke="black"/>
+<circle cx="736" cy="832" r="12" stroke="none" fill="black"/>
+<circle cx="736" cy="512" r="12" stroke="black" fill="white"/>
+<path d="M724,512 L748,512 M736,500 L736,524 " stroke="black"/>
 <path d="M736,1152 L736,1472 " stroke="black"/>
-<circle cx="736" cy="1472" r="8" stroke="none" fill="black"/>
-<circle cx="736" cy="1152" r="8" stroke="black" fill="white"/>
-<path d="M728,1152 L744,1152 M736,1144 L736,1160 " stroke="black"/>
+<circle cx="736" cy="1472" r="12" stroke="none" fill="black"/>
+<circle cx="736" cy="1152" r="12" stroke="black" fill="white"/>
+<path d="M724,1152 L748,1152 M736,1140 L736,1164 " stroke="black"/>
 <path d="M800,640 L800,960 " stroke="black"/>
-<circle cx="800" cy="960" r="8" stroke="none" fill="black"/>
-<circle cx="800" cy="640" r="8" stroke="black" fill="white"/>
-<path d="M792,640 L808,640 M800,632 L800,648 " stroke="black"/>
+<circle cx="800" cy="960" r="12" stroke="none" fill="black"/>
+<circle cx="800" cy="640" r="12" stroke="black" fill="white"/>
+<path d="M788,640 L812,640 M800,628 L800,652 " stroke="black"/>
 <path d="M800,1280 L800,1600 " stroke="black"/>
-<circle cx="800" cy="1600" r="8" stroke="none" fill="black"/>
-<circle cx="800" cy="1280" r="8" stroke="black" fill="white"/>
-<path d="M792,1280 L808,1280 M800,1272 L800,1288 " stroke="black"/>
+<circle cx="800" cy="1600" r="12" stroke="none" fill="black"/>
+<circle cx="800" cy="1280" r="12" stroke="black" fill="white"/>
+<path d="M788,1280 L812,1280 M800,1268 L800,1292 " stroke="black"/>
 <path d="M516,40 L516,32 L828,32 L828,40 " stroke="black" fill="none"/>
 <path d="M516,1656 L516,1664 L828,1664 L828,1656 " stroke="black" fill="none"/>
 <path d="M864,448 L864,768 " stroke="black"/>
-<circle cx="864" cy="768" r="8" stroke="none" fill="black"/>
-<circle cx="864" cy="448" r="8" stroke="black" fill="white"/>
-<path d="M856,448 L872,448 M864,440 L864,456 " stroke="black"/>
+<circle cx="864" cy="768" r="12" stroke="none" fill="black"/>
+<circle cx="864" cy="448" r="12" stroke="black" fill="white"/>
+<path d="M852,448 L876,448 M864,436 L864,460 " stroke="black"/>
 <path d="M864,1088 L864,1408 " stroke="black"/>
-<circle cx="864" cy="1408" r="8" stroke="none" fill="black"/>
-<circle cx="864" cy="1088" r="8" stroke="black" fill="white"/>
-<path d="M856,1088 L872,1088 M864,1080 L864,1096 " stroke="black"/>
+<circle cx="864" cy="1408" r="12" stroke="none" fill="black"/>
+<circle cx="864" cy="1088" r="12" stroke="black" fill="white"/>
+<path d="M852,1088 L876,1088 M864,1076 L864,1100 " stroke="black"/>
 <path d="M928,576 L928,896 " stroke="black"/>
-<circle cx="928" cy="896" r="8" stroke="none" fill="black"/>
-<circle cx="928" cy="576" r="8" stroke="black" fill="white"/>
-<path d="M920,576 L936,576 M928,568 L928,584 " stroke="black"/>
+<circle cx="928" cy="896" r="12" stroke="none" fill="black"/>
+<circle cx="928" cy="576" r="12" stroke="black" fill="white"/>
+<path d="M916,576 L940,576 M928,564 L928,588 " stroke="black"/>
 <path d="M928,1216 L928,1536 " stroke="black"/>
-<circle cx="928" cy="1536" r="8" stroke="none" fill="black"/>
-<circle cx="928" cy="1216" r="8" stroke="black" fill="white"/>
-<path d="M920,1216 L936,1216 M928,1208 L928,1224 " stroke="black"/>
+<circle cx="928" cy="1536" r="12" stroke="none" fill="black"/>
+<circle cx="928" cy="1216" r="12" stroke="black" fill="white"/>
+<path d="M916,1216 L940,1216 M928,1204 L928,1228 " stroke="black"/>
 <path d="M928,64 L928,384 " stroke="black"/>
-<circle cx="928" cy="64" r="8" stroke="none" fill="black"/>
-<circle cx="928" cy="384" r="8" stroke="black" fill="white"/>
-<path d="M920,384 L936,384 M928,376 L928,392 " stroke="black"/>
+<circle cx="928" cy="64" r="12" stroke="none" fill="black"/>
+<circle cx="928" cy="384" r="12" stroke="black" fill="white"/>
+<path d="M916,384 L940,384 M928,372 L928,396 " stroke="black"/>
 <path d="M992,704 L992,1024 " stroke="black"/>
-<circle cx="992" cy="704" r="8" stroke="none" fill="black"/>
-<circle cx="992" cy="1024" r="8" stroke="black" fill="white"/>
-<path d="M984,1024 L1000,1024 M992,1016 L992,1032 " stroke="black"/>
+<circle cx="992" cy="704" r="12" stroke="none" fill="black"/>
+<circle cx="992" cy="1024" r="12" stroke="black" fill="white"/>
+<path d="M980,1024 L1004,1024 M992,1012 L992,1036 " stroke="black"/>
 <path d="M992,192 L992,512 " stroke="black"/>
-<circle cx="992" cy="192" r="8" stroke="none" fill="black"/>
-<circle cx="992" cy="512" r="8" stroke="black" fill="white"/>
-<path d="M984,512 L1000,512 M992,504 L992,520 " stroke="black"/>
+<circle cx="992" cy="192" r="12" stroke="none" fill="black"/>
+<circle cx="992" cy="512" r="12" stroke="black" fill="white"/>
+<path d="M980,512 L1004,512 M992,500 L992,524 " stroke="black"/>
 <path d="M1056,832 L1056,1152 " stroke="black"/>
-<circle cx="1056" cy="832" r="8" stroke="none" fill="black"/>
-<circle cx="1056" cy="1152" r="8" stroke="black" fill="white"/>
-<path d="M1048,1152 L1064,1152 M1056,1144 L1056,1160 " stroke="black"/>
+<circle cx="1056" cy="832" r="12" stroke="none" fill="black"/>
+<circle cx="1056" cy="1152" r="12" stroke="black" fill="white"/>
+<path d="M1044,1152 L1068,1152 M1056,1140 L1056,1164 " stroke="black"/>
 <path d="M1056,320 L1056,640 " stroke="black"/>
-<circle cx="1056" cy="320" r="8" stroke="none" fill="black"/>
-<circle cx="1056" cy="640" r="8" stroke="black" fill="white"/>
-<path d="M1048,640 L1064,640 M1056,632 L1056,648 " stroke="black"/>
+<circle cx="1056" cy="320" r="12" stroke="none" fill="black"/>
+<circle cx="1056" cy="640" r="12" stroke="black" fill="white"/>
+<path d="M1044,640 L1068,640 M1056,628 L1056,652 " stroke="black"/>
 <path d="M1120,960 L1120,1280 " stroke="black"/>
-<circle cx="1120" cy="960" r="8" stroke="none" fill="black"/>
-<circle cx="1120" cy="1280" r="8" stroke="black" fill="white"/>
-<path d="M1112,1280 L1128,1280 M1120,1272 L1120,1288 " stroke="black"/>
+<circle cx="1120" cy="960" r="12" stroke="none" fill="black"/>
+<circle cx="1120" cy="1280" r="12" stroke="black" fill="white"/>
+<path d="M1108,1280 L1132,1280 M1120,1268 L1120,1292 " stroke="black"/>
 <path d="M836,40 L836,32 L1148,32 L1148,40 " stroke="black" fill="none"/>
 <path d="M836,1656 L836,1664 L1148,1664 L1148,1656 " stroke="black" fill="none"/>
 <path d="M1184,64 L1184,128 " stroke="black"/>
-<circle cx="1184" cy="128" r="8" stroke="none" fill="black"/>
-<circle cx="1184" cy="64" r="8" stroke="black" fill="white"/>
-<path d="M1176,64 L1192,64 M1184,56 L1184,72 " stroke="black"/>
+<circle cx="1184" cy="128" r="12" stroke="none" fill="black"/>
+<circle cx="1184" cy="64" r="12" stroke="black" fill="white"/>
+<path d="M1172,64 L1196,64 M1184,52 L1184,76 " stroke="black"/>
 <path d="M1184,704 L1184,768 " stroke="black"/>
-<circle cx="1184" cy="768" r="8" stroke="none" fill="black"/>
-<circle cx="1184" cy="704" r="8" stroke="black" fill="white"/>
-<path d="M1176,704 L1192,704 M1184,696 L1184,712 " stroke="black"/>
+<circle cx="1184" cy="768" r="12" stroke="none" fill="black"/>
+<circle cx="1184" cy="704" r="12" stroke="black" fill="white"/>
+<path d="M1172,704 L1196,704 M1184,692 L1184,716 " stroke="black"/>
 <path d="M1184,1344 L1184,1408 " stroke="black"/>
-<circle cx="1184" cy="1408" r="8" stroke="none" fill="black"/>
-<circle cx="1184" cy="1344" r="8" stroke="black" fill="white"/>
-<path d="M1176,1344 L1192,1344 M1184,1336 L1184,1352 " stroke="black"/>
+<circle cx="1184" cy="1408" r="12" stroke="none" fill="black"/>
+<circle cx="1184" cy="1344" r="12" stroke="black" fill="white"/>
+<path d="M1172,1344 L1196,1344 M1184,1332 L1184,1356 " stroke="black"/>
 <path d="M1184,192 L1184,256 " stroke="black"/>
-<circle cx="1184" cy="256" r="8" stroke="none" fill="black"/>
-<circle cx="1184" cy="192" r="8" stroke="black" fill="white"/>
-<path d="M1176,192 L1192,192 M1184,184 L1184,200 " stroke="black"/>
+<circle cx="1184" cy="256" r="12" stroke="none" fill="black"/>
+<circle cx="1184" cy="192" r="12" stroke="black" fill="white"/>
+<path d="M1172,192 L1196,192 M1184,180 L1184,204 " stroke="black"/>
 <path d="M1184,832 L1184,896 " stroke="black"/>
-<circle cx="1184" cy="896" r="8" stroke="none" fill="black"/>
-<circle cx="1184" cy="832" r="8" stroke="black" fill="white"/>
-<path d="M1176,832 L1192,832 M1184,824 L1184,840 " stroke="black"/>
+<circle cx="1184" cy="896" r="12" stroke="none" fill="black"/>
+<circle cx="1184" cy="832" r="12" stroke="black" fill="white"/>
+<path d="M1172,832 L1196,832 M1184,820 L1184,844 " stroke="black"/>
 <path d="M1184,1472 L1184,1536 " stroke="black"/>
-<circle cx="1184" cy="1536" r="8" stroke="none" fill="black"/>
-<circle cx="1184" cy="1472" r="8" stroke="black" fill="white"/>
-<path d="M1176,1472 L1192,1472 M1184,1464 L1184,1480 " stroke="black"/>
+<circle cx="1184" cy="1536" r="12" stroke="none" fill="black"/>
+<circle cx="1184" cy="1472" r="12" stroke="black" fill="white"/>
+<path d="M1172,1472 L1196,1472 M1184,1460 L1184,1484 " stroke="black"/>
 <path d="M1184,448 L1184,512 " stroke="black"/>
-<circle cx="1184" cy="448" r="8" stroke="none" fill="black"/>
-<circle cx="1184" cy="512" r="8" stroke="black" fill="white"/>
-<path d="M1176,512 L1192,512 M1184,504 L1184,520 " stroke="black"/>
+<circle cx="1184" cy="448" r="12" stroke="none" fill="black"/>
+<circle cx="1184" cy="512" r="12" stroke="black" fill="white"/>
+<path d="M1172,512 L1196,512 M1184,500 L1184,524 " stroke="black"/>
 <path d="M1184,1088 L1184,1152 " stroke="black"/>
-<circle cx="1184" cy="1088" r="8" stroke="none" fill="black"/>
-<circle cx="1184" cy="1152" r="8" stroke="black" fill="white"/>
-<path d="M1176,1152 L1192,1152 M1184,1144 L1184,1160 " stroke="black"/>
+<circle cx="1184" cy="1088" r="12" stroke="none" fill="black"/>
+<circle cx="1184" cy="1152" r="12" stroke="black" fill="white"/>
+<path d="M1172,1152 L1196,1152 M1184,1140 L1184,1164 " stroke="black"/>
 <path d="M1184,576 L1184,640 " stroke="black"/>
-<circle cx="1184" cy="576" r="8" stroke="none" fill="black"/>
-<circle cx="1184" cy="640" r="8" stroke="black" fill="white"/>
-<path d="M1176,640 L1192,640 M1184,632 L1184,648 " stroke="black"/>
+<circle cx="1184" cy="576" r="12" stroke="none" fill="black"/>
+<circle cx="1184" cy="640" r="12" stroke="black" fill="white"/>
+<path d="M1172,640 L1196,640 M1184,628 L1184,652 " stroke="black"/>
 <path d="M1184,1216 L1184,1280 " stroke="black"/>
-<circle cx="1184" cy="1216" r="8" stroke="none" fill="black"/>
-<circle cx="1184" cy="1280" r="8" stroke="black" fill="white"/>
-<path d="M1176,1280 L1192,1280 M1184,1272 L1184,1288 " stroke="black"/>
+<circle cx="1184" cy="1216" r="12" stroke="none" fill="black"/>
+<circle cx="1184" cy="1280" r="12" stroke="black" fill="white"/>
+<path d="M1172,1280 L1196,1280 M1184,1268 L1184,1292 " stroke="black"/>
 <rect x="1232" y="112" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1248" y="128">H</text>
 <rect x="1232" y="240" width="32" height="32" stroke="black" fill="white"/>
@@ -416,169 +416,169 @@
 <rect x="1744" y="1520" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1760" y="1536">H</text>
 <path d="M1824,128 L1824,192 " stroke="black"/>
-<circle cx="1824" cy="128" r="8" stroke="none" fill="black"/>
-<circle cx="1824" cy="192" r="8" stroke="black" fill="white"/>
-<path d="M1816,192 L1832,192 M1824,184 L1824,200 " stroke="black"/>
+<circle cx="1824" cy="128" r="12" stroke="none" fill="black"/>
+<circle cx="1824" cy="192" r="12" stroke="black" fill="white"/>
+<path d="M1812,192 L1836,192 M1824,180 L1824,204 " stroke="black"/>
 <path d="M1824,768 L1824,832 " stroke="black"/>
-<circle cx="1824" cy="768" r="8" stroke="none" fill="black"/>
-<circle cx="1824" cy="832" r="8" stroke="black" fill="white"/>
-<path d="M1816,832 L1832,832 M1824,824 L1824,840 " stroke="black"/>
+<circle cx="1824" cy="768" r="12" stroke="none" fill="black"/>
+<circle cx="1824" cy="832" r="12" stroke="black" fill="white"/>
+<path d="M1812,832 L1836,832 M1824,820 L1824,844 " stroke="black"/>
 <path d="M1824,1408 L1824,1472 " stroke="black"/>
-<circle cx="1824" cy="1408" r="8" stroke="none" fill="black"/>
-<circle cx="1824" cy="1472" r="8" stroke="black" fill="white"/>
-<path d="M1816,1472 L1832,1472 M1824,1464 L1824,1480 " stroke="black"/>
+<circle cx="1824" cy="1408" r="12" stroke="none" fill="black"/>
+<circle cx="1824" cy="1472" r="12" stroke="black" fill="white"/>
+<path d="M1812,1472 L1836,1472 M1824,1460 L1824,1484 " stroke="black"/>
 <path d="M1824,256 L1824,320 " stroke="black"/>
-<circle cx="1824" cy="256" r="8" stroke="none" fill="black"/>
-<circle cx="1824" cy="320" r="8" stroke="black" fill="white"/>
-<path d="M1816,320 L1832,320 M1824,312 L1824,328 " stroke="black"/>
+<circle cx="1824" cy="256" r="12" stroke="none" fill="black"/>
+<circle cx="1824" cy="320" r="12" stroke="black" fill="white"/>
+<path d="M1812,320 L1836,320 M1824,308 L1824,332 " stroke="black"/>
 <path d="M1824,896 L1824,960 " stroke="black"/>
-<circle cx="1824" cy="896" r="8" stroke="none" fill="black"/>
-<circle cx="1824" cy="960" r="8" stroke="black" fill="white"/>
-<path d="M1816,960 L1832,960 M1824,952 L1824,968 " stroke="black"/>
+<circle cx="1824" cy="896" r="12" stroke="none" fill="black"/>
+<circle cx="1824" cy="960" r="12" stroke="black" fill="white"/>
+<path d="M1812,960 L1836,960 M1824,948 L1824,972 " stroke="black"/>
 <path d="M1824,1536 L1824,1600 " stroke="black"/>
-<circle cx="1824" cy="1536" r="8" stroke="none" fill="black"/>
-<circle cx="1824" cy="1600" r="8" stroke="black" fill="white"/>
-<path d="M1816,1600 L1832,1600 M1824,1592 L1824,1608 " stroke="black"/>
+<circle cx="1824" cy="1536" r="12" stroke="none" fill="black"/>
+<circle cx="1824" cy="1600" r="12" stroke="black" fill="white"/>
+<path d="M1812,1600 L1836,1600 M1824,1588 L1824,1612 " stroke="black"/>
 <path d="M1824,384 L1824,448 " stroke="black"/>
-<circle cx="1824" cy="448" r="8" stroke="none" fill="black"/>
-<circle cx="1824" cy="384" r="8" stroke="black" fill="white"/>
-<path d="M1816,384 L1832,384 M1824,376 L1824,392 " stroke="black"/>
+<circle cx="1824" cy="448" r="12" stroke="none" fill="black"/>
+<circle cx="1824" cy="384" r="12" stroke="black" fill="white"/>
+<path d="M1812,384 L1836,384 M1824,372 L1824,396 " stroke="black"/>
 <path d="M1824,1024 L1824,1088 " stroke="black"/>
-<circle cx="1824" cy="1088" r="8" stroke="none" fill="black"/>
-<circle cx="1824" cy="1024" r="8" stroke="black" fill="white"/>
-<path d="M1816,1024 L1832,1024 M1824,1016 L1824,1032 " stroke="black"/>
+<circle cx="1824" cy="1088" r="12" stroke="none" fill="black"/>
+<circle cx="1824" cy="1024" r="12" stroke="black" fill="white"/>
+<path d="M1812,1024 L1836,1024 M1824,1012 L1824,1036 " stroke="black"/>
 <path d="M1824,512 L1824,576 " stroke="black"/>
-<circle cx="1824" cy="576" r="8" stroke="none" fill="black"/>
-<circle cx="1824" cy="512" r="8" stroke="black" fill="white"/>
-<path d="M1816,512 L1832,512 M1824,504 L1824,520 " stroke="black"/>
+<circle cx="1824" cy="576" r="12" stroke="none" fill="black"/>
+<circle cx="1824" cy="512" r="12" stroke="black" fill="white"/>
+<path d="M1812,512 L1836,512 M1824,500 L1824,524 " stroke="black"/>
 <path d="M1824,1152 L1824,1216 " stroke="black"/>
-<circle cx="1824" cy="1216" r="8" stroke="none" fill="black"/>
-<circle cx="1824" cy="1152" r="8" stroke="black" fill="white"/>
-<path d="M1816,1152 L1832,1152 M1824,1144 L1824,1160 " stroke="black"/>
+<circle cx="1824" cy="1216" r="12" stroke="none" fill="black"/>
+<circle cx="1824" cy="1152" r="12" stroke="black" fill="white"/>
+<path d="M1812,1152 L1836,1152 M1824,1140 L1824,1164 " stroke="black"/>
 <path d="M1888,128 L1888,448 " stroke="black"/>
-<circle cx="1888" cy="128" r="8" stroke="none" fill="black"/>
-<circle cx="1888" cy="448" r="8" stroke="black" fill="white"/>
-<path d="M1880,448 L1896,448 M1888,440 L1888,456 " stroke="black"/>
+<circle cx="1888" cy="128" r="12" stroke="none" fill="black"/>
+<circle cx="1888" cy="448" r="12" stroke="black" fill="white"/>
+<path d="M1876,448 L1900,448 M1888,436 L1888,460 " stroke="black"/>
 <path d="M1888,768 L1888,1088 " stroke="black"/>
-<circle cx="1888" cy="768" r="8" stroke="none" fill="black"/>
-<circle cx="1888" cy="1088" r="8" stroke="black" fill="white"/>
-<path d="M1880,1088 L1896,1088 M1888,1080 L1888,1096 " stroke="black"/>
+<circle cx="1888" cy="768" r="12" stroke="none" fill="black"/>
+<circle cx="1888" cy="1088" r="12" stroke="black" fill="white"/>
+<path d="M1876,1088 L1900,1088 M1888,1076 L1888,1100 " stroke="black"/>
 <path d="M1952,256 L1952,576 " stroke="black"/>
-<circle cx="1952" cy="256" r="8" stroke="none" fill="black"/>
-<circle cx="1952" cy="576" r="8" stroke="black" fill="white"/>
-<path d="M1944,576 L1960,576 M1952,568 L1952,584 " stroke="black"/>
+<circle cx="1952" cy="256" r="12" stroke="none" fill="black"/>
+<circle cx="1952" cy="576" r="12" stroke="black" fill="white"/>
+<path d="M1940,576 L1964,576 M1952,564 L1952,588 " stroke="black"/>
 <path d="M1952,896 L1952,1216 " stroke="black"/>
-<circle cx="1952" cy="896" r="8" stroke="none" fill="black"/>
-<circle cx="1952" cy="1216" r="8" stroke="black" fill="white"/>
-<path d="M1944,1216 L1960,1216 M1952,1208 L1952,1224 " stroke="black"/>
+<circle cx="1952" cy="896" r="12" stroke="none" fill="black"/>
+<circle cx="1952" cy="1216" r="12" stroke="black" fill="white"/>
+<path d="M1940,1216 L1964,1216 M1952,1204 L1952,1228 " stroke="black"/>
 <path d="M2016,384 L2016,704 " stroke="black"/>
-<circle cx="2016" cy="704" r="8" stroke="none" fill="black"/>
-<circle cx="2016" cy="384" r="8" stroke="black" fill="white"/>
-<path d="M2008,384 L2024,384 M2016,376 L2016,392 " stroke="black"/>
+<circle cx="2016" cy="704" r="12" stroke="none" fill="black"/>
+<circle cx="2016" cy="384" r="12" stroke="black" fill="white"/>
+<path d="M2004,384 L2028,384 M2016,372 L2016,396 " stroke="black"/>
 <path d="M2016,1024 L2016,1344 " stroke="black"/>
-<circle cx="2016" cy="1344" r="8" stroke="none" fill="black"/>
-<circle cx="2016" cy="1024" r="8" stroke="black" fill="white"/>
-<path d="M2008,1024 L2024,1024 M2016,1016 L2016,1032 " stroke="black"/>
+<circle cx="2016" cy="1344" r="12" stroke="none" fill="black"/>
+<circle cx="2016" cy="1024" r="12" stroke="black" fill="white"/>
+<path d="M2004,1024 L2028,1024 M2016,1012 L2016,1036 " stroke="black"/>
 <path d="M2080,512 L2080,832 " stroke="black"/>
-<circle cx="2080" cy="832" r="8" stroke="none" fill="black"/>
-<circle cx="2080" cy="512" r="8" stroke="black" fill="white"/>
-<path d="M2072,512 L2088,512 M2080,504 L2080,520 " stroke="black"/>
+<circle cx="2080" cy="832" r="12" stroke="none" fill="black"/>
+<circle cx="2080" cy="512" r="12" stroke="black" fill="white"/>
+<path d="M2068,512 L2092,512 M2080,500 L2080,524 " stroke="black"/>
 <path d="M2080,1152 L2080,1472 " stroke="black"/>
-<circle cx="2080" cy="1472" r="8" stroke="none" fill="black"/>
-<circle cx="2080" cy="1152" r="8" stroke="black" fill="white"/>
-<path d="M2072,1152 L2088,1152 M2080,1144 L2080,1160 " stroke="black"/>
+<circle cx="2080" cy="1472" r="12" stroke="none" fill="black"/>
+<circle cx="2080" cy="1152" r="12" stroke="black" fill="white"/>
+<path d="M2068,1152 L2092,1152 M2080,1140 L2080,1164 " stroke="black"/>
 <path d="M2144,640 L2144,960 " stroke="black"/>
-<circle cx="2144" cy="960" r="8" stroke="none" fill="black"/>
-<circle cx="2144" cy="640" r="8" stroke="black" fill="white"/>
-<path d="M2136,640 L2152,640 M2144,632 L2144,648 " stroke="black"/>
+<circle cx="2144" cy="960" r="12" stroke="none" fill="black"/>
+<circle cx="2144" cy="640" r="12" stroke="black" fill="white"/>
+<path d="M2132,640 L2156,640 M2144,628 L2144,652 " stroke="black"/>
 <path d="M2144,1280 L2144,1600 " stroke="black"/>
-<circle cx="2144" cy="1600" r="8" stroke="none" fill="black"/>
-<circle cx="2144" cy="1280" r="8" stroke="black" fill="white"/>
-<path d="M2136,1280 L2152,1280 M2144,1272 L2144,1288 " stroke="black"/>
+<circle cx="2144" cy="1600" r="12" stroke="none" fill="black"/>
+<circle cx="2144" cy="1280" r="12" stroke="black" fill="white"/>
+<path d="M2132,1280 L2156,1280 M2144,1268 L2144,1292 " stroke="black"/>
 <path d="M1860,40 L1860,32 L2172,32 L2172,40 " stroke="black" fill="none"/>
 <path d="M1860,1656 L1860,1664 L2172,1664 L2172,1656 " stroke="black" fill="none"/>
 <path d="M2208,448 L2208,768 " stroke="black"/>
-<circle cx="2208" cy="768" r="8" stroke="none" fill="black"/>
-<circle cx="2208" cy="448" r="8" stroke="black" fill="white"/>
-<path d="M2200,448 L2216,448 M2208,440 L2208,456 " stroke="black"/>
+<circle cx="2208" cy="768" r="12" stroke="none" fill="black"/>
+<circle cx="2208" cy="448" r="12" stroke="black" fill="white"/>
+<path d="M2196,448 L2220,448 M2208,436 L2208,460 " stroke="black"/>
 <path d="M2208,1088 L2208,1408 " stroke="black"/>
-<circle cx="2208" cy="1408" r="8" stroke="none" fill="black"/>
-<circle cx="2208" cy="1088" r="8" stroke="black" fill="white"/>
-<path d="M2200,1088 L2216,1088 M2208,1080 L2208,1096 " stroke="black"/>
+<circle cx="2208" cy="1408" r="12" stroke="none" fill="black"/>
+<circle cx="2208" cy="1088" r="12" stroke="black" fill="white"/>
+<path d="M2196,1088 L2220,1088 M2208,1076 L2208,1100 " stroke="black"/>
 <path d="M2272,576 L2272,896 " stroke="black"/>
-<circle cx="2272" cy="896" r="8" stroke="none" fill="black"/>
-<circle cx="2272" cy="576" r="8" stroke="black" fill="white"/>
-<path d="M2264,576 L2280,576 M2272,568 L2272,584 " stroke="black"/>
+<circle cx="2272" cy="896" r="12" stroke="none" fill="black"/>
+<circle cx="2272" cy="576" r="12" stroke="black" fill="white"/>
+<path d="M2260,576 L2284,576 M2272,564 L2272,588 " stroke="black"/>
 <path d="M2272,1216 L2272,1536 " stroke="black"/>
-<circle cx="2272" cy="1536" r="8" stroke="none" fill="black"/>
-<circle cx="2272" cy="1216" r="8" stroke="black" fill="white"/>
-<path d="M2264,1216 L2280,1216 M2272,1208 L2272,1224 " stroke="black"/>
+<circle cx="2272" cy="1536" r="12" stroke="none" fill="black"/>
+<circle cx="2272" cy="1216" r="12" stroke="black" fill="white"/>
+<path d="M2260,1216 L2284,1216 M2272,1204 L2272,1228 " stroke="black"/>
 <path d="M2272,64 L2272,384 " stroke="black"/>
-<circle cx="2272" cy="64" r="8" stroke="none" fill="black"/>
-<circle cx="2272" cy="384" r="8" stroke="black" fill="white"/>
-<path d="M2264,384 L2280,384 M2272,376 L2272,392 " stroke="black"/>
+<circle cx="2272" cy="64" r="12" stroke="none" fill="black"/>
+<circle cx="2272" cy="384" r="12" stroke="black" fill="white"/>
+<path d="M2260,384 L2284,384 M2272,372 L2272,396 " stroke="black"/>
 <path d="M2336,704 L2336,1024 " stroke="black"/>
-<circle cx="2336" cy="704" r="8" stroke="none" fill="black"/>
-<circle cx="2336" cy="1024" r="8" stroke="black" fill="white"/>
-<path d="M2328,1024 L2344,1024 M2336,1016 L2336,1032 " stroke="black"/>
+<circle cx="2336" cy="704" r="12" stroke="none" fill="black"/>
+<circle cx="2336" cy="1024" r="12" stroke="black" fill="white"/>
+<path d="M2324,1024 L2348,1024 M2336,1012 L2336,1036 " stroke="black"/>
 <path d="M2336,192 L2336,512 " stroke="black"/>
-<circle cx="2336" cy="192" r="8" stroke="none" fill="black"/>
-<circle cx="2336" cy="512" r="8" stroke="black" fill="white"/>
-<path d="M2328,512 L2344,512 M2336,504 L2336,520 " stroke="black"/>
+<circle cx="2336" cy="192" r="12" stroke="none" fill="black"/>
+<circle cx="2336" cy="512" r="12" stroke="black" fill="white"/>
+<path d="M2324,512 L2348,512 M2336,500 L2336,524 " stroke="black"/>
 <path d="M2400,832 L2400,1152 " stroke="black"/>
-<circle cx="2400" cy="832" r="8" stroke="none" fill="black"/>
-<circle cx="2400" cy="1152" r="8" stroke="black" fill="white"/>
-<path d="M2392,1152 L2408,1152 M2400,1144 L2400,1160 " stroke="black"/>
+<circle cx="2400" cy="832" r="12" stroke="none" fill="black"/>
+<circle cx="2400" cy="1152" r="12" stroke="black" fill="white"/>
+<path d="M2388,1152 L2412,1152 M2400,1140 L2400,1164 " stroke="black"/>
 <path d="M2400,320 L2400,640 " stroke="black"/>
-<circle cx="2400" cy="320" r="8" stroke="none" fill="black"/>
-<circle cx="2400" cy="640" r="8" stroke="black" fill="white"/>
-<path d="M2392,640 L2408,640 M2400,632 L2400,648 " stroke="black"/>
+<circle cx="2400" cy="320" r="12" stroke="none" fill="black"/>
+<circle cx="2400" cy="640" r="12" stroke="black" fill="white"/>
+<path d="M2388,640 L2412,640 M2400,628 L2400,652 " stroke="black"/>
 <path d="M2464,960 L2464,1280 " stroke="black"/>
-<circle cx="2464" cy="960" r="8" stroke="none" fill="black"/>
-<circle cx="2464" cy="1280" r="8" stroke="black" fill="white"/>
-<path d="M2456,1280 L2472,1280 M2464,1272 L2464,1288 " stroke="black"/>
+<circle cx="2464" cy="960" r="12" stroke="none" fill="black"/>
+<circle cx="2464" cy="1280" r="12" stroke="black" fill="white"/>
+<path d="M2452,1280 L2476,1280 M2464,1268 L2464,1292 " stroke="black"/>
 <path d="M2180,40 L2180,32 L2492,32 L2492,40 " stroke="black" fill="none"/>
 <path d="M2180,1656 L2180,1664 L2492,1664 L2492,1656 " stroke="black" fill="none"/>
 <path d="M2528,64 L2528,128 " stroke="black"/>
-<circle cx="2528" cy="128" r="8" stroke="none" fill="black"/>
-<circle cx="2528" cy="64" r="8" stroke="black" fill="white"/>
-<path d="M2520,64 L2536,64 M2528,56 L2528,72 " stroke="black"/>
+<circle cx="2528" cy="128" r="12" stroke="none" fill="black"/>
+<circle cx="2528" cy="64" r="12" stroke="black" fill="white"/>
+<path d="M2516,64 L2540,64 M2528,52 L2528,76 " stroke="black"/>
 <path d="M2528,704 L2528,768 " stroke="black"/>
-<circle cx="2528" cy="768" r="8" stroke="none" fill="black"/>
-<circle cx="2528" cy="704" r="8" stroke="black" fill="white"/>
-<path d="M2520,704 L2536,704 M2528,696 L2528,712 " stroke="black"/>
+<circle cx="2528" cy="768" r="12" stroke="none" fill="black"/>
+<circle cx="2528" cy="704" r="12" stroke="black" fill="white"/>
+<path d="M2516,704 L2540,704 M2528,692 L2528,716 " stroke="black"/>
 <path d="M2528,1344 L2528,1408 " stroke="black"/>
-<circle cx="2528" cy="1408" r="8" stroke="none" fill="black"/>
-<circle cx="2528" cy="1344" r="8" stroke="black" fill="white"/>
-<path d="M2520,1344 L2536,1344 M2528,1336 L2528,1352 " stroke="black"/>
+<circle cx="2528" cy="1408" r="12" stroke="none" fill="black"/>
+<circle cx="2528" cy="1344" r="12" stroke="black" fill="white"/>
+<path d="M2516,1344 L2540,1344 M2528,1332 L2528,1356 " stroke="black"/>
 <path d="M2528,192 L2528,256 " stroke="black"/>
-<circle cx="2528" cy="256" r="8" stroke="none" fill="black"/>
-<circle cx="2528" cy="192" r="8" stroke="black" fill="white"/>
-<path d="M2520,192 L2536,192 M2528,184 L2528,200 " stroke="black"/>
+<circle cx="2528" cy="256" r="12" stroke="none" fill="black"/>
+<circle cx="2528" cy="192" r="12" stroke="black" fill="white"/>
+<path d="M2516,192 L2540,192 M2528,180 L2528,204 " stroke="black"/>
 <path d="M2528,832 L2528,896 " stroke="black"/>
-<circle cx="2528" cy="896" r="8" stroke="none" fill="black"/>
-<circle cx="2528" cy="832" r="8" stroke="black" fill="white"/>
-<path d="M2520,832 L2536,832 M2528,824 L2528,840 " stroke="black"/>
+<circle cx="2528" cy="896" r="12" stroke="none" fill="black"/>
+<circle cx="2528" cy="832" r="12" stroke="black" fill="white"/>
+<path d="M2516,832 L2540,832 M2528,820 L2528,844 " stroke="black"/>
 <path d="M2528,1472 L2528,1536 " stroke="black"/>
-<circle cx="2528" cy="1536" r="8" stroke="none" fill="black"/>
-<circle cx="2528" cy="1472" r="8" stroke="black" fill="white"/>
-<path d="M2520,1472 L2536,1472 M2528,1464 L2528,1480 " stroke="black"/>
+<circle cx="2528" cy="1536" r="12" stroke="none" fill="black"/>
+<circle cx="2528" cy="1472" r="12" stroke="black" fill="white"/>
+<path d="M2516,1472 L2540,1472 M2528,1460 L2528,1484 " stroke="black"/>
 <path d="M2528,448 L2528,512 " stroke="black"/>
-<circle cx="2528" cy="448" r="8" stroke="none" fill="black"/>
-<circle cx="2528" cy="512" r="8" stroke="black" fill="white"/>
-<path d="M2520,512 L2536,512 M2528,504 L2528,520 " stroke="black"/>
+<circle cx="2528" cy="448" r="12" stroke="none" fill="black"/>
+<circle cx="2528" cy="512" r="12" stroke="black" fill="white"/>
+<path d="M2516,512 L2540,512 M2528,500 L2528,524 " stroke="black"/>
 <path d="M2528,1088 L2528,1152 " stroke="black"/>
-<circle cx="2528" cy="1088" r="8" stroke="none" fill="black"/>
-<circle cx="2528" cy="1152" r="8" stroke="black" fill="white"/>
-<path d="M2520,1152 L2536,1152 M2528,1144 L2528,1160 " stroke="black"/>
+<circle cx="2528" cy="1088" r="12" stroke="none" fill="black"/>
+<circle cx="2528" cy="1152" r="12" stroke="black" fill="white"/>
+<path d="M2516,1152 L2540,1152 M2528,1140 L2528,1164 " stroke="black"/>
 <path d="M2528,576 L2528,640 " stroke="black"/>
-<circle cx="2528" cy="576" r="8" stroke="none" fill="black"/>
-<circle cx="2528" cy="640" r="8" stroke="black" fill="white"/>
-<path d="M2520,640 L2536,640 M2528,632 L2528,648 " stroke="black"/>
+<circle cx="2528" cy="576" r="12" stroke="none" fill="black"/>
+<circle cx="2528" cy="640" r="12" stroke="black" fill="white"/>
+<path d="M2516,640 L2540,640 M2528,628 L2528,652 " stroke="black"/>
 <path d="M2528,1216 L2528,1280 " stroke="black"/>
-<circle cx="2528" cy="1216" r="8" stroke="none" fill="black"/>
-<circle cx="2528" cy="1280" r="8" stroke="black" fill="white"/>
-<path d="M2520,1280 L2536,1280 M2528,1272 L2528,1288 " stroke="black"/>
+<circle cx="2528" cy="1216" r="12" stroke="none" fill="black"/>
+<circle cx="2528" cy="1280" r="12" stroke="black" fill="white"/>
+<path d="M2516,1280 L2540,1280 M2528,1268 L2528,1292 " stroke="black"/>
 <rect x="2576" y="112" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="2592" y="128">H</text>
 <rect x="2576" y="240" width="32" height="32" stroke="black" fill="white"/>

--- a/testdata/surface_code_full_time_detector_slice.svg
+++ b/testdata/surface_code_full_time_detector_slice.svg
@@ -1430,166 +1430,166 @@
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="601.6" y="336">H</text>
 <rect x="713.6" y="320" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="729.6" y="336">H</text>
-<path d="M1059.2,80 L1123.2,80 " stroke="black" stroke-width="3"/>
-<circle cx="1059.2" cy="80" r="8" stroke="none" fill="black"/>
-<circle cx="1123.2" cy="80" r="8" stroke="black" fill="white"/>
-<path d="M1115.2,80 L1131.2,80 M1123.2,72 L1123.2,88 " stroke="black"/>
-<path d="M1059.2,208 L1123.2,208 " stroke="black" stroke-width="3"/>
-<circle cx="1059.2" cy="208" r="8" stroke="none" fill="black"/>
-<circle cx="1123.2" cy="208" r="8" stroke="black" fill="white"/>
-<path d="M1115.2,208 L1131.2,208 M1123.2,200 L1123.2,216 " stroke="black"/>
-<path d="M1059.2,336 L1123.2,336 " stroke="black" stroke-width="3"/>
-<circle cx="1059.2" cy="336" r="8" stroke="none" fill="black"/>
-<circle cx="1123.2" cy="336" r="8" stroke="black" fill="white"/>
-<path d="M1115.2,336 L1131.2,336 M1123.2,328 L1123.2,344 " stroke="black"/>
-<path d="M1187.2,80 L1251.2,80 " stroke="black" stroke-width="3"/>
-<circle cx="1187.2" cy="80" r="8" stroke="none" fill="black"/>
-<circle cx="1251.2" cy="80" r="8" stroke="black" fill="white"/>
-<path d="M1243.2,80 L1259.2,80 M1251.2,72 L1251.2,88 " stroke="black"/>
-<path d="M1187.2,208 L1251.2,208 " stroke="black" stroke-width="3"/>
-<circle cx="1187.2" cy="208" r="8" stroke="none" fill="black"/>
-<circle cx="1251.2" cy="208" r="8" stroke="black" fill="white"/>
-<path d="M1243.2,208 L1259.2,208 M1251.2,200 L1251.2,216 " stroke="black"/>
-<path d="M1187.2,336 L1251.2,336 " stroke="black" stroke-width="3"/>
-<circle cx="1187.2" cy="336" r="8" stroke="none" fill="black"/>
-<circle cx="1251.2" cy="336" r="8" stroke="black" fill="white"/>
-<path d="M1243.2,336 L1259.2,336 M1251.2,328 L1251.2,344 " stroke="black"/>
-<path d="M1059.2,144 L995.2,144 " stroke="black" stroke-width="3"/>
-<circle cx="1059.2" cy="144" r="8" stroke="none" fill="black"/>
-<circle cx="995.2" cy="144" r="8" stroke="black" fill="white"/>
-<path d="M987.2,144 L1003.2,144 M995.2,136 L995.2,152 " stroke="black"/>
-<path d="M1059.2,272 L995.2,272 " stroke="black" stroke-width="3"/>
-<circle cx="1059.2" cy="272" r="8" stroke="none" fill="black"/>
-<circle cx="995.2" cy="272" r="8" stroke="black" fill="white"/>
-<path d="M987.2,272 L1003.2,272 M995.2,264 L995.2,280 " stroke="black"/>
-<path d="M1187.2,144 L1123.2,144 " stroke="black" stroke-width="3"/>
-<circle cx="1187.2" cy="144" r="8" stroke="none" fill="black"/>
-<circle cx="1123.2" cy="144" r="8" stroke="black" fill="white"/>
-<path d="M1115.2,144 L1131.2,144 M1123.2,136 L1123.2,152 " stroke="black"/>
-<path d="M1187.2,272 L1123.2,272 " stroke="black" stroke-width="3"/>
-<circle cx="1187.2" cy="272" r="8" stroke="none" fill="black"/>
-<circle cx="1123.2" cy="272" r="8" stroke="black" fill="white"/>
-<path d="M1115.2,272 L1131.2,272 M1123.2,264 L1123.2,280 " stroke="black"/>
-<path d="M1516.8,80 L1516.8,144 " stroke="black" stroke-width="3"/>
-<circle cx="1516.8" cy="80" r="8" stroke="none" fill="black"/>
-<circle cx="1516.8" cy="144" r="8" stroke="black" fill="white"/>
-<path d="M1508.8,144 L1524.8,144 M1516.8,136 L1516.8,152 " stroke="black"/>
-<path d="M1516.8,208 L1516.8,272 " stroke="black" stroke-width="3"/>
-<circle cx="1516.8" cy="208" r="8" stroke="none" fill="black"/>
-<circle cx="1516.8" cy="272" r="8" stroke="black" fill="white"/>
-<path d="M1508.8,272 L1524.8,272 M1516.8,264 L1516.8,280 " stroke="black"/>
-<path d="M1644.8,80 L1644.8,144 " stroke="black" stroke-width="3"/>
-<circle cx="1644.8" cy="80" r="8" stroke="none" fill="black"/>
-<circle cx="1644.8" cy="144" r="8" stroke="black" fill="white"/>
-<path d="M1636.8,144 L1652.8,144 M1644.8,136 L1644.8,152 " stroke="black"/>
-<path d="M1644.8,208 L1644.8,272 " stroke="black" stroke-width="3"/>
-<circle cx="1644.8" cy="208" r="8" stroke="none" fill="black"/>
-<circle cx="1644.8" cy="272" r="8" stroke="black" fill="white"/>
-<path d="M1636.8,272 L1652.8,272 M1644.8,264 L1644.8,280 " stroke="black"/>
-<path d="M1452.8,208 L1452.8,144 " stroke="black" stroke-width="3"/>
-<circle cx="1452.8" cy="208" r="8" stroke="none" fill="black"/>
-<circle cx="1452.8" cy="144" r="8" stroke="black" fill="white"/>
-<path d="M1444.8,144 L1460.8,144 M1452.8,136 L1452.8,152 " stroke="black"/>
-<path d="M1452.8,336 L1452.8,272 " stroke="black" stroke-width="3"/>
-<circle cx="1452.8" cy="336" r="8" stroke="none" fill="black"/>
-<circle cx="1452.8" cy="272" r="8" stroke="black" fill="white"/>
-<path d="M1444.8,272 L1460.8,272 M1452.8,264 L1452.8,280 " stroke="black"/>
-<path d="M1580.8,208 L1580.8,144 " stroke="black" stroke-width="3"/>
-<circle cx="1580.8" cy="208" r="8" stroke="none" fill="black"/>
-<circle cx="1580.8" cy="144" r="8" stroke="black" fill="white"/>
-<path d="M1572.8,144 L1588.8,144 M1580.8,136 L1580.8,152 " stroke="black"/>
-<path d="M1580.8,336 L1580.8,272 " stroke="black" stroke-width="3"/>
-<circle cx="1580.8" cy="336" r="8" stroke="none" fill="black"/>
-<circle cx="1580.8" cy="272" r="8" stroke="black" fill="white"/>
-<path d="M1572.8,272 L1588.8,272 M1580.8,264 L1580.8,280 " stroke="black"/>
-<path d="M1708.8,208 L1708.8,144 " stroke="black" stroke-width="3"/>
-<circle cx="1708.8" cy="208" r="8" stroke="none" fill="black"/>
-<circle cx="1708.8" cy="144" r="8" stroke="black" fill="white"/>
-<path d="M1700.8,144 L1716.8,144 M1708.8,136 L1708.8,152 " stroke="black"/>
-<path d="M1708.8,336 L1708.8,272 " stroke="black" stroke-width="3"/>
-<circle cx="1708.8" cy="336" r="8" stroke="none" fill="black"/>
-<circle cx="1708.8" cy="272" r="8" stroke="black" fill="white"/>
-<path d="M1700.8,272 L1716.8,272 M1708.8,264 L1708.8,280 " stroke="black"/>
-<path d="M1974.4,208 L1974.4,144 " stroke="black" stroke-width="3"/>
-<circle cx="1974.4" cy="208" r="8" stroke="none" fill="black"/>
-<circle cx="1974.4" cy="144" r="8" stroke="black" fill="white"/>
-<path d="M1966.4,144 L1982.4,144 M1974.4,136 L1974.4,152 " stroke="black"/>
-<path d="M1974.4,336 L1974.4,272 " stroke="black" stroke-width="3"/>
-<circle cx="1974.4" cy="336" r="8" stroke="none" fill="black"/>
-<circle cx="1974.4" cy="272" r="8" stroke="black" fill="white"/>
-<path d="M1966.4,272 L1982.4,272 M1974.4,264 L1974.4,280 " stroke="black"/>
-<path d="M2102.4,208 L2102.4,144 " stroke="black" stroke-width="3"/>
-<circle cx="2102.4" cy="208" r="8" stroke="none" fill="black"/>
-<circle cx="2102.4" cy="144" r="8" stroke="black" fill="white"/>
-<path d="M2094.4,144 L2110.4,144 M2102.4,136 L2102.4,152 " stroke="black"/>
-<path d="M2102.4,336 L2102.4,272 " stroke="black" stroke-width="3"/>
-<circle cx="2102.4" cy="336" r="8" stroke="none" fill="black"/>
-<circle cx="2102.4" cy="272" r="8" stroke="black" fill="white"/>
-<path d="M2094.4,272 L2110.4,272 M2102.4,264 L2102.4,280 " stroke="black"/>
-<path d="M1910.4,80 L1910.4,144 " stroke="black" stroke-width="3"/>
-<circle cx="1910.4" cy="80" r="8" stroke="none" fill="black"/>
-<circle cx="1910.4" cy="144" r="8" stroke="black" fill="white"/>
-<path d="M1902.4,144 L1918.4,144 M1910.4,136 L1910.4,152 " stroke="black"/>
-<path d="M1910.4,208 L1910.4,272 " stroke="black" stroke-width="3"/>
-<circle cx="1910.4" cy="208" r="8" stroke="none" fill="black"/>
-<circle cx="1910.4" cy="272" r="8" stroke="black" fill="white"/>
-<path d="M1902.4,272 L1918.4,272 M1910.4,264 L1910.4,280 " stroke="black"/>
-<path d="M2038.4,80 L2038.4,144 " stroke="black" stroke-width="3"/>
-<circle cx="2038.4" cy="80" r="8" stroke="none" fill="black"/>
-<circle cx="2038.4" cy="144" r="8" stroke="black" fill="white"/>
-<path d="M2030.4,144 L2046.4,144 M2038.4,136 L2038.4,152 " stroke="black"/>
-<path d="M2038.4,208 L2038.4,272 " stroke="black" stroke-width="3"/>
-<circle cx="2038.4" cy="208" r="8" stroke="none" fill="black"/>
-<circle cx="2038.4" cy="272" r="8" stroke="black" fill="white"/>
-<path d="M2030.4,272 L2046.4,272 M2038.4,264 L2038.4,280 " stroke="black"/>
-<path d="M2166.4,80 L2166.4,144 " stroke="black" stroke-width="3"/>
-<circle cx="2166.4" cy="80" r="8" stroke="none" fill="black"/>
-<circle cx="2166.4" cy="144" r="8" stroke="black" fill="white"/>
-<path d="M2158.4,144 L2174.4,144 M2166.4,136 L2166.4,152 " stroke="black"/>
-<path d="M2166.4,208 L2166.4,272 " stroke="black" stroke-width="3"/>
-<circle cx="2166.4" cy="208" r="8" stroke="none" fill="black"/>
-<circle cx="2166.4" cy="272" r="8" stroke="black" fill="white"/>
-<path d="M2158.4,272 L2174.4,272 M2166.4,264 L2166.4,280 " stroke="black"/>
-<path d="M2432,80 L2368,80 " stroke="black" stroke-width="3"/>
-<circle cx="2432" cy="80" r="8" stroke="none" fill="black"/>
-<circle cx="2368" cy="80" r="8" stroke="black" fill="white"/>
-<path d="M2360,80 L2376,80 M2368,72 L2368,88 " stroke="black"/>
-<path d="M2432,208 L2368,208 " stroke="black" stroke-width="3"/>
-<circle cx="2432" cy="208" r="8" stroke="none" fill="black"/>
-<circle cx="2368" cy="208" r="8" stroke="black" fill="white"/>
-<path d="M2360,208 L2376,208 M2368,200 L2368,216 " stroke="black"/>
-<path d="M2432,336 L2368,336 " stroke="black" stroke-width="3"/>
-<circle cx="2432" cy="336" r="8" stroke="none" fill="black"/>
-<circle cx="2368" cy="336" r="8" stroke="black" fill="white"/>
-<path d="M2360,336 L2376,336 M2368,328 L2368,344 " stroke="black"/>
-<path d="M2560,80 L2496,80 " stroke="black" stroke-width="3"/>
-<circle cx="2560" cy="80" r="8" stroke="none" fill="black"/>
-<circle cx="2496" cy="80" r="8" stroke="black" fill="white"/>
-<path d="M2488,80 L2504,80 M2496,72 L2496,88 " stroke="black"/>
-<path d="M2560,208 L2496,208 " stroke="black" stroke-width="3"/>
-<circle cx="2560" cy="208" r="8" stroke="none" fill="black"/>
-<circle cx="2496" cy="208" r="8" stroke="black" fill="white"/>
-<path d="M2488,208 L2504,208 M2496,200 L2496,216 " stroke="black"/>
-<path d="M2560,336 L2496,336 " stroke="black" stroke-width="3"/>
-<circle cx="2560" cy="336" r="8" stroke="none" fill="black"/>
-<circle cx="2496" cy="336" r="8" stroke="black" fill="white"/>
-<path d="M2488,336 L2504,336 M2496,328 L2496,344 " stroke="black"/>
-<path d="M2432,144 L2496,144 " stroke="black" stroke-width="3"/>
-<circle cx="2432" cy="144" r="8" stroke="none" fill="black"/>
-<circle cx="2496" cy="144" r="8" stroke="black" fill="white"/>
-<path d="M2488,144 L2504,144 M2496,136 L2496,152 " stroke="black"/>
-<path d="M2432,272 L2496,272 " stroke="black" stroke-width="3"/>
-<circle cx="2432" cy="272" r="8" stroke="none" fill="black"/>
-<circle cx="2496" cy="272" r="8" stroke="black" fill="white"/>
-<path d="M2488,272 L2504,272 M2496,264 L2496,280 " stroke="black"/>
-<path d="M2560,144 L2624,144 " stroke="black" stroke-width="3"/>
-<circle cx="2560" cy="144" r="8" stroke="none" fill="black"/>
-<circle cx="2624" cy="144" r="8" stroke="black" fill="white"/>
-<path d="M2616,144 L2632,144 M2624,136 L2624,152 " stroke="black"/>
-<path d="M2560,272 L2624,272 " stroke="black" stroke-width="3"/>
-<circle cx="2560" cy="272" r="8" stroke="none" fill="black"/>
-<circle cx="2624" cy="272" r="8" stroke="black" fill="white"/>
-<path d="M2616,272 L2632,272 M2624,264 L2624,280 " stroke="black"/>
+<path d="M1059.2,80 L1123.2,80 " stroke="black" stroke-width="5"/>
+<circle cx="1059.2" cy="80" r="12" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="80" r="12" stroke="black" fill="white"/>
+<path d="M1111.2,80 L1135.2,80 M1123.2,68 L1123.2,92 " stroke="black"/>
+<path d="M1059.2,208 L1123.2,208 " stroke="black" stroke-width="5"/>
+<circle cx="1059.2" cy="208" r="12" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="208" r="12" stroke="black" fill="white"/>
+<path d="M1111.2,208 L1135.2,208 M1123.2,196 L1123.2,220 " stroke="black"/>
+<path d="M1059.2,336 L1123.2,336 " stroke="black" stroke-width="5"/>
+<circle cx="1059.2" cy="336" r="12" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="336" r="12" stroke="black" fill="white"/>
+<path d="M1111.2,336 L1135.2,336 M1123.2,324 L1123.2,348 " stroke="black"/>
+<path d="M1187.2,80 L1251.2,80 " stroke="black" stroke-width="5"/>
+<circle cx="1187.2" cy="80" r="12" stroke="none" fill="black"/>
+<circle cx="1251.2" cy="80" r="12" stroke="black" fill="white"/>
+<path d="M1239.2,80 L1263.2,80 M1251.2,68 L1251.2,92 " stroke="black"/>
+<path d="M1187.2,208 L1251.2,208 " stroke="black" stroke-width="5"/>
+<circle cx="1187.2" cy="208" r="12" stroke="none" fill="black"/>
+<circle cx="1251.2" cy="208" r="12" stroke="black" fill="white"/>
+<path d="M1239.2,208 L1263.2,208 M1251.2,196 L1251.2,220 " stroke="black"/>
+<path d="M1187.2,336 L1251.2,336 " stroke="black" stroke-width="5"/>
+<circle cx="1187.2" cy="336" r="12" stroke="none" fill="black"/>
+<circle cx="1251.2" cy="336" r="12" stroke="black" fill="white"/>
+<path d="M1239.2,336 L1263.2,336 M1251.2,324 L1251.2,348 " stroke="black"/>
+<path d="M1059.2,144 L995.2,144 " stroke="black" stroke-width="5"/>
+<circle cx="1059.2" cy="144" r="12" stroke="none" fill="black"/>
+<circle cx="995.2" cy="144" r="12" stroke="black" fill="white"/>
+<path d="M983.2,144 L1007.2,144 M995.2,132 L995.2,156 " stroke="black"/>
+<path d="M1059.2,272 L995.2,272 " stroke="black" stroke-width="5"/>
+<circle cx="1059.2" cy="272" r="12" stroke="none" fill="black"/>
+<circle cx="995.2" cy="272" r="12" stroke="black" fill="white"/>
+<path d="M983.2,272 L1007.2,272 M995.2,260 L995.2,284 " stroke="black"/>
+<path d="M1187.2,144 L1123.2,144 " stroke="black" stroke-width="5"/>
+<circle cx="1187.2" cy="144" r="12" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="144" r="12" stroke="black" fill="white"/>
+<path d="M1111.2,144 L1135.2,144 M1123.2,132 L1123.2,156 " stroke="black"/>
+<path d="M1187.2,272 L1123.2,272 " stroke="black" stroke-width="5"/>
+<circle cx="1187.2" cy="272" r="12" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="272" r="12" stroke="black" fill="white"/>
+<path d="M1111.2,272 L1135.2,272 M1123.2,260 L1123.2,284 " stroke="black"/>
+<path d="M1516.8,80 L1516.8,144 " stroke="black" stroke-width="5"/>
+<circle cx="1516.8" cy="80" r="12" stroke="none" fill="black"/>
+<circle cx="1516.8" cy="144" r="12" stroke="black" fill="white"/>
+<path d="M1504.8,144 L1528.8,144 M1516.8,132 L1516.8,156 " stroke="black"/>
+<path d="M1516.8,208 L1516.8,272 " stroke="black" stroke-width="5"/>
+<circle cx="1516.8" cy="208" r="12" stroke="none" fill="black"/>
+<circle cx="1516.8" cy="272" r="12" stroke="black" fill="white"/>
+<path d="M1504.8,272 L1528.8,272 M1516.8,260 L1516.8,284 " stroke="black"/>
+<path d="M1644.8,80 L1644.8,144 " stroke="black" stroke-width="5"/>
+<circle cx="1644.8" cy="80" r="12" stroke="none" fill="black"/>
+<circle cx="1644.8" cy="144" r="12" stroke="black" fill="white"/>
+<path d="M1632.8,144 L1656.8,144 M1644.8,132 L1644.8,156 " stroke="black"/>
+<path d="M1644.8,208 L1644.8,272 " stroke="black" stroke-width="5"/>
+<circle cx="1644.8" cy="208" r="12" stroke="none" fill="black"/>
+<circle cx="1644.8" cy="272" r="12" stroke="black" fill="white"/>
+<path d="M1632.8,272 L1656.8,272 M1644.8,260 L1644.8,284 " stroke="black"/>
+<path d="M1452.8,208 L1452.8,144 " stroke="black" stroke-width="5"/>
+<circle cx="1452.8" cy="208" r="12" stroke="none" fill="black"/>
+<circle cx="1452.8" cy="144" r="12" stroke="black" fill="white"/>
+<path d="M1440.8,144 L1464.8,144 M1452.8,132 L1452.8,156 " stroke="black"/>
+<path d="M1452.8,336 L1452.8,272 " stroke="black" stroke-width="5"/>
+<circle cx="1452.8" cy="336" r="12" stroke="none" fill="black"/>
+<circle cx="1452.8" cy="272" r="12" stroke="black" fill="white"/>
+<path d="M1440.8,272 L1464.8,272 M1452.8,260 L1452.8,284 " stroke="black"/>
+<path d="M1580.8,208 L1580.8,144 " stroke="black" stroke-width="5"/>
+<circle cx="1580.8" cy="208" r="12" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="144" r="12" stroke="black" fill="white"/>
+<path d="M1568.8,144 L1592.8,144 M1580.8,132 L1580.8,156 " stroke="black"/>
+<path d="M1580.8,336 L1580.8,272 " stroke="black" stroke-width="5"/>
+<circle cx="1580.8" cy="336" r="12" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="272" r="12" stroke="black" fill="white"/>
+<path d="M1568.8,272 L1592.8,272 M1580.8,260 L1580.8,284 " stroke="black"/>
+<path d="M1708.8,208 L1708.8,144 " stroke="black" stroke-width="5"/>
+<circle cx="1708.8" cy="208" r="12" stroke="none" fill="black"/>
+<circle cx="1708.8" cy="144" r="12" stroke="black" fill="white"/>
+<path d="M1696.8,144 L1720.8,144 M1708.8,132 L1708.8,156 " stroke="black"/>
+<path d="M1708.8,336 L1708.8,272 " stroke="black" stroke-width="5"/>
+<circle cx="1708.8" cy="336" r="12" stroke="none" fill="black"/>
+<circle cx="1708.8" cy="272" r="12" stroke="black" fill="white"/>
+<path d="M1696.8,272 L1720.8,272 M1708.8,260 L1708.8,284 " stroke="black"/>
+<path d="M1974.4,208 L1974.4,144 " stroke="black" stroke-width="5"/>
+<circle cx="1974.4" cy="208" r="12" stroke="none" fill="black"/>
+<circle cx="1974.4" cy="144" r="12" stroke="black" fill="white"/>
+<path d="M1962.4,144 L1986.4,144 M1974.4,132 L1974.4,156 " stroke="black"/>
+<path d="M1974.4,336 L1974.4,272 " stroke="black" stroke-width="5"/>
+<circle cx="1974.4" cy="336" r="12" stroke="none" fill="black"/>
+<circle cx="1974.4" cy="272" r="12" stroke="black" fill="white"/>
+<path d="M1962.4,272 L1986.4,272 M1974.4,260 L1974.4,284 " stroke="black"/>
+<path d="M2102.4,208 L2102.4,144 " stroke="black" stroke-width="5"/>
+<circle cx="2102.4" cy="208" r="12" stroke="none" fill="black"/>
+<circle cx="2102.4" cy="144" r="12" stroke="black" fill="white"/>
+<path d="M2090.4,144 L2114.4,144 M2102.4,132 L2102.4,156 " stroke="black"/>
+<path d="M2102.4,336 L2102.4,272 " stroke="black" stroke-width="5"/>
+<circle cx="2102.4" cy="336" r="12" stroke="none" fill="black"/>
+<circle cx="2102.4" cy="272" r="12" stroke="black" fill="white"/>
+<path d="M2090.4,272 L2114.4,272 M2102.4,260 L2102.4,284 " stroke="black"/>
+<path d="M1910.4,80 L1910.4,144 " stroke="black" stroke-width="5"/>
+<circle cx="1910.4" cy="80" r="12" stroke="none" fill="black"/>
+<circle cx="1910.4" cy="144" r="12" stroke="black" fill="white"/>
+<path d="M1898.4,144 L1922.4,144 M1910.4,132 L1910.4,156 " stroke="black"/>
+<path d="M1910.4,208 L1910.4,272 " stroke="black" stroke-width="5"/>
+<circle cx="1910.4" cy="208" r="12" stroke="none" fill="black"/>
+<circle cx="1910.4" cy="272" r="12" stroke="black" fill="white"/>
+<path d="M1898.4,272 L1922.4,272 M1910.4,260 L1910.4,284 " stroke="black"/>
+<path d="M2038.4,80 L2038.4,144 " stroke="black" stroke-width="5"/>
+<circle cx="2038.4" cy="80" r="12" stroke="none" fill="black"/>
+<circle cx="2038.4" cy="144" r="12" stroke="black" fill="white"/>
+<path d="M2026.4,144 L2050.4,144 M2038.4,132 L2038.4,156 " stroke="black"/>
+<path d="M2038.4,208 L2038.4,272 " stroke="black" stroke-width="5"/>
+<circle cx="2038.4" cy="208" r="12" stroke="none" fill="black"/>
+<circle cx="2038.4" cy="272" r="12" stroke="black" fill="white"/>
+<path d="M2026.4,272 L2050.4,272 M2038.4,260 L2038.4,284 " stroke="black"/>
+<path d="M2166.4,80 L2166.4,144 " stroke="black" stroke-width="5"/>
+<circle cx="2166.4" cy="80" r="12" stroke="none" fill="black"/>
+<circle cx="2166.4" cy="144" r="12" stroke="black" fill="white"/>
+<path d="M2154.4,144 L2178.4,144 M2166.4,132 L2166.4,156 " stroke="black"/>
+<path d="M2166.4,208 L2166.4,272 " stroke="black" stroke-width="5"/>
+<circle cx="2166.4" cy="208" r="12" stroke="none" fill="black"/>
+<circle cx="2166.4" cy="272" r="12" stroke="black" fill="white"/>
+<path d="M2154.4,272 L2178.4,272 M2166.4,260 L2166.4,284 " stroke="black"/>
+<path d="M2432,80 L2368,80 " stroke="black" stroke-width="5"/>
+<circle cx="2432" cy="80" r="12" stroke="none" fill="black"/>
+<circle cx="2368" cy="80" r="12" stroke="black" fill="white"/>
+<path d="M2356,80 L2380,80 M2368,68 L2368,92 " stroke="black"/>
+<path d="M2432,208 L2368,208 " stroke="black" stroke-width="5"/>
+<circle cx="2432" cy="208" r="12" stroke="none" fill="black"/>
+<circle cx="2368" cy="208" r="12" stroke="black" fill="white"/>
+<path d="M2356,208 L2380,208 M2368,196 L2368,220 " stroke="black"/>
+<path d="M2432,336 L2368,336 " stroke="black" stroke-width="5"/>
+<circle cx="2432" cy="336" r="12" stroke="none" fill="black"/>
+<circle cx="2368" cy="336" r="12" stroke="black" fill="white"/>
+<path d="M2356,336 L2380,336 M2368,324 L2368,348 " stroke="black"/>
+<path d="M2560,80 L2496,80 " stroke="black" stroke-width="5"/>
+<circle cx="2560" cy="80" r="12" stroke="none" fill="black"/>
+<circle cx="2496" cy="80" r="12" stroke="black" fill="white"/>
+<path d="M2484,80 L2508,80 M2496,68 L2496,92 " stroke="black"/>
+<path d="M2560,208 L2496,208 " stroke="black" stroke-width="5"/>
+<circle cx="2560" cy="208" r="12" stroke="none" fill="black"/>
+<circle cx="2496" cy="208" r="12" stroke="black" fill="white"/>
+<path d="M2484,208 L2508,208 M2496,196 L2496,220 " stroke="black"/>
+<path d="M2560,336 L2496,336 " stroke="black" stroke-width="5"/>
+<circle cx="2560" cy="336" r="12" stroke="none" fill="black"/>
+<circle cx="2496" cy="336" r="12" stroke="black" fill="white"/>
+<path d="M2484,336 L2508,336 M2496,324 L2496,348 " stroke="black"/>
+<path d="M2432,144 L2496,144 " stroke="black" stroke-width="5"/>
+<circle cx="2432" cy="144" r="12" stroke="none" fill="black"/>
+<circle cx="2496" cy="144" r="12" stroke="black" fill="white"/>
+<path d="M2484,144 L2508,144 M2496,132 L2496,156 " stroke="black"/>
+<path d="M2432,272 L2496,272 " stroke="black" stroke-width="5"/>
+<circle cx="2432" cy="272" r="12" stroke="none" fill="black"/>
+<circle cx="2496" cy="272" r="12" stroke="black" fill="white"/>
+<path d="M2484,272 L2508,272 M2496,260 L2496,284 " stroke="black"/>
+<path d="M2560,144 L2624,144 " stroke="black" stroke-width="5"/>
+<circle cx="2560" cy="144" r="12" stroke="none" fill="black"/>
+<circle cx="2624" cy="144" r="12" stroke="black" fill="white"/>
+<path d="M2612,144 L2636,144 M2624,132 L2624,156 " stroke="black"/>
+<path d="M2560,272 L2624,272 " stroke="black" stroke-width="5"/>
+<circle cx="2560" cy="272" r="12" stroke="none" fill="black"/>
+<circle cx="2624" cy="272" r="12" stroke="black" fill="white"/>
+<path d="M2612,272 L2636,272 M2624,260 L2624,284 " stroke="black"/>
 <rect x="128" y="521.6" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="144" y="537.6">H</text>
 <rect x="256" y="521.6" width="32" height="32" stroke="black" fill="white"/>
@@ -1638,166 +1638,166 @@
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1059.2" y="793.6">H</text>
 <rect x="1171.2" y="777.6" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1187.2" y="793.6">H</text>
-<path d="M1516.8,537.6 L1580.8,537.6 " stroke="black" stroke-width="3"/>
-<circle cx="1516.8" cy="537.6" r="8" stroke="none" fill="black"/>
-<circle cx="1580.8" cy="537.6" r="8" stroke="black" fill="white"/>
-<path d="M1572.8,537.6 L1588.8,537.6 M1580.8,529.6 L1580.8,545.6 " stroke="black"/>
-<path d="M1516.8,665.6 L1580.8,665.6 " stroke="black" stroke-width="3"/>
-<circle cx="1516.8" cy="665.6" r="8" stroke="none" fill="black"/>
-<circle cx="1580.8" cy="665.6" r="8" stroke="black" fill="white"/>
-<path d="M1572.8,665.6 L1588.8,665.6 M1580.8,657.6 L1580.8,673.6 " stroke="black"/>
-<path d="M1516.8,793.6 L1580.8,793.6 " stroke="black" stroke-width="3"/>
-<circle cx="1516.8" cy="793.6" r="8" stroke="none" fill="black"/>
-<circle cx="1580.8" cy="793.6" r="8" stroke="black" fill="white"/>
-<path d="M1572.8,793.6 L1588.8,793.6 M1580.8,785.6 L1580.8,801.6 " stroke="black"/>
-<path d="M1644.8,537.6 L1708.8,537.6 " stroke="black" stroke-width="3"/>
-<circle cx="1644.8" cy="537.6" r="8" stroke="none" fill="black"/>
-<circle cx="1708.8" cy="537.6" r="8" stroke="black" fill="white"/>
-<path d="M1700.8,537.6 L1716.8,537.6 M1708.8,529.6 L1708.8,545.6 " stroke="black"/>
-<path d="M1644.8,665.6 L1708.8,665.6 " stroke="black" stroke-width="3"/>
-<circle cx="1644.8" cy="665.6" r="8" stroke="none" fill="black"/>
-<circle cx="1708.8" cy="665.6" r="8" stroke="black" fill="white"/>
-<path d="M1700.8,665.6 L1716.8,665.6 M1708.8,657.6 L1708.8,673.6 " stroke="black"/>
-<path d="M1644.8,793.6 L1708.8,793.6 " stroke="black" stroke-width="3"/>
-<circle cx="1644.8" cy="793.6" r="8" stroke="none" fill="black"/>
-<circle cx="1708.8" cy="793.6" r="8" stroke="black" fill="white"/>
-<path d="M1700.8,793.6 L1716.8,793.6 M1708.8,785.6 L1708.8,801.6 " stroke="black"/>
-<path d="M1516.8,601.6 L1452.8,601.6 " stroke="black" stroke-width="3"/>
-<circle cx="1516.8" cy="601.6" r="8" stroke="none" fill="black"/>
-<circle cx="1452.8" cy="601.6" r="8" stroke="black" fill="white"/>
-<path d="M1444.8,601.6 L1460.8,601.6 M1452.8,593.6 L1452.8,609.6 " stroke="black"/>
-<path d="M1516.8,729.6 L1452.8,729.6 " stroke="black" stroke-width="3"/>
-<circle cx="1516.8" cy="729.6" r="8" stroke="none" fill="black"/>
-<circle cx="1452.8" cy="729.6" r="8" stroke="black" fill="white"/>
-<path d="M1444.8,729.6 L1460.8,729.6 M1452.8,721.6 L1452.8,737.6 " stroke="black"/>
-<path d="M1644.8,601.6 L1580.8,601.6 " stroke="black" stroke-width="3"/>
-<circle cx="1644.8" cy="601.6" r="8" stroke="none" fill="black"/>
-<circle cx="1580.8" cy="601.6" r="8" stroke="black" fill="white"/>
-<path d="M1572.8,601.6 L1588.8,601.6 M1580.8,593.6 L1580.8,609.6 " stroke="black"/>
-<path d="M1644.8,729.6 L1580.8,729.6 " stroke="black" stroke-width="3"/>
-<circle cx="1644.8" cy="729.6" r="8" stroke="none" fill="black"/>
-<circle cx="1580.8" cy="729.6" r="8" stroke="black" fill="white"/>
-<path d="M1572.8,729.6 L1588.8,729.6 M1580.8,721.6 L1580.8,737.6 " stroke="black"/>
-<path d="M1974.4,537.6 L1974.4,601.6 " stroke="black" stroke-width="3"/>
-<circle cx="1974.4" cy="537.6" r="8" stroke="none" fill="black"/>
-<circle cx="1974.4" cy="601.6" r="8" stroke="black" fill="white"/>
-<path d="M1966.4,601.6 L1982.4,601.6 M1974.4,593.6 L1974.4,609.6 " stroke="black"/>
-<path d="M1974.4,665.6 L1974.4,729.6 " stroke="black" stroke-width="3"/>
-<circle cx="1974.4" cy="665.6" r="8" stroke="none" fill="black"/>
-<circle cx="1974.4" cy="729.6" r="8" stroke="black" fill="white"/>
-<path d="M1966.4,729.6 L1982.4,729.6 M1974.4,721.6 L1974.4,737.6 " stroke="black"/>
-<path d="M2102.4,537.6 L2102.4,601.6 " stroke="black" stroke-width="3"/>
-<circle cx="2102.4" cy="537.6" r="8" stroke="none" fill="black"/>
-<circle cx="2102.4" cy="601.6" r="8" stroke="black" fill="white"/>
-<path d="M2094.4,601.6 L2110.4,601.6 M2102.4,593.6 L2102.4,609.6 " stroke="black"/>
-<path d="M2102.4,665.6 L2102.4,729.6 " stroke="black" stroke-width="3"/>
-<circle cx="2102.4" cy="665.6" r="8" stroke="none" fill="black"/>
-<circle cx="2102.4" cy="729.6" r="8" stroke="black" fill="white"/>
-<path d="M2094.4,729.6 L2110.4,729.6 M2102.4,721.6 L2102.4,737.6 " stroke="black"/>
-<path d="M1910.4,665.6 L1910.4,601.6 " stroke="black" stroke-width="3"/>
-<circle cx="1910.4" cy="665.6" r="8" stroke="none" fill="black"/>
-<circle cx="1910.4" cy="601.6" r="8" stroke="black" fill="white"/>
-<path d="M1902.4,601.6 L1918.4,601.6 M1910.4,593.6 L1910.4,609.6 " stroke="black"/>
-<path d="M1910.4,793.6 L1910.4,729.6 " stroke="black" stroke-width="3"/>
-<circle cx="1910.4" cy="793.6" r="8" stroke="none" fill="black"/>
-<circle cx="1910.4" cy="729.6" r="8" stroke="black" fill="white"/>
-<path d="M1902.4,729.6 L1918.4,729.6 M1910.4,721.6 L1910.4,737.6 " stroke="black"/>
-<path d="M2038.4,665.6 L2038.4,601.6 " stroke="black" stroke-width="3"/>
-<circle cx="2038.4" cy="665.6" r="8" stroke="none" fill="black"/>
-<circle cx="2038.4" cy="601.6" r="8" stroke="black" fill="white"/>
-<path d="M2030.4,601.6 L2046.4,601.6 M2038.4,593.6 L2038.4,609.6 " stroke="black"/>
-<path d="M2038.4,793.6 L2038.4,729.6 " stroke="black" stroke-width="3"/>
-<circle cx="2038.4" cy="793.6" r="8" stroke="none" fill="black"/>
-<circle cx="2038.4" cy="729.6" r="8" stroke="black" fill="white"/>
-<path d="M2030.4,729.6 L2046.4,729.6 M2038.4,721.6 L2038.4,737.6 " stroke="black"/>
-<path d="M2166.4,665.6 L2166.4,601.6 " stroke="black" stroke-width="3"/>
-<circle cx="2166.4" cy="665.6" r="8" stroke="none" fill="black"/>
-<circle cx="2166.4" cy="601.6" r="8" stroke="black" fill="white"/>
-<path d="M2158.4,601.6 L2174.4,601.6 M2166.4,593.6 L2166.4,609.6 " stroke="black"/>
-<path d="M2166.4,793.6 L2166.4,729.6 " stroke="black" stroke-width="3"/>
-<circle cx="2166.4" cy="793.6" r="8" stroke="none" fill="black"/>
-<circle cx="2166.4" cy="729.6" r="8" stroke="black" fill="white"/>
-<path d="M2158.4,729.6 L2174.4,729.6 M2166.4,721.6 L2166.4,737.6 " stroke="black"/>
-<path d="M2432,665.6 L2432,601.6 " stroke="black" stroke-width="3"/>
-<circle cx="2432" cy="665.6" r="8" stroke="none" fill="black"/>
-<circle cx="2432" cy="601.6" r="8" stroke="black" fill="white"/>
-<path d="M2424,601.6 L2440,601.6 M2432,593.6 L2432,609.6 " stroke="black"/>
-<path d="M2432,793.6 L2432,729.6 " stroke="black" stroke-width="3"/>
-<circle cx="2432" cy="793.6" r="8" stroke="none" fill="black"/>
-<circle cx="2432" cy="729.6" r="8" stroke="black" fill="white"/>
-<path d="M2424,729.6 L2440,729.6 M2432,721.6 L2432,737.6 " stroke="black"/>
-<path d="M2560,665.6 L2560,601.6 " stroke="black" stroke-width="3"/>
-<circle cx="2560" cy="665.6" r="8" stroke="none" fill="black"/>
-<circle cx="2560" cy="601.6" r="8" stroke="black" fill="white"/>
-<path d="M2552,601.6 L2568,601.6 M2560,593.6 L2560,609.6 " stroke="black"/>
-<path d="M2560,793.6 L2560,729.6 " stroke="black" stroke-width="3"/>
-<circle cx="2560" cy="793.6" r="8" stroke="none" fill="black"/>
-<circle cx="2560" cy="729.6" r="8" stroke="black" fill="white"/>
-<path d="M2552,729.6 L2568,729.6 M2560,721.6 L2560,737.6 " stroke="black"/>
-<path d="M2368,537.6 L2368,601.6 " stroke="black" stroke-width="3"/>
-<circle cx="2368" cy="537.6" r="8" stroke="none" fill="black"/>
-<circle cx="2368" cy="601.6" r="8" stroke="black" fill="white"/>
-<path d="M2360,601.6 L2376,601.6 M2368,593.6 L2368,609.6 " stroke="black"/>
-<path d="M2368,665.6 L2368,729.6 " stroke="black" stroke-width="3"/>
-<circle cx="2368" cy="665.6" r="8" stroke="none" fill="black"/>
-<circle cx="2368" cy="729.6" r="8" stroke="black" fill="white"/>
-<path d="M2360,729.6 L2376,729.6 M2368,721.6 L2368,737.6 " stroke="black"/>
-<path d="M2496,537.6 L2496,601.6 " stroke="black" stroke-width="3"/>
-<circle cx="2496" cy="537.6" r="8" stroke="none" fill="black"/>
-<circle cx="2496" cy="601.6" r="8" stroke="black" fill="white"/>
-<path d="M2488,601.6 L2504,601.6 M2496,593.6 L2496,609.6 " stroke="black"/>
-<path d="M2496,665.6 L2496,729.6 " stroke="black" stroke-width="3"/>
-<circle cx="2496" cy="665.6" r="8" stroke="none" fill="black"/>
-<circle cx="2496" cy="729.6" r="8" stroke="black" fill="white"/>
-<path d="M2488,729.6 L2504,729.6 M2496,721.6 L2496,737.6 " stroke="black"/>
-<path d="M2624,537.6 L2624,601.6 " stroke="black" stroke-width="3"/>
-<circle cx="2624" cy="537.6" r="8" stroke="none" fill="black"/>
-<circle cx="2624" cy="601.6" r="8" stroke="black" fill="white"/>
-<path d="M2616,601.6 L2632,601.6 M2624,593.6 L2624,609.6 " stroke="black"/>
-<path d="M2624,665.6 L2624,729.6 " stroke="black" stroke-width="3"/>
-<circle cx="2624" cy="665.6" r="8" stroke="none" fill="black"/>
-<circle cx="2624" cy="729.6" r="8" stroke="black" fill="white"/>
-<path d="M2616,729.6 L2632,729.6 M2624,721.6 L2624,737.6 " stroke="black"/>
-<path d="M144,995.2 L80,995.2 " stroke="black" stroke-width="3"/>
-<circle cx="144" cy="995.2" r="8" stroke="none" fill="black"/>
-<circle cx="80" cy="995.2" r="8" stroke="black" fill="white"/>
-<path d="M72,995.2 L88,995.2 M80,987.2 L80,1003.2 " stroke="black"/>
-<path d="M144,1123.2 L80,1123.2 " stroke="black" stroke-width="3"/>
-<circle cx="144" cy="1123.2" r="8" stroke="none" fill="black"/>
-<circle cx="80" cy="1123.2" r="8" stroke="black" fill="white"/>
-<path d="M72,1123.2 L88,1123.2 M80,1115.2 L80,1131.2 " stroke="black"/>
-<path d="M144,1251.2 L80,1251.2 " stroke="black" stroke-width="3"/>
-<circle cx="144" cy="1251.2" r="8" stroke="none" fill="black"/>
-<circle cx="80" cy="1251.2" r="8" stroke="black" fill="white"/>
-<path d="M72,1251.2 L88,1251.2 M80,1243.2 L80,1259.2 " stroke="black"/>
-<path d="M272,995.2 L208,995.2 " stroke="black" stroke-width="3"/>
-<circle cx="272" cy="995.2" r="8" stroke="none" fill="black"/>
-<circle cx="208" cy="995.2" r="8" stroke="black" fill="white"/>
-<path d="M200,995.2 L216,995.2 M208,987.2 L208,1003.2 " stroke="black"/>
-<path d="M272,1123.2 L208,1123.2 " stroke="black" stroke-width="3"/>
-<circle cx="272" cy="1123.2" r="8" stroke="none" fill="black"/>
-<circle cx="208" cy="1123.2" r="8" stroke="black" fill="white"/>
-<path d="M200,1123.2 L216,1123.2 M208,1115.2 L208,1131.2 " stroke="black"/>
-<path d="M272,1251.2 L208,1251.2 " stroke="black" stroke-width="3"/>
-<circle cx="272" cy="1251.2" r="8" stroke="none" fill="black"/>
-<circle cx="208" cy="1251.2" r="8" stroke="black" fill="white"/>
-<path d="M200,1251.2 L216,1251.2 M208,1243.2 L208,1259.2 " stroke="black"/>
-<path d="M144,1059.2 L208,1059.2 " stroke="black" stroke-width="3"/>
-<circle cx="144" cy="1059.2" r="8" stroke="none" fill="black"/>
-<circle cx="208" cy="1059.2" r="8" stroke="black" fill="white"/>
-<path d="M200,1059.2 L216,1059.2 M208,1051.2 L208,1067.2 " stroke="black"/>
-<path d="M144,1187.2 L208,1187.2 " stroke="black" stroke-width="3"/>
-<circle cx="144" cy="1187.2" r="8" stroke="none" fill="black"/>
-<circle cx="208" cy="1187.2" r="8" stroke="black" fill="white"/>
-<path d="M200,1187.2 L216,1187.2 M208,1179.2 L208,1195.2 " stroke="black"/>
-<path d="M272,1059.2 L336,1059.2 " stroke="black" stroke-width="3"/>
-<circle cx="272" cy="1059.2" r="8" stroke="none" fill="black"/>
-<circle cx="336" cy="1059.2" r="8" stroke="black" fill="white"/>
-<path d="M328,1059.2 L344,1059.2 M336,1051.2 L336,1067.2 " stroke="black"/>
-<path d="M272,1187.2 L336,1187.2 " stroke="black" stroke-width="3"/>
-<circle cx="272" cy="1187.2" r="8" stroke="none" fill="black"/>
-<circle cx="336" cy="1187.2" r="8" stroke="black" fill="white"/>
-<path d="M328,1187.2 L344,1187.2 M336,1179.2 L336,1195.2 " stroke="black"/>
+<path d="M1516.8,537.6 L1580.8,537.6 " stroke="black" stroke-width="5"/>
+<circle cx="1516.8" cy="537.6" r="12" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="537.6" r="12" stroke="black" fill="white"/>
+<path d="M1568.8,537.6 L1592.8,537.6 M1580.8,525.6 L1580.8,549.6 " stroke="black"/>
+<path d="M1516.8,665.6 L1580.8,665.6 " stroke="black" stroke-width="5"/>
+<circle cx="1516.8" cy="665.6" r="12" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="665.6" r="12" stroke="black" fill="white"/>
+<path d="M1568.8,665.6 L1592.8,665.6 M1580.8,653.6 L1580.8,677.6 " stroke="black"/>
+<path d="M1516.8,793.6 L1580.8,793.6 " stroke="black" stroke-width="5"/>
+<circle cx="1516.8" cy="793.6" r="12" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="793.6" r="12" stroke="black" fill="white"/>
+<path d="M1568.8,793.6 L1592.8,793.6 M1580.8,781.6 L1580.8,805.6 " stroke="black"/>
+<path d="M1644.8,537.6 L1708.8,537.6 " stroke="black" stroke-width="5"/>
+<circle cx="1644.8" cy="537.6" r="12" stroke="none" fill="black"/>
+<circle cx="1708.8" cy="537.6" r="12" stroke="black" fill="white"/>
+<path d="M1696.8,537.6 L1720.8,537.6 M1708.8,525.6 L1708.8,549.6 " stroke="black"/>
+<path d="M1644.8,665.6 L1708.8,665.6 " stroke="black" stroke-width="5"/>
+<circle cx="1644.8" cy="665.6" r="12" stroke="none" fill="black"/>
+<circle cx="1708.8" cy="665.6" r="12" stroke="black" fill="white"/>
+<path d="M1696.8,665.6 L1720.8,665.6 M1708.8,653.6 L1708.8,677.6 " stroke="black"/>
+<path d="M1644.8,793.6 L1708.8,793.6 " stroke="black" stroke-width="5"/>
+<circle cx="1644.8" cy="793.6" r="12" stroke="none" fill="black"/>
+<circle cx="1708.8" cy="793.6" r="12" stroke="black" fill="white"/>
+<path d="M1696.8,793.6 L1720.8,793.6 M1708.8,781.6 L1708.8,805.6 " stroke="black"/>
+<path d="M1516.8,601.6 L1452.8,601.6 " stroke="black" stroke-width="5"/>
+<circle cx="1516.8" cy="601.6" r="12" stroke="none" fill="black"/>
+<circle cx="1452.8" cy="601.6" r="12" stroke="black" fill="white"/>
+<path d="M1440.8,601.6 L1464.8,601.6 M1452.8,589.6 L1452.8,613.6 " stroke="black"/>
+<path d="M1516.8,729.6 L1452.8,729.6 " stroke="black" stroke-width="5"/>
+<circle cx="1516.8" cy="729.6" r="12" stroke="none" fill="black"/>
+<circle cx="1452.8" cy="729.6" r="12" stroke="black" fill="white"/>
+<path d="M1440.8,729.6 L1464.8,729.6 M1452.8,717.6 L1452.8,741.6 " stroke="black"/>
+<path d="M1644.8,601.6 L1580.8,601.6 " stroke="black" stroke-width="5"/>
+<circle cx="1644.8" cy="601.6" r="12" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="601.6" r="12" stroke="black" fill="white"/>
+<path d="M1568.8,601.6 L1592.8,601.6 M1580.8,589.6 L1580.8,613.6 " stroke="black"/>
+<path d="M1644.8,729.6 L1580.8,729.6 " stroke="black" stroke-width="5"/>
+<circle cx="1644.8" cy="729.6" r="12" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="729.6" r="12" stroke="black" fill="white"/>
+<path d="M1568.8,729.6 L1592.8,729.6 M1580.8,717.6 L1580.8,741.6 " stroke="black"/>
+<path d="M1974.4,537.6 L1974.4,601.6 " stroke="black" stroke-width="5"/>
+<circle cx="1974.4" cy="537.6" r="12" stroke="none" fill="black"/>
+<circle cx="1974.4" cy="601.6" r="12" stroke="black" fill="white"/>
+<path d="M1962.4,601.6 L1986.4,601.6 M1974.4,589.6 L1974.4,613.6 " stroke="black"/>
+<path d="M1974.4,665.6 L1974.4,729.6 " stroke="black" stroke-width="5"/>
+<circle cx="1974.4" cy="665.6" r="12" stroke="none" fill="black"/>
+<circle cx="1974.4" cy="729.6" r="12" stroke="black" fill="white"/>
+<path d="M1962.4,729.6 L1986.4,729.6 M1974.4,717.6 L1974.4,741.6 " stroke="black"/>
+<path d="M2102.4,537.6 L2102.4,601.6 " stroke="black" stroke-width="5"/>
+<circle cx="2102.4" cy="537.6" r="12" stroke="none" fill="black"/>
+<circle cx="2102.4" cy="601.6" r="12" stroke="black" fill="white"/>
+<path d="M2090.4,601.6 L2114.4,601.6 M2102.4,589.6 L2102.4,613.6 " stroke="black"/>
+<path d="M2102.4,665.6 L2102.4,729.6 " stroke="black" stroke-width="5"/>
+<circle cx="2102.4" cy="665.6" r="12" stroke="none" fill="black"/>
+<circle cx="2102.4" cy="729.6" r="12" stroke="black" fill="white"/>
+<path d="M2090.4,729.6 L2114.4,729.6 M2102.4,717.6 L2102.4,741.6 " stroke="black"/>
+<path d="M1910.4,665.6 L1910.4,601.6 " stroke="black" stroke-width="5"/>
+<circle cx="1910.4" cy="665.6" r="12" stroke="none" fill="black"/>
+<circle cx="1910.4" cy="601.6" r="12" stroke="black" fill="white"/>
+<path d="M1898.4,601.6 L1922.4,601.6 M1910.4,589.6 L1910.4,613.6 " stroke="black"/>
+<path d="M1910.4,793.6 L1910.4,729.6 " stroke="black" stroke-width="5"/>
+<circle cx="1910.4" cy="793.6" r="12" stroke="none" fill="black"/>
+<circle cx="1910.4" cy="729.6" r="12" stroke="black" fill="white"/>
+<path d="M1898.4,729.6 L1922.4,729.6 M1910.4,717.6 L1910.4,741.6 " stroke="black"/>
+<path d="M2038.4,665.6 L2038.4,601.6 " stroke="black" stroke-width="5"/>
+<circle cx="2038.4" cy="665.6" r="12" stroke="none" fill="black"/>
+<circle cx="2038.4" cy="601.6" r="12" stroke="black" fill="white"/>
+<path d="M2026.4,601.6 L2050.4,601.6 M2038.4,589.6 L2038.4,613.6 " stroke="black"/>
+<path d="M2038.4,793.6 L2038.4,729.6 " stroke="black" stroke-width="5"/>
+<circle cx="2038.4" cy="793.6" r="12" stroke="none" fill="black"/>
+<circle cx="2038.4" cy="729.6" r="12" stroke="black" fill="white"/>
+<path d="M2026.4,729.6 L2050.4,729.6 M2038.4,717.6 L2038.4,741.6 " stroke="black"/>
+<path d="M2166.4,665.6 L2166.4,601.6 " stroke="black" stroke-width="5"/>
+<circle cx="2166.4" cy="665.6" r="12" stroke="none" fill="black"/>
+<circle cx="2166.4" cy="601.6" r="12" stroke="black" fill="white"/>
+<path d="M2154.4,601.6 L2178.4,601.6 M2166.4,589.6 L2166.4,613.6 " stroke="black"/>
+<path d="M2166.4,793.6 L2166.4,729.6 " stroke="black" stroke-width="5"/>
+<circle cx="2166.4" cy="793.6" r="12" stroke="none" fill="black"/>
+<circle cx="2166.4" cy="729.6" r="12" stroke="black" fill="white"/>
+<path d="M2154.4,729.6 L2178.4,729.6 M2166.4,717.6 L2166.4,741.6 " stroke="black"/>
+<path d="M2432,665.6 L2432,601.6 " stroke="black" stroke-width="5"/>
+<circle cx="2432" cy="665.6" r="12" stroke="none" fill="black"/>
+<circle cx="2432" cy="601.6" r="12" stroke="black" fill="white"/>
+<path d="M2420,601.6 L2444,601.6 M2432,589.6 L2432,613.6 " stroke="black"/>
+<path d="M2432,793.6 L2432,729.6 " stroke="black" stroke-width="5"/>
+<circle cx="2432" cy="793.6" r="12" stroke="none" fill="black"/>
+<circle cx="2432" cy="729.6" r="12" stroke="black" fill="white"/>
+<path d="M2420,729.6 L2444,729.6 M2432,717.6 L2432,741.6 " stroke="black"/>
+<path d="M2560,665.6 L2560,601.6 " stroke="black" stroke-width="5"/>
+<circle cx="2560" cy="665.6" r="12" stroke="none" fill="black"/>
+<circle cx="2560" cy="601.6" r="12" stroke="black" fill="white"/>
+<path d="M2548,601.6 L2572,601.6 M2560,589.6 L2560,613.6 " stroke="black"/>
+<path d="M2560,793.6 L2560,729.6 " stroke="black" stroke-width="5"/>
+<circle cx="2560" cy="793.6" r="12" stroke="none" fill="black"/>
+<circle cx="2560" cy="729.6" r="12" stroke="black" fill="white"/>
+<path d="M2548,729.6 L2572,729.6 M2560,717.6 L2560,741.6 " stroke="black"/>
+<path d="M2368,537.6 L2368,601.6 " stroke="black" stroke-width="5"/>
+<circle cx="2368" cy="537.6" r="12" stroke="none" fill="black"/>
+<circle cx="2368" cy="601.6" r="12" stroke="black" fill="white"/>
+<path d="M2356,601.6 L2380,601.6 M2368,589.6 L2368,613.6 " stroke="black"/>
+<path d="M2368,665.6 L2368,729.6 " stroke="black" stroke-width="5"/>
+<circle cx="2368" cy="665.6" r="12" stroke="none" fill="black"/>
+<circle cx="2368" cy="729.6" r="12" stroke="black" fill="white"/>
+<path d="M2356,729.6 L2380,729.6 M2368,717.6 L2368,741.6 " stroke="black"/>
+<path d="M2496,537.6 L2496,601.6 " stroke="black" stroke-width="5"/>
+<circle cx="2496" cy="537.6" r="12" stroke="none" fill="black"/>
+<circle cx="2496" cy="601.6" r="12" stroke="black" fill="white"/>
+<path d="M2484,601.6 L2508,601.6 M2496,589.6 L2496,613.6 " stroke="black"/>
+<path d="M2496,665.6 L2496,729.6 " stroke="black" stroke-width="5"/>
+<circle cx="2496" cy="665.6" r="12" stroke="none" fill="black"/>
+<circle cx="2496" cy="729.6" r="12" stroke="black" fill="white"/>
+<path d="M2484,729.6 L2508,729.6 M2496,717.6 L2496,741.6 " stroke="black"/>
+<path d="M2624,537.6 L2624,601.6 " stroke="black" stroke-width="5"/>
+<circle cx="2624" cy="537.6" r="12" stroke="none" fill="black"/>
+<circle cx="2624" cy="601.6" r="12" stroke="black" fill="white"/>
+<path d="M2612,601.6 L2636,601.6 M2624,589.6 L2624,613.6 " stroke="black"/>
+<path d="M2624,665.6 L2624,729.6 " stroke="black" stroke-width="5"/>
+<circle cx="2624" cy="665.6" r="12" stroke="none" fill="black"/>
+<circle cx="2624" cy="729.6" r="12" stroke="black" fill="white"/>
+<path d="M2612,729.6 L2636,729.6 M2624,717.6 L2624,741.6 " stroke="black"/>
+<path d="M144,995.2 L80,995.2 " stroke="black" stroke-width="5"/>
+<circle cx="144" cy="995.2" r="12" stroke="none" fill="black"/>
+<circle cx="80" cy="995.2" r="12" stroke="black" fill="white"/>
+<path d="M68,995.2 L92,995.2 M80,983.2 L80,1007.2 " stroke="black"/>
+<path d="M144,1123.2 L80,1123.2 " stroke="black" stroke-width="5"/>
+<circle cx="144" cy="1123.2" r="12" stroke="none" fill="black"/>
+<circle cx="80" cy="1123.2" r="12" stroke="black" fill="white"/>
+<path d="M68,1123.2 L92,1123.2 M80,1111.2 L80,1135.2 " stroke="black"/>
+<path d="M144,1251.2 L80,1251.2 " stroke="black" stroke-width="5"/>
+<circle cx="144" cy="1251.2" r="12" stroke="none" fill="black"/>
+<circle cx="80" cy="1251.2" r="12" stroke="black" fill="white"/>
+<path d="M68,1251.2 L92,1251.2 M80,1239.2 L80,1263.2 " stroke="black"/>
+<path d="M272,995.2 L208,995.2 " stroke="black" stroke-width="5"/>
+<circle cx="272" cy="995.2" r="12" stroke="none" fill="black"/>
+<circle cx="208" cy="995.2" r="12" stroke="black" fill="white"/>
+<path d="M196,995.2 L220,995.2 M208,983.2 L208,1007.2 " stroke="black"/>
+<path d="M272,1123.2 L208,1123.2 " stroke="black" stroke-width="5"/>
+<circle cx="272" cy="1123.2" r="12" stroke="none" fill="black"/>
+<circle cx="208" cy="1123.2" r="12" stroke="black" fill="white"/>
+<path d="M196,1123.2 L220,1123.2 M208,1111.2 L208,1135.2 " stroke="black"/>
+<path d="M272,1251.2 L208,1251.2 " stroke="black" stroke-width="5"/>
+<circle cx="272" cy="1251.2" r="12" stroke="none" fill="black"/>
+<circle cx="208" cy="1251.2" r="12" stroke="black" fill="white"/>
+<path d="M196,1251.2 L220,1251.2 M208,1239.2 L208,1263.2 " stroke="black"/>
+<path d="M144,1059.2 L208,1059.2 " stroke="black" stroke-width="5"/>
+<circle cx="144" cy="1059.2" r="12" stroke="none" fill="black"/>
+<circle cx="208" cy="1059.2" r="12" stroke="black" fill="white"/>
+<path d="M196,1059.2 L220,1059.2 M208,1047.2 L208,1071.2 " stroke="black"/>
+<path d="M144,1187.2 L208,1187.2 " stroke="black" stroke-width="5"/>
+<circle cx="144" cy="1187.2" r="12" stroke="none" fill="black"/>
+<circle cx="208" cy="1187.2" r="12" stroke="black" fill="white"/>
+<path d="M196,1187.2 L220,1187.2 M208,1175.2 L208,1199.2 " stroke="black"/>
+<path d="M272,1059.2 L336,1059.2 " stroke="black" stroke-width="5"/>
+<circle cx="272" cy="1059.2" r="12" stroke="none" fill="black"/>
+<circle cx="336" cy="1059.2" r="12" stroke="black" fill="white"/>
+<path d="M324,1059.2 L348,1059.2 M336,1047.2 L336,1071.2 " stroke="black"/>
+<path d="M272,1187.2 L336,1187.2 " stroke="black" stroke-width="5"/>
+<circle cx="272" cy="1187.2" r="12" stroke="none" fill="black"/>
+<circle cx="336" cy="1187.2" r="12" stroke="black" fill="white"/>
+<path d="M324,1187.2 L348,1187.2 M336,1175.2 L336,1199.2 " stroke="black"/>
 <rect x="585.6" y="979.2" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="601.6" y="995.2">H</text>
 <rect x="713.6" y="979.2" width="32" height="32" stroke="black" fill="white"/>
@@ -1846,166 +1846,166 @@
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1516.8" y="1251.2">H</text>
 <rect x="1628.8" y="1235.2" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1644.8" y="1251.2">H</text>
-<path d="M1974.4,995.2 L2038.4,995.2 " stroke="black" stroke-width="3"/>
-<circle cx="1974.4" cy="995.2" r="8" stroke="none" fill="black"/>
-<circle cx="2038.4" cy="995.2" r="8" stroke="black" fill="white"/>
-<path d="M2030.4,995.2 L2046.4,995.2 M2038.4,987.2 L2038.4,1003.2 " stroke="black"/>
-<path d="M1974.4,1123.2 L2038.4,1123.2 " stroke="black" stroke-width="3"/>
-<circle cx="1974.4" cy="1123.2" r="8" stroke="none" fill="black"/>
-<circle cx="2038.4" cy="1123.2" r="8" stroke="black" fill="white"/>
-<path d="M2030.4,1123.2 L2046.4,1123.2 M2038.4,1115.2 L2038.4,1131.2 " stroke="black"/>
-<path d="M1974.4,1251.2 L2038.4,1251.2 " stroke="black" stroke-width="3"/>
-<circle cx="1974.4" cy="1251.2" r="8" stroke="none" fill="black"/>
-<circle cx="2038.4" cy="1251.2" r="8" stroke="black" fill="white"/>
-<path d="M2030.4,1251.2 L2046.4,1251.2 M2038.4,1243.2 L2038.4,1259.2 " stroke="black"/>
-<path d="M2102.4,995.2 L2166.4,995.2 " stroke="black" stroke-width="3"/>
-<circle cx="2102.4" cy="995.2" r="8" stroke="none" fill="black"/>
-<circle cx="2166.4" cy="995.2" r="8" stroke="black" fill="white"/>
-<path d="M2158.4,995.2 L2174.4,995.2 M2166.4,987.2 L2166.4,1003.2 " stroke="black"/>
-<path d="M2102.4,1123.2 L2166.4,1123.2 " stroke="black" stroke-width="3"/>
-<circle cx="2102.4" cy="1123.2" r="8" stroke="none" fill="black"/>
-<circle cx="2166.4" cy="1123.2" r="8" stroke="black" fill="white"/>
-<path d="M2158.4,1123.2 L2174.4,1123.2 M2166.4,1115.2 L2166.4,1131.2 " stroke="black"/>
-<path d="M2102.4,1251.2 L2166.4,1251.2 " stroke="black" stroke-width="3"/>
-<circle cx="2102.4" cy="1251.2" r="8" stroke="none" fill="black"/>
-<circle cx="2166.4" cy="1251.2" r="8" stroke="black" fill="white"/>
-<path d="M2158.4,1251.2 L2174.4,1251.2 M2166.4,1243.2 L2166.4,1259.2 " stroke="black"/>
-<path d="M1974.4,1059.2 L1910.4,1059.2 " stroke="black" stroke-width="3"/>
-<circle cx="1974.4" cy="1059.2" r="8" stroke="none" fill="black"/>
-<circle cx="1910.4" cy="1059.2" r="8" stroke="black" fill="white"/>
-<path d="M1902.4,1059.2 L1918.4,1059.2 M1910.4,1051.2 L1910.4,1067.2 " stroke="black"/>
-<path d="M1974.4,1187.2 L1910.4,1187.2 " stroke="black" stroke-width="3"/>
-<circle cx="1974.4" cy="1187.2" r="8" stroke="none" fill="black"/>
-<circle cx="1910.4" cy="1187.2" r="8" stroke="black" fill="white"/>
-<path d="M1902.4,1187.2 L1918.4,1187.2 M1910.4,1179.2 L1910.4,1195.2 " stroke="black"/>
-<path d="M2102.4,1059.2 L2038.4,1059.2 " stroke="black" stroke-width="3"/>
-<circle cx="2102.4" cy="1059.2" r="8" stroke="none" fill="black"/>
-<circle cx="2038.4" cy="1059.2" r="8" stroke="black" fill="white"/>
-<path d="M2030.4,1059.2 L2046.4,1059.2 M2038.4,1051.2 L2038.4,1067.2 " stroke="black"/>
-<path d="M2102.4,1187.2 L2038.4,1187.2 " stroke="black" stroke-width="3"/>
-<circle cx="2102.4" cy="1187.2" r="8" stroke="none" fill="black"/>
-<circle cx="2038.4" cy="1187.2" r="8" stroke="black" fill="white"/>
-<path d="M2030.4,1187.2 L2046.4,1187.2 M2038.4,1179.2 L2038.4,1195.2 " stroke="black"/>
-<path d="M2432,995.2 L2432,1059.2 " stroke="black" stroke-width="3"/>
-<circle cx="2432" cy="995.2" r="8" stroke="none" fill="black"/>
-<circle cx="2432" cy="1059.2" r="8" stroke="black" fill="white"/>
-<path d="M2424,1059.2 L2440,1059.2 M2432,1051.2 L2432,1067.2 " stroke="black"/>
-<path d="M2432,1123.2 L2432,1187.2 " stroke="black" stroke-width="3"/>
-<circle cx="2432" cy="1123.2" r="8" stroke="none" fill="black"/>
-<circle cx="2432" cy="1187.2" r="8" stroke="black" fill="white"/>
-<path d="M2424,1187.2 L2440,1187.2 M2432,1179.2 L2432,1195.2 " stroke="black"/>
-<path d="M2560,995.2 L2560,1059.2 " stroke="black" stroke-width="3"/>
-<circle cx="2560" cy="995.2" r="8" stroke="none" fill="black"/>
-<circle cx="2560" cy="1059.2" r="8" stroke="black" fill="white"/>
-<path d="M2552,1059.2 L2568,1059.2 M2560,1051.2 L2560,1067.2 " stroke="black"/>
-<path d="M2560,1123.2 L2560,1187.2 " stroke="black" stroke-width="3"/>
-<circle cx="2560" cy="1123.2" r="8" stroke="none" fill="black"/>
-<circle cx="2560" cy="1187.2" r="8" stroke="black" fill="white"/>
-<path d="M2552,1187.2 L2568,1187.2 M2560,1179.2 L2560,1195.2 " stroke="black"/>
-<path d="M2368,1123.2 L2368,1059.2 " stroke="black" stroke-width="3"/>
-<circle cx="2368" cy="1123.2" r="8" stroke="none" fill="black"/>
-<circle cx="2368" cy="1059.2" r="8" stroke="black" fill="white"/>
-<path d="M2360,1059.2 L2376,1059.2 M2368,1051.2 L2368,1067.2 " stroke="black"/>
-<path d="M2368,1251.2 L2368,1187.2 " stroke="black" stroke-width="3"/>
-<circle cx="2368" cy="1251.2" r="8" stroke="none" fill="black"/>
-<circle cx="2368" cy="1187.2" r="8" stroke="black" fill="white"/>
-<path d="M2360,1187.2 L2376,1187.2 M2368,1179.2 L2368,1195.2 " stroke="black"/>
-<path d="M2496,1123.2 L2496,1059.2 " stroke="black" stroke-width="3"/>
-<circle cx="2496" cy="1123.2" r="8" stroke="none" fill="black"/>
-<circle cx="2496" cy="1059.2" r="8" stroke="black" fill="white"/>
-<path d="M2488,1059.2 L2504,1059.2 M2496,1051.2 L2496,1067.2 " stroke="black"/>
-<path d="M2496,1251.2 L2496,1187.2 " stroke="black" stroke-width="3"/>
-<circle cx="2496" cy="1251.2" r="8" stroke="none" fill="black"/>
-<circle cx="2496" cy="1187.2" r="8" stroke="black" fill="white"/>
-<path d="M2488,1187.2 L2504,1187.2 M2496,1179.2 L2496,1195.2 " stroke="black"/>
-<path d="M2624,1123.2 L2624,1059.2 " stroke="black" stroke-width="3"/>
-<circle cx="2624" cy="1123.2" r="8" stroke="none" fill="black"/>
-<circle cx="2624" cy="1059.2" r="8" stroke="black" fill="white"/>
-<path d="M2616,1059.2 L2632,1059.2 M2624,1051.2 L2624,1067.2 " stroke="black"/>
-<path d="M2624,1251.2 L2624,1187.2 " stroke="black" stroke-width="3"/>
-<circle cx="2624" cy="1251.2" r="8" stroke="none" fill="black"/>
-<circle cx="2624" cy="1187.2" r="8" stroke="black" fill="white"/>
-<path d="M2616,1187.2 L2632,1187.2 M2624,1179.2 L2624,1195.2 " stroke="black"/>
-<path d="M144,1580.8 L144,1516.8 " stroke="black" stroke-width="3"/>
-<circle cx="144" cy="1580.8" r="8" stroke="none" fill="black"/>
-<circle cx="144" cy="1516.8" r="8" stroke="black" fill="white"/>
-<path d="M136,1516.8 L152,1516.8 M144,1508.8 L144,1524.8 " stroke="black"/>
-<path d="M144,1708.8 L144,1644.8 " stroke="black" stroke-width="3"/>
-<circle cx="144" cy="1708.8" r="8" stroke="none" fill="black"/>
-<circle cx="144" cy="1644.8" r="8" stroke="black" fill="white"/>
-<path d="M136,1644.8 L152,1644.8 M144,1636.8 L144,1652.8 " stroke="black"/>
-<path d="M272,1580.8 L272,1516.8 " stroke="black" stroke-width="3"/>
-<circle cx="272" cy="1580.8" r="8" stroke="none" fill="black"/>
-<circle cx="272" cy="1516.8" r="8" stroke="black" fill="white"/>
-<path d="M264,1516.8 L280,1516.8 M272,1508.8 L272,1524.8 " stroke="black"/>
-<path d="M272,1708.8 L272,1644.8 " stroke="black" stroke-width="3"/>
-<circle cx="272" cy="1708.8" r="8" stroke="none" fill="black"/>
-<circle cx="272" cy="1644.8" r="8" stroke="black" fill="white"/>
-<path d="M264,1644.8 L280,1644.8 M272,1636.8 L272,1652.8 " stroke="black"/>
-<path d="M80,1452.8 L80,1516.8 " stroke="black" stroke-width="3"/>
-<circle cx="80" cy="1452.8" r="8" stroke="none" fill="black"/>
-<circle cx="80" cy="1516.8" r="8" stroke="black" fill="white"/>
-<path d="M72,1516.8 L88,1516.8 M80,1508.8 L80,1524.8 " stroke="black"/>
-<path d="M80,1580.8 L80,1644.8 " stroke="black" stroke-width="3"/>
-<circle cx="80" cy="1580.8" r="8" stroke="none" fill="black"/>
-<circle cx="80" cy="1644.8" r="8" stroke="black" fill="white"/>
-<path d="M72,1644.8 L88,1644.8 M80,1636.8 L80,1652.8 " stroke="black"/>
-<path d="M208,1452.8 L208,1516.8 " stroke="black" stroke-width="3"/>
-<circle cx="208" cy="1452.8" r="8" stroke="none" fill="black"/>
-<circle cx="208" cy="1516.8" r="8" stroke="black" fill="white"/>
-<path d="M200,1516.8 L216,1516.8 M208,1508.8 L208,1524.8 " stroke="black"/>
-<path d="M208,1580.8 L208,1644.8 " stroke="black" stroke-width="3"/>
-<circle cx="208" cy="1580.8" r="8" stroke="none" fill="black"/>
-<circle cx="208" cy="1644.8" r="8" stroke="black" fill="white"/>
-<path d="M200,1644.8 L216,1644.8 M208,1636.8 L208,1652.8 " stroke="black"/>
-<path d="M336,1452.8 L336,1516.8 " stroke="black" stroke-width="3"/>
-<circle cx="336" cy="1452.8" r="8" stroke="none" fill="black"/>
-<circle cx="336" cy="1516.8" r="8" stroke="black" fill="white"/>
-<path d="M328,1516.8 L344,1516.8 M336,1508.8 L336,1524.8 " stroke="black"/>
-<path d="M336,1580.8 L336,1644.8 " stroke="black" stroke-width="3"/>
-<circle cx="336" cy="1580.8" r="8" stroke="none" fill="black"/>
-<circle cx="336" cy="1644.8" r="8" stroke="black" fill="white"/>
-<path d="M328,1644.8 L344,1644.8 M336,1636.8 L336,1652.8 " stroke="black"/>
-<path d="M601.6,1452.8 L537.6,1452.8 " stroke="black" stroke-width="3"/>
-<circle cx="601.6" cy="1452.8" r="8" stroke="none" fill="black"/>
-<circle cx="537.6" cy="1452.8" r="8" stroke="black" fill="white"/>
-<path d="M529.6,1452.8 L545.6,1452.8 M537.6,1444.8 L537.6,1460.8 " stroke="black"/>
-<path d="M601.6,1580.8 L537.6,1580.8 " stroke="black" stroke-width="3"/>
-<circle cx="601.6" cy="1580.8" r="8" stroke="none" fill="black"/>
-<circle cx="537.6" cy="1580.8" r="8" stroke="black" fill="white"/>
-<path d="M529.6,1580.8 L545.6,1580.8 M537.6,1572.8 L537.6,1588.8 " stroke="black"/>
-<path d="M601.6,1708.8 L537.6,1708.8 " stroke="black" stroke-width="3"/>
-<circle cx="601.6" cy="1708.8" r="8" stroke="none" fill="black"/>
-<circle cx="537.6" cy="1708.8" r="8" stroke="black" fill="white"/>
-<path d="M529.6,1708.8 L545.6,1708.8 M537.6,1700.8 L537.6,1716.8 " stroke="black"/>
-<path d="M729.6,1452.8 L665.6,1452.8 " stroke="black" stroke-width="3"/>
-<circle cx="729.6" cy="1452.8" r="8" stroke="none" fill="black"/>
-<circle cx="665.6" cy="1452.8" r="8" stroke="black" fill="white"/>
-<path d="M657.6,1452.8 L673.6,1452.8 M665.6,1444.8 L665.6,1460.8 " stroke="black"/>
-<path d="M729.6,1580.8 L665.6,1580.8 " stroke="black" stroke-width="3"/>
-<circle cx="729.6" cy="1580.8" r="8" stroke="none" fill="black"/>
-<circle cx="665.6" cy="1580.8" r="8" stroke="black" fill="white"/>
-<path d="M657.6,1580.8 L673.6,1580.8 M665.6,1572.8 L665.6,1588.8 " stroke="black"/>
-<path d="M729.6,1708.8 L665.6,1708.8 " stroke="black" stroke-width="3"/>
-<circle cx="729.6" cy="1708.8" r="8" stroke="none" fill="black"/>
-<circle cx="665.6" cy="1708.8" r="8" stroke="black" fill="white"/>
-<path d="M657.6,1708.8 L673.6,1708.8 M665.6,1700.8 L665.6,1716.8 " stroke="black"/>
-<path d="M601.6,1516.8 L665.6,1516.8 " stroke="black" stroke-width="3"/>
-<circle cx="601.6" cy="1516.8" r="8" stroke="none" fill="black"/>
-<circle cx="665.6" cy="1516.8" r="8" stroke="black" fill="white"/>
-<path d="M657.6,1516.8 L673.6,1516.8 M665.6,1508.8 L665.6,1524.8 " stroke="black"/>
-<path d="M601.6,1644.8 L665.6,1644.8 " stroke="black" stroke-width="3"/>
-<circle cx="601.6" cy="1644.8" r="8" stroke="none" fill="black"/>
-<circle cx="665.6" cy="1644.8" r="8" stroke="black" fill="white"/>
-<path d="M657.6,1644.8 L673.6,1644.8 M665.6,1636.8 L665.6,1652.8 " stroke="black"/>
-<path d="M729.6,1516.8 L793.6,1516.8 " stroke="black" stroke-width="3"/>
-<circle cx="729.6" cy="1516.8" r="8" stroke="none" fill="black"/>
-<circle cx="793.6" cy="1516.8" r="8" stroke="black" fill="white"/>
-<path d="M785.6,1516.8 L801.6,1516.8 M793.6,1508.8 L793.6,1524.8 " stroke="black"/>
-<path d="M729.6,1644.8 L793.6,1644.8 " stroke="black" stroke-width="3"/>
-<circle cx="729.6" cy="1644.8" r="8" stroke="none" fill="black"/>
-<circle cx="793.6" cy="1644.8" r="8" stroke="black" fill="white"/>
-<path d="M785.6,1644.8 L801.6,1644.8 M793.6,1636.8 L793.6,1652.8 " stroke="black"/>
+<path d="M1974.4,995.2 L2038.4,995.2 " stroke="black" stroke-width="5"/>
+<circle cx="1974.4" cy="995.2" r="12" stroke="none" fill="black"/>
+<circle cx="2038.4" cy="995.2" r="12" stroke="black" fill="white"/>
+<path d="M2026.4,995.2 L2050.4,995.2 M2038.4,983.2 L2038.4,1007.2 " stroke="black"/>
+<path d="M1974.4,1123.2 L2038.4,1123.2 " stroke="black" stroke-width="5"/>
+<circle cx="1974.4" cy="1123.2" r="12" stroke="none" fill="black"/>
+<circle cx="2038.4" cy="1123.2" r="12" stroke="black" fill="white"/>
+<path d="M2026.4,1123.2 L2050.4,1123.2 M2038.4,1111.2 L2038.4,1135.2 " stroke="black"/>
+<path d="M1974.4,1251.2 L2038.4,1251.2 " stroke="black" stroke-width="5"/>
+<circle cx="1974.4" cy="1251.2" r="12" stroke="none" fill="black"/>
+<circle cx="2038.4" cy="1251.2" r="12" stroke="black" fill="white"/>
+<path d="M2026.4,1251.2 L2050.4,1251.2 M2038.4,1239.2 L2038.4,1263.2 " stroke="black"/>
+<path d="M2102.4,995.2 L2166.4,995.2 " stroke="black" stroke-width="5"/>
+<circle cx="2102.4" cy="995.2" r="12" stroke="none" fill="black"/>
+<circle cx="2166.4" cy="995.2" r="12" stroke="black" fill="white"/>
+<path d="M2154.4,995.2 L2178.4,995.2 M2166.4,983.2 L2166.4,1007.2 " stroke="black"/>
+<path d="M2102.4,1123.2 L2166.4,1123.2 " stroke="black" stroke-width="5"/>
+<circle cx="2102.4" cy="1123.2" r="12" stroke="none" fill="black"/>
+<circle cx="2166.4" cy="1123.2" r="12" stroke="black" fill="white"/>
+<path d="M2154.4,1123.2 L2178.4,1123.2 M2166.4,1111.2 L2166.4,1135.2 " stroke="black"/>
+<path d="M2102.4,1251.2 L2166.4,1251.2 " stroke="black" stroke-width="5"/>
+<circle cx="2102.4" cy="1251.2" r="12" stroke="none" fill="black"/>
+<circle cx="2166.4" cy="1251.2" r="12" stroke="black" fill="white"/>
+<path d="M2154.4,1251.2 L2178.4,1251.2 M2166.4,1239.2 L2166.4,1263.2 " stroke="black"/>
+<path d="M1974.4,1059.2 L1910.4,1059.2 " stroke="black" stroke-width="5"/>
+<circle cx="1974.4" cy="1059.2" r="12" stroke="none" fill="black"/>
+<circle cx="1910.4" cy="1059.2" r="12" stroke="black" fill="white"/>
+<path d="M1898.4,1059.2 L1922.4,1059.2 M1910.4,1047.2 L1910.4,1071.2 " stroke="black"/>
+<path d="M1974.4,1187.2 L1910.4,1187.2 " stroke="black" stroke-width="5"/>
+<circle cx="1974.4" cy="1187.2" r="12" stroke="none" fill="black"/>
+<circle cx="1910.4" cy="1187.2" r="12" stroke="black" fill="white"/>
+<path d="M1898.4,1187.2 L1922.4,1187.2 M1910.4,1175.2 L1910.4,1199.2 " stroke="black"/>
+<path d="M2102.4,1059.2 L2038.4,1059.2 " stroke="black" stroke-width="5"/>
+<circle cx="2102.4" cy="1059.2" r="12" stroke="none" fill="black"/>
+<circle cx="2038.4" cy="1059.2" r="12" stroke="black" fill="white"/>
+<path d="M2026.4,1059.2 L2050.4,1059.2 M2038.4,1047.2 L2038.4,1071.2 " stroke="black"/>
+<path d="M2102.4,1187.2 L2038.4,1187.2 " stroke="black" stroke-width="5"/>
+<circle cx="2102.4" cy="1187.2" r="12" stroke="none" fill="black"/>
+<circle cx="2038.4" cy="1187.2" r="12" stroke="black" fill="white"/>
+<path d="M2026.4,1187.2 L2050.4,1187.2 M2038.4,1175.2 L2038.4,1199.2 " stroke="black"/>
+<path d="M2432,995.2 L2432,1059.2 " stroke="black" stroke-width="5"/>
+<circle cx="2432" cy="995.2" r="12" stroke="none" fill="black"/>
+<circle cx="2432" cy="1059.2" r="12" stroke="black" fill="white"/>
+<path d="M2420,1059.2 L2444,1059.2 M2432,1047.2 L2432,1071.2 " stroke="black"/>
+<path d="M2432,1123.2 L2432,1187.2 " stroke="black" stroke-width="5"/>
+<circle cx="2432" cy="1123.2" r="12" stroke="none" fill="black"/>
+<circle cx="2432" cy="1187.2" r="12" stroke="black" fill="white"/>
+<path d="M2420,1187.2 L2444,1187.2 M2432,1175.2 L2432,1199.2 " stroke="black"/>
+<path d="M2560,995.2 L2560,1059.2 " stroke="black" stroke-width="5"/>
+<circle cx="2560" cy="995.2" r="12" stroke="none" fill="black"/>
+<circle cx="2560" cy="1059.2" r="12" stroke="black" fill="white"/>
+<path d="M2548,1059.2 L2572,1059.2 M2560,1047.2 L2560,1071.2 " stroke="black"/>
+<path d="M2560,1123.2 L2560,1187.2 " stroke="black" stroke-width="5"/>
+<circle cx="2560" cy="1123.2" r="12" stroke="none" fill="black"/>
+<circle cx="2560" cy="1187.2" r="12" stroke="black" fill="white"/>
+<path d="M2548,1187.2 L2572,1187.2 M2560,1175.2 L2560,1199.2 " stroke="black"/>
+<path d="M2368,1123.2 L2368,1059.2 " stroke="black" stroke-width="5"/>
+<circle cx="2368" cy="1123.2" r="12" stroke="none" fill="black"/>
+<circle cx="2368" cy="1059.2" r="12" stroke="black" fill="white"/>
+<path d="M2356,1059.2 L2380,1059.2 M2368,1047.2 L2368,1071.2 " stroke="black"/>
+<path d="M2368,1251.2 L2368,1187.2 " stroke="black" stroke-width="5"/>
+<circle cx="2368" cy="1251.2" r="12" stroke="none" fill="black"/>
+<circle cx="2368" cy="1187.2" r="12" stroke="black" fill="white"/>
+<path d="M2356,1187.2 L2380,1187.2 M2368,1175.2 L2368,1199.2 " stroke="black"/>
+<path d="M2496,1123.2 L2496,1059.2 " stroke="black" stroke-width="5"/>
+<circle cx="2496" cy="1123.2" r="12" stroke="none" fill="black"/>
+<circle cx="2496" cy="1059.2" r="12" stroke="black" fill="white"/>
+<path d="M2484,1059.2 L2508,1059.2 M2496,1047.2 L2496,1071.2 " stroke="black"/>
+<path d="M2496,1251.2 L2496,1187.2 " stroke="black" stroke-width="5"/>
+<circle cx="2496" cy="1251.2" r="12" stroke="none" fill="black"/>
+<circle cx="2496" cy="1187.2" r="12" stroke="black" fill="white"/>
+<path d="M2484,1187.2 L2508,1187.2 M2496,1175.2 L2496,1199.2 " stroke="black"/>
+<path d="M2624,1123.2 L2624,1059.2 " stroke="black" stroke-width="5"/>
+<circle cx="2624" cy="1123.2" r="12" stroke="none" fill="black"/>
+<circle cx="2624" cy="1059.2" r="12" stroke="black" fill="white"/>
+<path d="M2612,1059.2 L2636,1059.2 M2624,1047.2 L2624,1071.2 " stroke="black"/>
+<path d="M2624,1251.2 L2624,1187.2 " stroke="black" stroke-width="5"/>
+<circle cx="2624" cy="1251.2" r="12" stroke="none" fill="black"/>
+<circle cx="2624" cy="1187.2" r="12" stroke="black" fill="white"/>
+<path d="M2612,1187.2 L2636,1187.2 M2624,1175.2 L2624,1199.2 " stroke="black"/>
+<path d="M144,1580.8 L144,1516.8 " stroke="black" stroke-width="5"/>
+<circle cx="144" cy="1580.8" r="12" stroke="none" fill="black"/>
+<circle cx="144" cy="1516.8" r="12" stroke="black" fill="white"/>
+<path d="M132,1516.8 L156,1516.8 M144,1504.8 L144,1528.8 " stroke="black"/>
+<path d="M144,1708.8 L144,1644.8 " stroke="black" stroke-width="5"/>
+<circle cx="144" cy="1708.8" r="12" stroke="none" fill="black"/>
+<circle cx="144" cy="1644.8" r="12" stroke="black" fill="white"/>
+<path d="M132,1644.8 L156,1644.8 M144,1632.8 L144,1656.8 " stroke="black"/>
+<path d="M272,1580.8 L272,1516.8 " stroke="black" stroke-width="5"/>
+<circle cx="272" cy="1580.8" r="12" stroke="none" fill="black"/>
+<circle cx="272" cy="1516.8" r="12" stroke="black" fill="white"/>
+<path d="M260,1516.8 L284,1516.8 M272,1504.8 L272,1528.8 " stroke="black"/>
+<path d="M272,1708.8 L272,1644.8 " stroke="black" stroke-width="5"/>
+<circle cx="272" cy="1708.8" r="12" stroke="none" fill="black"/>
+<circle cx="272" cy="1644.8" r="12" stroke="black" fill="white"/>
+<path d="M260,1644.8 L284,1644.8 M272,1632.8 L272,1656.8 " stroke="black"/>
+<path d="M80,1452.8 L80,1516.8 " stroke="black" stroke-width="5"/>
+<circle cx="80" cy="1452.8" r="12" stroke="none" fill="black"/>
+<circle cx="80" cy="1516.8" r="12" stroke="black" fill="white"/>
+<path d="M68,1516.8 L92,1516.8 M80,1504.8 L80,1528.8 " stroke="black"/>
+<path d="M80,1580.8 L80,1644.8 " stroke="black" stroke-width="5"/>
+<circle cx="80" cy="1580.8" r="12" stroke="none" fill="black"/>
+<circle cx="80" cy="1644.8" r="12" stroke="black" fill="white"/>
+<path d="M68,1644.8 L92,1644.8 M80,1632.8 L80,1656.8 " stroke="black"/>
+<path d="M208,1452.8 L208,1516.8 " stroke="black" stroke-width="5"/>
+<circle cx="208" cy="1452.8" r="12" stroke="none" fill="black"/>
+<circle cx="208" cy="1516.8" r="12" stroke="black" fill="white"/>
+<path d="M196,1516.8 L220,1516.8 M208,1504.8 L208,1528.8 " stroke="black"/>
+<path d="M208,1580.8 L208,1644.8 " stroke="black" stroke-width="5"/>
+<circle cx="208" cy="1580.8" r="12" stroke="none" fill="black"/>
+<circle cx="208" cy="1644.8" r="12" stroke="black" fill="white"/>
+<path d="M196,1644.8 L220,1644.8 M208,1632.8 L208,1656.8 " stroke="black"/>
+<path d="M336,1452.8 L336,1516.8 " stroke="black" stroke-width="5"/>
+<circle cx="336" cy="1452.8" r="12" stroke="none" fill="black"/>
+<circle cx="336" cy="1516.8" r="12" stroke="black" fill="white"/>
+<path d="M324,1516.8 L348,1516.8 M336,1504.8 L336,1528.8 " stroke="black"/>
+<path d="M336,1580.8 L336,1644.8 " stroke="black" stroke-width="5"/>
+<circle cx="336" cy="1580.8" r="12" stroke="none" fill="black"/>
+<circle cx="336" cy="1644.8" r="12" stroke="black" fill="white"/>
+<path d="M324,1644.8 L348,1644.8 M336,1632.8 L336,1656.8 " stroke="black"/>
+<path d="M601.6,1452.8 L537.6,1452.8 " stroke="black" stroke-width="5"/>
+<circle cx="601.6" cy="1452.8" r="12" stroke="none" fill="black"/>
+<circle cx="537.6" cy="1452.8" r="12" stroke="black" fill="white"/>
+<path d="M525.6,1452.8 L549.6,1452.8 M537.6,1440.8 L537.6,1464.8 " stroke="black"/>
+<path d="M601.6,1580.8 L537.6,1580.8 " stroke="black" stroke-width="5"/>
+<circle cx="601.6" cy="1580.8" r="12" stroke="none" fill="black"/>
+<circle cx="537.6" cy="1580.8" r="12" stroke="black" fill="white"/>
+<path d="M525.6,1580.8 L549.6,1580.8 M537.6,1568.8 L537.6,1592.8 " stroke="black"/>
+<path d="M601.6,1708.8 L537.6,1708.8 " stroke="black" stroke-width="5"/>
+<circle cx="601.6" cy="1708.8" r="12" stroke="none" fill="black"/>
+<circle cx="537.6" cy="1708.8" r="12" stroke="black" fill="white"/>
+<path d="M525.6,1708.8 L549.6,1708.8 M537.6,1696.8 L537.6,1720.8 " stroke="black"/>
+<path d="M729.6,1452.8 L665.6,1452.8 " stroke="black" stroke-width="5"/>
+<circle cx="729.6" cy="1452.8" r="12" stroke="none" fill="black"/>
+<circle cx="665.6" cy="1452.8" r="12" stroke="black" fill="white"/>
+<path d="M653.6,1452.8 L677.6,1452.8 M665.6,1440.8 L665.6,1464.8 " stroke="black"/>
+<path d="M729.6,1580.8 L665.6,1580.8 " stroke="black" stroke-width="5"/>
+<circle cx="729.6" cy="1580.8" r="12" stroke="none" fill="black"/>
+<circle cx="665.6" cy="1580.8" r="12" stroke="black" fill="white"/>
+<path d="M653.6,1580.8 L677.6,1580.8 M665.6,1568.8 L665.6,1592.8 " stroke="black"/>
+<path d="M729.6,1708.8 L665.6,1708.8 " stroke="black" stroke-width="5"/>
+<circle cx="729.6" cy="1708.8" r="12" stroke="none" fill="black"/>
+<circle cx="665.6" cy="1708.8" r="12" stroke="black" fill="white"/>
+<path d="M653.6,1708.8 L677.6,1708.8 M665.6,1696.8 L665.6,1720.8 " stroke="black"/>
+<path d="M601.6,1516.8 L665.6,1516.8 " stroke="black" stroke-width="5"/>
+<circle cx="601.6" cy="1516.8" r="12" stroke="none" fill="black"/>
+<circle cx="665.6" cy="1516.8" r="12" stroke="black" fill="white"/>
+<path d="M653.6,1516.8 L677.6,1516.8 M665.6,1504.8 L665.6,1528.8 " stroke="black"/>
+<path d="M601.6,1644.8 L665.6,1644.8 " stroke="black" stroke-width="5"/>
+<circle cx="601.6" cy="1644.8" r="12" stroke="none" fill="black"/>
+<circle cx="665.6" cy="1644.8" r="12" stroke="black" fill="white"/>
+<path d="M653.6,1644.8 L677.6,1644.8 M665.6,1632.8 L665.6,1656.8 " stroke="black"/>
+<path d="M729.6,1516.8 L793.6,1516.8 " stroke="black" stroke-width="5"/>
+<circle cx="729.6" cy="1516.8" r="12" stroke="none" fill="black"/>
+<circle cx="793.6" cy="1516.8" r="12" stroke="black" fill="white"/>
+<path d="M781.6,1516.8 L805.6,1516.8 M793.6,1504.8 L793.6,1528.8 " stroke="black"/>
+<path d="M729.6,1644.8 L793.6,1644.8 " stroke="black" stroke-width="5"/>
+<circle cx="729.6" cy="1644.8" r="12" stroke="none" fill="black"/>
+<circle cx="793.6" cy="1644.8" r="12" stroke="black" fill="white"/>
+<path d="M781.6,1644.8 L805.6,1644.8 M793.6,1632.8 L793.6,1656.8 " stroke="black"/>
 <rect x="1043.2" y="1436.8" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1059.2" y="1452.8">H</text>
 <rect x="1171.2" y="1436.8" width="32" height="32" stroke="black" fill="white"/>
@@ -2054,166 +2054,166 @@
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1974.4" y="1708.8">H</text>
 <rect x="2086.4" y="1692.8" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="2102.4" y="1708.8">H</text>
-<path d="M2432,1452.8 L2496,1452.8 " stroke="black" stroke-width="3"/>
-<circle cx="2432" cy="1452.8" r="8" stroke="none" fill="black"/>
-<circle cx="2496" cy="1452.8" r="8" stroke="black" fill="white"/>
-<path d="M2488,1452.8 L2504,1452.8 M2496,1444.8 L2496,1460.8 " stroke="black"/>
-<path d="M2432,1580.8 L2496,1580.8 " stroke="black" stroke-width="3"/>
-<circle cx="2432" cy="1580.8" r="8" stroke="none" fill="black"/>
-<circle cx="2496" cy="1580.8" r="8" stroke="black" fill="white"/>
-<path d="M2488,1580.8 L2504,1580.8 M2496,1572.8 L2496,1588.8 " stroke="black"/>
-<path d="M2432,1708.8 L2496,1708.8 " stroke="black" stroke-width="3"/>
-<circle cx="2432" cy="1708.8" r="8" stroke="none" fill="black"/>
-<circle cx="2496" cy="1708.8" r="8" stroke="black" fill="white"/>
-<path d="M2488,1708.8 L2504,1708.8 M2496,1700.8 L2496,1716.8 " stroke="black"/>
-<path d="M2560,1452.8 L2624,1452.8 " stroke="black" stroke-width="3"/>
-<circle cx="2560" cy="1452.8" r="8" stroke="none" fill="black"/>
-<circle cx="2624" cy="1452.8" r="8" stroke="black" fill="white"/>
-<path d="M2616,1452.8 L2632,1452.8 M2624,1444.8 L2624,1460.8 " stroke="black"/>
-<path d="M2560,1580.8 L2624,1580.8 " stroke="black" stroke-width="3"/>
-<circle cx="2560" cy="1580.8" r="8" stroke="none" fill="black"/>
-<circle cx="2624" cy="1580.8" r="8" stroke="black" fill="white"/>
-<path d="M2616,1580.8 L2632,1580.8 M2624,1572.8 L2624,1588.8 " stroke="black"/>
-<path d="M2560,1708.8 L2624,1708.8 " stroke="black" stroke-width="3"/>
-<circle cx="2560" cy="1708.8" r="8" stroke="none" fill="black"/>
-<circle cx="2624" cy="1708.8" r="8" stroke="black" fill="white"/>
-<path d="M2616,1708.8 L2632,1708.8 M2624,1700.8 L2624,1716.8 " stroke="black"/>
-<path d="M2432,1516.8 L2368,1516.8 " stroke="black" stroke-width="3"/>
-<circle cx="2432" cy="1516.8" r="8" stroke="none" fill="black"/>
-<circle cx="2368" cy="1516.8" r="8" stroke="black" fill="white"/>
-<path d="M2360,1516.8 L2376,1516.8 M2368,1508.8 L2368,1524.8 " stroke="black"/>
-<path d="M2432,1644.8 L2368,1644.8 " stroke="black" stroke-width="3"/>
-<circle cx="2432" cy="1644.8" r="8" stroke="none" fill="black"/>
-<circle cx="2368" cy="1644.8" r="8" stroke="black" fill="white"/>
-<path d="M2360,1644.8 L2376,1644.8 M2368,1636.8 L2368,1652.8 " stroke="black"/>
-<path d="M2560,1516.8 L2496,1516.8 " stroke="black" stroke-width="3"/>
-<circle cx="2560" cy="1516.8" r="8" stroke="none" fill="black"/>
-<circle cx="2496" cy="1516.8" r="8" stroke="black" fill="white"/>
-<path d="M2488,1516.8 L2504,1516.8 M2496,1508.8 L2496,1524.8 " stroke="black"/>
-<path d="M2560,1644.8 L2496,1644.8 " stroke="black" stroke-width="3"/>
-<circle cx="2560" cy="1644.8" r="8" stroke="none" fill="black"/>
-<circle cx="2496" cy="1644.8" r="8" stroke="black" fill="white"/>
-<path d="M2488,1644.8 L2504,1644.8 M2496,1636.8 L2496,1652.8 " stroke="black"/>
-<path d="M144,1910.4 L144,1974.4 " stroke="black" stroke-width="3"/>
-<circle cx="144" cy="1910.4" r="8" stroke="none" fill="black"/>
-<circle cx="144" cy="1974.4" r="8" stroke="black" fill="white"/>
-<path d="M136,1974.4 L152,1974.4 M144,1966.4 L144,1982.4 " stroke="black"/>
-<path d="M144,2038.4 L144,2102.4 " stroke="black" stroke-width="3"/>
-<circle cx="144" cy="2038.4" r="8" stroke="none" fill="black"/>
-<circle cx="144" cy="2102.4" r="8" stroke="black" fill="white"/>
-<path d="M136,2102.4 L152,2102.4 M144,2094.4 L144,2110.4 " stroke="black"/>
-<path d="M272,1910.4 L272,1974.4 " stroke="black" stroke-width="3"/>
-<circle cx="272" cy="1910.4" r="8" stroke="none" fill="black"/>
-<circle cx="272" cy="1974.4" r="8" stroke="black" fill="white"/>
-<path d="M264,1974.4 L280,1974.4 M272,1966.4 L272,1982.4 " stroke="black"/>
-<path d="M272,2038.4 L272,2102.4 " stroke="black" stroke-width="3"/>
-<circle cx="272" cy="2038.4" r="8" stroke="none" fill="black"/>
-<circle cx="272" cy="2102.4" r="8" stroke="black" fill="white"/>
-<path d="M264,2102.4 L280,2102.4 M272,2094.4 L272,2110.4 " stroke="black"/>
-<path d="M80,2038.4 L80,1974.4 " stroke="black" stroke-width="3"/>
-<circle cx="80" cy="2038.4" r="8" stroke="none" fill="black"/>
-<circle cx="80" cy="1974.4" r="8" stroke="black" fill="white"/>
-<path d="M72,1974.4 L88,1974.4 M80,1966.4 L80,1982.4 " stroke="black"/>
-<path d="M80,2166.4 L80,2102.4 " stroke="black" stroke-width="3"/>
-<circle cx="80" cy="2166.4" r="8" stroke="none" fill="black"/>
-<circle cx="80" cy="2102.4" r="8" stroke="black" fill="white"/>
-<path d="M72,2102.4 L88,2102.4 M80,2094.4 L80,2110.4 " stroke="black"/>
-<path d="M208,2038.4 L208,1974.4 " stroke="black" stroke-width="3"/>
-<circle cx="208" cy="2038.4" r="8" stroke="none" fill="black"/>
-<circle cx="208" cy="1974.4" r="8" stroke="black" fill="white"/>
-<path d="M200,1974.4 L216,1974.4 M208,1966.4 L208,1982.4 " stroke="black"/>
-<path d="M208,2166.4 L208,2102.4 " stroke="black" stroke-width="3"/>
-<circle cx="208" cy="2166.4" r="8" stroke="none" fill="black"/>
-<circle cx="208" cy="2102.4" r="8" stroke="black" fill="white"/>
-<path d="M200,2102.4 L216,2102.4 M208,2094.4 L208,2110.4 " stroke="black"/>
-<path d="M336,2038.4 L336,1974.4 " stroke="black" stroke-width="3"/>
-<circle cx="336" cy="2038.4" r="8" stroke="none" fill="black"/>
-<circle cx="336" cy="1974.4" r="8" stroke="black" fill="white"/>
-<path d="M328,1974.4 L344,1974.4 M336,1966.4 L336,1982.4 " stroke="black"/>
-<path d="M336,2166.4 L336,2102.4 " stroke="black" stroke-width="3"/>
-<circle cx="336" cy="2166.4" r="8" stroke="none" fill="black"/>
-<circle cx="336" cy="2102.4" r="8" stroke="black" fill="white"/>
-<path d="M328,2102.4 L344,2102.4 M336,2094.4 L336,2110.4 " stroke="black"/>
-<path d="M601.6,2038.4 L601.6,1974.4 " stroke="black" stroke-width="3"/>
-<circle cx="601.6" cy="2038.4" r="8" stroke="none" fill="black"/>
-<circle cx="601.6" cy="1974.4" r="8" stroke="black" fill="white"/>
-<path d="M593.6,1974.4 L609.6,1974.4 M601.6,1966.4 L601.6,1982.4 " stroke="black"/>
-<path d="M601.6,2166.4 L601.6,2102.4 " stroke="black" stroke-width="3"/>
-<circle cx="601.6" cy="2166.4" r="8" stroke="none" fill="black"/>
-<circle cx="601.6" cy="2102.4" r="8" stroke="black" fill="white"/>
-<path d="M593.6,2102.4 L609.6,2102.4 M601.6,2094.4 L601.6,2110.4 " stroke="black"/>
-<path d="M729.6,2038.4 L729.6,1974.4 " stroke="black" stroke-width="3"/>
-<circle cx="729.6" cy="2038.4" r="8" stroke="none" fill="black"/>
-<circle cx="729.6" cy="1974.4" r="8" stroke="black" fill="white"/>
-<path d="M721.6,1974.4 L737.6,1974.4 M729.6,1966.4 L729.6,1982.4 " stroke="black"/>
-<path d="M729.6,2166.4 L729.6,2102.4 " stroke="black" stroke-width="3"/>
-<circle cx="729.6" cy="2166.4" r="8" stroke="none" fill="black"/>
-<circle cx="729.6" cy="2102.4" r="8" stroke="black" fill="white"/>
-<path d="M721.6,2102.4 L737.6,2102.4 M729.6,2094.4 L729.6,2110.4 " stroke="black"/>
-<path d="M537.6,1910.4 L537.6,1974.4 " stroke="black" stroke-width="3"/>
-<circle cx="537.6" cy="1910.4" r="8" stroke="none" fill="black"/>
-<circle cx="537.6" cy="1974.4" r="8" stroke="black" fill="white"/>
-<path d="M529.6,1974.4 L545.6,1974.4 M537.6,1966.4 L537.6,1982.4 " stroke="black"/>
-<path d="M537.6,2038.4 L537.6,2102.4 " stroke="black" stroke-width="3"/>
-<circle cx="537.6" cy="2038.4" r="8" stroke="none" fill="black"/>
-<circle cx="537.6" cy="2102.4" r="8" stroke="black" fill="white"/>
-<path d="M529.6,2102.4 L545.6,2102.4 M537.6,2094.4 L537.6,2110.4 " stroke="black"/>
-<path d="M665.6,1910.4 L665.6,1974.4 " stroke="black" stroke-width="3"/>
-<circle cx="665.6" cy="1910.4" r="8" stroke="none" fill="black"/>
-<circle cx="665.6" cy="1974.4" r="8" stroke="black" fill="white"/>
-<path d="M657.6,1974.4 L673.6,1974.4 M665.6,1966.4 L665.6,1982.4 " stroke="black"/>
-<path d="M665.6,2038.4 L665.6,2102.4 " stroke="black" stroke-width="3"/>
-<circle cx="665.6" cy="2038.4" r="8" stroke="none" fill="black"/>
-<circle cx="665.6" cy="2102.4" r="8" stroke="black" fill="white"/>
-<path d="M657.6,2102.4 L673.6,2102.4 M665.6,2094.4 L665.6,2110.4 " stroke="black"/>
-<path d="M793.6,1910.4 L793.6,1974.4 " stroke="black" stroke-width="3"/>
-<circle cx="793.6" cy="1910.4" r="8" stroke="none" fill="black"/>
-<circle cx="793.6" cy="1974.4" r="8" stroke="black" fill="white"/>
-<path d="M785.6,1974.4 L801.6,1974.4 M793.6,1966.4 L793.6,1982.4 " stroke="black"/>
-<path d="M793.6,2038.4 L793.6,2102.4 " stroke="black" stroke-width="3"/>
-<circle cx="793.6" cy="2038.4" r="8" stroke="none" fill="black"/>
-<circle cx="793.6" cy="2102.4" r="8" stroke="black" fill="white"/>
-<path d="M785.6,2102.4 L801.6,2102.4 M793.6,2094.4 L793.6,2110.4 " stroke="black"/>
-<path d="M1059.2,1910.4 L995.2,1910.4 " stroke="black" stroke-width="3"/>
-<circle cx="1059.2" cy="1910.4" r="8" stroke="none" fill="black"/>
-<circle cx="995.2" cy="1910.4" r="8" stroke="black" fill="white"/>
-<path d="M987.2,1910.4 L1003.2,1910.4 M995.2,1902.4 L995.2,1918.4 " stroke="black"/>
-<path d="M1059.2,2038.4 L995.2,2038.4 " stroke="black" stroke-width="3"/>
-<circle cx="1059.2" cy="2038.4" r="8" stroke="none" fill="black"/>
-<circle cx="995.2" cy="2038.4" r="8" stroke="black" fill="white"/>
-<path d="M987.2,2038.4 L1003.2,2038.4 M995.2,2030.4 L995.2,2046.4 " stroke="black"/>
-<path d="M1059.2,2166.4 L995.2,2166.4 " stroke="black" stroke-width="3"/>
-<circle cx="1059.2" cy="2166.4" r="8" stroke="none" fill="black"/>
-<circle cx="995.2" cy="2166.4" r="8" stroke="black" fill="white"/>
-<path d="M987.2,2166.4 L1003.2,2166.4 M995.2,2158.4 L995.2,2174.4 " stroke="black"/>
-<path d="M1187.2,1910.4 L1123.2,1910.4 " stroke="black" stroke-width="3"/>
-<circle cx="1187.2" cy="1910.4" r="8" stroke="none" fill="black"/>
-<circle cx="1123.2" cy="1910.4" r="8" stroke="black" fill="white"/>
-<path d="M1115.2,1910.4 L1131.2,1910.4 M1123.2,1902.4 L1123.2,1918.4 " stroke="black"/>
-<path d="M1187.2,2038.4 L1123.2,2038.4 " stroke="black" stroke-width="3"/>
-<circle cx="1187.2" cy="2038.4" r="8" stroke="none" fill="black"/>
-<circle cx="1123.2" cy="2038.4" r="8" stroke="black" fill="white"/>
-<path d="M1115.2,2038.4 L1131.2,2038.4 M1123.2,2030.4 L1123.2,2046.4 " stroke="black"/>
-<path d="M1187.2,2166.4 L1123.2,2166.4 " stroke="black" stroke-width="3"/>
-<circle cx="1187.2" cy="2166.4" r="8" stroke="none" fill="black"/>
-<circle cx="1123.2" cy="2166.4" r="8" stroke="black" fill="white"/>
-<path d="M1115.2,2166.4 L1131.2,2166.4 M1123.2,2158.4 L1123.2,2174.4 " stroke="black"/>
-<path d="M1059.2,1974.4 L1123.2,1974.4 " stroke="black" stroke-width="3"/>
-<circle cx="1059.2" cy="1974.4" r="8" stroke="none" fill="black"/>
-<circle cx="1123.2" cy="1974.4" r="8" stroke="black" fill="white"/>
-<path d="M1115.2,1974.4 L1131.2,1974.4 M1123.2,1966.4 L1123.2,1982.4 " stroke="black"/>
-<path d="M1059.2,2102.4 L1123.2,2102.4 " stroke="black" stroke-width="3"/>
-<circle cx="1059.2" cy="2102.4" r="8" stroke="none" fill="black"/>
-<circle cx="1123.2" cy="2102.4" r="8" stroke="black" fill="white"/>
-<path d="M1115.2,2102.4 L1131.2,2102.4 M1123.2,2094.4 L1123.2,2110.4 " stroke="black"/>
-<path d="M1187.2,1974.4 L1251.2,1974.4 " stroke="black" stroke-width="3"/>
-<circle cx="1187.2" cy="1974.4" r="8" stroke="none" fill="black"/>
-<circle cx="1251.2" cy="1974.4" r="8" stroke="black" fill="white"/>
-<path d="M1243.2,1974.4 L1259.2,1974.4 M1251.2,1966.4 L1251.2,1982.4 " stroke="black"/>
-<path d="M1187.2,2102.4 L1251.2,2102.4 " stroke="black" stroke-width="3"/>
-<circle cx="1187.2" cy="2102.4" r="8" stroke="none" fill="black"/>
-<circle cx="1251.2" cy="2102.4" r="8" stroke="black" fill="white"/>
-<path d="M1243.2,2102.4 L1259.2,2102.4 M1251.2,2094.4 L1251.2,2110.4 " stroke="black"/>
+<path d="M2432,1452.8 L2496,1452.8 " stroke="black" stroke-width="5"/>
+<circle cx="2432" cy="1452.8" r="12" stroke="none" fill="black"/>
+<circle cx="2496" cy="1452.8" r="12" stroke="black" fill="white"/>
+<path d="M2484,1452.8 L2508,1452.8 M2496,1440.8 L2496,1464.8 " stroke="black"/>
+<path d="M2432,1580.8 L2496,1580.8 " stroke="black" stroke-width="5"/>
+<circle cx="2432" cy="1580.8" r="12" stroke="none" fill="black"/>
+<circle cx="2496" cy="1580.8" r="12" stroke="black" fill="white"/>
+<path d="M2484,1580.8 L2508,1580.8 M2496,1568.8 L2496,1592.8 " stroke="black"/>
+<path d="M2432,1708.8 L2496,1708.8 " stroke="black" stroke-width="5"/>
+<circle cx="2432" cy="1708.8" r="12" stroke="none" fill="black"/>
+<circle cx="2496" cy="1708.8" r="12" stroke="black" fill="white"/>
+<path d="M2484,1708.8 L2508,1708.8 M2496,1696.8 L2496,1720.8 " stroke="black"/>
+<path d="M2560,1452.8 L2624,1452.8 " stroke="black" stroke-width="5"/>
+<circle cx="2560" cy="1452.8" r="12" stroke="none" fill="black"/>
+<circle cx="2624" cy="1452.8" r="12" stroke="black" fill="white"/>
+<path d="M2612,1452.8 L2636,1452.8 M2624,1440.8 L2624,1464.8 " stroke="black"/>
+<path d="M2560,1580.8 L2624,1580.8 " stroke="black" stroke-width="5"/>
+<circle cx="2560" cy="1580.8" r="12" stroke="none" fill="black"/>
+<circle cx="2624" cy="1580.8" r="12" stroke="black" fill="white"/>
+<path d="M2612,1580.8 L2636,1580.8 M2624,1568.8 L2624,1592.8 " stroke="black"/>
+<path d="M2560,1708.8 L2624,1708.8 " stroke="black" stroke-width="5"/>
+<circle cx="2560" cy="1708.8" r="12" stroke="none" fill="black"/>
+<circle cx="2624" cy="1708.8" r="12" stroke="black" fill="white"/>
+<path d="M2612,1708.8 L2636,1708.8 M2624,1696.8 L2624,1720.8 " stroke="black"/>
+<path d="M2432,1516.8 L2368,1516.8 " stroke="black" stroke-width="5"/>
+<circle cx="2432" cy="1516.8" r="12" stroke="none" fill="black"/>
+<circle cx="2368" cy="1516.8" r="12" stroke="black" fill="white"/>
+<path d="M2356,1516.8 L2380,1516.8 M2368,1504.8 L2368,1528.8 " stroke="black"/>
+<path d="M2432,1644.8 L2368,1644.8 " stroke="black" stroke-width="5"/>
+<circle cx="2432" cy="1644.8" r="12" stroke="none" fill="black"/>
+<circle cx="2368" cy="1644.8" r="12" stroke="black" fill="white"/>
+<path d="M2356,1644.8 L2380,1644.8 M2368,1632.8 L2368,1656.8 " stroke="black"/>
+<path d="M2560,1516.8 L2496,1516.8 " stroke="black" stroke-width="5"/>
+<circle cx="2560" cy="1516.8" r="12" stroke="none" fill="black"/>
+<circle cx="2496" cy="1516.8" r="12" stroke="black" fill="white"/>
+<path d="M2484,1516.8 L2508,1516.8 M2496,1504.8 L2496,1528.8 " stroke="black"/>
+<path d="M2560,1644.8 L2496,1644.8 " stroke="black" stroke-width="5"/>
+<circle cx="2560" cy="1644.8" r="12" stroke="none" fill="black"/>
+<circle cx="2496" cy="1644.8" r="12" stroke="black" fill="white"/>
+<path d="M2484,1644.8 L2508,1644.8 M2496,1632.8 L2496,1656.8 " stroke="black"/>
+<path d="M144,1910.4 L144,1974.4 " stroke="black" stroke-width="5"/>
+<circle cx="144" cy="1910.4" r="12" stroke="none" fill="black"/>
+<circle cx="144" cy="1974.4" r="12" stroke="black" fill="white"/>
+<path d="M132,1974.4 L156,1974.4 M144,1962.4 L144,1986.4 " stroke="black"/>
+<path d="M144,2038.4 L144,2102.4 " stroke="black" stroke-width="5"/>
+<circle cx="144" cy="2038.4" r="12" stroke="none" fill="black"/>
+<circle cx="144" cy="2102.4" r="12" stroke="black" fill="white"/>
+<path d="M132,2102.4 L156,2102.4 M144,2090.4 L144,2114.4 " stroke="black"/>
+<path d="M272,1910.4 L272,1974.4 " stroke="black" stroke-width="5"/>
+<circle cx="272" cy="1910.4" r="12" stroke="none" fill="black"/>
+<circle cx="272" cy="1974.4" r="12" stroke="black" fill="white"/>
+<path d="M260,1974.4 L284,1974.4 M272,1962.4 L272,1986.4 " stroke="black"/>
+<path d="M272,2038.4 L272,2102.4 " stroke="black" stroke-width="5"/>
+<circle cx="272" cy="2038.4" r="12" stroke="none" fill="black"/>
+<circle cx="272" cy="2102.4" r="12" stroke="black" fill="white"/>
+<path d="M260,2102.4 L284,2102.4 M272,2090.4 L272,2114.4 " stroke="black"/>
+<path d="M80,2038.4 L80,1974.4 " stroke="black" stroke-width="5"/>
+<circle cx="80" cy="2038.4" r="12" stroke="none" fill="black"/>
+<circle cx="80" cy="1974.4" r="12" stroke="black" fill="white"/>
+<path d="M68,1974.4 L92,1974.4 M80,1962.4 L80,1986.4 " stroke="black"/>
+<path d="M80,2166.4 L80,2102.4 " stroke="black" stroke-width="5"/>
+<circle cx="80" cy="2166.4" r="12" stroke="none" fill="black"/>
+<circle cx="80" cy="2102.4" r="12" stroke="black" fill="white"/>
+<path d="M68,2102.4 L92,2102.4 M80,2090.4 L80,2114.4 " stroke="black"/>
+<path d="M208,2038.4 L208,1974.4 " stroke="black" stroke-width="5"/>
+<circle cx="208" cy="2038.4" r="12" stroke="none" fill="black"/>
+<circle cx="208" cy="1974.4" r="12" stroke="black" fill="white"/>
+<path d="M196,1974.4 L220,1974.4 M208,1962.4 L208,1986.4 " stroke="black"/>
+<path d="M208,2166.4 L208,2102.4 " stroke="black" stroke-width="5"/>
+<circle cx="208" cy="2166.4" r="12" stroke="none" fill="black"/>
+<circle cx="208" cy="2102.4" r="12" stroke="black" fill="white"/>
+<path d="M196,2102.4 L220,2102.4 M208,2090.4 L208,2114.4 " stroke="black"/>
+<path d="M336,2038.4 L336,1974.4 " stroke="black" stroke-width="5"/>
+<circle cx="336" cy="2038.4" r="12" stroke="none" fill="black"/>
+<circle cx="336" cy="1974.4" r="12" stroke="black" fill="white"/>
+<path d="M324,1974.4 L348,1974.4 M336,1962.4 L336,1986.4 " stroke="black"/>
+<path d="M336,2166.4 L336,2102.4 " stroke="black" stroke-width="5"/>
+<circle cx="336" cy="2166.4" r="12" stroke="none" fill="black"/>
+<circle cx="336" cy="2102.4" r="12" stroke="black" fill="white"/>
+<path d="M324,2102.4 L348,2102.4 M336,2090.4 L336,2114.4 " stroke="black"/>
+<path d="M601.6,2038.4 L601.6,1974.4 " stroke="black" stroke-width="5"/>
+<circle cx="601.6" cy="2038.4" r="12" stroke="none" fill="black"/>
+<circle cx="601.6" cy="1974.4" r="12" stroke="black" fill="white"/>
+<path d="M589.6,1974.4 L613.6,1974.4 M601.6,1962.4 L601.6,1986.4 " stroke="black"/>
+<path d="M601.6,2166.4 L601.6,2102.4 " stroke="black" stroke-width="5"/>
+<circle cx="601.6" cy="2166.4" r="12" stroke="none" fill="black"/>
+<circle cx="601.6" cy="2102.4" r="12" stroke="black" fill="white"/>
+<path d="M589.6,2102.4 L613.6,2102.4 M601.6,2090.4 L601.6,2114.4 " stroke="black"/>
+<path d="M729.6,2038.4 L729.6,1974.4 " stroke="black" stroke-width="5"/>
+<circle cx="729.6" cy="2038.4" r="12" stroke="none" fill="black"/>
+<circle cx="729.6" cy="1974.4" r="12" stroke="black" fill="white"/>
+<path d="M717.6,1974.4 L741.6,1974.4 M729.6,1962.4 L729.6,1986.4 " stroke="black"/>
+<path d="M729.6,2166.4 L729.6,2102.4 " stroke="black" stroke-width="5"/>
+<circle cx="729.6" cy="2166.4" r="12" stroke="none" fill="black"/>
+<circle cx="729.6" cy="2102.4" r="12" stroke="black" fill="white"/>
+<path d="M717.6,2102.4 L741.6,2102.4 M729.6,2090.4 L729.6,2114.4 " stroke="black"/>
+<path d="M537.6,1910.4 L537.6,1974.4 " stroke="black" stroke-width="5"/>
+<circle cx="537.6" cy="1910.4" r="12" stroke="none" fill="black"/>
+<circle cx="537.6" cy="1974.4" r="12" stroke="black" fill="white"/>
+<path d="M525.6,1974.4 L549.6,1974.4 M537.6,1962.4 L537.6,1986.4 " stroke="black"/>
+<path d="M537.6,2038.4 L537.6,2102.4 " stroke="black" stroke-width="5"/>
+<circle cx="537.6" cy="2038.4" r="12" stroke="none" fill="black"/>
+<circle cx="537.6" cy="2102.4" r="12" stroke="black" fill="white"/>
+<path d="M525.6,2102.4 L549.6,2102.4 M537.6,2090.4 L537.6,2114.4 " stroke="black"/>
+<path d="M665.6,1910.4 L665.6,1974.4 " stroke="black" stroke-width="5"/>
+<circle cx="665.6" cy="1910.4" r="12" stroke="none" fill="black"/>
+<circle cx="665.6" cy="1974.4" r="12" stroke="black" fill="white"/>
+<path d="M653.6,1974.4 L677.6,1974.4 M665.6,1962.4 L665.6,1986.4 " stroke="black"/>
+<path d="M665.6,2038.4 L665.6,2102.4 " stroke="black" stroke-width="5"/>
+<circle cx="665.6" cy="2038.4" r="12" stroke="none" fill="black"/>
+<circle cx="665.6" cy="2102.4" r="12" stroke="black" fill="white"/>
+<path d="M653.6,2102.4 L677.6,2102.4 M665.6,2090.4 L665.6,2114.4 " stroke="black"/>
+<path d="M793.6,1910.4 L793.6,1974.4 " stroke="black" stroke-width="5"/>
+<circle cx="793.6" cy="1910.4" r="12" stroke="none" fill="black"/>
+<circle cx="793.6" cy="1974.4" r="12" stroke="black" fill="white"/>
+<path d="M781.6,1974.4 L805.6,1974.4 M793.6,1962.4 L793.6,1986.4 " stroke="black"/>
+<path d="M793.6,2038.4 L793.6,2102.4 " stroke="black" stroke-width="5"/>
+<circle cx="793.6" cy="2038.4" r="12" stroke="none" fill="black"/>
+<circle cx="793.6" cy="2102.4" r="12" stroke="black" fill="white"/>
+<path d="M781.6,2102.4 L805.6,2102.4 M793.6,2090.4 L793.6,2114.4 " stroke="black"/>
+<path d="M1059.2,1910.4 L995.2,1910.4 " stroke="black" stroke-width="5"/>
+<circle cx="1059.2" cy="1910.4" r="12" stroke="none" fill="black"/>
+<circle cx="995.2" cy="1910.4" r="12" stroke="black" fill="white"/>
+<path d="M983.2,1910.4 L1007.2,1910.4 M995.2,1898.4 L995.2,1922.4 " stroke="black"/>
+<path d="M1059.2,2038.4 L995.2,2038.4 " stroke="black" stroke-width="5"/>
+<circle cx="1059.2" cy="2038.4" r="12" stroke="none" fill="black"/>
+<circle cx="995.2" cy="2038.4" r="12" stroke="black" fill="white"/>
+<path d="M983.2,2038.4 L1007.2,2038.4 M995.2,2026.4 L995.2,2050.4 " stroke="black"/>
+<path d="M1059.2,2166.4 L995.2,2166.4 " stroke="black" stroke-width="5"/>
+<circle cx="1059.2" cy="2166.4" r="12" stroke="none" fill="black"/>
+<circle cx="995.2" cy="2166.4" r="12" stroke="black" fill="white"/>
+<path d="M983.2,2166.4 L1007.2,2166.4 M995.2,2154.4 L995.2,2178.4 " stroke="black"/>
+<path d="M1187.2,1910.4 L1123.2,1910.4 " stroke="black" stroke-width="5"/>
+<circle cx="1187.2" cy="1910.4" r="12" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="1910.4" r="12" stroke="black" fill="white"/>
+<path d="M1111.2,1910.4 L1135.2,1910.4 M1123.2,1898.4 L1123.2,1922.4 " stroke="black"/>
+<path d="M1187.2,2038.4 L1123.2,2038.4 " stroke="black" stroke-width="5"/>
+<circle cx="1187.2" cy="2038.4" r="12" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="2038.4" r="12" stroke="black" fill="white"/>
+<path d="M1111.2,2038.4 L1135.2,2038.4 M1123.2,2026.4 L1123.2,2050.4 " stroke="black"/>
+<path d="M1187.2,2166.4 L1123.2,2166.4 " stroke="black" stroke-width="5"/>
+<circle cx="1187.2" cy="2166.4" r="12" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="2166.4" r="12" stroke="black" fill="white"/>
+<path d="M1111.2,2166.4 L1135.2,2166.4 M1123.2,2154.4 L1123.2,2178.4 " stroke="black"/>
+<path d="M1059.2,1974.4 L1123.2,1974.4 " stroke="black" stroke-width="5"/>
+<circle cx="1059.2" cy="1974.4" r="12" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="1974.4" r="12" stroke="black" fill="white"/>
+<path d="M1111.2,1974.4 L1135.2,1974.4 M1123.2,1962.4 L1123.2,1986.4 " stroke="black"/>
+<path d="M1059.2,2102.4 L1123.2,2102.4 " stroke="black" stroke-width="5"/>
+<circle cx="1059.2" cy="2102.4" r="12" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="2102.4" r="12" stroke="black" fill="white"/>
+<path d="M1111.2,2102.4 L1135.2,2102.4 M1123.2,2090.4 L1123.2,2114.4 " stroke="black"/>
+<path d="M1187.2,1974.4 L1251.2,1974.4 " stroke="black" stroke-width="5"/>
+<circle cx="1187.2" cy="1974.4" r="12" stroke="none" fill="black"/>
+<circle cx="1251.2" cy="1974.4" r="12" stroke="black" fill="white"/>
+<path d="M1239.2,1974.4 L1263.2,1974.4 M1251.2,1962.4 L1251.2,1986.4 " stroke="black"/>
+<path d="M1187.2,2102.4 L1251.2,2102.4 " stroke="black" stroke-width="5"/>
+<circle cx="1187.2" cy="2102.4" r="12" stroke="none" fill="black"/>
+<circle cx="1251.2" cy="2102.4" r="12" stroke="black" fill="white"/>
+<path d="M1239.2,2102.4 L1263.2,2102.4 M1251.2,2090.4 L1251.2,2114.4 " stroke="black"/>
 <rect x="1500.8" y="1894.4" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1516.8" y="1910.4">H</text>
 <rect x="1628.8" y="1894.4" width="32" height="32" stroke="black" fill="white"/>
@@ -2262,166 +2262,166 @@
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="2432" y="2166.4">H</text>
 <rect x="2544" y="2150.4" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="2560" y="2166.4">H</text>
-<path d="M144,2368 L208,2368 " stroke="black" stroke-width="3"/>
-<circle cx="144" cy="2368" r="8" stroke="none" fill="black"/>
-<circle cx="208" cy="2368" r="8" stroke="black" fill="white"/>
-<path d="M200,2368 L216,2368 M208,2360 L208,2376 " stroke="black"/>
-<path d="M144,2496 L208,2496 " stroke="black" stroke-width="3"/>
-<circle cx="144" cy="2496" r="8" stroke="none" fill="black"/>
-<circle cx="208" cy="2496" r="8" stroke="black" fill="white"/>
-<path d="M200,2496 L216,2496 M208,2488 L208,2504 " stroke="black"/>
-<path d="M144,2624 L208,2624 " stroke="black" stroke-width="3"/>
-<circle cx="144" cy="2624" r="8" stroke="none" fill="black"/>
-<circle cx="208" cy="2624" r="8" stroke="black" fill="white"/>
-<path d="M200,2624 L216,2624 M208,2616 L208,2632 " stroke="black"/>
-<path d="M272,2368 L336,2368 " stroke="black" stroke-width="3"/>
-<circle cx="272" cy="2368" r="8" stroke="none" fill="black"/>
-<circle cx="336" cy="2368" r="8" stroke="black" fill="white"/>
-<path d="M328,2368 L344,2368 M336,2360 L336,2376 " stroke="black"/>
-<path d="M272,2496 L336,2496 " stroke="black" stroke-width="3"/>
-<circle cx="272" cy="2496" r="8" stroke="none" fill="black"/>
-<circle cx="336" cy="2496" r="8" stroke="black" fill="white"/>
-<path d="M328,2496 L344,2496 M336,2488 L336,2504 " stroke="black"/>
-<path d="M272,2624 L336,2624 " stroke="black" stroke-width="3"/>
-<circle cx="272" cy="2624" r="8" stroke="none" fill="black"/>
-<circle cx="336" cy="2624" r="8" stroke="black" fill="white"/>
-<path d="M328,2624 L344,2624 M336,2616 L336,2632 " stroke="black"/>
-<path d="M144,2432 L80,2432 " stroke="black" stroke-width="3"/>
-<circle cx="144" cy="2432" r="8" stroke="none" fill="black"/>
-<circle cx="80" cy="2432" r="8" stroke="black" fill="white"/>
-<path d="M72,2432 L88,2432 M80,2424 L80,2440 " stroke="black"/>
-<path d="M144,2560 L80,2560 " stroke="black" stroke-width="3"/>
-<circle cx="144" cy="2560" r="8" stroke="none" fill="black"/>
-<circle cx="80" cy="2560" r="8" stroke="black" fill="white"/>
-<path d="M72,2560 L88,2560 M80,2552 L80,2568 " stroke="black"/>
-<path d="M272,2432 L208,2432 " stroke="black" stroke-width="3"/>
-<circle cx="272" cy="2432" r="8" stroke="none" fill="black"/>
-<circle cx="208" cy="2432" r="8" stroke="black" fill="white"/>
-<path d="M200,2432 L216,2432 M208,2424 L208,2440 " stroke="black"/>
-<path d="M272,2560 L208,2560 " stroke="black" stroke-width="3"/>
-<circle cx="272" cy="2560" r="8" stroke="none" fill="black"/>
-<circle cx="208" cy="2560" r="8" stroke="black" fill="white"/>
-<path d="M200,2560 L216,2560 M208,2552 L208,2568 " stroke="black"/>
-<path d="M601.6,2368 L601.6,2432 " stroke="black" stroke-width="3"/>
-<circle cx="601.6" cy="2368" r="8" stroke="none" fill="black"/>
-<circle cx="601.6" cy="2432" r="8" stroke="black" fill="white"/>
-<path d="M593.6,2432 L609.6,2432 M601.6,2424 L601.6,2440 " stroke="black"/>
-<path d="M601.6,2496 L601.6,2560 " stroke="black" stroke-width="3"/>
-<circle cx="601.6" cy="2496" r="8" stroke="none" fill="black"/>
-<circle cx="601.6" cy="2560" r="8" stroke="black" fill="white"/>
-<path d="M593.6,2560 L609.6,2560 M601.6,2552 L601.6,2568 " stroke="black"/>
-<path d="M729.6,2368 L729.6,2432 " stroke="black" stroke-width="3"/>
-<circle cx="729.6" cy="2368" r="8" stroke="none" fill="black"/>
-<circle cx="729.6" cy="2432" r="8" stroke="black" fill="white"/>
-<path d="M721.6,2432 L737.6,2432 M729.6,2424 L729.6,2440 " stroke="black"/>
-<path d="M729.6,2496 L729.6,2560 " stroke="black" stroke-width="3"/>
-<circle cx="729.6" cy="2496" r="8" stroke="none" fill="black"/>
-<circle cx="729.6" cy="2560" r="8" stroke="black" fill="white"/>
-<path d="M721.6,2560 L737.6,2560 M729.6,2552 L729.6,2568 " stroke="black"/>
-<path d="M537.6,2496 L537.6,2432 " stroke="black" stroke-width="3"/>
-<circle cx="537.6" cy="2496" r="8" stroke="none" fill="black"/>
-<circle cx="537.6" cy="2432" r="8" stroke="black" fill="white"/>
-<path d="M529.6,2432 L545.6,2432 M537.6,2424 L537.6,2440 " stroke="black"/>
-<path d="M537.6,2624 L537.6,2560 " stroke="black" stroke-width="3"/>
-<circle cx="537.6" cy="2624" r="8" stroke="none" fill="black"/>
-<circle cx="537.6" cy="2560" r="8" stroke="black" fill="white"/>
-<path d="M529.6,2560 L545.6,2560 M537.6,2552 L537.6,2568 " stroke="black"/>
-<path d="M665.6,2496 L665.6,2432 " stroke="black" stroke-width="3"/>
-<circle cx="665.6" cy="2496" r="8" stroke="none" fill="black"/>
-<circle cx="665.6" cy="2432" r="8" stroke="black" fill="white"/>
-<path d="M657.6,2432 L673.6,2432 M665.6,2424 L665.6,2440 " stroke="black"/>
-<path d="M665.6,2624 L665.6,2560 " stroke="black" stroke-width="3"/>
-<circle cx="665.6" cy="2624" r="8" stroke="none" fill="black"/>
-<circle cx="665.6" cy="2560" r="8" stroke="black" fill="white"/>
-<path d="M657.6,2560 L673.6,2560 M665.6,2552 L665.6,2568 " stroke="black"/>
-<path d="M793.6,2496 L793.6,2432 " stroke="black" stroke-width="3"/>
-<circle cx="793.6" cy="2496" r="8" stroke="none" fill="black"/>
-<circle cx="793.6" cy="2432" r="8" stroke="black" fill="white"/>
-<path d="M785.6,2432 L801.6,2432 M793.6,2424 L793.6,2440 " stroke="black"/>
-<path d="M793.6,2624 L793.6,2560 " stroke="black" stroke-width="3"/>
-<circle cx="793.6" cy="2624" r="8" stroke="none" fill="black"/>
-<circle cx="793.6" cy="2560" r="8" stroke="black" fill="white"/>
-<path d="M785.6,2560 L801.6,2560 M793.6,2552 L793.6,2568 " stroke="black"/>
-<path d="M1059.2,2496 L1059.2,2432 " stroke="black" stroke-width="3"/>
-<circle cx="1059.2" cy="2496" r="8" stroke="none" fill="black"/>
-<circle cx="1059.2" cy="2432" r="8" stroke="black" fill="white"/>
-<path d="M1051.2,2432 L1067.2,2432 M1059.2,2424 L1059.2,2440 " stroke="black"/>
-<path d="M1059.2,2624 L1059.2,2560 " stroke="black" stroke-width="3"/>
-<circle cx="1059.2" cy="2624" r="8" stroke="none" fill="black"/>
-<circle cx="1059.2" cy="2560" r="8" stroke="black" fill="white"/>
-<path d="M1051.2,2560 L1067.2,2560 M1059.2,2552 L1059.2,2568 " stroke="black"/>
-<path d="M1187.2,2496 L1187.2,2432 " stroke="black" stroke-width="3"/>
-<circle cx="1187.2" cy="2496" r="8" stroke="none" fill="black"/>
-<circle cx="1187.2" cy="2432" r="8" stroke="black" fill="white"/>
-<path d="M1179.2,2432 L1195.2,2432 M1187.2,2424 L1187.2,2440 " stroke="black"/>
-<path d="M1187.2,2624 L1187.2,2560 " stroke="black" stroke-width="3"/>
-<circle cx="1187.2" cy="2624" r="8" stroke="none" fill="black"/>
-<circle cx="1187.2" cy="2560" r="8" stroke="black" fill="white"/>
-<path d="M1179.2,2560 L1195.2,2560 M1187.2,2552 L1187.2,2568 " stroke="black"/>
-<path d="M995.2,2368 L995.2,2432 " stroke="black" stroke-width="3"/>
-<circle cx="995.2" cy="2368" r="8" stroke="none" fill="black"/>
-<circle cx="995.2" cy="2432" r="8" stroke="black" fill="white"/>
-<path d="M987.2,2432 L1003.2,2432 M995.2,2424 L995.2,2440 " stroke="black"/>
-<path d="M995.2,2496 L995.2,2560 " stroke="black" stroke-width="3"/>
-<circle cx="995.2" cy="2496" r="8" stroke="none" fill="black"/>
-<circle cx="995.2" cy="2560" r="8" stroke="black" fill="white"/>
-<path d="M987.2,2560 L1003.2,2560 M995.2,2552 L995.2,2568 " stroke="black"/>
-<path d="M1123.2,2368 L1123.2,2432 " stroke="black" stroke-width="3"/>
-<circle cx="1123.2" cy="2368" r="8" stroke="none" fill="black"/>
-<circle cx="1123.2" cy="2432" r="8" stroke="black" fill="white"/>
-<path d="M1115.2,2432 L1131.2,2432 M1123.2,2424 L1123.2,2440 " stroke="black"/>
-<path d="M1123.2,2496 L1123.2,2560 " stroke="black" stroke-width="3"/>
-<circle cx="1123.2" cy="2496" r="8" stroke="none" fill="black"/>
-<circle cx="1123.2" cy="2560" r="8" stroke="black" fill="white"/>
-<path d="M1115.2,2560 L1131.2,2560 M1123.2,2552 L1123.2,2568 " stroke="black"/>
-<path d="M1251.2,2368 L1251.2,2432 " stroke="black" stroke-width="3"/>
-<circle cx="1251.2" cy="2368" r="8" stroke="none" fill="black"/>
-<circle cx="1251.2" cy="2432" r="8" stroke="black" fill="white"/>
-<path d="M1243.2,2432 L1259.2,2432 M1251.2,2424 L1251.2,2440 " stroke="black"/>
-<path d="M1251.2,2496 L1251.2,2560 " stroke="black" stroke-width="3"/>
-<circle cx="1251.2" cy="2496" r="8" stroke="none" fill="black"/>
-<circle cx="1251.2" cy="2560" r="8" stroke="black" fill="white"/>
-<path d="M1243.2,2560 L1259.2,2560 M1251.2,2552 L1251.2,2568 " stroke="black"/>
-<path d="M1516.8,2368 L1452.8,2368 " stroke="black" stroke-width="3"/>
-<circle cx="1516.8" cy="2368" r="8" stroke="none" fill="black"/>
-<circle cx="1452.8" cy="2368" r="8" stroke="black" fill="white"/>
-<path d="M1444.8,2368 L1460.8,2368 M1452.8,2360 L1452.8,2376 " stroke="black"/>
-<path d="M1516.8,2496 L1452.8,2496 " stroke="black" stroke-width="3"/>
-<circle cx="1516.8" cy="2496" r="8" stroke="none" fill="black"/>
-<circle cx="1452.8" cy="2496" r="8" stroke="black" fill="white"/>
-<path d="M1444.8,2496 L1460.8,2496 M1452.8,2488 L1452.8,2504 " stroke="black"/>
-<path d="M1516.8,2624 L1452.8,2624 " stroke="black" stroke-width="3"/>
-<circle cx="1516.8" cy="2624" r="8" stroke="none" fill="black"/>
-<circle cx="1452.8" cy="2624" r="8" stroke="black" fill="white"/>
-<path d="M1444.8,2624 L1460.8,2624 M1452.8,2616 L1452.8,2632 " stroke="black"/>
-<path d="M1644.8,2368 L1580.8,2368 " stroke="black" stroke-width="3"/>
-<circle cx="1644.8" cy="2368" r="8" stroke="none" fill="black"/>
-<circle cx="1580.8" cy="2368" r="8" stroke="black" fill="white"/>
-<path d="M1572.8,2368 L1588.8,2368 M1580.8,2360 L1580.8,2376 " stroke="black"/>
-<path d="M1644.8,2496 L1580.8,2496 " stroke="black" stroke-width="3"/>
-<circle cx="1644.8" cy="2496" r="8" stroke="none" fill="black"/>
-<circle cx="1580.8" cy="2496" r="8" stroke="black" fill="white"/>
-<path d="M1572.8,2496 L1588.8,2496 M1580.8,2488 L1580.8,2504 " stroke="black"/>
-<path d="M1644.8,2624 L1580.8,2624 " stroke="black" stroke-width="3"/>
-<circle cx="1644.8" cy="2624" r="8" stroke="none" fill="black"/>
-<circle cx="1580.8" cy="2624" r="8" stroke="black" fill="white"/>
-<path d="M1572.8,2624 L1588.8,2624 M1580.8,2616 L1580.8,2632 " stroke="black"/>
-<path d="M1516.8,2432 L1580.8,2432 " stroke="black" stroke-width="3"/>
-<circle cx="1516.8" cy="2432" r="8" stroke="none" fill="black"/>
-<circle cx="1580.8" cy="2432" r="8" stroke="black" fill="white"/>
-<path d="M1572.8,2432 L1588.8,2432 M1580.8,2424 L1580.8,2440 " stroke="black"/>
-<path d="M1516.8,2560 L1580.8,2560 " stroke="black" stroke-width="3"/>
-<circle cx="1516.8" cy="2560" r="8" stroke="none" fill="black"/>
-<circle cx="1580.8" cy="2560" r="8" stroke="black" fill="white"/>
-<path d="M1572.8,2560 L1588.8,2560 M1580.8,2552 L1580.8,2568 " stroke="black"/>
-<path d="M1644.8,2432 L1708.8,2432 " stroke="black" stroke-width="3"/>
-<circle cx="1644.8" cy="2432" r="8" stroke="none" fill="black"/>
-<circle cx="1708.8" cy="2432" r="8" stroke="black" fill="white"/>
-<path d="M1700.8,2432 L1716.8,2432 M1708.8,2424 L1708.8,2440 " stroke="black"/>
-<path d="M1644.8,2560 L1708.8,2560 " stroke="black" stroke-width="3"/>
-<circle cx="1644.8" cy="2560" r="8" stroke="none" fill="black"/>
-<circle cx="1708.8" cy="2560" r="8" stroke="black" fill="white"/>
-<path d="M1700.8,2560 L1716.8,2560 M1708.8,2552 L1708.8,2568 " stroke="black"/>
+<path d="M144,2368 L208,2368 " stroke="black" stroke-width="5"/>
+<circle cx="144" cy="2368" r="12" stroke="none" fill="black"/>
+<circle cx="208" cy="2368" r="12" stroke="black" fill="white"/>
+<path d="M196,2368 L220,2368 M208,2356 L208,2380 " stroke="black"/>
+<path d="M144,2496 L208,2496 " stroke="black" stroke-width="5"/>
+<circle cx="144" cy="2496" r="12" stroke="none" fill="black"/>
+<circle cx="208" cy="2496" r="12" stroke="black" fill="white"/>
+<path d="M196,2496 L220,2496 M208,2484 L208,2508 " stroke="black"/>
+<path d="M144,2624 L208,2624 " stroke="black" stroke-width="5"/>
+<circle cx="144" cy="2624" r="12" stroke="none" fill="black"/>
+<circle cx="208" cy="2624" r="12" stroke="black" fill="white"/>
+<path d="M196,2624 L220,2624 M208,2612 L208,2636 " stroke="black"/>
+<path d="M272,2368 L336,2368 " stroke="black" stroke-width="5"/>
+<circle cx="272" cy="2368" r="12" stroke="none" fill="black"/>
+<circle cx="336" cy="2368" r="12" stroke="black" fill="white"/>
+<path d="M324,2368 L348,2368 M336,2356 L336,2380 " stroke="black"/>
+<path d="M272,2496 L336,2496 " stroke="black" stroke-width="5"/>
+<circle cx="272" cy="2496" r="12" stroke="none" fill="black"/>
+<circle cx="336" cy="2496" r="12" stroke="black" fill="white"/>
+<path d="M324,2496 L348,2496 M336,2484 L336,2508 " stroke="black"/>
+<path d="M272,2624 L336,2624 " stroke="black" stroke-width="5"/>
+<circle cx="272" cy="2624" r="12" stroke="none" fill="black"/>
+<circle cx="336" cy="2624" r="12" stroke="black" fill="white"/>
+<path d="M324,2624 L348,2624 M336,2612 L336,2636 " stroke="black"/>
+<path d="M144,2432 L80,2432 " stroke="black" stroke-width="5"/>
+<circle cx="144" cy="2432" r="12" stroke="none" fill="black"/>
+<circle cx="80" cy="2432" r="12" stroke="black" fill="white"/>
+<path d="M68,2432 L92,2432 M80,2420 L80,2444 " stroke="black"/>
+<path d="M144,2560 L80,2560 " stroke="black" stroke-width="5"/>
+<circle cx="144" cy="2560" r="12" stroke="none" fill="black"/>
+<circle cx="80" cy="2560" r="12" stroke="black" fill="white"/>
+<path d="M68,2560 L92,2560 M80,2548 L80,2572 " stroke="black"/>
+<path d="M272,2432 L208,2432 " stroke="black" stroke-width="5"/>
+<circle cx="272" cy="2432" r="12" stroke="none" fill="black"/>
+<circle cx="208" cy="2432" r="12" stroke="black" fill="white"/>
+<path d="M196,2432 L220,2432 M208,2420 L208,2444 " stroke="black"/>
+<path d="M272,2560 L208,2560 " stroke="black" stroke-width="5"/>
+<circle cx="272" cy="2560" r="12" stroke="none" fill="black"/>
+<circle cx="208" cy="2560" r="12" stroke="black" fill="white"/>
+<path d="M196,2560 L220,2560 M208,2548 L208,2572 " stroke="black"/>
+<path d="M601.6,2368 L601.6,2432 " stroke="black" stroke-width="5"/>
+<circle cx="601.6" cy="2368" r="12" stroke="none" fill="black"/>
+<circle cx="601.6" cy="2432" r="12" stroke="black" fill="white"/>
+<path d="M589.6,2432 L613.6,2432 M601.6,2420 L601.6,2444 " stroke="black"/>
+<path d="M601.6,2496 L601.6,2560 " stroke="black" stroke-width="5"/>
+<circle cx="601.6" cy="2496" r="12" stroke="none" fill="black"/>
+<circle cx="601.6" cy="2560" r="12" stroke="black" fill="white"/>
+<path d="M589.6,2560 L613.6,2560 M601.6,2548 L601.6,2572 " stroke="black"/>
+<path d="M729.6,2368 L729.6,2432 " stroke="black" stroke-width="5"/>
+<circle cx="729.6" cy="2368" r="12" stroke="none" fill="black"/>
+<circle cx="729.6" cy="2432" r="12" stroke="black" fill="white"/>
+<path d="M717.6,2432 L741.6,2432 M729.6,2420 L729.6,2444 " stroke="black"/>
+<path d="M729.6,2496 L729.6,2560 " stroke="black" stroke-width="5"/>
+<circle cx="729.6" cy="2496" r="12" stroke="none" fill="black"/>
+<circle cx="729.6" cy="2560" r="12" stroke="black" fill="white"/>
+<path d="M717.6,2560 L741.6,2560 M729.6,2548 L729.6,2572 " stroke="black"/>
+<path d="M537.6,2496 L537.6,2432 " stroke="black" stroke-width="5"/>
+<circle cx="537.6" cy="2496" r="12" stroke="none" fill="black"/>
+<circle cx="537.6" cy="2432" r="12" stroke="black" fill="white"/>
+<path d="M525.6,2432 L549.6,2432 M537.6,2420 L537.6,2444 " stroke="black"/>
+<path d="M537.6,2624 L537.6,2560 " stroke="black" stroke-width="5"/>
+<circle cx="537.6" cy="2624" r="12" stroke="none" fill="black"/>
+<circle cx="537.6" cy="2560" r="12" stroke="black" fill="white"/>
+<path d="M525.6,2560 L549.6,2560 M537.6,2548 L537.6,2572 " stroke="black"/>
+<path d="M665.6,2496 L665.6,2432 " stroke="black" stroke-width="5"/>
+<circle cx="665.6" cy="2496" r="12" stroke="none" fill="black"/>
+<circle cx="665.6" cy="2432" r="12" stroke="black" fill="white"/>
+<path d="M653.6,2432 L677.6,2432 M665.6,2420 L665.6,2444 " stroke="black"/>
+<path d="M665.6,2624 L665.6,2560 " stroke="black" stroke-width="5"/>
+<circle cx="665.6" cy="2624" r="12" stroke="none" fill="black"/>
+<circle cx="665.6" cy="2560" r="12" stroke="black" fill="white"/>
+<path d="M653.6,2560 L677.6,2560 M665.6,2548 L665.6,2572 " stroke="black"/>
+<path d="M793.6,2496 L793.6,2432 " stroke="black" stroke-width="5"/>
+<circle cx="793.6" cy="2496" r="12" stroke="none" fill="black"/>
+<circle cx="793.6" cy="2432" r="12" stroke="black" fill="white"/>
+<path d="M781.6,2432 L805.6,2432 M793.6,2420 L793.6,2444 " stroke="black"/>
+<path d="M793.6,2624 L793.6,2560 " stroke="black" stroke-width="5"/>
+<circle cx="793.6" cy="2624" r="12" stroke="none" fill="black"/>
+<circle cx="793.6" cy="2560" r="12" stroke="black" fill="white"/>
+<path d="M781.6,2560 L805.6,2560 M793.6,2548 L793.6,2572 " stroke="black"/>
+<path d="M1059.2,2496 L1059.2,2432 " stroke="black" stroke-width="5"/>
+<circle cx="1059.2" cy="2496" r="12" stroke="none" fill="black"/>
+<circle cx="1059.2" cy="2432" r="12" stroke="black" fill="white"/>
+<path d="M1047.2,2432 L1071.2,2432 M1059.2,2420 L1059.2,2444 " stroke="black"/>
+<path d="M1059.2,2624 L1059.2,2560 " stroke="black" stroke-width="5"/>
+<circle cx="1059.2" cy="2624" r="12" stroke="none" fill="black"/>
+<circle cx="1059.2" cy="2560" r="12" stroke="black" fill="white"/>
+<path d="M1047.2,2560 L1071.2,2560 M1059.2,2548 L1059.2,2572 " stroke="black"/>
+<path d="M1187.2,2496 L1187.2,2432 " stroke="black" stroke-width="5"/>
+<circle cx="1187.2" cy="2496" r="12" stroke="none" fill="black"/>
+<circle cx="1187.2" cy="2432" r="12" stroke="black" fill="white"/>
+<path d="M1175.2,2432 L1199.2,2432 M1187.2,2420 L1187.2,2444 " stroke="black"/>
+<path d="M1187.2,2624 L1187.2,2560 " stroke="black" stroke-width="5"/>
+<circle cx="1187.2" cy="2624" r="12" stroke="none" fill="black"/>
+<circle cx="1187.2" cy="2560" r="12" stroke="black" fill="white"/>
+<path d="M1175.2,2560 L1199.2,2560 M1187.2,2548 L1187.2,2572 " stroke="black"/>
+<path d="M995.2,2368 L995.2,2432 " stroke="black" stroke-width="5"/>
+<circle cx="995.2" cy="2368" r="12" stroke="none" fill="black"/>
+<circle cx="995.2" cy="2432" r="12" stroke="black" fill="white"/>
+<path d="M983.2,2432 L1007.2,2432 M995.2,2420 L995.2,2444 " stroke="black"/>
+<path d="M995.2,2496 L995.2,2560 " stroke="black" stroke-width="5"/>
+<circle cx="995.2" cy="2496" r="12" stroke="none" fill="black"/>
+<circle cx="995.2" cy="2560" r="12" stroke="black" fill="white"/>
+<path d="M983.2,2560 L1007.2,2560 M995.2,2548 L995.2,2572 " stroke="black"/>
+<path d="M1123.2,2368 L1123.2,2432 " stroke="black" stroke-width="5"/>
+<circle cx="1123.2" cy="2368" r="12" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="2432" r="12" stroke="black" fill="white"/>
+<path d="M1111.2,2432 L1135.2,2432 M1123.2,2420 L1123.2,2444 " stroke="black"/>
+<path d="M1123.2,2496 L1123.2,2560 " stroke="black" stroke-width="5"/>
+<circle cx="1123.2" cy="2496" r="12" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="2560" r="12" stroke="black" fill="white"/>
+<path d="M1111.2,2560 L1135.2,2560 M1123.2,2548 L1123.2,2572 " stroke="black"/>
+<path d="M1251.2,2368 L1251.2,2432 " stroke="black" stroke-width="5"/>
+<circle cx="1251.2" cy="2368" r="12" stroke="none" fill="black"/>
+<circle cx="1251.2" cy="2432" r="12" stroke="black" fill="white"/>
+<path d="M1239.2,2432 L1263.2,2432 M1251.2,2420 L1251.2,2444 " stroke="black"/>
+<path d="M1251.2,2496 L1251.2,2560 " stroke="black" stroke-width="5"/>
+<circle cx="1251.2" cy="2496" r="12" stroke="none" fill="black"/>
+<circle cx="1251.2" cy="2560" r="12" stroke="black" fill="white"/>
+<path d="M1239.2,2560 L1263.2,2560 M1251.2,2548 L1251.2,2572 " stroke="black"/>
+<path d="M1516.8,2368 L1452.8,2368 " stroke="black" stroke-width="5"/>
+<circle cx="1516.8" cy="2368" r="12" stroke="none" fill="black"/>
+<circle cx="1452.8" cy="2368" r="12" stroke="black" fill="white"/>
+<path d="M1440.8,2368 L1464.8,2368 M1452.8,2356 L1452.8,2380 " stroke="black"/>
+<path d="M1516.8,2496 L1452.8,2496 " stroke="black" stroke-width="5"/>
+<circle cx="1516.8" cy="2496" r="12" stroke="none" fill="black"/>
+<circle cx="1452.8" cy="2496" r="12" stroke="black" fill="white"/>
+<path d="M1440.8,2496 L1464.8,2496 M1452.8,2484 L1452.8,2508 " stroke="black"/>
+<path d="M1516.8,2624 L1452.8,2624 " stroke="black" stroke-width="5"/>
+<circle cx="1516.8" cy="2624" r="12" stroke="none" fill="black"/>
+<circle cx="1452.8" cy="2624" r="12" stroke="black" fill="white"/>
+<path d="M1440.8,2624 L1464.8,2624 M1452.8,2612 L1452.8,2636 " stroke="black"/>
+<path d="M1644.8,2368 L1580.8,2368 " stroke="black" stroke-width="5"/>
+<circle cx="1644.8" cy="2368" r="12" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="2368" r="12" stroke="black" fill="white"/>
+<path d="M1568.8,2368 L1592.8,2368 M1580.8,2356 L1580.8,2380 " stroke="black"/>
+<path d="M1644.8,2496 L1580.8,2496 " stroke="black" stroke-width="5"/>
+<circle cx="1644.8" cy="2496" r="12" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="2496" r="12" stroke="black" fill="white"/>
+<path d="M1568.8,2496 L1592.8,2496 M1580.8,2484 L1580.8,2508 " stroke="black"/>
+<path d="M1644.8,2624 L1580.8,2624 " stroke="black" stroke-width="5"/>
+<circle cx="1644.8" cy="2624" r="12" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="2624" r="12" stroke="black" fill="white"/>
+<path d="M1568.8,2624 L1592.8,2624 M1580.8,2612 L1580.8,2636 " stroke="black"/>
+<path d="M1516.8,2432 L1580.8,2432 " stroke="black" stroke-width="5"/>
+<circle cx="1516.8" cy="2432" r="12" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="2432" r="12" stroke="black" fill="white"/>
+<path d="M1568.8,2432 L1592.8,2432 M1580.8,2420 L1580.8,2444 " stroke="black"/>
+<path d="M1516.8,2560 L1580.8,2560 " stroke="black" stroke-width="5"/>
+<circle cx="1516.8" cy="2560" r="12" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="2560" r="12" stroke="black" fill="white"/>
+<path d="M1568.8,2560 L1592.8,2560 M1580.8,2548 L1580.8,2572 " stroke="black"/>
+<path d="M1644.8,2432 L1708.8,2432 " stroke="black" stroke-width="5"/>
+<circle cx="1644.8" cy="2432" r="12" stroke="none" fill="black"/>
+<circle cx="1708.8" cy="2432" r="12" stroke="black" fill="white"/>
+<path d="M1696.8,2432 L1720.8,2432 M1708.8,2420 L1708.8,2444 " stroke="black"/>
+<path d="M1644.8,2560 L1708.8,2560 " stroke="black" stroke-width="5"/>
+<circle cx="1644.8" cy="2560" r="12" stroke="none" fill="black"/>
+<circle cx="1708.8" cy="2560" r="12" stroke="black" fill="white"/>
+<path d="M1696.8,2560 L1720.8,2560 M1708.8,2548 L1708.8,2572 " stroke="black"/>
 <rect x="1958.4" y="2352" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1974.4" y="2368">H</text>
 <rect x="2086.4" y="2352" width="32" height="32" stroke="black" fill="white"/>

--- a/testdata/surface_code_time_detector_slice.svg
+++ b/testdata/surface_code_time_detector_slice.svg
@@ -362,46 +362,46 @@
 <circle cx="1580.8" cy="793.6" r="2" stroke="none" fill="black"/>
 <circle cx="1644.8" cy="793.6" r="2" stroke="none" fill="black"/>
 <circle cx="1708.8" cy="793.6" r="2" stroke="none" fill="black"/>
-<path d="M144,80 L80,80 " stroke="black" stroke-width="3"/>
-<circle cx="144" cy="80" r="8" stroke="none" fill="black"/>
-<circle cx="80" cy="80" r="8" stroke="black" fill="white"/>
-<path d="M72,80 L88,80 M80,72 L80,88 " stroke="black"/>
-<path d="M144,208 L80,208 " stroke="black" stroke-width="3"/>
-<circle cx="144" cy="208" r="8" stroke="none" fill="black"/>
-<circle cx="80" cy="208" r="8" stroke="black" fill="white"/>
-<path d="M72,208 L88,208 M80,200 L80,216 " stroke="black"/>
-<path d="M144,336 L80,336 " stroke="black" stroke-width="3"/>
-<circle cx="144" cy="336" r="8" stroke="none" fill="black"/>
-<circle cx="80" cy="336" r="8" stroke="black" fill="white"/>
-<path d="M72,336 L88,336 M80,328 L80,344 " stroke="black"/>
-<path d="M272,80 L208,80 " stroke="black" stroke-width="3"/>
-<circle cx="272" cy="80" r="8" stroke="none" fill="black"/>
-<circle cx="208" cy="80" r="8" stroke="black" fill="white"/>
-<path d="M200,80 L216,80 M208,72 L208,88 " stroke="black"/>
-<path d="M272,208 L208,208 " stroke="black" stroke-width="3"/>
-<circle cx="272" cy="208" r="8" stroke="none" fill="black"/>
-<circle cx="208" cy="208" r="8" stroke="black" fill="white"/>
-<path d="M200,208 L216,208 M208,200 L208,216 " stroke="black"/>
-<path d="M272,336 L208,336 " stroke="black" stroke-width="3"/>
-<circle cx="272" cy="336" r="8" stroke="none" fill="black"/>
-<circle cx="208" cy="336" r="8" stroke="black" fill="white"/>
-<path d="M200,336 L216,336 M208,328 L208,344 " stroke="black"/>
-<path d="M144,144 L208,144 " stroke="black" stroke-width="3"/>
-<circle cx="144" cy="144" r="8" stroke="none" fill="black"/>
-<circle cx="208" cy="144" r="8" stroke="black" fill="white"/>
-<path d="M200,144 L216,144 M208,136 L208,152 " stroke="black"/>
-<path d="M144,272 L208,272 " stroke="black" stroke-width="3"/>
-<circle cx="144" cy="272" r="8" stroke="none" fill="black"/>
-<circle cx="208" cy="272" r="8" stroke="black" fill="white"/>
-<path d="M200,272 L216,272 M208,264 L208,280 " stroke="black"/>
-<path d="M272,144 L336,144 " stroke="black" stroke-width="3"/>
-<circle cx="272" cy="144" r="8" stroke="none" fill="black"/>
-<circle cx="336" cy="144" r="8" stroke="black" fill="white"/>
-<path d="M328,144 L344,144 M336,136 L336,152 " stroke="black"/>
-<path d="M272,272 L336,272 " stroke="black" stroke-width="3"/>
-<circle cx="272" cy="272" r="8" stroke="none" fill="black"/>
-<circle cx="336" cy="272" r="8" stroke="black" fill="white"/>
-<path d="M328,272 L344,272 M336,264 L336,280 " stroke="black"/>
+<path d="M144,80 L80,80 " stroke="black" stroke-width="5"/>
+<circle cx="144" cy="80" r="12" stroke="none" fill="black"/>
+<circle cx="80" cy="80" r="12" stroke="black" fill="white"/>
+<path d="M68,80 L92,80 M80,68 L80,92 " stroke="black"/>
+<path d="M144,208 L80,208 " stroke="black" stroke-width="5"/>
+<circle cx="144" cy="208" r="12" stroke="none" fill="black"/>
+<circle cx="80" cy="208" r="12" stroke="black" fill="white"/>
+<path d="M68,208 L92,208 M80,196 L80,220 " stroke="black"/>
+<path d="M144,336 L80,336 " stroke="black" stroke-width="5"/>
+<circle cx="144" cy="336" r="12" stroke="none" fill="black"/>
+<circle cx="80" cy="336" r="12" stroke="black" fill="white"/>
+<path d="M68,336 L92,336 M80,324 L80,348 " stroke="black"/>
+<path d="M272,80 L208,80 " stroke="black" stroke-width="5"/>
+<circle cx="272" cy="80" r="12" stroke="none" fill="black"/>
+<circle cx="208" cy="80" r="12" stroke="black" fill="white"/>
+<path d="M196,80 L220,80 M208,68 L208,92 " stroke="black"/>
+<path d="M272,208 L208,208 " stroke="black" stroke-width="5"/>
+<circle cx="272" cy="208" r="12" stroke="none" fill="black"/>
+<circle cx="208" cy="208" r="12" stroke="black" fill="white"/>
+<path d="M196,208 L220,208 M208,196 L208,220 " stroke="black"/>
+<path d="M272,336 L208,336 " stroke="black" stroke-width="5"/>
+<circle cx="272" cy="336" r="12" stroke="none" fill="black"/>
+<circle cx="208" cy="336" r="12" stroke="black" fill="white"/>
+<path d="M196,336 L220,336 M208,324 L208,348 " stroke="black"/>
+<path d="M144,144 L208,144 " stroke="black" stroke-width="5"/>
+<circle cx="144" cy="144" r="12" stroke="none" fill="black"/>
+<circle cx="208" cy="144" r="12" stroke="black" fill="white"/>
+<path d="M196,144 L220,144 M208,132 L208,156 " stroke="black"/>
+<path d="M144,272 L208,272 " stroke="black" stroke-width="5"/>
+<circle cx="144" cy="272" r="12" stroke="none" fill="black"/>
+<circle cx="208" cy="272" r="12" stroke="black" fill="white"/>
+<path d="M196,272 L220,272 M208,260 L208,284 " stroke="black"/>
+<path d="M272,144 L336,144 " stroke="black" stroke-width="5"/>
+<circle cx="272" cy="144" r="12" stroke="none" fill="black"/>
+<circle cx="336" cy="144" r="12" stroke="black" fill="white"/>
+<path d="M324,144 L348,144 M336,132 L336,156 " stroke="black"/>
+<path d="M272,272 L336,272 " stroke="black" stroke-width="5"/>
+<circle cx="272" cy="272" r="12" stroke="none" fill="black"/>
+<circle cx="336" cy="272" r="12" stroke="black" fill="white"/>
+<path d="M324,272 L348,272 M336,260 L336,284 " stroke="black"/>
 <rect x="585.6" y="64" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="601.6" y="80">H</text>
 <rect x="713.6" y="64" width="32" height="32" stroke="black" fill="white"/>
@@ -450,166 +450,166 @@
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1516.8" y="336">H</text>
 <rect x="1628.8" y="320" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1644.8" y="336">H</text>
-<path d="M144,537.6 L208,537.6 " stroke="black" stroke-width="3"/>
-<circle cx="144" cy="537.6" r="8" stroke="none" fill="black"/>
-<circle cx="208" cy="537.6" r="8" stroke="black" fill="white"/>
-<path d="M200,537.6 L216,537.6 M208,529.6 L208,545.6 " stroke="black"/>
-<path d="M144,665.6 L208,665.6 " stroke="black" stroke-width="3"/>
-<circle cx="144" cy="665.6" r="8" stroke="none" fill="black"/>
-<circle cx="208" cy="665.6" r="8" stroke="black" fill="white"/>
-<path d="M200,665.6 L216,665.6 M208,657.6 L208,673.6 " stroke="black"/>
-<path d="M144,793.6 L208,793.6 " stroke="black" stroke-width="3"/>
-<circle cx="144" cy="793.6" r="8" stroke="none" fill="black"/>
-<circle cx="208" cy="793.6" r="8" stroke="black" fill="white"/>
-<path d="M200,793.6 L216,793.6 M208,785.6 L208,801.6 " stroke="black"/>
-<path d="M272,537.6 L336,537.6 " stroke="black" stroke-width="3"/>
-<circle cx="272" cy="537.6" r="8" stroke="none" fill="black"/>
-<circle cx="336" cy="537.6" r="8" stroke="black" fill="white"/>
-<path d="M328,537.6 L344,537.6 M336,529.6 L336,545.6 " stroke="black"/>
-<path d="M272,665.6 L336,665.6 " stroke="black" stroke-width="3"/>
-<circle cx="272" cy="665.6" r="8" stroke="none" fill="black"/>
-<circle cx="336" cy="665.6" r="8" stroke="black" fill="white"/>
-<path d="M328,665.6 L344,665.6 M336,657.6 L336,673.6 " stroke="black"/>
-<path d="M272,793.6 L336,793.6 " stroke="black" stroke-width="3"/>
-<circle cx="272" cy="793.6" r="8" stroke="none" fill="black"/>
-<circle cx="336" cy="793.6" r="8" stroke="black" fill="white"/>
-<path d="M328,793.6 L344,793.6 M336,785.6 L336,801.6 " stroke="black"/>
-<path d="M144,601.6 L80,601.6 " stroke="black" stroke-width="3"/>
-<circle cx="144" cy="601.6" r="8" stroke="none" fill="black"/>
-<circle cx="80" cy="601.6" r="8" stroke="black" fill="white"/>
-<path d="M72,601.6 L88,601.6 M80,593.6 L80,609.6 " stroke="black"/>
-<path d="M144,729.6 L80,729.6 " stroke="black" stroke-width="3"/>
-<circle cx="144" cy="729.6" r="8" stroke="none" fill="black"/>
-<circle cx="80" cy="729.6" r="8" stroke="black" fill="white"/>
-<path d="M72,729.6 L88,729.6 M80,721.6 L80,737.6 " stroke="black"/>
-<path d="M272,601.6 L208,601.6 " stroke="black" stroke-width="3"/>
-<circle cx="272" cy="601.6" r="8" stroke="none" fill="black"/>
-<circle cx="208" cy="601.6" r="8" stroke="black" fill="white"/>
-<path d="M200,601.6 L216,601.6 M208,593.6 L208,609.6 " stroke="black"/>
-<path d="M272,729.6 L208,729.6 " stroke="black" stroke-width="3"/>
-<circle cx="272" cy="729.6" r="8" stroke="none" fill="black"/>
-<circle cx="208" cy="729.6" r="8" stroke="black" fill="white"/>
-<path d="M200,729.6 L216,729.6 M208,721.6 L208,737.6 " stroke="black"/>
-<path d="M601.6,537.6 L601.6,601.6 " stroke="black" stroke-width="3"/>
-<circle cx="601.6" cy="537.6" r="8" stroke="none" fill="black"/>
-<circle cx="601.6" cy="601.6" r="8" stroke="black" fill="white"/>
-<path d="M593.6,601.6 L609.6,601.6 M601.6,593.6 L601.6,609.6 " stroke="black"/>
-<path d="M601.6,665.6 L601.6,729.6 " stroke="black" stroke-width="3"/>
-<circle cx="601.6" cy="665.6" r="8" stroke="none" fill="black"/>
-<circle cx="601.6" cy="729.6" r="8" stroke="black" fill="white"/>
-<path d="M593.6,729.6 L609.6,729.6 M601.6,721.6 L601.6,737.6 " stroke="black"/>
-<path d="M729.6,537.6 L729.6,601.6 " stroke="black" stroke-width="3"/>
-<circle cx="729.6" cy="537.6" r="8" stroke="none" fill="black"/>
-<circle cx="729.6" cy="601.6" r="8" stroke="black" fill="white"/>
-<path d="M721.6,601.6 L737.6,601.6 M729.6,593.6 L729.6,609.6 " stroke="black"/>
-<path d="M729.6,665.6 L729.6,729.6 " stroke="black" stroke-width="3"/>
-<circle cx="729.6" cy="665.6" r="8" stroke="none" fill="black"/>
-<circle cx="729.6" cy="729.6" r="8" stroke="black" fill="white"/>
-<path d="M721.6,729.6 L737.6,729.6 M729.6,721.6 L729.6,737.6 " stroke="black"/>
-<path d="M537.6,665.6 L537.6,601.6 " stroke="black" stroke-width="3"/>
-<circle cx="537.6" cy="665.6" r="8" stroke="none" fill="black"/>
-<circle cx="537.6" cy="601.6" r="8" stroke="black" fill="white"/>
-<path d="M529.6,601.6 L545.6,601.6 M537.6,593.6 L537.6,609.6 " stroke="black"/>
-<path d="M537.6,793.6 L537.6,729.6 " stroke="black" stroke-width="3"/>
-<circle cx="537.6" cy="793.6" r="8" stroke="none" fill="black"/>
-<circle cx="537.6" cy="729.6" r="8" stroke="black" fill="white"/>
-<path d="M529.6,729.6 L545.6,729.6 M537.6,721.6 L537.6,737.6 " stroke="black"/>
-<path d="M665.6,665.6 L665.6,601.6 " stroke="black" stroke-width="3"/>
-<circle cx="665.6" cy="665.6" r="8" stroke="none" fill="black"/>
-<circle cx="665.6" cy="601.6" r="8" stroke="black" fill="white"/>
-<path d="M657.6,601.6 L673.6,601.6 M665.6,593.6 L665.6,609.6 " stroke="black"/>
-<path d="M665.6,793.6 L665.6,729.6 " stroke="black" stroke-width="3"/>
-<circle cx="665.6" cy="793.6" r="8" stroke="none" fill="black"/>
-<circle cx="665.6" cy="729.6" r="8" stroke="black" fill="white"/>
-<path d="M657.6,729.6 L673.6,729.6 M665.6,721.6 L665.6,737.6 " stroke="black"/>
-<path d="M793.6,665.6 L793.6,601.6 " stroke="black" stroke-width="3"/>
-<circle cx="793.6" cy="665.6" r="8" stroke="none" fill="black"/>
-<circle cx="793.6" cy="601.6" r="8" stroke="black" fill="white"/>
-<path d="M785.6,601.6 L801.6,601.6 M793.6,593.6 L793.6,609.6 " stroke="black"/>
-<path d="M793.6,793.6 L793.6,729.6 " stroke="black" stroke-width="3"/>
-<circle cx="793.6" cy="793.6" r="8" stroke="none" fill="black"/>
-<circle cx="793.6" cy="729.6" r="8" stroke="black" fill="white"/>
-<path d="M785.6,729.6 L801.6,729.6 M793.6,721.6 L793.6,737.6 " stroke="black"/>
-<path d="M1059.2,665.6 L1059.2,601.6 " stroke="black" stroke-width="3"/>
-<circle cx="1059.2" cy="665.6" r="8" stroke="none" fill="black"/>
-<circle cx="1059.2" cy="601.6" r="8" stroke="black" fill="white"/>
-<path d="M1051.2,601.6 L1067.2,601.6 M1059.2,593.6 L1059.2,609.6 " stroke="black"/>
-<path d="M1059.2,793.6 L1059.2,729.6 " stroke="black" stroke-width="3"/>
-<circle cx="1059.2" cy="793.6" r="8" stroke="none" fill="black"/>
-<circle cx="1059.2" cy="729.6" r="8" stroke="black" fill="white"/>
-<path d="M1051.2,729.6 L1067.2,729.6 M1059.2,721.6 L1059.2,737.6 " stroke="black"/>
-<path d="M1187.2,665.6 L1187.2,601.6 " stroke="black" stroke-width="3"/>
-<circle cx="1187.2" cy="665.6" r="8" stroke="none" fill="black"/>
-<circle cx="1187.2" cy="601.6" r="8" stroke="black" fill="white"/>
-<path d="M1179.2,601.6 L1195.2,601.6 M1187.2,593.6 L1187.2,609.6 " stroke="black"/>
-<path d="M1187.2,793.6 L1187.2,729.6 " stroke="black" stroke-width="3"/>
-<circle cx="1187.2" cy="793.6" r="8" stroke="none" fill="black"/>
-<circle cx="1187.2" cy="729.6" r="8" stroke="black" fill="white"/>
-<path d="M1179.2,729.6 L1195.2,729.6 M1187.2,721.6 L1187.2,737.6 " stroke="black"/>
-<path d="M995.2,537.6 L995.2,601.6 " stroke="black" stroke-width="3"/>
-<circle cx="995.2" cy="537.6" r="8" stroke="none" fill="black"/>
-<circle cx="995.2" cy="601.6" r="8" stroke="black" fill="white"/>
-<path d="M987.2,601.6 L1003.2,601.6 M995.2,593.6 L995.2,609.6 " stroke="black"/>
-<path d="M995.2,665.6 L995.2,729.6 " stroke="black" stroke-width="3"/>
-<circle cx="995.2" cy="665.6" r="8" stroke="none" fill="black"/>
-<circle cx="995.2" cy="729.6" r="8" stroke="black" fill="white"/>
-<path d="M987.2,729.6 L1003.2,729.6 M995.2,721.6 L995.2,737.6 " stroke="black"/>
-<path d="M1123.2,537.6 L1123.2,601.6 " stroke="black" stroke-width="3"/>
-<circle cx="1123.2" cy="537.6" r="8" stroke="none" fill="black"/>
-<circle cx="1123.2" cy="601.6" r="8" stroke="black" fill="white"/>
-<path d="M1115.2,601.6 L1131.2,601.6 M1123.2,593.6 L1123.2,609.6 " stroke="black"/>
-<path d="M1123.2,665.6 L1123.2,729.6 " stroke="black" stroke-width="3"/>
-<circle cx="1123.2" cy="665.6" r="8" stroke="none" fill="black"/>
-<circle cx="1123.2" cy="729.6" r="8" stroke="black" fill="white"/>
-<path d="M1115.2,729.6 L1131.2,729.6 M1123.2,721.6 L1123.2,737.6 " stroke="black"/>
-<path d="M1251.2,537.6 L1251.2,601.6 " stroke="black" stroke-width="3"/>
-<circle cx="1251.2" cy="537.6" r="8" stroke="none" fill="black"/>
-<circle cx="1251.2" cy="601.6" r="8" stroke="black" fill="white"/>
-<path d="M1243.2,601.6 L1259.2,601.6 M1251.2,593.6 L1251.2,609.6 " stroke="black"/>
-<path d="M1251.2,665.6 L1251.2,729.6 " stroke="black" stroke-width="3"/>
-<circle cx="1251.2" cy="665.6" r="8" stroke="none" fill="black"/>
-<circle cx="1251.2" cy="729.6" r="8" stroke="black" fill="white"/>
-<path d="M1243.2,729.6 L1259.2,729.6 M1251.2,721.6 L1251.2,737.6 " stroke="black"/>
-<path d="M1516.8,537.6 L1452.8,537.6 " stroke="black" stroke-width="3"/>
-<circle cx="1516.8" cy="537.6" r="8" stroke="none" fill="black"/>
-<circle cx="1452.8" cy="537.6" r="8" stroke="black" fill="white"/>
-<path d="M1444.8,537.6 L1460.8,537.6 M1452.8,529.6 L1452.8,545.6 " stroke="black"/>
-<path d="M1516.8,665.6 L1452.8,665.6 " stroke="black" stroke-width="3"/>
-<circle cx="1516.8" cy="665.6" r="8" stroke="none" fill="black"/>
-<circle cx="1452.8" cy="665.6" r="8" stroke="black" fill="white"/>
-<path d="M1444.8,665.6 L1460.8,665.6 M1452.8,657.6 L1452.8,673.6 " stroke="black"/>
-<path d="M1516.8,793.6 L1452.8,793.6 " stroke="black" stroke-width="3"/>
-<circle cx="1516.8" cy="793.6" r="8" stroke="none" fill="black"/>
-<circle cx="1452.8" cy="793.6" r="8" stroke="black" fill="white"/>
-<path d="M1444.8,793.6 L1460.8,793.6 M1452.8,785.6 L1452.8,801.6 " stroke="black"/>
-<path d="M1644.8,537.6 L1580.8,537.6 " stroke="black" stroke-width="3"/>
-<circle cx="1644.8" cy="537.6" r="8" stroke="none" fill="black"/>
-<circle cx="1580.8" cy="537.6" r="8" stroke="black" fill="white"/>
-<path d="M1572.8,537.6 L1588.8,537.6 M1580.8,529.6 L1580.8,545.6 " stroke="black"/>
-<path d="M1644.8,665.6 L1580.8,665.6 " stroke="black" stroke-width="3"/>
-<circle cx="1644.8" cy="665.6" r="8" stroke="none" fill="black"/>
-<circle cx="1580.8" cy="665.6" r="8" stroke="black" fill="white"/>
-<path d="M1572.8,665.6 L1588.8,665.6 M1580.8,657.6 L1580.8,673.6 " stroke="black"/>
-<path d="M1644.8,793.6 L1580.8,793.6 " stroke="black" stroke-width="3"/>
-<circle cx="1644.8" cy="793.6" r="8" stroke="none" fill="black"/>
-<circle cx="1580.8" cy="793.6" r="8" stroke="black" fill="white"/>
-<path d="M1572.8,793.6 L1588.8,793.6 M1580.8,785.6 L1580.8,801.6 " stroke="black"/>
-<path d="M1516.8,601.6 L1580.8,601.6 " stroke="black" stroke-width="3"/>
-<circle cx="1516.8" cy="601.6" r="8" stroke="none" fill="black"/>
-<circle cx="1580.8" cy="601.6" r="8" stroke="black" fill="white"/>
-<path d="M1572.8,601.6 L1588.8,601.6 M1580.8,593.6 L1580.8,609.6 " stroke="black"/>
-<path d="M1516.8,729.6 L1580.8,729.6 " stroke="black" stroke-width="3"/>
-<circle cx="1516.8" cy="729.6" r="8" stroke="none" fill="black"/>
-<circle cx="1580.8" cy="729.6" r="8" stroke="black" fill="white"/>
-<path d="M1572.8,729.6 L1588.8,729.6 M1580.8,721.6 L1580.8,737.6 " stroke="black"/>
-<path d="M1644.8,601.6 L1708.8,601.6 " stroke="black" stroke-width="3"/>
-<circle cx="1644.8" cy="601.6" r="8" stroke="none" fill="black"/>
-<circle cx="1708.8" cy="601.6" r="8" stroke="black" fill="white"/>
-<path d="M1700.8,601.6 L1716.8,601.6 M1708.8,593.6 L1708.8,609.6 " stroke="black"/>
-<path d="M1644.8,729.6 L1708.8,729.6 " stroke="black" stroke-width="3"/>
-<circle cx="1644.8" cy="729.6" r="8" stroke="none" fill="black"/>
-<circle cx="1708.8" cy="729.6" r="8" stroke="black" fill="white"/>
-<path d="M1700.8,729.6 L1716.8,729.6 M1708.8,721.6 L1708.8,737.6 " stroke="black"/>
+<path d="M144,537.6 L208,537.6 " stroke="black" stroke-width="5"/>
+<circle cx="144" cy="537.6" r="12" stroke="none" fill="black"/>
+<circle cx="208" cy="537.6" r="12" stroke="black" fill="white"/>
+<path d="M196,537.6 L220,537.6 M208,525.6 L208,549.6 " stroke="black"/>
+<path d="M144,665.6 L208,665.6 " stroke="black" stroke-width="5"/>
+<circle cx="144" cy="665.6" r="12" stroke="none" fill="black"/>
+<circle cx="208" cy="665.6" r="12" stroke="black" fill="white"/>
+<path d="M196,665.6 L220,665.6 M208,653.6 L208,677.6 " stroke="black"/>
+<path d="M144,793.6 L208,793.6 " stroke="black" stroke-width="5"/>
+<circle cx="144" cy="793.6" r="12" stroke="none" fill="black"/>
+<circle cx="208" cy="793.6" r="12" stroke="black" fill="white"/>
+<path d="M196,793.6 L220,793.6 M208,781.6 L208,805.6 " stroke="black"/>
+<path d="M272,537.6 L336,537.6 " stroke="black" stroke-width="5"/>
+<circle cx="272" cy="537.6" r="12" stroke="none" fill="black"/>
+<circle cx="336" cy="537.6" r="12" stroke="black" fill="white"/>
+<path d="M324,537.6 L348,537.6 M336,525.6 L336,549.6 " stroke="black"/>
+<path d="M272,665.6 L336,665.6 " stroke="black" stroke-width="5"/>
+<circle cx="272" cy="665.6" r="12" stroke="none" fill="black"/>
+<circle cx="336" cy="665.6" r="12" stroke="black" fill="white"/>
+<path d="M324,665.6 L348,665.6 M336,653.6 L336,677.6 " stroke="black"/>
+<path d="M272,793.6 L336,793.6 " stroke="black" stroke-width="5"/>
+<circle cx="272" cy="793.6" r="12" stroke="none" fill="black"/>
+<circle cx="336" cy="793.6" r="12" stroke="black" fill="white"/>
+<path d="M324,793.6 L348,793.6 M336,781.6 L336,805.6 " stroke="black"/>
+<path d="M144,601.6 L80,601.6 " stroke="black" stroke-width="5"/>
+<circle cx="144" cy="601.6" r="12" stroke="none" fill="black"/>
+<circle cx="80" cy="601.6" r="12" stroke="black" fill="white"/>
+<path d="M68,601.6 L92,601.6 M80,589.6 L80,613.6 " stroke="black"/>
+<path d="M144,729.6 L80,729.6 " stroke="black" stroke-width="5"/>
+<circle cx="144" cy="729.6" r="12" stroke="none" fill="black"/>
+<circle cx="80" cy="729.6" r="12" stroke="black" fill="white"/>
+<path d="M68,729.6 L92,729.6 M80,717.6 L80,741.6 " stroke="black"/>
+<path d="M272,601.6 L208,601.6 " stroke="black" stroke-width="5"/>
+<circle cx="272" cy="601.6" r="12" stroke="none" fill="black"/>
+<circle cx="208" cy="601.6" r="12" stroke="black" fill="white"/>
+<path d="M196,601.6 L220,601.6 M208,589.6 L208,613.6 " stroke="black"/>
+<path d="M272,729.6 L208,729.6 " stroke="black" stroke-width="5"/>
+<circle cx="272" cy="729.6" r="12" stroke="none" fill="black"/>
+<circle cx="208" cy="729.6" r="12" stroke="black" fill="white"/>
+<path d="M196,729.6 L220,729.6 M208,717.6 L208,741.6 " stroke="black"/>
+<path d="M601.6,537.6 L601.6,601.6 " stroke="black" stroke-width="5"/>
+<circle cx="601.6" cy="537.6" r="12" stroke="none" fill="black"/>
+<circle cx="601.6" cy="601.6" r="12" stroke="black" fill="white"/>
+<path d="M589.6,601.6 L613.6,601.6 M601.6,589.6 L601.6,613.6 " stroke="black"/>
+<path d="M601.6,665.6 L601.6,729.6 " stroke="black" stroke-width="5"/>
+<circle cx="601.6" cy="665.6" r="12" stroke="none" fill="black"/>
+<circle cx="601.6" cy="729.6" r="12" stroke="black" fill="white"/>
+<path d="M589.6,729.6 L613.6,729.6 M601.6,717.6 L601.6,741.6 " stroke="black"/>
+<path d="M729.6,537.6 L729.6,601.6 " stroke="black" stroke-width="5"/>
+<circle cx="729.6" cy="537.6" r="12" stroke="none" fill="black"/>
+<circle cx="729.6" cy="601.6" r="12" stroke="black" fill="white"/>
+<path d="M717.6,601.6 L741.6,601.6 M729.6,589.6 L729.6,613.6 " stroke="black"/>
+<path d="M729.6,665.6 L729.6,729.6 " stroke="black" stroke-width="5"/>
+<circle cx="729.6" cy="665.6" r="12" stroke="none" fill="black"/>
+<circle cx="729.6" cy="729.6" r="12" stroke="black" fill="white"/>
+<path d="M717.6,729.6 L741.6,729.6 M729.6,717.6 L729.6,741.6 " stroke="black"/>
+<path d="M537.6,665.6 L537.6,601.6 " stroke="black" stroke-width="5"/>
+<circle cx="537.6" cy="665.6" r="12" stroke="none" fill="black"/>
+<circle cx="537.6" cy="601.6" r="12" stroke="black" fill="white"/>
+<path d="M525.6,601.6 L549.6,601.6 M537.6,589.6 L537.6,613.6 " stroke="black"/>
+<path d="M537.6,793.6 L537.6,729.6 " stroke="black" stroke-width="5"/>
+<circle cx="537.6" cy="793.6" r="12" stroke="none" fill="black"/>
+<circle cx="537.6" cy="729.6" r="12" stroke="black" fill="white"/>
+<path d="M525.6,729.6 L549.6,729.6 M537.6,717.6 L537.6,741.6 " stroke="black"/>
+<path d="M665.6,665.6 L665.6,601.6 " stroke="black" stroke-width="5"/>
+<circle cx="665.6" cy="665.6" r="12" stroke="none" fill="black"/>
+<circle cx="665.6" cy="601.6" r="12" stroke="black" fill="white"/>
+<path d="M653.6,601.6 L677.6,601.6 M665.6,589.6 L665.6,613.6 " stroke="black"/>
+<path d="M665.6,793.6 L665.6,729.6 " stroke="black" stroke-width="5"/>
+<circle cx="665.6" cy="793.6" r="12" stroke="none" fill="black"/>
+<circle cx="665.6" cy="729.6" r="12" stroke="black" fill="white"/>
+<path d="M653.6,729.6 L677.6,729.6 M665.6,717.6 L665.6,741.6 " stroke="black"/>
+<path d="M793.6,665.6 L793.6,601.6 " stroke="black" stroke-width="5"/>
+<circle cx="793.6" cy="665.6" r="12" stroke="none" fill="black"/>
+<circle cx="793.6" cy="601.6" r="12" stroke="black" fill="white"/>
+<path d="M781.6,601.6 L805.6,601.6 M793.6,589.6 L793.6,613.6 " stroke="black"/>
+<path d="M793.6,793.6 L793.6,729.6 " stroke="black" stroke-width="5"/>
+<circle cx="793.6" cy="793.6" r="12" stroke="none" fill="black"/>
+<circle cx="793.6" cy="729.6" r="12" stroke="black" fill="white"/>
+<path d="M781.6,729.6 L805.6,729.6 M793.6,717.6 L793.6,741.6 " stroke="black"/>
+<path d="M1059.2,665.6 L1059.2,601.6 " stroke="black" stroke-width="5"/>
+<circle cx="1059.2" cy="665.6" r="12" stroke="none" fill="black"/>
+<circle cx="1059.2" cy="601.6" r="12" stroke="black" fill="white"/>
+<path d="M1047.2,601.6 L1071.2,601.6 M1059.2,589.6 L1059.2,613.6 " stroke="black"/>
+<path d="M1059.2,793.6 L1059.2,729.6 " stroke="black" stroke-width="5"/>
+<circle cx="1059.2" cy="793.6" r="12" stroke="none" fill="black"/>
+<circle cx="1059.2" cy="729.6" r="12" stroke="black" fill="white"/>
+<path d="M1047.2,729.6 L1071.2,729.6 M1059.2,717.6 L1059.2,741.6 " stroke="black"/>
+<path d="M1187.2,665.6 L1187.2,601.6 " stroke="black" stroke-width="5"/>
+<circle cx="1187.2" cy="665.6" r="12" stroke="none" fill="black"/>
+<circle cx="1187.2" cy="601.6" r="12" stroke="black" fill="white"/>
+<path d="M1175.2,601.6 L1199.2,601.6 M1187.2,589.6 L1187.2,613.6 " stroke="black"/>
+<path d="M1187.2,793.6 L1187.2,729.6 " stroke="black" stroke-width="5"/>
+<circle cx="1187.2" cy="793.6" r="12" stroke="none" fill="black"/>
+<circle cx="1187.2" cy="729.6" r="12" stroke="black" fill="white"/>
+<path d="M1175.2,729.6 L1199.2,729.6 M1187.2,717.6 L1187.2,741.6 " stroke="black"/>
+<path d="M995.2,537.6 L995.2,601.6 " stroke="black" stroke-width="5"/>
+<circle cx="995.2" cy="537.6" r="12" stroke="none" fill="black"/>
+<circle cx="995.2" cy="601.6" r="12" stroke="black" fill="white"/>
+<path d="M983.2,601.6 L1007.2,601.6 M995.2,589.6 L995.2,613.6 " stroke="black"/>
+<path d="M995.2,665.6 L995.2,729.6 " stroke="black" stroke-width="5"/>
+<circle cx="995.2" cy="665.6" r="12" stroke="none" fill="black"/>
+<circle cx="995.2" cy="729.6" r="12" stroke="black" fill="white"/>
+<path d="M983.2,729.6 L1007.2,729.6 M995.2,717.6 L995.2,741.6 " stroke="black"/>
+<path d="M1123.2,537.6 L1123.2,601.6 " stroke="black" stroke-width="5"/>
+<circle cx="1123.2" cy="537.6" r="12" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="601.6" r="12" stroke="black" fill="white"/>
+<path d="M1111.2,601.6 L1135.2,601.6 M1123.2,589.6 L1123.2,613.6 " stroke="black"/>
+<path d="M1123.2,665.6 L1123.2,729.6 " stroke="black" stroke-width="5"/>
+<circle cx="1123.2" cy="665.6" r="12" stroke="none" fill="black"/>
+<circle cx="1123.2" cy="729.6" r="12" stroke="black" fill="white"/>
+<path d="M1111.2,729.6 L1135.2,729.6 M1123.2,717.6 L1123.2,741.6 " stroke="black"/>
+<path d="M1251.2,537.6 L1251.2,601.6 " stroke="black" stroke-width="5"/>
+<circle cx="1251.2" cy="537.6" r="12" stroke="none" fill="black"/>
+<circle cx="1251.2" cy="601.6" r="12" stroke="black" fill="white"/>
+<path d="M1239.2,601.6 L1263.2,601.6 M1251.2,589.6 L1251.2,613.6 " stroke="black"/>
+<path d="M1251.2,665.6 L1251.2,729.6 " stroke="black" stroke-width="5"/>
+<circle cx="1251.2" cy="665.6" r="12" stroke="none" fill="black"/>
+<circle cx="1251.2" cy="729.6" r="12" stroke="black" fill="white"/>
+<path d="M1239.2,729.6 L1263.2,729.6 M1251.2,717.6 L1251.2,741.6 " stroke="black"/>
+<path d="M1516.8,537.6 L1452.8,537.6 " stroke="black" stroke-width="5"/>
+<circle cx="1516.8" cy="537.6" r="12" stroke="none" fill="black"/>
+<circle cx="1452.8" cy="537.6" r="12" stroke="black" fill="white"/>
+<path d="M1440.8,537.6 L1464.8,537.6 M1452.8,525.6 L1452.8,549.6 " stroke="black"/>
+<path d="M1516.8,665.6 L1452.8,665.6 " stroke="black" stroke-width="5"/>
+<circle cx="1516.8" cy="665.6" r="12" stroke="none" fill="black"/>
+<circle cx="1452.8" cy="665.6" r="12" stroke="black" fill="white"/>
+<path d="M1440.8,665.6 L1464.8,665.6 M1452.8,653.6 L1452.8,677.6 " stroke="black"/>
+<path d="M1516.8,793.6 L1452.8,793.6 " stroke="black" stroke-width="5"/>
+<circle cx="1516.8" cy="793.6" r="12" stroke="none" fill="black"/>
+<circle cx="1452.8" cy="793.6" r="12" stroke="black" fill="white"/>
+<path d="M1440.8,793.6 L1464.8,793.6 M1452.8,781.6 L1452.8,805.6 " stroke="black"/>
+<path d="M1644.8,537.6 L1580.8,537.6 " stroke="black" stroke-width="5"/>
+<circle cx="1644.8" cy="537.6" r="12" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="537.6" r="12" stroke="black" fill="white"/>
+<path d="M1568.8,537.6 L1592.8,537.6 M1580.8,525.6 L1580.8,549.6 " stroke="black"/>
+<path d="M1644.8,665.6 L1580.8,665.6 " stroke="black" stroke-width="5"/>
+<circle cx="1644.8" cy="665.6" r="12" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="665.6" r="12" stroke="black" fill="white"/>
+<path d="M1568.8,665.6 L1592.8,665.6 M1580.8,653.6 L1580.8,677.6 " stroke="black"/>
+<path d="M1644.8,793.6 L1580.8,793.6 " stroke="black" stroke-width="5"/>
+<circle cx="1644.8" cy="793.6" r="12" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="793.6" r="12" stroke="black" fill="white"/>
+<path d="M1568.8,793.6 L1592.8,793.6 M1580.8,781.6 L1580.8,805.6 " stroke="black"/>
+<path d="M1516.8,601.6 L1580.8,601.6 " stroke="black" stroke-width="5"/>
+<circle cx="1516.8" cy="601.6" r="12" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="601.6" r="12" stroke="black" fill="white"/>
+<path d="M1568.8,601.6 L1592.8,601.6 M1580.8,589.6 L1580.8,613.6 " stroke="black"/>
+<path d="M1516.8,729.6 L1580.8,729.6 " stroke="black" stroke-width="5"/>
+<circle cx="1516.8" cy="729.6" r="12" stroke="none" fill="black"/>
+<circle cx="1580.8" cy="729.6" r="12" stroke="black" fill="white"/>
+<path d="M1568.8,729.6 L1592.8,729.6 M1580.8,717.6 L1580.8,741.6 " stroke="black"/>
+<path d="M1644.8,601.6 L1708.8,601.6 " stroke="black" stroke-width="5"/>
+<circle cx="1644.8" cy="601.6" r="12" stroke="none" fill="black"/>
+<circle cx="1708.8" cy="601.6" r="12" stroke="black" fill="white"/>
+<path d="M1696.8,601.6 L1720.8,601.6 M1708.8,589.6 L1708.8,613.6 " stroke="black"/>
+<path d="M1644.8,729.6 L1708.8,729.6 " stroke="black" stroke-width="5"/>
+<circle cx="1644.8" cy="729.6" r="12" stroke="none" fill="black"/>
+<circle cx="1708.8" cy="729.6" r="12" stroke="black" fill="white"/>
+<path d="M1696.8,729.6 L1720.8,729.6 M1708.8,717.6 L1708.8,741.6 " stroke="black"/>
 <rect x="128" y="979.2" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="144" y="995.2">H</text>
 <rect x="256" y="979.2" width="32" height="32" stroke="black" fill="white"/>

--- a/testdata/surface_code_time_slice.svg
+++ b/testdata/surface_code_time_slice.svg
@@ -186,30 +186,30 @@
 <circle cx="1685.07" cy="735.701" r="2" stroke="none" fill="black"/>
 <circle cx="1730.32" cy="780.956" r="2" stroke="none" fill="black"/>
 <circle cx="1685.07" cy="826.211" r="2" stroke="none" fill="black"/>
-<path d="M170.51,261.019 L125.255,215.764 " stroke="black" stroke-width="3"/>
-<circle cx="170.51" cy="261.019" r="8" stroke="none" fill="black"/>
-<circle cx="125.255" cy="215.764" r="8" stroke="black" fill="white"/>
-<path d="M117.255,215.764 L133.255,215.764 M125.255,207.764 L125.255,223.764 " stroke="black"/>
-<path d="M261.019,170.51 L215.764,125.255 " stroke="black" stroke-width="3"/>
-<circle cx="261.019" cy="170.51" r="8" stroke="none" fill="black"/>
-<circle cx="215.764" cy="125.255" r="8" stroke="black" fill="white"/>
-<path d="M207.764,125.255 L223.764,125.255 M215.764,117.255 L215.764,133.255 " stroke="black"/>
-<path d="M261.019,351.529 L215.764,306.274 " stroke="black" stroke-width="3"/>
-<circle cx="261.019" cy="351.529" r="8" stroke="none" fill="black"/>
-<circle cx="215.764" cy="306.274" r="8" stroke="black" fill="white"/>
-<path d="M207.764,306.274 L223.764,306.274 M215.764,298.274 L215.764,314.274 " stroke="black"/>
-<path d="M125.255,125.255 L170.51,170.51 " stroke="black" stroke-width="3"/>
-<circle cx="125.255" cy="125.255" r="8" stroke="none" fill="black"/>
-<circle cx="170.51" cy="170.51" r="8" stroke="black" fill="white"/>
-<path d="M162.51,170.51 L178.51,170.51 M170.51,162.51 L170.51,178.51 " stroke="black"/>
-<path d="M215.764,215.764 L261.019,261.019 " stroke="black" stroke-width="3"/>
-<circle cx="215.764" cy="215.764" r="8" stroke="none" fill="black"/>
-<circle cx="261.019" cy="261.019" r="8" stroke="black" fill="white"/>
-<path d="M253.019,261.019 L269.019,261.019 M261.019,253.019 L261.019,269.019 " stroke="black"/>
-<path d="M306.274,125.255 L351.529,170.51 " stroke="black" stroke-width="3"/>
-<circle cx="306.274" cy="125.255" r="8" stroke="none" fill="black"/>
-<circle cx="351.529" cy="170.51" r="8" stroke="black" fill="white"/>
-<path d="M343.529,170.51 L359.529,170.51 M351.529,162.51 L351.529,178.51 " stroke="black"/>
+<path d="M170.51,261.019 L125.255,215.764 " stroke="black" stroke-width="5"/>
+<circle cx="170.51" cy="261.019" r="12" stroke="none" fill="black"/>
+<circle cx="125.255" cy="215.764" r="12" stroke="black" fill="white"/>
+<path d="M113.255,215.764 L137.255,215.764 M125.255,203.764 L125.255,227.764 " stroke="black"/>
+<path d="M261.019,170.51 L215.764,125.255 " stroke="black" stroke-width="5"/>
+<circle cx="261.019" cy="170.51" r="12" stroke="none" fill="black"/>
+<circle cx="215.764" cy="125.255" r="12" stroke="black" fill="white"/>
+<path d="M203.764,125.255 L227.764,125.255 M215.764,113.255 L215.764,137.255 " stroke="black"/>
+<path d="M261.019,351.529 L215.764,306.274 " stroke="black" stroke-width="5"/>
+<circle cx="261.019" cy="351.529" r="12" stroke="none" fill="black"/>
+<circle cx="215.764" cy="306.274" r="12" stroke="black" fill="white"/>
+<path d="M203.764,306.274 L227.764,306.274 M215.764,294.274 L215.764,318.274 " stroke="black"/>
+<path d="M125.255,125.255 L170.51,170.51 " stroke="black" stroke-width="5"/>
+<circle cx="125.255" cy="125.255" r="12" stroke="none" fill="black"/>
+<circle cx="170.51" cy="170.51" r="12" stroke="black" fill="white"/>
+<path d="M158.51,170.51 L182.51,170.51 M170.51,158.51 L170.51,182.51 " stroke="black"/>
+<path d="M215.764,215.764 L261.019,261.019 " stroke="black" stroke-width="5"/>
+<circle cx="215.764" cy="215.764" r="12" stroke="none" fill="black"/>
+<circle cx="261.019" cy="261.019" r="12" stroke="black" fill="white"/>
+<path d="M249.019,261.019 L273.019,261.019 M261.019,249.019 L261.019,273.019 " stroke="black"/>
+<path d="M306.274,125.255 L351.529,170.51 " stroke="black" stroke-width="5"/>
+<circle cx="306.274" cy="125.255" r="12" stroke="none" fill="black"/>
+<circle cx="351.529" cy="170.51" r="12" stroke="black" fill="white"/>
+<path d="M339.529,170.51 L363.529,170.51 M351.529,158.51 L351.529,182.51 " stroke="black"/>
 <rect x="629.192" y="64" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="645.192" y="80">H</text>
 <rect x="719.701" y="154.51" width="32" height="32" stroke="black" fill="white"/>
@@ -242,102 +242,102 @@
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1594.56" y="261.019">H</text>
 <rect x="1669.06" y="335.529" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1685.06" y="351.529">H</text>
-<path d="M170.51,554.682 L215.764,599.937 " stroke="black" stroke-width="3"/>
-<circle cx="170.51" cy="554.682" r="8" stroke="none" fill="black"/>
-<circle cx="215.764" cy="599.937" r="8" stroke="black" fill="white"/>
-<path d="M207.764,599.937 L223.764,599.937 M215.764,591.937 L215.764,607.937 " stroke="black"/>
-<path d="M170.51,735.701 L215.764,780.956 " stroke="black" stroke-width="3"/>
-<circle cx="170.51" cy="735.701" r="8" stroke="none" fill="black"/>
-<circle cx="215.764" cy="780.956" r="8" stroke="black" fill="white"/>
-<path d="M207.764,780.956 L223.764,780.956 M215.764,772.956 L215.764,788.956 " stroke="black"/>
-<path d="M261.019,645.192 L306.274,690.446 " stroke="black" stroke-width="3"/>
-<circle cx="261.019" cy="645.192" r="8" stroke="none" fill="black"/>
-<circle cx="306.274" cy="690.446" r="8" stroke="black" fill="white"/>
-<path d="M298.274,690.446 L314.274,690.446 M306.274,682.446 L306.274,698.446 " stroke="black"/>
-<path d="M125.255,780.956 L80,735.701 " stroke="black" stroke-width="3"/>
-<circle cx="125.255" cy="780.956" r="8" stroke="none" fill="black"/>
-<circle cx="80" cy="735.701" r="8" stroke="black" fill="white"/>
-<path d="M72,735.701 L88,735.701 M80,727.701 L80,743.701 " stroke="black"/>
-<path d="M215.764,690.446 L170.51,645.192 " stroke="black" stroke-width="3"/>
-<circle cx="215.764" cy="690.446" r="8" stroke="none" fill="black"/>
-<circle cx="170.51" cy="645.192" r="8" stroke="black" fill="white"/>
-<path d="M162.51,645.192 L178.51,645.192 M170.51,637.192 L170.51,653.192 " stroke="black"/>
-<path d="M306.274,780.956 L261.019,735.701 " stroke="black" stroke-width="3"/>
-<circle cx="306.274" cy="780.956" r="8" stroke="none" fill="black"/>
-<circle cx="261.019" cy="735.701" r="8" stroke="black" fill="white"/>
-<path d="M253.019,735.701 L269.019,735.701 M261.019,727.701 L261.019,743.701 " stroke="black"/>
-<path d="M645.192,554.682 L599.937,599.937 " stroke="black" stroke-width="3"/>
-<circle cx="645.192" cy="554.682" r="8" stroke="none" fill="black"/>
-<circle cx="599.937" cy="599.937" r="8" stroke="black" fill="white"/>
-<path d="M591.937,599.937 L607.937,599.937 M599.937,591.937 L599.937,607.937 " stroke="black"/>
-<path d="M645.192,735.701 L599.937,780.956 " stroke="black" stroke-width="3"/>
-<circle cx="645.192" cy="735.701" r="8" stroke="none" fill="black"/>
-<circle cx="599.937" cy="780.956" r="8" stroke="black" fill="white"/>
-<path d="M591.937,780.956 L607.937,780.956 M599.937,772.956 L599.937,788.956 " stroke="black"/>
-<path d="M735.701,645.192 L690.446,690.446 " stroke="black" stroke-width="3"/>
-<circle cx="735.701" cy="645.192" r="8" stroke="none" fill="black"/>
-<circle cx="690.446" cy="690.446" r="8" stroke="black" fill="white"/>
-<path d="M682.446,690.446 L698.446,690.446 M690.446,682.446 L690.446,698.446 " stroke="black"/>
-<path d="M599.937,690.446 L554.682,735.701 " stroke="black" stroke-width="3"/>
-<circle cx="599.937" cy="690.446" r="8" stroke="none" fill="black"/>
-<circle cx="554.682" cy="735.701" r="8" stroke="black" fill="white"/>
-<path d="M546.682,735.701 L562.682,735.701 M554.682,727.701 L554.682,743.701 " stroke="black"/>
-<path d="M690.446,599.937 L645.192,645.192 " stroke="black" stroke-width="3"/>
-<circle cx="690.446" cy="599.937" r="8" stroke="none" fill="black"/>
-<circle cx="645.192" cy="645.192" r="8" stroke="black" fill="white"/>
-<path d="M637.192,645.192 L653.192,645.192 M645.192,637.192 L645.192,653.192 " stroke="black"/>
-<path d="M780.956,690.446 L735.701,735.701 " stroke="black" stroke-width="3"/>
-<circle cx="780.956" cy="690.446" r="8" stroke="none" fill="black"/>
-<circle cx="735.701" cy="735.701" r="8" stroke="black" fill="white"/>
-<path d="M727.701,735.701 L743.701,735.701 M735.701,727.701 L735.701,743.701 " stroke="black"/>
-<path d="M1119.87,735.701 L1165.13,690.446 " stroke="black" stroke-width="3"/>
-<circle cx="1119.87" cy="735.701" r="8" stroke="none" fill="black"/>
-<circle cx="1165.13" cy="690.446" r="8" stroke="black" fill="white"/>
-<path d="M1157.13,690.446 L1173.13,690.446 M1165.13,682.446 L1165.13,698.446 " stroke="black"/>
-<path d="M1210.38,645.192 L1255.64,599.937 " stroke="black" stroke-width="3"/>
-<circle cx="1210.38" cy="645.192" r="8" stroke="none" fill="black"/>
-<circle cx="1255.64" cy="599.937" r="8" stroke="black" fill="white"/>
-<path d="M1247.64,599.937 L1263.64,599.937 M1255.64,591.937 L1255.64,607.937 " stroke="black"/>
-<path d="M1210.38,826.211 L1255.64,780.956 " stroke="black" stroke-width="3"/>
-<circle cx="1210.38" cy="826.211" r="8" stroke="none" fill="black"/>
-<circle cx="1255.64" cy="780.956" r="8" stroke="black" fill="white"/>
-<path d="M1247.64,780.956 L1263.64,780.956 M1255.64,772.956 L1255.64,788.956 " stroke="black"/>
-<path d="M1074.62,690.446 L1119.87,645.192 " stroke="black" stroke-width="3"/>
-<circle cx="1074.62" cy="690.446" r="8" stroke="none" fill="black"/>
-<circle cx="1119.87" cy="645.192" r="8" stroke="black" fill="white"/>
-<path d="M1111.87,645.192 L1127.87,645.192 M1119.87,637.192 L1119.87,653.192 " stroke="black"/>
-<path d="M1165.13,780.956 L1210.38,735.701 " stroke="black" stroke-width="3"/>
-<circle cx="1165.13" cy="780.956" r="8" stroke="none" fill="black"/>
-<circle cx="1210.38" cy="735.701" r="8" stroke="black" fill="white"/>
-<path d="M1202.38,735.701 L1218.38,735.701 M1210.38,727.701 L1210.38,743.701 " stroke="black"/>
-<path d="M1255.64,690.446 L1300.89,645.192 " stroke="black" stroke-width="3"/>
-<circle cx="1255.64" cy="690.446" r="8" stroke="none" fill="black"/>
-<circle cx="1300.89" cy="645.192" r="8" stroke="black" fill="white"/>
-<path d="M1292.89,645.192 L1308.89,645.192 M1300.89,637.192 L1300.89,653.192 " stroke="black"/>
-<path d="M1594.56,735.701 L1549.3,690.446 " stroke="black" stroke-width="3"/>
-<circle cx="1594.56" cy="735.701" r="8" stroke="none" fill="black"/>
-<circle cx="1549.3" cy="690.446" r="8" stroke="black" fill="white"/>
-<path d="M1541.3,690.446 L1557.3,690.446 M1549.3,682.446 L1549.3,698.446 " stroke="black"/>
-<path d="M1685.06,645.192 L1639.81,599.937 " stroke="black" stroke-width="3"/>
-<circle cx="1685.06" cy="645.192" r="8" stroke="none" fill="black"/>
-<circle cx="1639.81" cy="599.937" r="8" stroke="black" fill="white"/>
-<path d="M1631.81,599.937 L1647.81,599.937 M1639.81,591.937 L1639.81,607.937 " stroke="black"/>
-<path d="M1685.06,826.211 L1639.81,780.956 " stroke="black" stroke-width="3"/>
-<circle cx="1685.06" cy="826.211" r="8" stroke="none" fill="black"/>
-<circle cx="1639.81" cy="780.956" r="8" stroke="black" fill="white"/>
-<path d="M1631.81,780.956 L1647.81,780.956 M1639.81,772.956 L1639.81,788.956 " stroke="black"/>
-<path d="M1549.3,599.937 L1594.56,645.192 " stroke="black" stroke-width="3"/>
-<circle cx="1549.3" cy="599.937" r="8" stroke="none" fill="black"/>
-<circle cx="1594.56" cy="645.192" r="8" stroke="black" fill="white"/>
-<path d="M1586.56,645.192 L1602.56,645.192 M1594.56,637.192 L1594.56,653.192 " stroke="black"/>
-<path d="M1639.81,690.446 L1685.06,735.701 " stroke="black" stroke-width="3"/>
-<circle cx="1639.81" cy="690.446" r="8" stroke="none" fill="black"/>
-<circle cx="1685.06" cy="735.701" r="8" stroke="black" fill="white"/>
-<path d="M1677.06,735.701 L1693.06,735.701 M1685.06,727.701 L1685.06,743.701 " stroke="black"/>
-<path d="M1730.32,599.937 L1775.57,645.192 " stroke="black" stroke-width="3"/>
-<circle cx="1730.32" cy="599.937" r="8" stroke="none" fill="black"/>
-<circle cx="1775.57" cy="645.192" r="8" stroke="black" fill="white"/>
-<path d="M1767.57,645.192 L1783.57,645.192 M1775.57,637.192 L1775.57,653.192 " stroke="black"/>
+<path d="M170.51,554.682 L215.764,599.937 " stroke="black" stroke-width="5"/>
+<circle cx="170.51" cy="554.682" r="12" stroke="none" fill="black"/>
+<circle cx="215.764" cy="599.937" r="12" stroke="black" fill="white"/>
+<path d="M203.764,599.937 L227.764,599.937 M215.764,587.937 L215.764,611.937 " stroke="black"/>
+<path d="M170.51,735.701 L215.764,780.956 " stroke="black" stroke-width="5"/>
+<circle cx="170.51" cy="735.701" r="12" stroke="none" fill="black"/>
+<circle cx="215.764" cy="780.956" r="12" stroke="black" fill="white"/>
+<path d="M203.764,780.956 L227.764,780.956 M215.764,768.956 L215.764,792.956 " stroke="black"/>
+<path d="M261.019,645.192 L306.274,690.446 " stroke="black" stroke-width="5"/>
+<circle cx="261.019" cy="645.192" r="12" stroke="none" fill="black"/>
+<circle cx="306.274" cy="690.446" r="12" stroke="black" fill="white"/>
+<path d="M294.274,690.446 L318.274,690.446 M306.274,678.446 L306.274,702.446 " stroke="black"/>
+<path d="M125.255,780.956 L80,735.701 " stroke="black" stroke-width="5"/>
+<circle cx="125.255" cy="780.956" r="12" stroke="none" fill="black"/>
+<circle cx="80" cy="735.701" r="12" stroke="black" fill="white"/>
+<path d="M68,735.701 L92,735.701 M80,723.701 L80,747.701 " stroke="black"/>
+<path d="M215.764,690.446 L170.51,645.192 " stroke="black" stroke-width="5"/>
+<circle cx="215.764" cy="690.446" r="12" stroke="none" fill="black"/>
+<circle cx="170.51" cy="645.192" r="12" stroke="black" fill="white"/>
+<path d="M158.51,645.192 L182.51,645.192 M170.51,633.192 L170.51,657.192 " stroke="black"/>
+<path d="M306.274,780.956 L261.019,735.701 " stroke="black" stroke-width="5"/>
+<circle cx="306.274" cy="780.956" r="12" stroke="none" fill="black"/>
+<circle cx="261.019" cy="735.701" r="12" stroke="black" fill="white"/>
+<path d="M249.019,735.701 L273.019,735.701 M261.019,723.701 L261.019,747.701 " stroke="black"/>
+<path d="M645.192,554.682 L599.937,599.937 " stroke="black" stroke-width="5"/>
+<circle cx="645.192" cy="554.682" r="12" stroke="none" fill="black"/>
+<circle cx="599.937" cy="599.937" r="12" stroke="black" fill="white"/>
+<path d="M587.937,599.937 L611.937,599.937 M599.937,587.937 L599.937,611.937 " stroke="black"/>
+<path d="M645.192,735.701 L599.937,780.956 " stroke="black" stroke-width="5"/>
+<circle cx="645.192" cy="735.701" r="12" stroke="none" fill="black"/>
+<circle cx="599.937" cy="780.956" r="12" stroke="black" fill="white"/>
+<path d="M587.937,780.956 L611.937,780.956 M599.937,768.956 L599.937,792.956 " stroke="black"/>
+<path d="M735.701,645.192 L690.446,690.446 " stroke="black" stroke-width="5"/>
+<circle cx="735.701" cy="645.192" r="12" stroke="none" fill="black"/>
+<circle cx="690.446" cy="690.446" r="12" stroke="black" fill="white"/>
+<path d="M678.446,690.446 L702.446,690.446 M690.446,678.446 L690.446,702.446 " stroke="black"/>
+<path d="M599.937,690.446 L554.682,735.701 " stroke="black" stroke-width="5"/>
+<circle cx="599.937" cy="690.446" r="12" stroke="none" fill="black"/>
+<circle cx="554.682" cy="735.701" r="12" stroke="black" fill="white"/>
+<path d="M542.682,735.701 L566.682,735.701 M554.682,723.701 L554.682,747.701 " stroke="black"/>
+<path d="M690.446,599.937 L645.192,645.192 " stroke="black" stroke-width="5"/>
+<circle cx="690.446" cy="599.937" r="12" stroke="none" fill="black"/>
+<circle cx="645.192" cy="645.192" r="12" stroke="black" fill="white"/>
+<path d="M633.192,645.192 L657.192,645.192 M645.192,633.192 L645.192,657.192 " stroke="black"/>
+<path d="M780.956,690.446 L735.701,735.701 " stroke="black" stroke-width="5"/>
+<circle cx="780.956" cy="690.446" r="12" stroke="none" fill="black"/>
+<circle cx="735.701" cy="735.701" r="12" stroke="black" fill="white"/>
+<path d="M723.701,735.701 L747.701,735.701 M735.701,723.701 L735.701,747.701 " stroke="black"/>
+<path d="M1119.87,735.701 L1165.13,690.446 " stroke="black" stroke-width="5"/>
+<circle cx="1119.87" cy="735.701" r="12" stroke="none" fill="black"/>
+<circle cx="1165.13" cy="690.446" r="12" stroke="black" fill="white"/>
+<path d="M1153.13,690.446 L1177.13,690.446 M1165.13,678.446 L1165.13,702.446 " stroke="black"/>
+<path d="M1210.38,645.192 L1255.64,599.937 " stroke="black" stroke-width="5"/>
+<circle cx="1210.38" cy="645.192" r="12" stroke="none" fill="black"/>
+<circle cx="1255.64" cy="599.937" r="12" stroke="black" fill="white"/>
+<path d="M1243.64,599.937 L1267.64,599.937 M1255.64,587.937 L1255.64,611.937 " stroke="black"/>
+<path d="M1210.38,826.211 L1255.64,780.956 " stroke="black" stroke-width="5"/>
+<circle cx="1210.38" cy="826.211" r="12" stroke="none" fill="black"/>
+<circle cx="1255.64" cy="780.956" r="12" stroke="black" fill="white"/>
+<path d="M1243.64,780.956 L1267.64,780.956 M1255.64,768.956 L1255.64,792.956 " stroke="black"/>
+<path d="M1074.62,690.446 L1119.87,645.192 " stroke="black" stroke-width="5"/>
+<circle cx="1074.62" cy="690.446" r="12" stroke="none" fill="black"/>
+<circle cx="1119.87" cy="645.192" r="12" stroke="black" fill="white"/>
+<path d="M1107.87,645.192 L1131.87,645.192 M1119.87,633.192 L1119.87,657.192 " stroke="black"/>
+<path d="M1165.13,780.956 L1210.38,735.701 " stroke="black" stroke-width="5"/>
+<circle cx="1165.13" cy="780.956" r="12" stroke="none" fill="black"/>
+<circle cx="1210.38" cy="735.701" r="12" stroke="black" fill="white"/>
+<path d="M1198.38,735.701 L1222.38,735.701 M1210.38,723.701 L1210.38,747.701 " stroke="black"/>
+<path d="M1255.64,690.446 L1300.89,645.192 " stroke="black" stroke-width="5"/>
+<circle cx="1255.64" cy="690.446" r="12" stroke="none" fill="black"/>
+<circle cx="1300.89" cy="645.192" r="12" stroke="black" fill="white"/>
+<path d="M1288.89,645.192 L1312.89,645.192 M1300.89,633.192 L1300.89,657.192 " stroke="black"/>
+<path d="M1594.56,735.701 L1549.3,690.446 " stroke="black" stroke-width="5"/>
+<circle cx="1594.56" cy="735.701" r="12" stroke="none" fill="black"/>
+<circle cx="1549.3" cy="690.446" r="12" stroke="black" fill="white"/>
+<path d="M1537.3,690.446 L1561.3,690.446 M1549.3,678.446 L1549.3,702.446 " stroke="black"/>
+<path d="M1685.06,645.192 L1639.81,599.937 " stroke="black" stroke-width="5"/>
+<circle cx="1685.06" cy="645.192" r="12" stroke="none" fill="black"/>
+<circle cx="1639.81" cy="599.937" r="12" stroke="black" fill="white"/>
+<path d="M1627.81,599.937 L1651.81,599.937 M1639.81,587.937 L1639.81,611.937 " stroke="black"/>
+<path d="M1685.06,826.211 L1639.81,780.956 " stroke="black" stroke-width="5"/>
+<circle cx="1685.06" cy="826.211" r="12" stroke="none" fill="black"/>
+<circle cx="1639.81" cy="780.956" r="12" stroke="black" fill="white"/>
+<path d="M1627.81,780.956 L1651.81,780.956 M1639.81,768.956 L1639.81,792.956 " stroke="black"/>
+<path d="M1549.3,599.937 L1594.56,645.192 " stroke="black" stroke-width="5"/>
+<circle cx="1549.3" cy="599.937" r="12" stroke="none" fill="black"/>
+<circle cx="1594.56" cy="645.192" r="12" stroke="black" fill="white"/>
+<path d="M1582.56,645.192 L1606.56,645.192 M1594.56,633.192 L1594.56,657.192 " stroke="black"/>
+<path d="M1639.81,690.446 L1685.06,735.701 " stroke="black" stroke-width="5"/>
+<circle cx="1639.81" cy="690.446" r="12" stroke="none" fill="black"/>
+<circle cx="1685.06" cy="735.701" r="12" stroke="black" fill="white"/>
+<path d="M1673.06,735.701 L1697.06,735.701 M1685.06,723.701 L1685.06,747.701 " stroke="black"/>
+<path d="M1730.32,599.937 L1775.57,645.192 " stroke="black" stroke-width="5"/>
+<circle cx="1730.32" cy="599.937" r="12" stroke="none" fill="black"/>
+<circle cx="1775.57" cy="645.192" r="12" stroke="black" fill="white"/>
+<path d="M1763.57,645.192 L1787.57,645.192 M1775.57,633.192 L1775.57,657.192 " stroke="black"/>
 <rect x="154.51" y="1013.36" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="170.51" y="1029.36">H</text>
 <rect x="245.019" y="1103.87" width="32" height="32" stroke="black" fill="white"/>

--- a/testdata/tick.svg
+++ b/testdata/tick.svg
@@ -33,7 +33,7 @@
 <rect x="720" y="48" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="736" y="64">H</text>
 <rect x="784" y="48" width="32" height="32" stroke="black" fill="white"/>
-<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="800" y="64">√X</text>
+<text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="24" x="800" y="64">√X</text>
 <path d="M644,40 L644,32 L828,32 L828,40 " stroke="black" fill="none"/>
 <path d="M644,184 L644,192 L828,192 L828,184 " stroke="black" fill="none"/>
 <rect x="848" y="48" width="32" height="32" stroke="black" fill="white"/>

--- a/testdata/two_qubits_gates.svg
+++ b/testdata/two_qubits_gates.svg
@@ -12,34 +12,34 @@
 <path d="M64,384 L1088,384 " stroke="black"/>
 <text dominant-baseline="central" text-anchor="end" font-family="monospace" font-size="12" x="64" y="384">q5</text>
 <path d="M96,64 L96,128 " stroke="black"/>
-<circle cx="96" cy="64" r="8" stroke="none" fill="black"/>
-<circle cx="96" cy="128" r="8" stroke="black" fill="white"/>
-<path d="M88,128 L104,128 M96,120 L96,136 " stroke="black"/>
+<circle cx="96" cy="64" r="12" stroke="none" fill="black"/>
+<circle cx="96" cy="128" r="12" stroke="black" fill="white"/>
+<path d="M84,128 L108,128 M96,116 L96,140 " stroke="black"/>
 <path d="M96,192 L96,256 " stroke="black"/>
-<circle cx="96" cy="192" r="8" stroke="none" fill="black"/>
-<circle cx="96" cy="256" r="8" stroke="black" fill="white"/>
-<path d="M88,256 L104,256 M96,248 L96,264 " stroke="black"/>
+<circle cx="96" cy="192" r="12" stroke="none" fill="black"/>
+<circle cx="96" cy="256" r="12" stroke="black" fill="white"/>
+<path d="M84,256 L108,256 M96,244 L96,268 " stroke="black"/>
 <path d="M96,320 L96,384 " stroke="black"/>
-<circle cx="96" cy="320" r="8" stroke="none" fill="black"/>
-<path d="M96,394 L87.3397,379 L104.66,379 Z" stroke="black" fill="gray"/>
+<circle cx="96" cy="320" r="12" stroke="none" fill="black"/>
+<path d="M96,400.8 L81.4508,375.6 L110.549,375.6 Z" stroke="black" fill="gray"/>
 <path d="M160,320 L160,384 " stroke="black"/>
-<circle cx="160" cy="384" r="8" stroke="none" fill="black"/>
-<path d="M160,330 L151.34,315 L168.66,315 Z" stroke="black" fill="gray"/>
+<circle cx="160" cy="384" r="12" stroke="none" fill="black"/>
+<path d="M160,336.8 L145.451,311.6 L174.549,311.6 Z" stroke="black" fill="gray"/>
 <path d="M160,64 L160,192 " stroke="black"/>
-<circle cx="160" cy="64" r="8" stroke="none" fill="black"/>
-<circle cx="160" cy="192" r="8" stroke="none" fill="black"/>
+<circle cx="160" cy="64" r="12" stroke="none" fill="black"/>
+<circle cx="160" cy="192" r="12" stroke="none" fill="black"/>
 <path d="M224,128 L224,256 " stroke="black"/>
-<circle cx="224" cy="128" r="8" stroke="none" fill="gray"/>
-<path d="M220,124 L228,132 M228,124 L220,132 " stroke="black"/>
-<circle cx="224" cy="256" r="8" stroke="none" fill="gray"/>
-<path d="M220,252 L228,260 M228,252 L220,260 " stroke="black"/>
+<circle cx="224" cy="128" r="12" stroke="none" fill="gray"/>
+<path d="M218,122 L230,134 M230,122 L218,134 " stroke="black"/>
+<circle cx="224" cy="256" r="12" stroke="none" fill="gray"/>
+<path d="M218,250 L230,262 M230,250 L218,262 " stroke="black"/>
 <path d="M288,192 L288,320 " stroke="black"/>
-<circle cx="288" cy="192" r="8" stroke="none" fill="gray"/>
-<path d="M284,188 L292,196 M292,188 L284,196 " stroke="black"/>
-<path d="M292,182 L300,182 M296,178 L296,190 " stroke="black"/>
-<circle cx="288" cy="320" r="8" stroke="none" fill="gray"/>
-<path d="M284,316 L292,324 M292,316 L284,324 " stroke="black"/>
-<path d="M292,310 L300,310 M296,306 L296,318 " stroke="black"/>
+<circle cx="288" cy="192" r="12" stroke="none" fill="gray"/>
+<path d="M282,186 L294,198 M294,186 L282,198 " stroke="black"/>
+<path d="M296,178 L304,178 M300,174 L300,190 " stroke="black"/>
+<circle cx="288" cy="320" r="12" stroke="none" fill="gray"/>
+<path d="M282,314 L294,326 M294,314 L282,326 " stroke="black"/>
+<path d="M296,306 L304,306 M300,302 L300,318 " stroke="black"/>
 <path d="M352,256 L352,384 " stroke="black"/>
 <rect x="336" y="240" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="16" x="352" y="256">√XX</text>
@@ -76,45 +76,45 @@
 <rect x="592" y="368" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="608" y="384">√ZZ<tspan baseline-shift="super" font-size="10">†</tspan></text>
 <path d="M608,64 L608,128 " stroke="black"/>
-<path d="M604,60 L612,68 M612,60 L604,68 " stroke="black"/>
-<path d="M604,124 L612,132 M612,124 L604,132 " stroke="black"/>
+<path d="M602,58 L614,70 M614,58 L602,70 " stroke="black"/>
+<path d="M602,122 L614,134 M614,122 L602,134 " stroke="black"/>
 <path d="M672,192 L672,256 " stroke="black"/>
-<circle cx="672" cy="192" r="8" stroke="black" fill="white"/>
-<path d="M664,192 L680,192 M672,184 L672,200 " stroke="black"/>
-<circle cx="672" cy="256" r="8" stroke="black" fill="white"/>
-<path d="M664,256 L680,256 M672,248 L672,264 " stroke="black"/>
+<circle cx="672" cy="192" r="12" stroke="black" fill="white"/>
+<path d="M660,192 L684,192 M672,180 L672,204 " stroke="black"/>
+<circle cx="672" cy="256" r="12" stroke="black" fill="white"/>
+<path d="M660,256 L684,256 M672,244 L672,268 " stroke="black"/>
 <path d="M736,256 L736,320 " stroke="black"/>
-<circle cx="736" cy="256" r="8" stroke="black" fill="white"/>
-<path d="M728,256 L744,256 M736,248 L736,264 " stroke="black"/>
-<path d="M736,330 L727.34,315 L744.66,315 Z" stroke="black" fill="gray"/>
+<circle cx="736" cy="256" r="12" stroke="black" fill="white"/>
+<path d="M724,256 L748,256 M736,244 L736,268 " stroke="black"/>
+<path d="M736,336.8 L721.451,311.6 L750.549,311.6 Z" stroke="black" fill="gray"/>
 <path d="M736,64 L736,128 " stroke="black"/>
-<circle cx="736" cy="64" r="8" stroke="black" fill="white"/>
-<path d="M728,64 L744,64 M736,56 L736,72 " stroke="black"/>
-<circle cx="736" cy="128" r="8" stroke="none" fill="black"/>
+<circle cx="736" cy="64" r="12" stroke="black" fill="white"/>
+<path d="M724,64 L748,64 M736,52 L736,76 " stroke="black"/>
+<circle cx="736" cy="128" r="12" stroke="none" fill="black"/>
 <path d="M800,192 L800,256 " stroke="black"/>
-<path d="M800,202 L791.34,187 L808.66,187 Z" stroke="black" fill="gray"/>
-<circle cx="800" cy="256" r="8" stroke="black" fill="white"/>
-<path d="M792,256 L808,256 M800,248 L800,264 " stroke="black"/>
+<path d="M800,208.8 L785.451,183.6 L814.549,183.6 Z" stroke="black" fill="gray"/>
+<circle cx="800" cy="256" r="12" stroke="black" fill="white"/>
+<path d="M788,256 L812,256 M800,244 L800,268 " stroke="black"/>
 <path d="M800,320 L800,384 " stroke="black"/>
-<path d="M800,330 L791.34,315 L808.66,315 Z" stroke="black" fill="gray"/>
-<path d="M800,394 L791.34,379 L808.66,379 Z" stroke="black" fill="gray"/>
+<path d="M800,336.8 L785.451,311.6 L814.549,311.6 Z" stroke="black" fill="gray"/>
+<path d="M800,400.8 L785.451,375.6 L814.549,375.6 Z" stroke="black" fill="gray"/>
 <path d="M800,64 L800,128 " stroke="black"/>
-<path d="M800,74 L791.34,59 L808.66,59 Z" stroke="black" fill="gray"/>
-<circle cx="800" cy="128" r="8" stroke="none" fill="black"/>
+<path d="M800,80.8 L785.451,55.6 L814.549,55.6 Z" stroke="black" fill="gray"/>
+<circle cx="800" cy="128" r="12" stroke="none" fill="black"/>
 <path d="M864,192 L864,256 " stroke="black"/>
-<circle cx="864" cy="192" r="8" stroke="none" fill="black"/>
-<circle cx="864" cy="256" r="8" stroke="black" fill="white"/>
-<path d="M856,256 L872,256 M864,248 L864,264 " stroke="black"/>
+<circle cx="864" cy="192" r="12" stroke="none" fill="black"/>
+<circle cx="864" cy="256" r="12" stroke="black" fill="white"/>
+<path d="M852,256 L876,256 M864,244 L864,268 " stroke="black"/>
 <path d="M864,320 L864,384 " stroke="black"/>
-<circle cx="864" cy="320" r="8" stroke="none" fill="black"/>
-<path d="M864,394 L855.34,379 L872.66,379 Z" stroke="black" fill="gray"/>
+<circle cx="864" cy="320" r="12" stroke="none" fill="black"/>
+<path d="M864,400.8 L849.451,375.6 L878.549,375.6 Z" stroke="black" fill="gray"/>
 <path d="M928,64 L928,384 " stroke="black"/>
-<circle cx="928" cy="64" r="8" stroke="none" fill="black"/>
-<circle cx="928" cy="384" r="8" stroke="none" fill="black"/>
+<circle cx="928" cy="64" r="12" stroke="none" fill="black"/>
+<circle cx="928" cy="384" r="12" stroke="none" fill="black"/>
 <path d="M992,192 L992,256 " stroke="black"/>
-<circle cx="992" cy="192" r="8" stroke="none" fill="black"/>
-<circle cx="992" cy="256" r="8" stroke="none" fill="black"/>
+<circle cx="992" cy="192" r="12" stroke="none" fill="black"/>
+<circle cx="992" cy="256" r="12" stroke="none" fill="black"/>
 <path d="M1056,128 L1056,320 " stroke="black"/>
-<circle cx="1056" cy="128" r="8" stroke="none" fill="black"/>
-<circle cx="1056" cy="320" r="8" stroke="none" fill="black"/>
+<circle cx="1056" cy="128" r="12" stroke="none" fill="black"/>
+<circle cx="1056" cy="320" r="12" stroke="none" fill="black"/>
 </svg>


### PR DESCRIPTION
This generalizes (and obsoletes) the clunky "depend on 4th coordinate being non-zero" flag

- Also fixed a few doc typos
- Also made some tweaks to the look of detector slice diagrams