### PR TITLE
Fix quadratic overhead when iteratively resizing Pauli strings and tableaus

### DIFF
--- a/src/stim/simulators/tableau_simulator.cc
+++ b/src/stim/simulators/tableau_simulator.cc
@@ -777,7 +777,7 @@ void TableauSimulator::ensure_large_enough_for_qubits(size_t num_qubits) {
     if (num_qubits <= inv_state.num_qubits) {
         return;
     }
-    inv_state.expand(num_qubits);
+    inv_state.expand(num_qubits, 1.1);
 }
 
 void TableauSimulator::sample_stream(FILE *in, FILE *out, SampleFormat format, bool interactive, std::mt19937_64 &rng) {

--- a/src/stim/simulators/tableau_simulator.test.cc
+++ b/src/stim/simulators/tableau_simulator.test.cc
@@ -960,7 +960,7 @@ TEST(TableauSimulator, set_num_qubits_reduce_preserves_scrambled_stabilizers) {
     TableauSimulator sim(rng, 4);
     sim.inv_state = Tableau::random(4, SHARED_TEST_RNG());
     auto s1 = sim.canonical_stabilizers();
-    sim.inv_state.expand(8);
+    sim.inv_state.expand(8, 1.0);
     scramble_stabilizers(sim);
     sim.set_num_qubits(4);
     auto s2 = sim.canonical_stabilizers();
@@ -2126,4 +2126,10 @@ TEST(TableauSimulator, measure_pauli_string) {
     }
     ASSERT_GT(t / 10000.0, 0.05);
     ASSERT_LT(t / 10000.0, 0.35);
+}
+
+TEST(TableauSimulator, amortized_resizing) {
+    TableauSimulator sim(SHARED_TEST_RNG(), 5120);
+    sim.ensure_large_enough_for_qubits(5121);
+    ASSERT_GT(sim.inv_state.xs.xt.num_minor_bits_padded(), 5600);
 }

--- a/src/stim/stabilizers/pauli_string.h
+++ b/src/stim/stabilizers/pauli_string.h
@@ -111,7 +111,19 @@ struct PauliString {
     /// Returns a string describing the given Pauli string, with one character per qubit.
     std::string str() const;
 
-    void ensure_num_qubits(size_t min_num_qubits);
+    /// Grows the pauli string to be at least as large as the given number
+    /// of qubits.
+    ///
+    /// Requires:
+    ///     resize_pad_factor >= 1
+    ///
+    /// Args:
+    ///     min_num_qubits: A minimum number of qubits that will be needed.
+    ///     resize_pad_factor: When resizing, memory will be overallocated
+    ///          so that the pauli string can be expanded to at least this
+    ///          many times the number of requested qubits. Use this to
+    ///          avoid quadratic overheads from constant slight expansions.
+    void ensure_num_qubits(size_t min_num_qubits, double resize_pad_factor);
 };
 
 /// Writes a string describing the given Pauli string to an output stream.

--- a/src/stim/stabilizers/pauli_string.pybind.cc
+++ b/src/stim/stabilizers/pauli_string.pybind.cc
@@ -102,7 +102,7 @@ PyPauliString &PyPauliString::operator+=(const PyPauliString &rhs) {
     }
 
     size_t n = value.num_qubits;
-    value.ensure_num_qubits(value.num_qubits + rhs.value.num_qubits);
+    value.ensure_num_qubits(value.num_qubits + rhs.value.num_qubits, 1.1);
     for (size_t k = 0; k < rhs.value.num_qubits; k++) {
         value.xs[k + n] = rhs.value.xs[k];
         value.zs[k + n] = rhs.value.zs[k];
@@ -281,10 +281,10 @@ PyPauliString PyPauliString::operator*(const PyPauliString &rhs) const {
 }
 
 PyPauliString &PyPauliString::operator*=(const PyPauliString &rhs) {
-    value.ensure_num_qubits(rhs.value.num_qubits);
+    value.ensure_num_qubits(rhs.value.num_qubits, 1.1);
     if (rhs.value.num_qubits < value.num_qubits) {
         PyPauliString copy = rhs;
-        copy.value.ensure_num_qubits(value.num_qubits);
+        copy.value.ensure_num_qubits(value.num_qubits, 1.0);
         *this *= copy;
         return *this;
     }

--- a/src/stim/stabilizers/pauli_string.test.cc
+++ b/src/stim/stabilizers/pauli_string.test.cc
@@ -317,8 +317,8 @@ TEST(PauliString, ensure_num_qubits) {
 TEST(PauliString, ensure_num_qubits_padded) {
     auto p = PauliString::from_str("IXYZ_I");
     auto p2 = p;
-    p.ensure_num_qubits(100, 10.0);
-    p2.ensure_num_qubits(100, 1.0);
+    p.ensure_num_qubits(1121, 10.0);
+    p2.ensure_num_qubits(1121, 1.0);
     ASSERT_GT(p.xs.num_simd_words, p2.xs.num_simd_words);
     ASSERT_EQ(p, p2);
 }

--- a/src/stim/stabilizers/pauli_string.test.cc
+++ b/src/stim/stabilizers/pauli_string.test.cc
@@ -217,10 +217,11 @@ TEST(pauli_string, foreign_memory) {
     size_t bits = 2048;
     auto buffer = simd_bits<MAX_BITWORD_WIDTH>::random(bits, SHARED_TEST_RNG());
     bool signs = false;
+    size_t num_qubits = MAX_BITWORD_WIDTH*2 - 12;
 
-    auto p1 = PauliStringRef(500, bit_ref(&signs, 0), buffer.word_range_ref(0, 2), buffer.word_range_ref(4, 2));
-    auto p1b = new PauliStringRef(500, bit_ref(&signs, 0), buffer.word_range_ref(0, 2), buffer.word_range_ref(4, 2));
-    auto p2 = PauliStringRef(500, bit_ref(&signs, 1), buffer.word_range_ref(2, 2), buffer.word_range_ref(6, 2));
+    auto p1 = PauliStringRef(num_qubits, bit_ref(&signs, 0), buffer.word_range_ref(0, 2), buffer.word_range_ref(4, 2));
+    auto p1b = new PauliStringRef(num_qubits, bit_ref(&signs, 0), buffer.word_range_ref(0, 2), buffer.word_range_ref(4, 2));
+    auto p2 = PauliStringRef(num_qubits, bit_ref(&signs, 1), buffer.word_range_ref(2, 2), buffer.word_range_ref(6, 2));
     PauliString copy_p1 = p1;
     // p1 aliases p1b.
     ASSERT_EQ(p1, *p1b);
@@ -298,18 +299,27 @@ TEST(PauliStringPtr, sparse_str) {
 
 TEST(PauliString, ensure_num_qubits) {
     auto p = PauliString::from_str("IXYZ_I");
-    p.ensure_num_qubits(1);
+    p.ensure_num_qubits(1, 1.0);
     ASSERT_EQ(p, PauliString::from_str("IXYZ_I"));
-    p.ensure_num_qubits(6);
+    p.ensure_num_qubits(6, 1.0);
     ASSERT_EQ(p, PauliString::from_str("IXYZ_I"));
-    p.ensure_num_qubits(7);
+    p.ensure_num_qubits(7, 1.0);
     ASSERT_EQ(p, PauliString::from_str("IXYZ_I_"));
-    p.ensure_num_qubits(1000);
+    p.ensure_num_qubits(1000, 1.0);
     PauliString p2(1000);
     p2.xs[1] = true;
     p2.xs[2] = true;
     p2.zs[2] = true;
     p2.zs[3] = true;
+    ASSERT_EQ(p, p2);
+}
+
+TEST(PauliString, ensure_num_qubits_padded) {
+    auto p = PauliString::from_str("IXYZ_I");
+    auto p2 = p;
+    p.ensure_num_qubits(100, 10.0);
+    p2.ensure_num_qubits(100, 1.0);
+    ASSERT_GT(p.xs.num_simd_words, p2.xs.num_simd_words);
     ASSERT_EQ(p, p2);
 }
 

--- a/src/stim/stabilizers/pauli_string_ref.cc
+++ b/src/stim/stabilizers/pauli_string_ref.cc
@@ -26,6 +26,8 @@ PauliStringRef::PauliStringRef(
     simd_bits_range_ref<MAX_BITWORD_WIDTH> init_xs,
     simd_bits_range_ref<MAX_BITWORD_WIDTH> init_zs)
     : num_qubits(init_num_qubits), sign(init_sign), xs(init_xs), zs(init_zs) {
+    assert(init_xs.num_bits_padded() == init_zs.num_bits_padded());
+    assert(init_xs.num_simd_words == (init_num_qubits + MAX_BITWORD_WIDTH - 1) / MAX_BITWORD_WIDTH);
 }
 
 std::string PauliStringRef::sparse_str() const {

--- a/src/stim/stabilizers/pauli_string_ref.h
+++ b/src/stim/stabilizers/pauli_string_ref.h
@@ -39,6 +39,10 @@ struct PauliStringRef {
     simd_bits_range_ref<MAX_BITWORD_WIDTH> xs, zs;
 
     /// Constructs a PauliStringRef pointing at the given sign, x, and z data.
+    ///
+    /// Requires:
+    ///     xs.num_bits_padded() == zs.num_bits_padded()
+    ///     xs.num_simd_words == ceil(num_qubits / MAX_BITWORD_WIDTH)
     PauliStringRef(
         size_t num_qubits,
         bit_ref sign,

--- a/src/stim/stabilizers/tableau.cc
+++ b/src/stim/stabilizers/tableau.cc
@@ -69,11 +69,21 @@ void Tableau::expand(size_t new_num_qubits, double resize_pad_factor) {
 }
 
 PauliStringRef TableauHalf::operator[](size_t input_qubit) {
-    return PauliStringRef(num_qubits, signs[input_qubit], xt[input_qubit], zt[input_qubit]);
+    size_t nw = (num_qubits + MAX_BITWORD_WIDTH - 1) / MAX_BITWORD_WIDTH;
+    return PauliStringRef(
+        num_qubits,
+        signs[input_qubit],
+        xt[input_qubit].word_range_ref(0, nw),
+        zt[input_qubit].word_range_ref(0, nw));
 }
 
 const PauliStringRef TableauHalf::operator[](size_t input_qubit) const {
-    return PauliStringRef(num_qubits, signs[input_qubit], xt[input_qubit], zt[input_qubit]);
+    size_t nw = (num_qubits + MAX_BITWORD_WIDTH - 1) / MAX_BITWORD_WIDTH;
+    return PauliStringRef(
+        num_qubits,
+        signs[input_qubit],
+        xt[input_qubit].word_range_ref(0, nw),
+        zt[input_qubit].word_range_ref(0, nw));
 }
 
 PauliString Tableau::eval_y_obs(size_t qubit) const {

--- a/src/stim/stabilizers/tableau.h
+++ b/src/stim/stabilizers/tableau.h
@@ -57,7 +57,21 @@ struct Tableau {
     PauliString eval_y_obs(size_t qubit) const;
 
     std::string str() const;
-    void expand(size_t new_num_qubits);
+
+    /// Grows the size of the tableau (or leaves it the same) by adding
+    /// new rows and columns with identity elements along the diagonal.
+    ///
+    /// Requires:
+    ///     new_num_qubits >= this.num_qubits
+    ///     resize_pad_factor >= 1
+    ///
+    /// Args:
+    ///     new_num_qubits: The new number of qubits the tableau represents.
+    ///     resize_pad_factor: When resizing, memory will be overallocated
+    ///          so that the tableau can be expanded to at least this many
+    ///          times the number of requested qubits. Use this to avoid
+    ///          quadratic overheads from constant slight expansions.
+    void expand(size_t new_num_qubits, double resize_pad_factor);
 
     /// Creates a Tableau representing the identity operation.
     static Tableau identity(size_t num_qubits);

--- a/src/stim/stabilizers/tableau.test.cc
+++ b/src/stim/stabilizers/tableau.test.cc
@@ -701,6 +701,14 @@ TEST(tableau, expand_pad) {
     }
 }
 
+TEST(tableau, expand_pad_equals) {
+    auto t = Tableau::random(15, SHARED_TEST_RNG());
+    auto t2 = t;
+    t.expand(500, 1.0);
+    t2.expand(500, 2.0);
+    ASSERT_EQ(t, t2);
+}
+
 TEST(tableau, transposed_access) {
     size_t n = 1000;
     Tableau t(n);

--- a/src/stim/stabilizers/tableau.test.cc
+++ b/src/stim/stabilizers/tableau.test.cc
@@ -876,7 +876,7 @@ TEST(tableau, direct_sum) {
     ASSERT_EQ(t3, t1 + t2);
 
     PauliString p1 = t1.xs[5];
-    p1.ensure_num_qubits(260 + 270);
+    p1.ensure_num_qubits(260 + 270, 1.0);
     ASSERT_EQ(t3.xs[5], p1);
 
     std::string p2 = t2.xs[6].str();

--- a/src/stim/stabilizers/tableau.test.cc
+++ b/src/stim/stabilizers/tableau.test.cc
@@ -624,8 +624,8 @@ TEST(tableau, expand) {
     auto t = Tableau::random(4, SHARED_TEST_RNG());
     auto t2 = t;
     for (size_t n = 8; n < 500; n += 255) {
-        t2.expand(n);
-        assert(t2.num_qubits == n);
+        t2.expand(n, n);
+        ASSERT_EQ(t2.num_qubits, n);
         for (size_t k = 0; k < n; k++) {
             if (k < 4) {
                 ASSERT_EQ(t.xs[k].sign, t2.xs[k].sign);
@@ -651,6 +651,51 @@ TEST(tableau, expand) {
                     ASSERT_EQ(t2.zs[k].xs[k2], false);
                     ASSERT_EQ(t2.zs[k].zs[k2], false);
                 }
+            }
+        }
+    }
+}
+
+TEST(tableau, expand_pad) {
+    auto t = Tableau::random(4, SHARED_TEST_RNG());
+    auto t2 = t;
+    size_t n = 8;
+    while (n < 10000) {
+        n++;
+        t2.expand(n, 2);
+    }
+
+    ASSERT_EQ(t2.num_qubits, n);
+    for (size_t k = 0; k < n; k++) {
+        if (k < 4) {
+            ASSERT_EQ(t.xs[k].sign, t2.xs[k].sign);
+            ASSERT_EQ(t.zs[k].sign, t2.zs[k].sign);
+        } else {
+            ASSERT_EQ(t2.xs[k].sign, false);
+            ASSERT_EQ(t2.zs[k].sign, false);
+        }
+        for (size_t k2 = 0; k2 < n; k2++) {
+            if (k2 == 4 && k > 8) {
+                k2 = k - 2;
+            }
+            if (k2 == k + 2) {
+                k2 = n - 1;
+            }
+            if (k < 4 && k2 < 4) {
+                ASSERT_EQ(t.xs[k].xs[k2], t2.xs[k].xs[k2]);
+                ASSERT_EQ(t.xs[k].zs[k2], t2.xs[k].zs[k2]);
+                ASSERT_EQ(t.zs[k].xs[k2], t2.zs[k].xs[k2]);
+                ASSERT_EQ(t.zs[k].zs[k2], t2.zs[k].zs[k2]);
+            } else if (k == k2) {
+                ASSERT_EQ(t2.xs[k].xs[k2], true);
+                ASSERT_EQ(t2.xs[k].zs[k2], false);
+                ASSERT_EQ(t2.zs[k].xs[k2], false);
+                ASSERT_EQ(t2.zs[k].zs[k2], true);
+            } else {
+                ASSERT_EQ(t2.xs[k].xs[k2], false);
+                ASSERT_EQ(t2.xs[k].zs[k2], false);
+                ASSERT_EQ(t2.zs[k].xs[k2], false);
+                ASSERT_EQ(t2.zs[k].zs[k2], false);
             }
         }
     }

--- a/src/stim/stabilizers/tableau.test.cc
+++ b/src/stim/stabilizers/tableau.test.cc
@@ -624,7 +624,7 @@ TEST(tableau, expand) {
     auto t = Tableau::random(4, SHARED_TEST_RNG());
     auto t2 = t;
     for (size_t n = 8; n < 500; n += 255) {
-        t2.expand(n, n);
+        t2.expand(n, 1.0);
         ASSERT_EQ(t2.num_qubits, n);
         for (size_t k = 0; k < n; k++) {
             if (k < 4) {


### PR DESCRIPTION
- I thought it wouldn't matter because the step size was at least 64, but a user running sims with hundreds of thousands of qubits noticed it being very slow due to this
- Add a required "resize pad factor" to the underlying C++ resizing methods for pauli strings and tableaus, and set it to `1.1` in most cases
- Break the invariant that the backing storage for tableaus and pauli strings must be exactly minimum after simd alignment (still a requirement for the PauliStringRef class; now explicitly asserted)