### PR TITLE
Squash more issues in preparation for v1.11

### DIFF
--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -250,10 +250,13 @@ API references for stable versions are kept on the [stim github wiki](https://gi
     - [`stim.Tableau.to_unitary_matrix`](#stim.Tableau.to_unitary_matrix)
     - [`stim.Tableau.x_output`](#stim.Tableau.x_output)
     - [`stim.Tableau.x_output_pauli`](#stim.Tableau.x_output_pauli)
+    - [`stim.Tableau.x_sign`](#stim.Tableau.x_sign)
     - [`stim.Tableau.y_output`](#stim.Tableau.y_output)
     - [`stim.Tableau.y_output_pauli`](#stim.Tableau.y_output_pauli)
+    - [`stim.Tableau.y_sign`](#stim.Tableau.y_sign)
     - [`stim.Tableau.z_output`](#stim.Tableau.z_output)
     - [`stim.Tableau.z_output_pauli`](#stim.Tableau.z_output_pauli)
+    - [`stim.Tableau.z_sign`](#stim.Tableau.z_sign)
 - [`stim.TableauIterator`](#stim.TableauIterator)
     - [`stim.TableauIterator.__iter__`](#stim.TableauIterator.__iter__)
     - [`stim.TableauIterator.__next__`](#stim.TableauIterator.__next__)
@@ -269,6 +272,8 @@ API references for stable versions are kept on the [stim github wiki](https://gi
     - [`stim.TableauSimulator.cx`](#stim.TableauSimulator.cx)
     - [`stim.TableauSimulator.cy`](#stim.TableauSimulator.cy)
     - [`stim.TableauSimulator.cz`](#stim.TableauSimulator.cz)
+    - [`stim.TableauSimulator.depolarize1`](#stim.TableauSimulator.depolarize1)
+    - [`stim.TableauSimulator.depolarize2`](#stim.TableauSimulator.depolarize2)
     - [`stim.TableauSimulator.do`](#stim.TableauSimulator.do)
     - [`stim.TableauSimulator.do_circuit`](#stim.TableauSimulator.do_circuit)
     - [`stim.TableauSimulator.do_pauli_string`](#stim.TableauSimulator.do_pauli_string)
@@ -309,14 +314,17 @@ API references for stable versions are kept on the [stim github wiki](https://gi
     - [`stim.TableauSimulator.state_vector`](#stim.TableauSimulator.state_vector)
     - [`stim.TableauSimulator.swap`](#stim.TableauSimulator.swap)
     - [`stim.TableauSimulator.x`](#stim.TableauSimulator.x)
+    - [`stim.TableauSimulator.x_error`](#stim.TableauSimulator.x_error)
     - [`stim.TableauSimulator.xcx`](#stim.TableauSimulator.xcx)
     - [`stim.TableauSimulator.xcy`](#stim.TableauSimulator.xcy)
     - [`stim.TableauSimulator.xcz`](#stim.TableauSimulator.xcz)
     - [`stim.TableauSimulator.y`](#stim.TableauSimulator.y)
+    - [`stim.TableauSimulator.y_error`](#stim.TableauSimulator.y_error)
     - [`stim.TableauSimulator.ycx`](#stim.TableauSimulator.ycx)
     - [`stim.TableauSimulator.ycy`](#stim.TableauSimulator.ycy)
     - [`stim.TableauSimulator.ycz`](#stim.TableauSimulator.ycz)
     - [`stim.TableauSimulator.z`](#stim.TableauSimulator.z)
+    - [`stim.TableauSimulator.z_error`](#stim.TableauSimulator.z_error)
     - [`stim.TableauSimulator.zcx`](#stim.TableauSimulator.zcx)
     - [`stim.TableauSimulator.zcy`](#stim.TableauSimulator.zcy)
     - [`stim.TableauSimulator.zcz`](#stim.TableauSimulator.zcz)
@@ -8494,6 +8502,31 @@ def x_output_pauli(
     """
 ```
 
+<a name="stim.Tableau.x_sign"></a>
+```python
+# stim.Tableau.x_sign
+
+# (in class stim.Tableau)
+def x_sign(
+    self,
+    target: int,
+) -> int:
+    """Returns just the sign of the result of conjugating an X generator.
+
+    This operation runs in constant time.
+
+    Args:
+        target: The qubit the X generator applies to.
+
+    Examples:
+        >>> import stim
+        >>> stim.Tableau.from_named_gate("S_DAG").x_sign(0)
+        -1
+        >>> stim.Tableau.from_named_gate("S").x_sign(0)
+        1
+    """
+```
+
 <a name="stim.Tableau.y_output"></a>
 ```python
 # stim.Tableau.y_output
@@ -8565,6 +8598,33 @@ def y_output_pauli(
     """
 ```
 
+<a name="stim.Tableau.y_sign"></a>
+```python
+# stim.Tableau.y_sign
+
+# (in class stim.Tableau)
+def y_sign(
+    self,
+    target: int,
+) -> int:
+    """Returns just the sign of the result of conjugating a Y generator.
+
+    Unlike x_sign and z_sign, this operation runs in linear time.
+    The Y generator has to be computed by multiplying the X and Z
+    outputs and the sign depends on all terms.
+
+    Args:
+        target: The qubit the Y generator applies to.
+
+    Examples:
+        >>> import stim
+        >>> stim.Tableau.from_named_gate("S_DAG").y_sign(0)
+        1
+        >>> stim.Tableau.from_named_gate("S").y_sign(0)
+        -1
+    """
+```
+
 <a name="stim.Tableau.z_output"></a>
 ```python
 # stim.Tableau.z_output
@@ -8633,6 +8693,31 @@ def z_output_pauli(
         2
         >>> t.z_output_pauli(1, 1)
         1
+    """
+```
+
+<a name="stim.Tableau.z_sign"></a>
+```python
+# stim.Tableau.z_sign
+
+# (in class stim.Tableau)
+def z_sign(
+    self,
+    target: int,
+) -> int:
+    """Returns just the sign of the result of conjugating a Z generator.
+
+    This operation runs in constant time.
+
+    Args:
+        target: The qubit the Z generator applies to.
+
+    Examples:
+        >>> import stim
+        >>> stim.Tableau.from_named_gate("SQRT_X_DAG").z_sign(0)
+        1
+        >>> stim.Tableau.from_named_gate("SQRT_X").z_sign(0)
+        -1
     """
 ```
 
@@ -9085,6 +9170,46 @@ def cz(
         *targets: The indices of the qubits to target with the gate.
             Applies the gate to the first two targets, then the next two targets,
             and so forth. There must be an even number of targets.
+    """
+```
+
+<a name="stim.TableauSimulator.depolarize1"></a>
+```python
+# stim.TableauSimulator.depolarize1
+
+# (in class stim.TableauSimulator)
+def depolarize1(
+    self,
+    *targets: int,
+    p: float,
+):
+    """Probabilistically applies single-qubit depolarization to targets.
+
+    Args:
+        *targets: The indices of the qubits to target with the noise.
+        p: The chance of the error being applied,
+            independently, to each qubit.
+    """
+```
+
+<a name="stim.TableauSimulator.depolarize2"></a>
+```python
+# stim.TableauSimulator.depolarize2
+
+# (in class stim.TableauSimulator)
+def depolarize2(
+    self,
+    *targets: int,
+    p: float,
+):
+    """Probabilistically applies two-qubit depolarization to targets.
+
+    Args:
+        *targets: The indices of the qubits to target with the noise.
+            The pairs of qubits are formed by
+            zip(targets[::1], targets[1::2]).
+        p: The chance of the error being applied,
+            independently, to each qubit pair.
     """
 ```
 
@@ -10338,6 +10463,25 @@ def x(
     """
 ```
 
+<a name="stim.TableauSimulator.x_error"></a>
+```python
+# stim.TableauSimulator.x_error
+
+# (in class stim.TableauSimulator)
+def x_error(
+    self,
+    *targets: int,
+    p: float,
+):
+    """Probabilistically applies X errors to targets.
+
+    Args:
+        *targets: The indices of the qubits to target with the noise.
+        p: The chance of the X error being applied,
+            independently, to each qubit.
+    """
+```
+
 <a name="stim.TableauSimulator.xcx"></a>
 ```python
 # stim.TableauSimulator.xcx
@@ -10408,6 +10552,25 @@ def y(
     """
 ```
 
+<a name="stim.TableauSimulator.y_error"></a>
+```python
+# stim.TableauSimulator.y_error
+
+# (in class stim.TableauSimulator)
+def y_error(
+    self,
+    *targets: int,
+    p: float,
+):
+    """Probabilistically applies Y errors to targets.
+
+    Args:
+        *targets: The indices of the qubits to target with the noise.
+        p: The chance of the Y error being applied,
+            independently, to each qubit.
+    """
+```
+
 <a name="stim.TableauSimulator.ycx"></a>
 ```python
 # stim.TableauSimulator.ycx
@@ -10475,6 +10638,25 @@ def z(
 
     Args:
         *targets: The indices of the qubits to target with the gate.
+    """
+```
+
+<a name="stim.TableauSimulator.z_error"></a>
+```python
+# stim.TableauSimulator.z_error
+
+# (in class stim.TableauSimulator)
+def y_error(
+    self,
+    *targets: int,
+    p: float,
+):
+    """Probabilistically applies Z errors to targets.
+
+    Args:
+        *targets: The indices of the qubits to target with the noise.
+        p: The chance of the Z error being applied,
+            independently, to each qubit.
     """
 ```
 

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -6540,6 +6540,24 @@ class Tableau:
             >>> t.x_output_pauli(1, 1)
             3
         """
+    def x_sign(
+        self,
+        target: int,
+    ) -> int:
+        """Returns just the sign of the result of conjugating an X generator.
+
+        This operation runs in constant time.
+
+        Args:
+            target: The qubit the X generator applies to.
+
+        Examples:
+            >>> import stim
+            >>> stim.Tableau.from_named_gate("S_DAG").x_sign(0)
+            -1
+            >>> stim.Tableau.from_named_gate("S").x_sign(0)
+            1
+        """
     def y_output(
         self,
         target: int,
@@ -6597,6 +6615,26 @@ class Tableau:
             >>> t.y_output_pauli(1, 1)
             2
         """
+    def y_sign(
+        self,
+        target: int,
+    ) -> int:
+        """Returns just the sign of the result of conjugating a Y generator.
+
+        Unlike x_sign and z_sign, this operation runs in linear time.
+        The Y generator has to be computed by multiplying the X and Z
+        outputs and the sign depends on all terms.
+
+        Args:
+            target: The qubit the Y generator applies to.
+
+        Examples:
+            >>> import stim
+            >>> stim.Tableau.from_named_gate("S_DAG").y_sign(0)
+            1
+            >>> stim.Tableau.from_named_gate("S").y_sign(0)
+            -1
+        """
     def z_output(
         self,
         target: int,
@@ -6653,6 +6691,24 @@ class Tableau:
             2
             >>> t.z_output_pauli(1, 1)
             1
+        """
+    def z_sign(
+        self,
+        target: int,
+    ) -> int:
+        """Returns just the sign of the result of conjugating a Z generator.
+
+        This operation runs in constant time.
+
+        Args:
+            target: The qubit the Z generator applies to.
+
+        Examples:
+            >>> import stim
+            >>> stim.Tableau.from_named_gate("SQRT_X_DAG").z_sign(0)
+            1
+            >>> stim.Tableau.from_named_gate("SQRT_X").z_sign(0)
+            -1
         """
 class TableauIterator:
     """Iterates over all stabilizer tableaus of a specified size.
@@ -7000,6 +7056,32 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+        """
+    def depolarize1(
+        self,
+        *targets: int,
+        p: float,
+    ):
+        """Probabilistically applies single-qubit depolarization to targets.
+
+        Args:
+            *targets: The indices of the qubits to target with the noise.
+            p: The chance of the error being applied,
+                independently, to each qubit.
+        """
+    def depolarize2(
+        self,
+        *targets: int,
+        p: float,
+    ):
+        """Probabilistically applies two-qubit depolarization to targets.
+
+        Args:
+            *targets: The indices of the qubits to target with the noise.
+                The pairs of qubits are formed by
+                zip(targets[::1], targets[1::2]).
+            p: The chance of the error being applied,
+                independently, to each qubit pair.
         """
     def do(
         self,
@@ -7971,6 +8053,18 @@ class TableauSimulator:
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
+    def x_error(
+        self,
+        *targets: int,
+        p: float,
+    ):
+        """Probabilistically applies X errors to targets.
+
+        Args:
+            *targets: The indices of the qubits to target with the noise.
+            p: The chance of the X error being applied,
+                independently, to each qubit.
+        """
     def xcx(
         self,
         *targets,
@@ -8013,6 +8107,18 @@ class TableauSimulator:
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
+    def y_error(
+        self,
+        *targets: int,
+        p: float,
+    ):
+        """Probabilistically applies Y errors to targets.
+
+        Args:
+            *targets: The indices of the qubits to target with the noise.
+            p: The chance of the Y error being applied,
+                independently, to each qubit.
+        """
     def ycx(
         self,
         *targets,
@@ -8054,6 +8160,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+        """
+    def y_error(
+        self,
+        *targets: int,
+        p: float,
+    ):
+        """Probabilistically applies Z errors to targets.
+
+        Args:
+            *targets: The indices of the qubits to target with the noise.
+            p: The chance of the Z error being applied,
+                independently, to each qubit.
         """
     def zcx(
         self,

--- a/doc/usage_command_line.md
+++ b/doc/usage_command_line.md
@@ -1112,6 +1112,7 @@ SYNOPSIS
         [--obs_out_format 01|b8|r8|ptb64|hits|dets] \
         [--out filepath] \
         [--out_format 01|b8|r8|ptb64|hits|dets] \
+        [--ran_without_feedback] \
         [--skip_reference_sample] \
         --sweep filepath \
         [--sweep_format 01|b8|r8|ptb64|hits|dets]
@@ -1247,6 +1248,22 @@ OPTIONS
         For a detailed description of each result format, see the result
         format reference:
         https://github.com/quantumlib/Stim/blob/main/doc/result_formats.md
+
+
+    --ran_without_feedback
+        Converts the results assuming all feedback operations were skipped.
+
+        Pauli feedback operations don't need to be performed on the quantum
+        computer. They can be performed within the classical control system.
+        As such, it often makes sense to skip them when sampling from the
+        circuit on hardware, and then account for this later during data
+        analysis. Turning on this flag means that the quantum computer
+        didn't apply the feedback operations, and it's the job of the m2d
+        conversion to read the measurement data, rewrite it to account for
+        feedback effects, then convert to detection events.
+
+        In the python API, the same effect can be achieved by using
+        stim.Circuit.with_inlined_feedback().compile_m2d_converter().
 
 
     --skip_reference_sample

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -6540,6 +6540,24 @@ class Tableau:
             >>> t.x_output_pauli(1, 1)
             3
         """
+    def x_sign(
+        self,
+        target: int,
+    ) -> int:
+        """Returns just the sign of the result of conjugating an X generator.
+
+        This operation runs in constant time.
+
+        Args:
+            target: The qubit the X generator applies to.
+
+        Examples:
+            >>> import stim
+            >>> stim.Tableau.from_named_gate("S_DAG").x_sign(0)
+            -1
+            >>> stim.Tableau.from_named_gate("S").x_sign(0)
+            1
+        """
     def y_output(
         self,
         target: int,
@@ -6597,6 +6615,26 @@ class Tableau:
             >>> t.y_output_pauli(1, 1)
             2
         """
+    def y_sign(
+        self,
+        target: int,
+    ) -> int:
+        """Returns just the sign of the result of conjugating a Y generator.
+
+        Unlike x_sign and z_sign, this operation runs in linear time.
+        The Y generator has to be computed by multiplying the X and Z
+        outputs and the sign depends on all terms.
+
+        Args:
+            target: The qubit the Y generator applies to.
+
+        Examples:
+            >>> import stim
+            >>> stim.Tableau.from_named_gate("S_DAG").y_sign(0)
+            1
+            >>> stim.Tableau.from_named_gate("S").y_sign(0)
+            -1
+        """
     def z_output(
         self,
         target: int,
@@ -6653,6 +6691,24 @@ class Tableau:
             2
             >>> t.z_output_pauli(1, 1)
             1
+        """
+    def z_sign(
+        self,
+        target: int,
+    ) -> int:
+        """Returns just the sign of the result of conjugating a Z generator.
+
+        This operation runs in constant time.
+
+        Args:
+            target: The qubit the Z generator applies to.
+
+        Examples:
+            >>> import stim
+            >>> stim.Tableau.from_named_gate("SQRT_X_DAG").z_sign(0)
+            1
+            >>> stim.Tableau.from_named_gate("SQRT_X").z_sign(0)
+            -1
         """
 class TableauIterator:
     """Iterates over all stabilizer tableaus of a specified size.
@@ -7000,6 +7056,32 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+        """
+    def depolarize1(
+        self,
+        *targets: int,
+        p: float,
+    ):
+        """Probabilistically applies single-qubit depolarization to targets.
+
+        Args:
+            *targets: The indices of the qubits to target with the noise.
+            p: The chance of the error being applied,
+                independently, to each qubit.
+        """
+    def depolarize2(
+        self,
+        *targets: int,
+        p: float,
+    ):
+        """Probabilistically applies two-qubit depolarization to targets.
+
+        Args:
+            *targets: The indices of the qubits to target with the noise.
+                The pairs of qubits are formed by
+                zip(targets[::1], targets[1::2]).
+            p: The chance of the error being applied,
+                independently, to each qubit pair.
         """
     def do(
         self,
@@ -7971,6 +8053,18 @@ class TableauSimulator:
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
+    def x_error(
+        self,
+        *targets: int,
+        p: float,
+    ):
+        """Probabilistically applies X errors to targets.
+
+        Args:
+            *targets: The indices of the qubits to target with the noise.
+            p: The chance of the X error being applied,
+                independently, to each qubit.
+        """
     def xcx(
         self,
         *targets,
@@ -8013,6 +8107,18 @@ class TableauSimulator:
         Args:
             *targets: The indices of the qubits to target with the gate.
         """
+    def y_error(
+        self,
+        *targets: int,
+        p: float,
+    ):
+        """Probabilistically applies Y errors to targets.
+
+        Args:
+            *targets: The indices of the qubits to target with the noise.
+            p: The chance of the Y error being applied,
+                independently, to each qubit.
+        """
     def ycx(
         self,
         *targets,
@@ -8054,6 +8160,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+        """
+    def y_error(
+        self,
+        *targets: int,
+        p: float,
+    ):
+        """Probabilistically applies Z errors to targets.
+
+        Args:
+            *targets: The indices of the qubits to target with the noise.
+            p: The chance of the Z error being applied,
+                independently, to each qubit.
         """
     def zcx(
         self,

--- a/src/stim/cmd/command_m2d.test.cc
+++ b/src/stim/cmd/command_m2d.test.cc
@@ -61,3 +61,56 @@ shot D0
 shot D0 D1
             )output"));
 }
+
+TEST(command_m2d, m2d_without_feedback) {
+    RaiiTempNamedFile tmp;
+    tmp.write_contents(R"CIRCUIT(
+        CX 0 2 1 2
+        M 2
+        CX rec[-1] 2
+        DETECTOR rec[-1]
+        TICK
+
+        CX 0 2 1 2
+        M 2
+        CX rec[-1] 2
+        DETECTOR rec[-1] rec[-2]
+        TICK
+
+        CX 0 2 1 2
+        M 2
+        CX rec[-1] 2
+        DETECTOR rec[-1] rec[-2]
+        TICK
+
+        M 0 1
+        DETECTOR rec[-1] rec[-2] rec[-3]
+        OBSERVABLE_INCLUDE(0) rec[-1]
+    )CIRCUIT");
+
+    ASSERT_EQ(
+        trim(run_captured_stim_main(
+            {"m2d", "--in_format=01", "--append_observables", "--out_format=dets", "--circuit", tmp.path.data()},
+            "00000\n10000\n01000\n00100\n00010\n00001\n")),
+        trim(R"output(
+shot
+shot D0 D1
+shot D1 D2
+shot D2 D3
+shot D3
+shot D3 L0
+            )output"));
+
+    ASSERT_EQ(
+        trim(run_captured_stim_main(
+            {"m2d", "--in_format=01", "--append_observables", "--out_format=dets", "--circuit", tmp.path.data(), "--ran_without_feedback"},
+            "00000\n11100\n01100\n00100\n00010\n00001\n")),
+        trim(R"output(
+shot
+shot D0 D1
+shot D1 D2
+shot D2 D3
+shot D3
+shot D3 L0
+            )output"));
+}

--- a/src/stim/simulators/tableau_simulator_pybind_test.py
+++ b/src/stim/simulators/tableau_simulator_pybind_test.py
@@ -640,3 +640,60 @@ def test_measure_observable():
     assert not s.measure_observable(stim.PauliString(5))
     n = sum(s.measure_observable(stim.PauliString(0), flip_probability=0.1) for _ in range(1000))
     assert 25 <= n <= 300
+
+
+def test_x_error():
+    s = stim.TableauSimulator()
+    assert s.peek_bloch(0) == stim.PauliString("+Z")
+    s.x_error(0, 1, 2, p=0)
+    assert s.peek_bloch(0) == stim.PauliString("+Z")
+    s.x_error(0, p=1)
+    assert s.peek_bloch(0) == stim.PauliString("-Z")
+
+
+def test_z_error():
+    s = stim.TableauSimulator()
+    s.reset_x(0)
+    assert s.peek_bloch(0) == stim.PauliString("+X")
+    s.z_error(0, p=0)
+    assert s.peek_bloch(0) == stim.PauliString("+X")
+    s.z_error(0, p=1)
+    assert s.peek_bloch(0) == stim.PauliString("-X")
+
+
+def test_y_error():
+    s = stim.TableauSimulator()
+    s.reset_y(0)
+    assert s.peek_bloch(0) == stim.PauliString("+Y")
+    s.x_error(0, p=0)
+    assert s.peek_bloch(0) == stim.PauliString("+Y")
+    s.x_error(0, p=1)
+    assert s.peek_bloch(0) == stim.PauliString("-Y")
+
+
+def test_depolarize1_error():
+    s = stim.TableauSimulator()
+    s.h(0)
+    s.cnot(0, 1)
+    t = s.current_inverse_tableau()
+    s.depolarize1(0, p=0)
+    assert s.current_inverse_tableau() == t
+    s.depolarize1(0, p=1)
+    assert s.current_inverse_tableau() != t
+
+
+def test_depolarize2_error():
+    s = stim.TableauSimulator()
+    s.h(0, 1)
+    s.cnot(0, 2, 1, 3)
+    t = s.current_inverse_tableau()
+    s.depolarize2(0, 1, p=0)
+    assert s.current_inverse_tableau() == t
+    with pytest.raises(ValueError, match='Two qubit'):
+        s.depolarize2(1, p=1)
+    assert s.current_inverse_tableau() == t
+    s.depolarize2(0, 1, p=1)
+    assert s.current_inverse_tableau() != t
+
+    with pytest.raises(ValueError, match='Unexpected argument'):
+        s.depolarize2(1, p=1, q=2)

--- a/src/stim/stabilizers/tableau.pybind.cc
+++ b/src/stim/stabilizers/tableau.pybind.cc
@@ -1041,6 +1041,86 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
             .data());
 
     c.def(
+        "x_sign",
+        [](Tableau &self, pybind11::ssize_t target) -> int {
+            if (target < 0 || (size_t)target >= self.num_qubits) {
+                throw std::invalid_argument("not 0 <= target < len(tableau)");
+            }
+            return self.xs.signs[target] ? -1 : +1;
+        },
+        pybind11::arg("target"),
+        clean_doc_string(R"DOC(
+            Returns just the sign of the result of conjugating an X generator.
+
+            This operation runs in constant time.
+
+            Args:
+                target: The qubit the X generator applies to.
+
+            Examples:
+                >>> import stim
+                >>> stim.Tableau.from_named_gate("S_DAG").x_sign(0)
+                -1
+                >>> stim.Tableau.from_named_gate("S").x_sign(0)
+                1
+        )DOC")
+            .data());
+
+    c.def(
+        "z_sign",
+        [](Tableau &self, pybind11::ssize_t target) -> int {
+            if (target < 0 || (size_t)target >= self.num_qubits) {
+                throw std::invalid_argument("not 0 <= target < len(tableau)");
+            }
+            return self.zs.signs[target] ? -1 : +1;
+        },
+        pybind11::arg("target"),
+        clean_doc_string(R"DOC(
+            Returns just the sign of the result of conjugating a Z generator.
+
+            This operation runs in constant time.
+
+            Args:
+                target: The qubit the Z generator applies to.
+
+            Examples:
+                >>> import stim
+                >>> stim.Tableau.from_named_gate("SQRT_X_DAG").z_sign(0)
+                1
+                >>> stim.Tableau.from_named_gate("SQRT_X").z_sign(0)
+                -1
+        )DOC")
+            .data());
+
+    c.def(
+        "y_sign",
+        [](Tableau &self, pybind11::ssize_t target) -> int {
+            if (target < 0 || (size_t)target >= self.num_qubits) {
+                throw std::invalid_argument("not 0 <= target < len(tableau)");
+            }
+            return self.y_output(target).sign ? -1 : +1;
+        },
+        pybind11::arg("target"),
+        clean_doc_string(R"DOC(
+            Returns just the sign of the result of conjugating a Y generator.
+
+            Unlike x_sign and z_sign, this operation runs in linear time.
+            The Y generator has to be computed by multiplying the X and Z
+            outputs and the sign depends on all terms.
+
+            Args:
+                target: The qubit the Y generator applies to.
+
+            Examples:
+                >>> import stim
+                >>> stim.Tableau.from_named_gate("S_DAG").y_sign(0)
+                1
+                >>> stim.Tableau.from_named_gate("S").y_sign(0)
+                -1
+        )DOC")
+            .data());
+
+    c.def(
         "y_output",
         [](Tableau &self, size_t target) {
             if (target >= self.num_qubits) {

--- a/src/stim/stabilizers/tableau_pybind_test.py
+++ b/src/stim/stabilizers/tableau_pybind_test.py
@@ -877,3 +877,48 @@ def test_to_from_numpy_fuzz(n: int):
     x2x, x2z, z2x, z2z, x_signs, z_signs = t.to_numpy(bit_packed=True)
     t2 = stim.Tableau.from_numpy(x2x=x2x, x2z=x2z, z2x=z2x, z2z=z2z, x_signs=x_signs, z_signs=z_signs)
     assert t2 == t
+
+
+def test_signs():
+    t = stim.Tableau.from_named_gate("S")
+    assert t.x_sign(0) == +1
+    assert t.y_sign(0) == -1
+    assert t.z_sign(0) == +1
+    t = stim.Tableau.from_named_gate("S_DAG")
+    assert t.x_sign(0) == -1
+    assert t.y_sign(0) == +1
+    assert t.z_sign(0) == +1
+    t = stim.Tableau.from_named_gate("SQRT_X")
+    assert t.x_sign(0) == +1
+    assert t.y_sign(0) == +1
+    assert t.z_sign(0) == -1
+
+    t = stim.Tableau.from_conjugated_generators(
+        xs=[
+            stim.PauliString("-XX"),
+            stim.PauliString("-ZZ"),
+        ],
+        zs=[
+            stim.PauliString("+IZ"),
+            stim.PauliString("-XI"),
+        ],
+    )
+    assert t.x_sign(0) == -1 == t.x_output(0).sign
+    assert t.x_sign(1) == -1 == t.x_output(1).sign
+    assert t.y_sign(0) == -1 == t.y_output(0).sign
+    assert t.y_sign(1) == -1 == t.y_output(1).sign
+    assert t.z_sign(0) == +1 == t.z_output(0).sign
+    assert t.z_sign(1) == -1 == t.z_output(1).sign
+
+    with pytest.raises(ValueError, match="target"):
+        _ = t.x_sign(-1)
+    with pytest.raises(ValueError, match="target"):
+        _ = t.y_sign(-1)
+    with pytest.raises(ValueError, match="target"):
+        _ = t.z_sign(-1)
+    with pytest.raises(ValueError, match="target"):
+        _ = t.x_sign(2)
+    with pytest.raises(ValueError, match="target"):
+        _ = t.y_sign(2)
+    with pytest.raises(ValueError, match="target"):
+        _ = t.z_sign(2)


### PR DESCRIPTION
- Add `stim.Tableau.{x,y,z}_sign`
- Add `stim.TableauSimulator.{x_error,y_error,z_error,depolarize1,depolarize2}`
- Add `--ran_without_feedback` option to `stim m2d`

Fixes https://github.com/quantumlib/Stim/issues/398

Fixes https://github.com/quantumlib/Stim/issues/411

Fixes https://github.com/quantumlib/Stim/issues/286