### PR TITLE
Fix SSSS=I redundancies in example decompositions

### DIFF
--- a/doc/gates.md
+++ b/doc/gates.md
@@ -1022,11 +1022,7 @@ Decomposition (into H, S, CX, M, R):
     S 1
     H 1
     CNOT 1 0
-    S 0
-    S 0
-    S 0
     CNOT 0 1
-    S 0
     H 0
     
 

--- a/doc/gates.md
+++ b/doc/gates.md
@@ -970,11 +970,7 @@ Decomposition (into H, S, CX, M, R):
 
     # The following circuit is equivalent (up to global phase) to `ISWAP 0 1`
     H 0
-    S 0
-    S 0
-    S 0
     CNOT 0 1
-    S 0
     CNOT 1 0
     H 1
     S 1

--- a/src/stim/circuit/gate_data_swaps.cc
+++ b/src/stim/circuit/gate_data_swaps.cc
@@ -89,11 +89,7 @@ Targets:
                     {"+ZY", "+IZ", "+YZ", "+ZI"},
                     R"CIRCUIT(
 H 0
-S 0
-S 0
-S 0
 CNOT 0 1
-S 0
 CNOT 1 0
 H 1
 S 1

--- a/src/stim/circuit/gate_data_swaps.cc
+++ b/src/stim/circuit/gate_data_swaps.cc
@@ -205,11 +205,7 @@ S 1
 S 1
 H 1
 CNOT 1 0
-S 0
-S 0
-S 0
 CNOT 0 1
-S 0
 H 0
 )CIRCUIT",
                 };


### PR DESCRIPTION
Fixes #499. Oops. Sorry.