### PR TITLE
Fix some flaky tests

### DIFF
--- a/src/stim/circuit/circuit.cc
+++ b/src/stim/circuit/circuit.cc
@@ -608,7 +608,7 @@ void circuit_read_operations(Circuit &circuit, SOURCE read_char, READ_CONDITION 
         }
 
         // Fuse operations.
-        while (ops.size() > 1 && ops[ops.size() - 2].can_fuse(new_op)) {
+        if (ops.size() > 1 && ops[ops.size() - 2].can_fuse(new_op)) {
             fuse_data(ops[ops.size() - 2].target_data.targets, new_op.target_data.targets, circuit.target_buf);
             ops.pop_back();
         }

--- a/src/stim/cmd/command_sample.test.cc
+++ b/src/stim/cmd/command_sample.test.cc
@@ -161,7 +161,7 @@ TEST(command_sample, basic_distributions) {
     ASSERT_EQ(
         "",
         deviation(
-            run_captured_stim_main({"--sample=1000"}, R"input(
+            run_captured_stim_main({"--sample=10000"}, R"input(
 H 0
 CNOT 0 1
 M 0 1
@@ -171,7 +171,7 @@ M 0 1
     ASSERT_EQ(
         "",
         deviation(
-            run_captured_stim_main({"--sample=1000"}, R"input(
+            run_captured_stim_main({"--sample=10000"}, R"input(
 H 0
 CNOT 0 1
 SQRT_X 0 1
@@ -182,7 +182,7 @@ M 0 1
     ASSERT_EQ(
         "",
         deviation(
-            run_captured_stim_main({"--sample=1000"}, R"input(
+            run_captured_stim_main({"--sample=10000"}, R"input(
 H 0
 CNOT 0 1
 SQRT_Y 0 1
@@ -195,7 +195,7 @@ TEST(command_sample, sample_x_error) {
     ASSERT_EQ(
         "",
         deviation(
-            run_captured_stim_main({"--sample=10000"}, R"input(
+            run_captured_stim_main({"--sample=100000"}, R"input(
 X_ERROR(0.1) 0 1
 M 0 1
             )input"),
@@ -217,7 +217,7 @@ TEST(command_sample, sample_z_error) {
     ASSERT_EQ(
         "",
         deviation(
-            run_captured_stim_main({"--sample=10000"}, R"input(
+            run_captured_stim_main({"--sample=100000"}, R"input(
 H 0 1
 Z_ERROR(0.1) 0 1
 H 0 1
@@ -239,7 +239,7 @@ TEST(command_sample, sample_y_error) {
     ASSERT_EQ(
         "",
         deviation(
-            run_captured_stim_main({"--sample=10000"}, R"input(
+            run_captured_stim_main({"--sample=100000"}, R"input(
 Y_ERROR(0.1) 0 1
 M 0 1
             )input"),
@@ -261,7 +261,7 @@ TEST(command_sample, sample_depolarize1_error) {
     ASSERT_EQ(
         "",
         deviation(
-            run_captured_stim_main({"--sample=10000"}, R"input(
+            run_captured_stim_main({"--sample=100000"}, R"input(
 DEPOLARIZE1(0.3) 0 1
 M 0 1
             )input"),
@@ -270,7 +270,7 @@ M 0 1
     ASSERT_EQ(
         "",
         deviation(
-            run_captured_stim_main({"--sample=10000"}, R"input(
+            run_captured_stim_main({"--sample=100000"}, R"input(
 H 0 1
 DEPOLARIZE1(0.3) 0 1
 H 0 1
@@ -281,7 +281,7 @@ M 0 1
     ASSERT_EQ(
         "",
         deviation(
-            run_captured_stim_main({"--sample=10000"}, R"input(
+            run_captured_stim_main({"--sample=100000"}, R"input(
 H_YZ 0 1
 DEPOLARIZE1(0.3) 0 1
 H_YZ 0 1
@@ -294,7 +294,7 @@ TEST(command_sample, sample_depolarize2_error) {
     ASSERT_EQ(
         "",
         deviation(
-            run_captured_stim_main({"--sample=10000"}, R"input(
+            run_captured_stim_main({"--sample=100000"}, R"input(
 DEPOLARIZE2(0.1) 0 1
 M 0 1
             )input"),
@@ -303,7 +303,7 @@ M 0 1
     ASSERT_EQ(
         "",
         deviation(
-            run_captured_stim_main({"--sample=10000"}, R"input(
+            run_captured_stim_main({"--sample=100000"}, R"input(
 H 0
 H_YZ 1
 DEPOLARIZE2(0.3) 0 1

--- a/src/stim/diagram/circuit_timeline_helper.cc
+++ b/src/stim/diagram/circuit_timeline_helper.cc
@@ -125,7 +125,7 @@ ConstPointerRange<double> CircuitTimelineHelper::shifted_coordinates_in_workspac
             coord_workspace[k] += cur_coord_shift[k];
         }
     }
-    return {&coord_workspace[0], &coord_workspace[coords.size()]};
+    return {coord_workspace.data(), coord_workspace.data() + coords.size()};
 }
 
 void CircuitTimelineHelper::do_detector(const Operation &op) {

--- a/src/stim/diagram/detector_slice/detector_slice_set.cc
+++ b/src/stim/diagram/detector_slice/detector_slice_set.cc
@@ -562,7 +562,7 @@ void _draw_observable(
     size_t scale) {
     std::vector<GateTarget> terms_copy;
     terms_copy.insert(terms_copy.end(), terms.begin(), terms.end());
-    std::sort(terms_copy.begin(), terms_copy.end(), [&](GateTarget a, GateTarget b) {
+    std::stable_sort(terms_copy.begin(), terms_copy.end(), [&](GateTarget a, GateTarget b) {
         auto a2 = inv_space_fill_transform(unscaled_coords(a.qubit_value()));
         auto b2 = inv_space_fill_transform(unscaled_coords(b.qubit_value()));
         if (a2 != b2) {
@@ -647,7 +647,7 @@ void _start_many_body_svg_path(
         pts_workspace.push_back(coords(tick, term.qubit_value()));
     }
     auto center = pick_polygon_center(pts_workspace);
-    std::sort(pts_workspace.begin(), pts_workspace.end(), [&](Coord<2> a, Coord<2> b) {
+    std::stable_sort(pts_workspace.begin(), pts_workspace.end(), [&](Coord<2> a, Coord<2> b) {
         return angle_from_to(center, a) < angle_from_to(center, b);
     });
 

--- a/src/stim/mem/fixed_cap_vector.h
+++ b/src/stim/mem/fixed_cap_vector.h
@@ -61,10 +61,10 @@ class FixedCapVector {
         return &data[0];
     }
     T *end() {
-        return &data[num_used];
+        return &data[0] + num_used;
     }
     const T *end() const {
-        return &data[num_used];
+        return &data[0] + num_used;
     }
     const T *begin() const {
         return &data[0];

--- a/src/stim/stabilizers/conversions.cc
+++ b/src/stim/stabilizers/conversions.cc
@@ -163,7 +163,9 @@ std::vector<std::vector<std::complex<float>>> stim::tableau_to_unitary(const Tab
     size_t n = 1 << tableau.num_qubits;
     for (size_t row = 0; row < n; row++) {
         result.push_back({});
-        result.back().insert(result.back().end(), &flat[row * n], &flat[row * n + n]);
+        auto &back = result.back();
+        std::complex<float> *start = &flat[row * n];
+        back.insert(back.end(), start, start + n);
     }
     return result;
 }


### PR DESCRIPTION
- Use stable_sort in diagrams to avoid accidental reordering
- Fix re-checking for circuit operation fusing after fusing was done
- Increase sample counts in statistical tests
- Fix using &vector[vector.size()] instead of vector.data() + vector.size() to get end ptr of vector data