### PR TITLE
Separate repeat block in their own moment

### DIFF
--- a/glue/cirq/stimcirq/_stim_to_cirq.py
+++ b/glue/cirq/stimcirq/_stim_to_cirq.py
@@ -117,13 +117,19 @@ class CircuitTranslationTracker:
         child.qubit_coords = self.qubit_coords.copy()
         child.have_seen_loop = True
         child.process_circuit(1, block.body_copy())
-        self.append_operation(
+
+        # Circuit operation will always be in their own cirq.Moment
+        if len(self.tick_circuit):
+            self.full_circuit += self.tick_circuit
+        self.full_circuit += cirq.Moment(
             cirq.CircuitOperation(
                 cirq.FrozenCircuit(child.full_circuit + child.tick_circuit),
                 repetitions=block.repeat_count,
                 use_repetition_ids=False,
             )
         )
+        self.tick_circuit = cirq.Circuit()
+
         self.qubit_coords = child.qubit_coords
         self.num_measurements_seen += (
             child.num_measurements_seen - self.num_measurements_seen

--- a/glue/cirq/stimcirq/_stim_to_cirq_test.py
+++ b/glue/cirq/stimcirq/_stim_to_cirq_test.py
@@ -589,3 +589,15 @@ def test_single_repeat_loops_always_flattened():
             repetitions=1,
         ),
     )) == stim.Circuit("H 0\nTICK")
+
+def test_circuit_operations_always_in_isolated_moment():
+    stim_circuit = stim.Circuit(
+        """
+        REPEAT 2 {
+            H 0 1
+        }
+        H 2 3
+        """
+    )
+    cirq_circuit = stimcirq.stim_circuit_to_cirq_circuit(stim_circuit)
+    assert len(cirq_circuit) == 2 # 1 moment would mean overlap of circuit operation

--- a/glue/cirq/stimcirq/_stim_to_cirq_test.py
+++ b/glue/cirq/stimcirq/_stim_to_cirq_test.py
@@ -601,3 +601,5 @@ def test_circuit_operations_always_in_isolated_moment():
     )
     cirq_circuit = stimcirq.stim_circuit_to_cirq_circuit(stim_circuit)
     assert len(cirq_circuit) == 2 # 1 moment would mean overlap of circuit operation
+    assert len(cirq_circuit[0].operations) == 1
+    assert isinstance(cirq_circuit[0].operations[0].untagged, cirq.CircuitOperation)

--- a/glue/cirq/stimcirq/_stim_to_cirq_test.py
+++ b/glue/cirq/stimcirq/_stim_to_cirq_test.py
@@ -600,6 +600,13 @@ def test_circuit_operations_always_in_isolated_moment():
         """
     )
     cirq_circuit = stimcirq.stim_circuit_to_cirq_circuit(stim_circuit)
-    assert len(cirq_circuit) == 2 # 1 moment would mean overlap of circuit operation
-    assert len(cirq_circuit[0].operations) == 1
-    assert isinstance(cirq_circuit[0].operations[0].untagged, cirq.CircuitOperation)
+    qs = cirq.LineQubit.range(4)
+    expected_cirq_circuit = cirq.Circuit(
+        cirq.CircuitOperation(
+            circuit=cirq.FrozenCircuit([cirq.H(qs[0]),cirq.H(qs[1])]), 
+            repetitions=2, 
+            use_repetition_ids=False
+        ),
+        cirq.Moment(cirq.H(qs[2]),cirq.H(qs[3])),
+    )
+    assert cirq_circuit == expected_cirq_circuit


### PR DESCRIPTION
This modification ensures that `cirq.CircuitOperation` are always isolated in their own `cirq.Moment`