### PR TITLE
Squash issues in preparation for v1.11

### DIFF
--- a/glue/sample/src/sinter/_plotting.py
+++ b/glue/sample/src/sinter/_plotting.py
@@ -137,6 +137,9 @@ def plot_discard_rate(
             Must be 1 or larger. Hypothesis probabilities at most that many times as unlikely as the max likelihood
             hypothesis will be highlighted.
     """
+    if highlight_max_likelihood_factor is None:
+        highlight_max_likelihood_factor = 1
+
     def y_func(stat: 'sinter.TaskStats') -> Union[float, 'sinter.Fit']:
         result = fit_binomial(
             num_shots=stat.shots,
@@ -210,6 +213,8 @@ def plot_error_rate(
             Must be 1 or larger. Hypothesis probabilities at most that many times as unlikely as the max likelihood
             hypothesis will be highlighted.
     """
+    if highlight_max_likelihood_factor is None:
+        highlight_max_likelihood_factor = 1
     if not (highlight_max_likelihood_factor >= 1):
         raise ValueError(f"not (highlight_max_likelihood_factor={highlight_max_likelihood_factor} >= 1)")
 

--- a/glue/sample/src/sinter/_plotting_test.py
+++ b/glue/sample/src/sinter/_plotting_test.py
@@ -57,12 +57,29 @@ def test_plotting_does_not_crash():
         plot_args_func=lambda k, e: {'marker': "ov*sp^<>8PhH+xXDd|"[k]},
         failure_units_per_shot_func=lambda stats: stats.json_metadata['d'] * 3,
     )
+    sinter.plot_error_rate(
+        ax=ax,
+        stats=stats,
+        group_func=lambda e: f"Rotated Surface Code d={e.json_metadata['d']}",
+        x_func=lambda e: e.json_metadata['p'],
+        plot_args_func=lambda k, e: {'marker': "ov*sp^<>8PhH+xXDd|"[k]},
+        failure_units_per_shot_func=lambda stats: stats.json_metadata['d'] * 3,
+        highlight_max_likelihood_factor=None,
+    )
     sinter.plot_discard_rate(
         ax=ax,
         stats=stats,
         group_func=lambda e: f"Rotated Surface Code d={e.json_metadata['d']}",
         x_func=lambda e: e.json_metadata['p'],
         plot_args_func=lambda k, e: {'marker': "ov*sp^<>8PhH+xXDd|"[k]},
+    )
+    sinter.plot_discard_rate(
+        ax=ax,
+        stats=stats,
+        group_func=lambda e: f"Rotated Surface Code d={e.json_metadata['d']}",
+        x_func=lambda e: e.json_metadata['p'],
+        plot_args_func=lambda k, e: {'marker': "ov*sp^<>8PhH+xXDd|"[k]},
+        highlight_max_likelihood_factor=None,
     )
     sinter.plot_discard_rate(
         ax=ax,

--- a/src/stim/io/read_write_pytest.py
+++ b/src/stim/io/read_write_pytest.py
@@ -102,7 +102,6 @@ def test_read_shot_data_file_dets():
             num_detectors=10,
             num_observables=2,
         )
-
         assert result.dtype == np.bool8
         assert result.shape == (2, 12)
         np.testing.assert_array_equal(
@@ -110,6 +109,59 @@ def test_read_shot_data_file_dets():
             [
                 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                 [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0],
+            ])
+
+        # Separate observables
+        result_dets, result_obs = stim.read_shot_data_file(
+            path=path,
+            format='dets',
+            num_measurements=0,
+            num_detectors=10,
+            num_observables=2,
+            separate_observables=True,
+        )
+        assert result_dets.dtype == np.bool8
+        assert result_dets.shape == (2, 10)
+        np.testing.assert_array_equal(
+            result_dets,
+            [
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [1, 0, 0, 0, 0, 1, 0, 0, 0, 0],
+            ])
+        assert result_obs.dtype == np.bool8
+        assert result_obs.shape == (2, 2)
+        np.testing.assert_array_equal(
+            result_obs,
+            [
+                [0, 0],
+                [1, 0],
+            ])
+
+        # Separate observables bit packed.
+        result_dets, result_obs = stim.read_shot_data_file(
+            path=path,
+            format='dets',
+            num_measurements=0,
+            num_detectors=10,
+            num_observables=2,
+            separate_observables=True,
+            bit_packed=True,
+        )
+        assert result_dets.dtype == np.uint8
+        assert result_dets.shape == (2, 2)
+        np.testing.assert_array_equal(
+            result_dets,
+            [
+                [0, 0],
+                [0b00100001, 0],
+            ])
+        assert result_obs.dtype == np.uint8
+        assert result_obs.shape == (2, 1)
+        np.testing.assert_array_equal(
+            result_obs,
+            [
+                [0],
+                [1],
             ])
 
 

--- a/src/stim/simulators/dem_sampler.pybind.cc
+++ b/src/stim/simulators/dem_sampler.pybind.cc
@@ -135,8 +135,8 @@ void stim_pybind::pybind_dem_sampler_methods(pybind11::module &m, pybind11::clas
                     has the performance benefit of the data never being expanded into an
                     unpacked form.
                 return_errors: Defaults to False.
-                    False: the first entry of the returned tuple is None.
-                    True: the first entry of the returned tuple is a numpy array recording
+                    False: the third entry of the returned tuple is None.
+                    True: the third entry of the returned tuple is a numpy array recording
                     which errors were sampled.
                 recorded_errors_to_replay: Defaults to None, meaning sample errors randomly.
                     If not None, this is expected to be a 2d numpy array specifying which

--- a/src/stim/simulators/measurements_to_detection_events.pybind.cc
+++ b/src/stim/simulators/measurements_to_detection_events.pybind.cc
@@ -91,7 +91,10 @@ pybind11::object CompiledMeasurementsToDetectionEventsConverter::convert(
     const pybind11::object &sweep_bits,
     const pybind11::object &separate_observables_obj,
     const pybind11::object &append_observables_obj,
+    bool bit_pack_result_old_compat,
     bool bit_pack_result) {
+    bit_pack_result |= bit_pack_result_old_compat;
+
     if (separate_observables_obj.is_none() && append_observables_obj.is_none()) {
         throw std::invalid_argument(
             "To ignore observable flip data, you must explicitly specify either separate_observables=False or "
@@ -292,12 +295,13 @@ void stim_pybind::pybind_compiled_measurements_to_detection_events_converter_met
         pybind11::arg("sweep_bits") = pybind11::none(),
         pybind11::arg("separate_observables") = pybind11::none(),
         pybind11::arg("append_observables") = pybind11::none(),
-        pybind11::arg("bit_pack_result") = false,
+        pybind11::arg("bit_packed") = false,
+        pybind11::arg("bit_pack_result") = false, // deprecated variant
         clean_doc_string(R"DOC(
             Converts measurement data into detection event data.
-            @overload def convert(self, *, measurements: np.ndarray, sweep_bits: Optional[np.ndarray] = None, append_observables: bool = False, bit_pack_result: bool = False) -> np.ndarray:
-            @overload def convert(self, *, measurements: np.ndarray, sweep_bits: Optional[np.ndarray] = None, separate_observables: 'Literal[True]', append_observables: bool = False, bit_pack_result: bool = False) -> Tuple[np.ndarray, np.ndarray]:
-            @signature def convert(self, *, measurements: np.ndarray, sweep_bits: Optional[np.ndarray] = None, separate_observables: bool = False, append_observables: bool = False, bit_pack_result: bool = False) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
+            @overload def convert(self, *, measurements: np.ndarray, sweep_bits: Optional[np.ndarray] = None, append_observables: bool = False, bit_packed: bool = False) -> np.ndarray:
+            @overload def convert(self, *, measurements: np.ndarray, sweep_bits: Optional[np.ndarray] = None, separate_observables: 'Literal[True]', append_observables: bool = False, bit_packed: bool = False) -> Tuple[np.ndarray, np.ndarray]:
+            @signature def convert(self, *, measurements: np.ndarray, sweep_bits: Optional[np.ndarray] = None, separate_observables: bool = False, append_observables: bool = False, bit_packed: bool = False) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
 
             Args:
                 measurements: A numpy array containing measurement data.
@@ -321,7 +325,7 @@ void stim_pybind::pybind_compiled_measurements_to_detection_events_converter_met
                 append_observables: Defaults to False. When set to True, the observables in
                     the circuit are treated as if they were additional detectors. Their
                     results are appended to the end of the detection event data.
-                bit_pack_result: Defaults to False. When set to True, the returned numpy
+                bit_packed: Defaults to False. When set to True, the returned numpy
                     array contains bit packed data (dtype=np.uint8 with 8 bits per item)
                     instead of unpacked data (dtype=np.bool8).
 
@@ -333,7 +337,7 @@ void stim_pybind::pybind_compiled_measurements_to_detection_events_converter_met
                 When returning two numpy arrays, the first array is the detection event data
                 and the second is the observable flip data.
 
-                The dtype of the returned arrays is np.bool8 if bit_pack_result is false,
+                The dtype of the returned arrays is np.bool8 if bit_packed is false,
                 otherwise they're np.uint8 arrays.
 
                 shape[0] of the array(s) is the number of shots.

--- a/src/stim/simulators/measurements_to_detection_events.pybind.h
+++ b/src/stim/simulators/measurements_to_detection_events.pybind.h
@@ -46,6 +46,7 @@ struct CompiledMeasurementsToDetectionEventsConverter {
         const pybind11::object &sweep_bits,
         const pybind11::object &separate_observables,
         const pybind11::object &append_observables,
+        bool bit_pack_result_old_compat,
         bool bit_pack_result);
     void convert_file(
         const std::string &measurements_filepath,

--- a/src/stim/simulators/measurements_to_detection_events_test.py
+++ b/src/stim/simulators/measurements_to_detection_events_test.py
@@ -144,10 +144,20 @@ def test_convert_bit_packed():
         assert result.shape == (2, 100)
         np.testing.assert_array_equal(result, expected_detections)
 
+        # Check legacy argument name `bit_pack_result`.
         result = converter.convert(
             measurements=m,
             append_observables=False,
             bit_pack_result=True,
+        )
+        assert result.dtype == np.uint8
+        assert result.shape == (2, 13)
+        np.testing.assert_array_equal(result, expected_detections_packed)
+
+        result = converter.convert(
+            measurements=m,
+            append_observables=False,
+            bit_packed=True,
         )
         assert result.dtype == np.uint8
         assert result.shape == (2, 13)

--- a/src/stim/stabilizers/conversions.cc
+++ b/src/stim/stabilizers/conversions.cc
@@ -492,6 +492,19 @@ Tableau stim::stabilizers_to_tableau(
         num_qubits = std::max(num_qubits, e.num_qubits);
     }
 
+    for (size_t k1 = 0; k1 < stabilizers.size(); k1++) {
+        for (size_t k2 = 0; k2 < stabilizers.size(); k2++) {
+            if (!stabilizers[k1].ref().commutes(stabilizers[k2])) {
+                std::stringstream ss;
+                ss << "Some of the given stabilizers anticommute.\n";
+                ss << "For example:\n    ";
+                ss << stabilizers[k1];
+                ss << "\nanticommutes with\n";
+                ss << stabilizers[k2] << "\n";
+                throw std::invalid_argument(ss.str());
+            }
+        }
+    }
     Tableau inverted(num_qubits);
 
     PauliString cur(num_qubits);

--- a/src/stim/stabilizers/conversions.test.cc
+++ b/src/stim/stabilizers/conversions.test.cc
@@ -645,3 +645,10 @@ TEST(conversions, stabilizers_to_tableau_bell_pair) {
     // Anticommutes!
     ASSERT_THROW({ stabilizers_to_tableau(input_stabilizers, true, true, false); }, std::invalid_argument);
 }
+
+TEST(conversions, stabilizer_to_tableau_detect_anticommutation) {
+    std::vector<stim::PauliString> input_stabilizers;
+    input_stabilizers.push_back(PauliString::from_str("YY"));
+    input_stabilizers.push_back(PauliString::from_str("YX"));
+    ASSERT_THROW({ stabilizers_to_tableau(input_stabilizers, false, false, false); }, std::invalid_argument);
+}

--- a/src/stim/stabilizers/pauli_string.pybind.h
+++ b/src/stim/stabilizers/pauli_string.pybind.h
@@ -48,7 +48,7 @@ struct PyPauliString {
     PyPauliString &operator/=(const std::complex<float> &divisor);
 
     pybind11::object to_unitary_matrix(const std::string &endian) const;
-    static PyPauliString from_unitary_matrix(const pybind11::object &matrix, const std::string &endian);
+    static PyPauliString from_unitary_matrix(const pybind11::object &matrix, const std::string &endian, bool ignore_sign);
 
     bool operator==(const PyPauliString &other) const;
     bool operator!=(const PyPauliString &other) const;

--- a/src/stim/stabilizers/pauli_string_pybind_test.py
+++ b/src/stim/stabilizers/pauli_string_pybind_test.py
@@ -708,6 +708,19 @@ def test_from_unitary_matrix():
         [[-1, 0], [0, 1]]
     ) == stim.PauliString("-Z")
 
+    assert stim.PauliString.from_unitary_matrix(
+        [[1]], unsigned=True
+    ) == stim.PauliString("")
+    assert stim.PauliString.from_unitary_matrix(
+        [[-1]], unsigned=True
+    ) == stim.PauliString("")
+    assert stim.PauliString.from_unitary_matrix(
+        [[0, 1], [-1, 0]], unsigned=True
+    ) == stim.PauliString("Y")
+    assert stim.PauliString.from_unitary_matrix(
+        [[0, +1 * 1j**0.1], [-1 * 1j**0.1, 0]], unsigned=True
+    ) == stim.PauliString("Y")
+
     assert stim.PauliString.from_unitary_matrix([
         [0, 0, 0, -1j, 0, 0, 0, 0],
         [0, 0, -1j, 0, 0, 0, 0, 0],
@@ -728,6 +741,26 @@ def test_from_unitary_matrix():
         [0, 0, 0, 0, 0, -1j, 0, 0],
         [0, 0, 0, 0, -1j, 0, 0, 0],
     ], endian="big") == stim.PauliString("ZYX")
+    assert stim.PauliString.from_unitary_matrix(np.array([
+        [0, 0, 0, -1j, 0, 0, 0, 0],
+        [0, 0, -1j, 0, 0, 0, 0, 0],
+        [0, 1j, 0, 0, 0, 0, 0, 0],
+        [1j, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 1j],
+        [0, 0, 0, 0, 0, 0, 1j, 0],
+        [0, 0, 0, 0, 0, -1j, 0, 0],
+        [0, 0, 0, 0, -1j, 0, 0, 0],
+    ]) * 1j**0.1, endian="big", unsigned=True) == stim.PauliString("ZYX")
+    assert stim.PauliString.from_unitary_matrix(np.array([
+        [0, 0, 0, -1j, 0, 0, 0, 0],
+        [0, 0, -1j, 0, 0, 0, 0, 0],
+        [0, 1j, 0, 0, 0, 0, 0, 0],
+        [1j, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 1j],
+        [0, 0, 0, 0, 0, 0, 1j, 0],
+        [0, 0, 0, 0, 0, -1j, 0, 0],
+        [0, 0, 0, 0, -1j, 0, 0, 0],
+    ]) * -1, endian="big", unsigned=True) == stim.PauliString("ZYX")
 
 
 def test_from_unitary_matrix_detect_bad_matrix():


### PR DESCRIPTION
- Fix `stim.Tableau.from_stabilizers` not failing when given anticommuting stabilizers
- Add `unsigned` option to `stim.PauliString.from_unitary_matrix`
- Add prefered name `bit_packed` over legacy `bit_pack_result` to `CompiledMeasurementsToDetectionEventsConverter.convert`
- Add `separate_observables=False` to `stim.read_shot_data_file`

Fixes https://github.com/quantumlib/Stim/issues/468
Fixes https://github.com/quantumlib/Stim/issues/462
Fixes https://github.com/quantumlib/Stim/issues/459
Fixes https://github.com/quantumlib/Stim/issues/425
Fixes https://github.com/quantumlib/Stim/issues/413
Fixes https://github.com/quantumlib/Stim/issues/408