### PR TITLE
Fix the cirq to stim conversion for circuits with tagged operations

### DIFF
--- a/glue/cirq/stimcirq/_cirq_to_stim.py
+++ b/glue/cirq/stimcirq/_cirq_to_stim.py
@@ -377,6 +377,7 @@ class CirqToStimHelper:
         t2f = gate_type_to_stim_append_func()
         for op in operations:
             assert isinstance(op, cirq.Operation)
+            op = op.untagged
             gate = op.gate
             targets = [self.q2i[q] for q in op.qubits]
 

--- a/glue/cirq/stimcirq/_cirq_to_stim_test.py
+++ b/glue/cirq/stimcirq/_cirq_to_stim_test.py
@@ -336,10 +336,13 @@ def test_on_loop():
                 cirq.measure(b, key="b"),
             ),
             repetitions=3,
-        )
+        ).with_tags('my_tag')
     )
     result = stimcirq.StimSampler().run(c)
     assert result.measurements.keys() == {'0:a', '0:b', '1:a', '1:b', '2:a', '2:b'}
+    
+    stim_circuit = stimcirq.cirq_circuit_to_stim_circuit(c)
+    assert stim.CircuitRepeatBlock in {type(instr) for instr in stim_circuit}
 
 
 def test_random_gate_channel():

--- a/glue/cirq/stimcirq/_cirq_to_stim_test.py
+++ b/glue/cirq/stimcirq/_cirq_to_stim_test.py
@@ -336,10 +336,24 @@ def test_on_loop():
                 cirq.measure(b, key="b"),
             ),
             repetitions=3,
-        ).with_tags('my_tag')
+        )
     )
     result = stimcirq.StimSampler().run(c)
     assert result.measurements.keys() == {'0:a', '0:b', '1:a', '1:b', '2:a', '2:b'}
+
+def test_on_tagged_loop():
+    a, b = cirq.LineQubit.range(2)
+    c = cirq.Circuit(
+        cirq.CircuitOperation(
+            cirq.FrozenCircuit(
+                cirq.X(a),
+                cirq.X(b),
+                cirq.measure(a, key="a"),
+                cirq.measure(b, key="b"),
+            ),
+            repetitions=3,
+        ).with_tags('my_tag')
+    )
     
     stim_circuit = stimcirq.cirq_circuit_to_stim_circuit(c)
     assert stim.CircuitRepeatBlock in {type(instr) for instr in stim_circuit}


### PR DESCRIPTION
In particular, tagged loops will make following check fail

```python
if isinstance(op, cirq.CircuitOperation):
        self.process_circuit_operation_into_repeat_block(op)
        continue
```

Since the conversion function seems to be ignoring the tags, I simply untagged them at the beginning of the loop and let everything else proceed with the same current assumption of untagged operations.