### PR TITLE
Make stim.PauliString.before/after work in more situations

### DIFF
--- a/src/stim/circuit/circuit.h
+++ b/src/stim/circuit/circuit.h
@@ -192,7 +192,20 @@ struct Circuit {
     Circuit flattened() const;
 
     /// Returns a circuit that implements the inverse Clifford operation.
-    Circuit inverse() const;
+    ///
+    /// Args:
+    ///     allow_weak_inverse: When this is set to true, the inverse of the circuit doesn't need
+    ///         to be exact. In particular, noise and measurement becomes self-inverse. Examples:
+    ///             - The weak inverse of MX is MX.
+    ///             - The weak inverse of MRX is MRX.
+    ///             - The weak inverse of RX is MRX.
+    ///             - The weak inverse of X_ERROR(0.1) is X_ERROR(0.1).
+    ///             - The weak inverse of DETECTOR is [discard the operation].
+    ///             - The weak inverse of OBSERVABLE_INCLUDE is [discard the operation].
+    ///
+    /// Returns:
+    ///     The inverted circuit.
+    Circuit inverse(bool allow_weak_inverse = false) const;
 
     /// Helper method for executing the circuit, e.g. repeating REPEAT blocks.
     template <typename CALLBACK>

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -1877,7 +1877,9 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
 
     c.def(
         "inverse",
-        &Circuit::inverse,
+        [](const Circuit &self) -> Circuit {
+            return self.inverse();
+        },
         clean_doc_string(R"DOC(
             Returns a circuit that applies the same operations but inverted and in reverse.
 

--- a/src/stim/circuit/circuit.test.cc
+++ b/src/stim/circuit/circuit.test.cc
@@ -1512,6 +1512,70 @@ TEST(circuit, inverse) {
             S 0
         )CIRCUIT"));
 
+    ASSERT_EQ(
+        Circuit(R"CIRCUIT(
+            SHIFT_COORDS(-2, 3)
+            TICK
+            TICK
+            SHIFT_COORDS(4)
+            TICK
+        )CIRCUIT")
+            .inverse(),
+        Circuit(R"CIRCUIT(
+            TICK
+            SHIFT_COORDS(-4)
+            TICK
+            TICK
+            SHIFT_COORDS(2, -3)
+        )CIRCUIT"));
+
+    ASSERT_EQ(
+        Circuit(R"CIRCUIT(
+            X_ERROR(0.125) 0 1
+            Y_ERROR(0.125) 1 2
+            Z_ERROR(0.125) 2 3
+            PAULI_CHANNEL_1(0.125, 0.25, 0) 0 1 0 0
+            PAULI_CHANNEL_2(0, 0.125, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) 5 7 2 3
+            DEPOLARIZE1(0.25) 4 5 6
+            DEPOLARIZE2(0.25) 1 2 3 4
+            REPEAT 2 {
+                MX(0.125) 3 4
+                MY(0.125) 5 6
+                M(0.125) 7 8
+            }
+            MRX(0.125) 9 10
+            MRY(0.125) 11 12
+            MR(0.125) 13 14
+            RX 15 16
+            DETECTOR rec[-1]
+            OBSERVABLE_INCLUDE(0) rec[-1]
+            RY 17 18
+            R 19 20
+            MPP(0.125) X0*X1 Y2*Y3*Y4 Z5*Y6
+        )CIRCUIT")
+            .inverse(true),
+        Circuit(R"CIRCUIT(
+            MPP(0.125) Y6*Z5 Y4*Y3*Y2 X1*X0
+            MR 20 19
+            MRY 18 17
+            MRX 16 15
+            MR(0.125) 14 13
+            MRY(0.125) 12 11
+            MRX(0.125) 10 9
+            REPEAT 2 {
+                M(0.125) 8 7
+                MY(0.125) 6 5
+                MX(0.125) 4 3
+            }
+            DEPOLARIZE2(0.25) 3 4 1 2
+            DEPOLARIZE1(0.25) 6 5 4
+            PAULI_CHANNEL_2(0, 0.125, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) 2 3 5 7
+            PAULI_CHANNEL_1(0.125, 0.25, 0) 0 0 1 0
+            Z_ERROR(0.125) 3 2
+            Y_ERROR(0.125) 2 1
+            X_ERROR(0.125) 1 0
+        )CIRCUIT"));
+
     ASSERT_THROW({ Circuit("X_ERROR(0.125) 0").inverse(); }, std::invalid_argument);
     ASSERT_THROW({ Circuit("M(0.125) 0").inverse(); }, std::invalid_argument);
     ASSERT_THROW({ Circuit("M 0").inverse(); }, std::invalid_argument);
@@ -1520,4 +1584,5 @@ TEST(circuit, inverse) {
     ASSERT_THROW({ Circuit("MPP X0*X1").inverse(); }, std::invalid_argument);
     ASSERT_THROW({ Circuit("DETECTOR").inverse(); }, std::invalid_argument);
     ASSERT_THROW({ Circuit("OBSERVABLE_INCLUDE").inverse(); }, std::invalid_argument);
+    ASSERT_THROW({ Circuit("ELSE_CORRELATED_ERROR(0.125) X0").inverse(true); }, std::invalid_argument);
 }

--- a/src/stim/circuit/gate_data.cc
+++ b/src/stim/circuit/gate_data.cc
@@ -70,26 +70,10 @@ std::vector<std::vector<std::complex<float>>> Gate::unitary() const {
 
 const Gate &Gate::inverse() const {
     std::string inv_name = name;
-    if (!(flags & GATE_IS_UNITARY)) {
-        throw std::out_of_range(inv_name + " has no inverse.");
+    if ((flags & GATE_IS_UNITARY) || id == gate_name_to_id("TICK")) {
+        return GATE_DATA.items[best_candidate_inverse_id];
     }
-
-    if (GATE_DATA.has(inv_name + "_DAG")) {
-        inv_name += "_DAG";
-    } else if (inv_name.size() > 4 && inv_name.substr(inv_name.size() - 4) == "_DAG") {
-        inv_name = inv_name.substr(0, inv_name.size() - 4);
-    } else if (id == gate_name_to_id("C_XYZ")) {
-        inv_name = "C_ZYX";
-    } else if (id == gate_name_to_id("C_ZYX")) {
-        inv_name = "C_XYZ";
-    } else if (id == gate_name_to_id("CXSWAP")) {
-        inv_name = "SWAPCX";
-    } else if (id == gate_name_to_id("SWAPCX")) {
-        inv_name = "CXSWAP";
-    } else {
-        // Self inverse.
-    }
-    return GATE_DATA.at(inv_name);
+    throw std::out_of_range(inv_name + " has no inverse.");
 }
 
 Gate::Gate() : name(nullptr) {
@@ -97,6 +81,7 @@ Gate::Gate() : name(nullptr) {
 
 Gate::Gate(
     const char *name,
+    const char *best_inverse_name,
     uint8_t arg_count,
     void (TableauSimulator::*tableau_simulator_function)(const OperationData &),
     void (FrameSimulator::*frame_simulator_function)(const OperationData &),
@@ -113,7 +98,8 @@ Gate::Gate(
       flags(flags),
       arg_count(arg_count),
       name_len((uint8_t)strlen(name)),
-      id(gate_name_to_id(name)) {
+      id(gate_name_to_id(name)),
+      best_candidate_inverse_id(gate_name_to_id(best_inverse_name)) {
 }
 
 void GateDataMap::add_gate(bool &failed, const Gate &gate) {

--- a/src/stim/circuit/gate_data.h
+++ b/src/stim/circuit/gate_data.h
@@ -111,6 +111,9 @@ enum GateFlags : uint16_t {
     GATE_TARGETS_COMBINERS = 1 << 12,
     // Measurements and resets are dissipative operations.
     GATE_IS_RESET = 1 << 13,
+    // Annotations like DETECTOR aren't strictly speaking identity operations, but they can be ignored by code that only
+    // cares about effects that happen to qubits (as opposed to in the classical control system).
+    GATE_HAS_NO_EFFECT_ON_QUBITS = 1 << 14,
 };
 
 struct ExtraGateData {
@@ -144,10 +147,12 @@ struct Gate {
     uint8_t arg_count;
     uint8_t name_len;
     uint8_t id;
+    uint8_t best_candidate_inverse_id;
 
     Gate();
     Gate(
         const char *name,
+        const char *best_inverse_name,
         uint8_t arg_count,
         void (TableauSimulator::*tableau_simulator_function)(const OperationData &),
         void (FrameSimulator::*frame_simulator_function)(const OperationData &),
@@ -245,7 +250,6 @@ inline bool _case_insensitive_mismatch(const char *text, size_t text_len, const 
 
 struct GateDataMap {
    private:
-    std::array<Gate, 256> items;
     void add_gate(bool &failed, const Gate &data);
     void add_gate_alias(bool &failed, const char *alt_name, const char *canon_name);
     void add_gate_data_annotations(bool &failed);
@@ -261,6 +265,7 @@ struct GateDataMap {
     void add_gate_data_swaps(bool &failed);
 
    public:
+    std::array<Gate, 256> items;
     GateDataMap();
 
     std::vector<Gate> gates() const;

--- a/src/stim/circuit/gate_data.test.cc
+++ b/src/stim/circuit/gate_data.test.cc
@@ -94,3 +94,13 @@ TEST(gate_data, decompositions_are_correct) {
         }
     }
 }
+
+TEST(gate_data, unitary_inverses_are_correct) {
+    for (const auto &g : GATE_DATA.gates()) {
+        if (g.flags & GATE_IS_UNITARY) {
+            auto g_t_inv = g.tableau().inverse(false);
+            auto g_inv_t = GATE_DATA.items[g.best_candidate_inverse_id].tableau();
+            EXPECT_EQ(g_t_inv, g_inv_t) << g.name;
+        }
+    }
+}

--- a/src/stim/circuit/gate_data_annotations.cc
+++ b/src/stim/circuit/gate_data_annotations.cc
@@ -25,12 +25,13 @@ void GateDataMap::add_gate_data_annotations(bool &failed) {
         failed,
         Gate{
             "DETECTOR",
+            "DETECTOR",
             ARG_COUNT_SYGIL_ANY,
             &TableauSimulator::I,
             &FrameSimulator::I,
             &ErrorAnalyzer::DETECTOR,
             &SparseUnsignedRevFrameTracker::undo_DETECTOR,
-            (GateFlags)(GATE_ONLY_TARGETS_MEASUREMENT_RECORD | GATE_IS_NOT_FUSABLE),
+            (GateFlags)(GATE_ONLY_TARGETS_MEASUREMENT_RECORD | GATE_IS_NOT_FUSABLE | GATE_HAS_NO_EFFECT_ON_QUBITS),
             []() -> ExtraGateData {
                 return {
                     "Z_Annotations",
@@ -115,12 +116,13 @@ Example:
         failed,
         Gate{
             "OBSERVABLE_INCLUDE",
+            "OBSERVABLE_INCLUDE",
             1,
             &TableauSimulator::I,
             &FrameSimulator::I,
             &ErrorAnalyzer::OBSERVABLE_INCLUDE,
             &SparseUnsignedRevFrameTracker::undo_OBSERVABLE_INCLUDE,
-            (GateFlags)(GATE_ONLY_TARGETS_MEASUREMENT_RECORD | GATE_IS_NOT_FUSABLE | GATE_ARGS_ARE_UNSIGNED_INTEGERS),
+            (GateFlags)(GATE_ONLY_TARGETS_MEASUREMENT_RECORD | GATE_IS_NOT_FUSABLE | GATE_ARGS_ARE_UNSIGNED_INTEGERS | GATE_HAS_NO_EFFECT_ON_QUBITS),
             []() -> ExtraGateData {
                 return {
                     "Z_Annotations",
@@ -191,12 +193,13 @@ Example:
         failed,
         Gate{
             "TICK",
+            "TICK",
             0,
             &TableauSimulator::I,
             &FrameSimulator::I,
             &ErrorAnalyzer::TICK,
             &SparseUnsignedRevFrameTracker::undo_I,
-            (GateFlags)(GATE_IS_NOT_FUSABLE | GATE_TAKES_NO_TARGETS),
+            (GateFlags)(GATE_IS_NOT_FUSABLE | GATE_TAKES_NO_TARGETS | GATE_HAS_NO_EFFECT_ON_QUBITS),
             []() -> ExtraGateData {
                 return {
                     "Z_Annotations",
@@ -243,12 +246,13 @@ Example:
         failed,
         Gate{
             "QUBIT_COORDS",
+            "QUBIT_COORDS",
             ARG_COUNT_SYGIL_ANY,
             &TableauSimulator::I,
             &FrameSimulator::I,
             &ErrorAnalyzer::I,
             &SparseUnsignedRevFrameTracker::undo_I,
-            GATE_IS_NOT_FUSABLE,
+            (GateFlags)(GATE_IS_NOT_FUSABLE | GATE_HAS_NO_EFFECT_ON_QUBITS),
             []() -> ExtraGateData {
                 return {
                     "Z_Annotations",
@@ -294,12 +298,13 @@ Example:
         failed,
         Gate{
             "SHIFT_COORDS",
+            "SHIFT_COORDS",
             ARG_COUNT_SYGIL_ANY,
             &TableauSimulator::I,
             &FrameSimulator::I,
             &ErrorAnalyzer::SHIFT_COORDS,
             &SparseUnsignedRevFrameTracker::undo_I,
-            (GateFlags)(GATE_IS_NOT_FUSABLE | GATE_TAKES_NO_TARGETS),
+            (GateFlags)(GATE_IS_NOT_FUSABLE | GATE_TAKES_NO_TARGETS | GATE_HAS_NO_EFFECT_ON_QUBITS),
             []() -> ExtraGateData {
                 return {
                     "Z_Annotations",

--- a/src/stim/circuit/gate_data_blocks.cc
+++ b/src/stim/circuit/gate_data_blocks.cc
@@ -25,6 +25,7 @@ void GateDataMap::add_gate_data_blocks(bool &failed) {
         failed,
         Gate{
             "REPEAT",
+            "REPEAT",
             0,
             &TableauSimulator::I,
             &FrameSimulator::I,

--- a/src/stim/circuit/gate_data_collapsing.cc
+++ b/src/stim/circuit/gate_data_collapsing.cc
@@ -26,6 +26,7 @@ void GateDataMap::add_gate_data_collapsing(bool &failed) {
         failed,
         Gate{
             "MX",
+            "MX",
             ARG_COUNT_SYGIL_ZERO_OR_ONE,
             &TableauSimulator::measure_x,
             &FrameSimulator::measure_x,
@@ -80,6 +81,7 @@ H 0
     add_gate(
         failed,
         Gate{
+            "MY",
             "MY",
             ARG_COUNT_SYGIL_ZERO_OR_ONE,
             &TableauSimulator::measure_y,
@@ -140,6 +142,7 @@ S 0
         failed,
         Gate{
             "M",
+            "M",
             ARG_COUNT_SYGIL_ZERO_OR_ONE,
             &TableauSimulator::measure_z,
             &FrameSimulator::measure_z,
@@ -199,6 +202,7 @@ M 0
         failed,
         Gate{
             "MRX",
+            "MRX",
             ARG_COUNT_SYGIL_ZERO_OR_ONE,
             &TableauSimulator::measure_reset_x,
             &FrameSimulator::measure_reset_x,
@@ -255,6 +259,7 @@ H 0
     add_gate(
         failed,
         Gate{
+            "MRY",
             "MRY",
             ARG_COUNT_SYGIL_ZERO_OR_ONE,
             &TableauSimulator::measure_reset_y,
@@ -317,6 +322,7 @@ S 0
         failed,
         Gate{
             "MR",
+            "MR",
             ARG_COUNT_SYGIL_ZERO_OR_ONE,
             &TableauSimulator::measure_reset_z,
             &FrameSimulator::measure_reset_z,
@@ -378,6 +384,7 @@ R 0
         failed,
         Gate{
             "RX",
+            "MRX",
             0,
             &TableauSimulator::reset_x,
             &FrameSimulator::reset_x,
@@ -421,6 +428,7 @@ H 0
         failed,
         Gate{
             "RY",
+            "MRY",
             0,
             &TableauSimulator::reset_y,
             &FrameSimulator::reset_y,
@@ -468,6 +476,7 @@ S 0
         failed,
         Gate{
             "R",
+            "MR",
             0,
             &TableauSimulator::reset_z,
             &FrameSimulator::reset_z,
@@ -513,6 +522,7 @@ R 0
     add_gate(
         failed,
         Gate{
+            "MPP",
             "MPP",
             ARG_COUNT_SYGIL_ZERO_OR_ONE,
             &TableauSimulator::MPP,

--- a/src/stim/circuit/gate_data_controlled.cc
+++ b/src/stim/circuit/gate_data_controlled.cc
@@ -29,6 +29,7 @@ void GateDataMap::add_gate_data_controlled(bool &failed) {
         failed,
         Gate{
             "XCX",
+            "XCX",
             0,
             &TableauSimulator::XCX,
             &FrameSimulator::XCX,
@@ -71,6 +72,7 @@ H 0
     add_gate(
         failed,
         Gate{
+            "XCY",
             "XCY",
             0,
             &TableauSimulator::XCY,
@@ -119,6 +121,7 @@ S 1
         failed,
         Gate{
             "XCZ",
+            "XCZ",
             0,
             &TableauSimulator::XCZ,
             &FrameSimulator::XCZ,
@@ -157,6 +160,7 @@ CNOT 1 0
     add_gate(
         failed,
         Gate{
+            "YCX",
             "YCX",
             0,
             &TableauSimulator::YCX,
@@ -204,6 +208,7 @@ H 1
     add_gate(
         failed,
         Gate{
+            "YCY",
             "YCY",
             0,
             &TableauSimulator::YCY,
@@ -256,6 +261,7 @@ S 1
         failed,
         Gate{
             "YCZ",
+            "YCZ",
             0,
             &TableauSimulator::YCZ,
             &FrameSimulator::YCZ,
@@ -299,6 +305,7 @@ S 0
         failed,
         Gate{
             "CX",
+            "CX",
             0,
             &TableauSimulator::ZCX,
             &FrameSimulator::ZCX,
@@ -339,6 +346,7 @@ CNOT 0 1
     add_gate(
         failed,
         Gate{
+            "CY",
             "CY",
             0,
             &TableauSimulator::ZCY,
@@ -383,6 +391,7 @@ S 1
     add_gate(
         failed,
         Gate{
+            "CZ",
             "CZ",
             0,
             &TableauSimulator::ZCZ,

--- a/src/stim/circuit/gate_data_hada.cc
+++ b/src/stim/circuit/gate_data_hada.cc
@@ -30,6 +30,7 @@ void GateDataMap::add_gate_data_hada(bool &failed) {
         failed,
         Gate{
             "H",
+            "H",
             0,
             &TableauSimulator::H_XZ,
             &FrameSimulator::H_XZ,
@@ -64,6 +65,7 @@ H 0
     add_gate(
         failed,
         Gate{
+            "H_XY",
             "H_XY",
             0,
             &TableauSimulator::H_XY,
@@ -101,6 +103,7 @@ S 0
     add_gate(
         failed,
         Gate{
+            "H_YZ",
             "H_YZ",
             0,
             &TableauSimulator::H_YZ,

--- a/src/stim/circuit/gate_data_noisy.cc
+++ b/src/stim/circuit/gate_data_noisy.cc
@@ -25,6 +25,7 @@ void GateDataMap::add_gate_data_noisy(bool &failed) {
         failed,
         Gate{
             "DEPOLARIZE1",
+            "DEPOLARIZE1",
             1,
             &TableauSimulator::DEPOLARIZE1,
             &FrameSimulator::DEPOLARIZE1,
@@ -64,6 +65,7 @@ Pauli Mixture:
     add_gate(
         failed,
         Gate{
+            "DEPOLARIZE2",
             "DEPOLARIZE2",
             1,
             &TableauSimulator::DEPOLARIZE2,
@@ -117,6 +119,7 @@ Pauli Mixture:
         failed,
         Gate{
             "X_ERROR",
+            "X_ERROR",
             1,
             &TableauSimulator::X_ERROR,
             &FrameSimulator::X_ERROR,
@@ -152,6 +155,7 @@ Pauli Mixture:
     add_gate(
         failed,
         Gate{
+            "Y_ERROR",
             "Y_ERROR",
             1,
             &TableauSimulator::Y_ERROR,
@@ -189,6 +193,7 @@ Pauli Mixture:
         failed,
         Gate{
             "Z_ERROR",
+            "Z_ERROR",
             1,
             &TableauSimulator::Z_ERROR,
             &FrameSimulator::Z_ERROR,
@@ -224,6 +229,7 @@ Pauli Mixture:
     add_gate(
         failed,
         Gate{
+            "PAULI_CHANNEL_1",
             "PAULI_CHANNEL_1",
             3,
             &TableauSimulator::PAULI_CHANNEL_1,
@@ -271,6 +277,7 @@ Pauli Mixture:
     add_gate(
         failed,
         Gate{
+            "PAULI_CHANNEL_2",
             "PAULI_CHANNEL_2",
             15,
             &TableauSimulator::PAULI_CHANNEL_2,
@@ -347,6 +354,7 @@ Pauli Mixture:
         failed,
         Gate{
             "E",
+            "E",
             1,
             &TableauSimulator::CORRELATED_ERROR,
             &FrameSimulator::CORRELATED_ERROR,
@@ -391,6 +399,7 @@ Example:
     add_gate(
         failed,
         Gate{
+            "ELSE_CORRELATED_ERROR",
             "ELSE_CORRELATED_ERROR",
             1,
             &TableauSimulator::ELSE_CORRELATED_ERROR,

--- a/src/stim/circuit/gate_data_pauli.cc
+++ b/src/stim/circuit/gate_data_pauli.cc
@@ -29,6 +29,7 @@ void GateDataMap::add_gate_data_pauli(bool &failed) {
         failed,
         Gate{
             "I",
+            "I",
             0,
             &TableauSimulator::I,
             &FrameSimulator::I,
@@ -62,6 +63,7 @@ Targets:
     add_gate(
         failed,
         Gate{
+            "X",
             "X",
             0,
             &TableauSimulator::X,
@@ -100,6 +102,7 @@ H 0
         failed,
         Gate{
             "Y",
+            "Y",
             0,
             &TableauSimulator::Y,
             &FrameSimulator::I,
@@ -137,6 +140,7 @@ H 0
     add_gate(
         failed,
         Gate{
+            "Z",
             "Z",
             0,
             &TableauSimulator::Z,

--- a/src/stim/circuit/gate_data_period_3.cc
+++ b/src/stim/circuit/gate_data_period_3.cc
@@ -29,6 +29,7 @@ void GateDataMap::add_gate_data_period_3(bool &failed) {
         failed,
         Gate{
             "C_XYZ",
+            "C_ZYX",
             0,
             &TableauSimulator::C_XYZ,
             &FrameSimulator::C_XYZ,
@@ -65,6 +66,7 @@ H 0
         failed,
         Gate{
             "C_ZYX",
+            "C_XYZ",
             0,
             &TableauSimulator::C_ZYX,
             &FrameSimulator::C_ZYX,

--- a/src/stim/circuit/gate_data_period_4.cc
+++ b/src/stim/circuit/gate_data_period_4.cc
@@ -29,6 +29,7 @@ void GateDataMap::add_gate_data_period_4(bool &failed) {
         failed,
         Gate{
             "SQRT_X",
+            "SQRT_X_DAG",
             0,
             &TableauSimulator::SQRT_X,
             &FrameSimulator::H_YZ,
@@ -65,6 +66,7 @@ H 0
         failed,
         Gate{
             "SQRT_X_DAG",
+            "SQRT_X",
             0,
             &TableauSimulator::SQRT_X_DAG,
             &FrameSimulator::H_YZ,
@@ -101,6 +103,7 @@ S 0
         failed,
         Gate{
             "SQRT_Y",
+            "SQRT_Y_DAG",
             0,
             &TableauSimulator::SQRT_Y,
             &FrameSimulator::H_XZ,
@@ -137,6 +140,7 @@ H 0
         failed,
         Gate{
             "SQRT_Y_DAG",
+            "SQRT_Y",
             0,
             &TableauSimulator::SQRT_Y_DAG,
             &FrameSimulator::H_XZ,
@@ -173,6 +177,7 @@ S 0
         failed,
         Gate{
             "S",
+            "S_DAG",
             0,
             &TableauSimulator::SQRT_Z,
             &FrameSimulator::H_XY,
@@ -208,6 +213,7 @@ S 0
         failed,
         Gate{
             "S_DAG",
+            "S",
             0,
             &TableauSimulator::SQRT_Z_DAG,
             &FrameSimulator::H_XY,

--- a/src/stim/circuit/gate_data_pp.cc
+++ b/src/stim/circuit/gate_data_pp.cc
@@ -29,6 +29,7 @@ void GateDataMap::add_gate_data_pp(bool &failed) {
         failed,
         Gate{
             "SQRT_XX",
+            "SQRT_XX_DAG",
             0,
             &TableauSimulator::SQRT_XX,
             &FrameSimulator::SQRT_XX,
@@ -70,6 +71,7 @@ H 1
         failed,
         Gate{
             "SQRT_XX_DAG",
+            "SQRT_XX",
             0,
             &TableauSimulator::SQRT_XX_DAG,
             &FrameSimulator::SQRT_XX,
@@ -116,6 +118,7 @@ H 1
         failed,
         Gate{
             "SQRT_YY",
+            "SQRT_YY_DAG",
             0,
             &TableauSimulator::SQRT_YY,
             &FrameSimulator::SQRT_YY,
@@ -165,6 +168,7 @@ S 1
         failed,
         Gate{
             "SQRT_YY_DAG",
+            "SQRT_YY",
             0,
             &TableauSimulator::SQRT_YY_DAG,
             &FrameSimulator::SQRT_YY,
@@ -215,6 +219,7 @@ S 1
         failed,
         Gate{
             "SQRT_ZZ",
+            "SQRT_ZZ_DAG",
             0,
             &TableauSimulator::SQRT_ZZ,
             &FrameSimulator::SQRT_ZZ,
@@ -251,6 +256,7 @@ S 1
         failed,
         Gate{
             "SQRT_ZZ_DAG",
+            "SQRT_ZZ",
             0,
             &TableauSimulator::SQRT_ZZ_DAG,
             &FrameSimulator::SQRT_ZZ,

--- a/src/stim/circuit/gate_data_swaps.cc
+++ b/src/stim/circuit/gate_data_swaps.cc
@@ -29,6 +29,7 @@ void GateDataMap::add_gate_data_swaps(bool &failed) {
         failed,
         Gate{
             "SWAP",
+            "SWAP",
             0,
             &TableauSimulator::SWAP,
             &FrameSimulator::SWAP,
@@ -64,6 +65,7 @@ CNOT 0 1
         failed,
         Gate{
             "ISWAP",
+            "ISWAP_DAG",
             0,
             &TableauSimulator::ISWAP,
             &FrameSimulator::ISWAP,
@@ -102,7 +104,52 @@ S 0
     add_gate(
         failed,
         Gate{
+            "ISWAP_DAG",
+            "ISWAP",
+            0,
+            &TableauSimulator::ISWAP_DAG,
+            &FrameSimulator::ISWAP,
+            &ErrorAnalyzer::ISWAP,
+            &SparseUnsignedRevFrameTracker::undo_ISWAP,
+            (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS),
+            []() -> ExtraGateData {
+                return {
+                    "C_Two Qubit Clifford Gates",
+                    R"MARKDOWN(
+Swaps two qubits and phases the -1 eigenspace of the ZZ observable by -i.
+Equivalent to `SWAP` then `CZ` then `S_DAG` on both targets.
+
+Parens Arguments:
+
+    This instruction takes no parens arguments.
+
+Targets:
+
+    Qubit pairs to operate on.
+)MARKDOWN",
+                    {{1, 0, 0, 0}, {0, 0, -i, 0}, {0, -i, 0, 0}, {0, 0, 0, 1}},
+                    {"-ZY", "+IZ", "-YZ", "+ZI"},
+                    R"CIRCUIT(
+S 0
+S 0
+S 0
+S 1
+S 1
+S 1
+H 1
+CNOT 1 0
+CNOT 0 1
+H 0
+)CIRCUIT",
+                };
+            },
+        });
+
+    add_gate(
+        failed,
+        Gate{
             "CXSWAP",
+            "SWAPCX",
             0,
             &TableauSimulator::CXSWAP,
             &FrameSimulator::CXSWAP,
@@ -138,6 +185,7 @@ CNOT 0 1
         failed,
         Gate{
             "SWAPCX",
+            "CXSWAP",
             0,
             &TableauSimulator::SWAPCX,
             &FrameSimulator::SWAPCX,
@@ -164,49 +212,6 @@ Targets:
                     R"CIRCUIT(
 CNOT 0 1
 CNOT 1 0
-)CIRCUIT",
-                };
-            },
-        });
-
-    add_gate(
-        failed,
-        Gate{
-            "ISWAP_DAG",
-            0,
-            &TableauSimulator::ISWAP_DAG,
-            &FrameSimulator::ISWAP,
-            &ErrorAnalyzer::ISWAP,
-            &SparseUnsignedRevFrameTracker::undo_ISWAP,
-            (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS),
-            []() -> ExtraGateData {
-                return {
-                    "C_Two Qubit Clifford Gates",
-                    R"MARKDOWN(
-Swaps two qubits and phases the -1 eigenspace of the ZZ observable by -i.
-Equivalent to `SWAP` then `CZ` then `S_DAG` on both targets.
-
-Parens Arguments:
-
-    This instruction takes no parens arguments.
-
-Targets:
-
-    Qubit pairs to operate on.
-)MARKDOWN",
-                    {{1, 0, 0, 0}, {0, 0, -i, 0}, {0, -i, 0, 0}, {0, 0, 0, 1}},
-                    {"-ZY", "+IZ", "-YZ", "+ZI"},
-                    R"CIRCUIT(
-S 0
-S 0
-S 0
-S 1
-S 1
-S 1
-H 1
-CNOT 1 0
-CNOT 0 1
-H 0
 )CIRCUIT",
                 };
             },


### PR DESCRIPTION
- Ignore annotations like TICK and OBSERVABLE_INCLUDE instead of failing if they are present
- When a reset or measure-reset operation is present, only fail if the pauli string actually touches it with a non-identity term
- When a measure operation is present, only fail if the pauli string anticommutes with it
- Add a "allow_weak_inverse" argument to stim::Circuit::inverse, that makes it use approximate inversion where e.g. noise is its own inverse and a measurement is its own inverse
- Added a "best guess inverse" field to Gate objects
- Make stim::Circuit::inverse work on SHIFT_COORDS
- Refactored stim::Gate::inverse to use the inverse data added to all gates
- Added GATE_HAS_NO_EFFECT_ON_QUBITS flag data to gates

Fixes https://github.com/quantumlib/Stim/issues/497 Fixes https://github.com/quantumlib/Stim/issues/497