### PR TITLE
Templatised simulator function VTables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 cmake_minimum_required(VERSION 3.13)
 project(stim)
 include_directories(src)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY out)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY out)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY out)

--- a/src/stim/circuit/circuit.cc
+++ b/src/stim/circuit/circuit.cc
@@ -216,12 +216,12 @@ DetectorsAndObservables::DetectorsAndObservables(const Circuit &circuit) {
     circuit.for_each_operation([&](const Operation &p) {
         if (p.gate->flags & GATE_PRODUCES_NOISY_RESULTS) {
             tick += p.count_measurement_results();
-        } else if (p.gate->id == gate_name_to_id("DETECTOR")) {
+        } else if (p.gate->id == static_cast<uint8_t>(Gates::DETECTOR)) {
             resolve_into(p, [&](uint64_t k) {
                 jagged_detector_data.append_tail(k);
             });
             detectors.push_back(jagged_detector_data.commit_tail());
-        } else if (p.gate->id == gate_name_to_id("OBSERVABLE_INCLUDE")) {
+        } else if (p.gate->id == static_cast<uint8_t>(Gates::OBSERVABLE_INCLUDE)) {
             size_t obs = (size_t)p.target_data.args[0];
             if (obs != p.target_data.args[0]) {
                 throw std::invalid_argument("Observable index must be an integer.");
@@ -584,7 +584,7 @@ void circuit_read_operations(Circuit &circuit, SOURCE read_char, READ_CONDITION 
         circuit_read_single_operation(circuit, c, read_char);
         Operation &new_op = ops.back();
 
-        if (new_op.gate->id == gate_name_to_id("REPEAT")) {
+        if (new_op.gate->id == static_cast<uint8_t>(Gates::REPEAT)) {
             if (new_op.target_data.targets.size() != 2) {
                 throw std::invalid_argument("Invalid instruction. Expected one repetition arg like `REPEAT 100 {`.");
             }
@@ -718,7 +718,7 @@ void stim::print_circuit(std::ostream &out, const Circuit &c, const std::string 
         }
 
         // Recurse on repeat blocks.
-        if (op.gate && op.gate->id == gate_name_to_id("REPEAT")) {
+        if (op.gate && op.gate->id == static_cast<uint8_t>(Gates::REPEAT)) {
             if (op.target_data.targets.size() == 3 && op.target_data.targets[0].data < c.blocks.size()) {
                 out << indentation << "REPEAT " << op_data_rep_count(op.target_data) << " {\n";
                 print_circuit(out, c.blocks[op.target_data.targets[0].data], indentation + "    ");
@@ -764,7 +764,7 @@ Circuit Circuit::operator*(uint64_t repetitions) const {
         return *this;
     }
     // If the entire circuit is a repeat block, just adjust its repeat count.
-    if (operations.size() == 1 && operations[0].gate->id == gate_name_to_id("REPEAT")) {
+    if (operations.size() == 1 && operations[0].gate->id == static_cast<uint8_t>(Gates::REPEAT)) {
         uint64_t old_reps = op_data_rep_count(operations[0].target_data);
         uint64_t new_reps = old_reps * repetitions;
         if (old_reps != new_reps / repetitions) {
@@ -828,7 +828,7 @@ Circuit &Circuit::operator+=(const Circuit &other) {
         PointerRange<stim::GateTarget> target_data = target_buf.take_copy(op.target_data.targets);
         OperationData op_data{arg_buf.take_copy(op.target_data.args), target_data};
         operations.push_back({op.gate, op_data});
-        if (op.gate->id == gate_name_to_id("REPEAT")) {
+        if (op.gate->id == static_cast<uint8_t>(Gates::REPEAT)) {
             assert(op.target_data.targets.size() == 3);
             target_data[0].data += block_offset;
         }
@@ -1007,7 +1007,7 @@ Circuit Circuit::py_get_slice(int64_t start, int64_t step, int64_t slice_length)
     Circuit result;
     for (size_t k = 0; k < (size_t)slice_length; k++) {
         const auto &op = operations[start + step * k];
-        if (op.gate->id == gate_name_to_id("REPEAT")) {
+        if (op.gate->id == static_cast<uint8_t>(Gates::REPEAT)) {
             result.target_buf.append_tail(GateTarget{(uint32_t)result.blocks.size()});
             result.target_buf.append_tail(op.target_data.targets[1]);
             result.target_buf.append_tail(op.target_data.targets[2]);
@@ -1072,7 +1072,7 @@ Circuit Circuit::without_noise() const {
             // Drop result flip probabilities.
             auto targets = result.target_buf.take_copy(op.target_data.targets);
             result.safe_append(*op.gate, targets, {});
-        } else if (op.gate->id == gate_name_to_id("REPEAT")) {
+        } else if (op.gate->id == static_cast<uint8_t>(Gates::REPEAT)) {
             auto args = result.arg_buf.take_copy(op.target_data.args);
             auto targets = result.target_buf.take_copy(op.target_data.targets);
             result.operations.push_back({op.gate, {args, targets}});
@@ -1091,10 +1091,10 @@ Circuit Circuit::without_noise() const {
 
 void flattened_helper(
     const Circuit &body, std::vector<double> &cur_coordinate_shift, std::vector<double> &coord_buffer, Circuit &out) {
-    const uint8_t shift = gate_name_to_id("SHIFT_COORDS");
-    const uint8_t rep = gate_name_to_id("REPEAT");
-    const uint8_t qubit_coords = gate_name_to_id("QUBIT_COORDS");
-    const uint8_t detector = gate_name_to_id("DETECTOR");
+    const uint8_t shift = static_cast<uint8_t>(Gates::SHIFT_COORDS);
+    const uint8_t rep = static_cast<uint8_t>(Gates::REPEAT);
+    const uint8_t qubit_coords = static_cast<uint8_t>(Gates::QUBIT_COORDS);
+    const uint8_t detector = static_cast<uint8_t>(Gates::DETECTOR);
     for (const auto &op : body.operations) {
         uint8_t id = op.gate->id;
         if (id == shift) {
@@ -1142,7 +1142,7 @@ Circuit Circuit::inverse(bool allow_weak_inverse) const {
     std::vector<double> args_buf;
     for (size_t k = 0; k < operations.size(); k++) {
         const auto &op = operations[k];
-        if (op.gate->id == gate_name_to_id("REPEAT")) {
+        if (op.gate->id == static_cast<uint8_t>(Gates::REPEAT)) {
             const auto &block = op_data_block_body(*this, op.target_data);
             uint64_t reps = op_data_rep_count(op.target_data);
             result.append_repeat_block(reps, block.inverse(allow_weak_inverse));
@@ -1152,15 +1152,16 @@ Circuit Circuit::inverse(bool allow_weak_inverse) const {
         ConstPointerRange<double> args = op.target_data.args;
         if (op.gate->flags & GATE_IS_UNITARY) {
             // Unitary gates always have an inverse.
-        } else if (op.gate->id == gate_name_to_id("TICK")) {
+        } else if (op.gate->id == static_cast<uint8_t>(Gates::TICK)) {
             // Ticks are self-inverse.
         } else if (op.gate->flags & GATE_IS_NOISE) {
             // Noise isn't invertible, but it is weakly invertible.
             // ELSE_CORRELATED_ERROR isn't implemented due to complex order dependencies.
-            if (!allow_weak_inverse || op.gate->id == gate_name_to_id("ELSE_CORRELATED_ERROR")) {
+            if (!allow_weak_inverse || op.gate->id == static_cast<uint8_t>(Gates::ELSE_CORRELATED_ERROR)) {
                 throw std::invalid_argument(
                     "The circuit has no well-defined inverse because it contains noise.\n"
-                    "For example it contains a '" + op.str() + "' instruction.");
+                    "For example it contains a '" +
+                    op.str() + "' instruction.");
             }
         } else if (op.gate->flags & (GATE_IS_RESET | GATE_PRODUCES_NOISY_RESULTS)) {
             // Dissipative operations aren't invertible, but they are weakly invertible.
@@ -1170,21 +1171,21 @@ Circuit Circuit::inverse(bool allow_weak_inverse) const {
                     "For example it contains a '" +
                     op.str() + "' instruction.");
             }
-        } else if (op.gate->id == gate_name_to_id("QUBIT_COORDS")) {
+        } else if (op.gate->id == static_cast<uint8_t>(Gates::QUBIT_COORDS)) {
             // Qubit coordinate headers are kept at the beginning.
             if (k > skip_reversing) {
                 throw std::invalid_argument(
                     "Inverting QUBIT_COORDS is not implemented except at the start of the circuit.");
             }
             skip_reversing++;
-        } else if (op.gate->id == gate_name_to_id("SHIFT_COORDS")) {
+        } else if (op.gate->id == static_cast<uint8_t>(Gates::SHIFT_COORDS)) {
             // Coordinate shifts reverse.
             args_buf.clear();
             for (const auto &a : op.target_data.args) {
                 args_buf.push_back(-a);
             }
             args = args_buf;
-        } else if (op.gate->id == gate_name_to_id("DETECTOR") || op.gate->id == gate_name_to_id("OBSERVABLE_INCLUDE")) {
+        } else if (op.gate->id == static_cast<uint8_t>(Gates::DETECTOR) || op.gate->id == static_cast<uint8_t>(Gates::OBSERVABLE_INCLUDE)) {
             if (allow_weak_inverse) {
                 // If strong inverse for these gets implemented, they should be included in the weak inverse.
                 // But for now it's sufficient to just drop them for the weak inverse.
@@ -1238,13 +1239,13 @@ void get_final_qubit_coords_helper(
     std::map<uint64_t, std::vector<double>> new_qubit_coords;
 
     for (const auto &op : circuit.operations) {
-        if (op.gate->id == gate_name_to_id("REPEAT")) {
+        if (op.gate->id == static_cast<uint8_t>(Gates::REPEAT)) {
             const auto &block = circuit.blocks[op.target_data.targets[0].data];
             uint64_t block_repeats = op_data_rep_count(op.target_data);
             get_final_qubit_coords_helper(block, block_repeats, out_coord_shift, new_qubit_coords);
-        } else if (op.gate->id == gate_name_to_id("SHIFT_COORDS")) {
+        } else if (op.gate->id == static_cast<uint8_t>(Gates::SHIFT_COORDS)) {
             vec_pad_add_mul(out_coord_shift, op.target_data.args);
-        } else if (op.gate->id == gate_name_to_id("QUBIT_COORDS")) {
+        } else if (op.gate->id == static_cast<uint8_t>(Gates::QUBIT_COORDS)) {
             while (out_coord_shift.size() < op.target_data.args.size()) {
                 out_coord_shift.push_back(0);
             }
@@ -1295,9 +1296,9 @@ std::map<uint64_t, std::vector<double>> Circuit::get_final_qubit_coords() const 
 std::vector<double> Circuit::final_coord_shift() const {
     std::vector<double> coord_shift;
     for (const auto &op : operations) {
-        if (op.gate->id == gate_name_to_id("SHIFT_COORDS")) {
+        if (op.gate->id == static_cast<uint8_t>(Gates::SHIFT_COORDS)) {
             vec_pad_add_mul(coord_shift, op.target_data.args);
-        } else if (op.gate->id == gate_name_to_id("REPEAT")) {
+        } else if (op.gate->id == static_cast<uint8_t>(Gates::REPEAT)) {
             const auto &block = op_data_block_body(*this, op.target_data);
             uint64_t reps = op_data_rep_count(op.target_data);
             vec_pad_add_mul(coord_shift, block.final_coord_shift(), reps);
@@ -1319,9 +1320,9 @@ void get_detector_coordinates_helper(
 
     std::vector<double> coord_shift = initial_coord_shift;
     for (const auto &op : circuit.operations) {
-        if (op.gate->id == gate_name_to_id("SHIFT_COORDS")) {
+        if (op.gate->id == static_cast<uint8_t>(Gates::SHIFT_COORDS)) {
             vec_pad_add_mul(coord_shift, op.target_data.args);
-        } else if (op.gate->id == gate_name_to_id("REPEAT")) {
+        } else if (op.gate->id == static_cast<uint8_t>(Gates::REPEAT)) {
             const auto &block = op_data_block_body(circuit, op.target_data);
             auto block_shift = block.final_coord_shift();
             uint64_t per = block.count_detectors();
@@ -1348,7 +1349,7 @@ void get_detector_coordinates_helper(
                     }
                 }
             }
-        } else if (op.gate->id == gate_name_to_id("DETECTOR")) {
+        } else if (op.gate->id == static_cast<uint8_t>(Gates::DETECTOR)) {
             if (next_detector_index == *iter_desired_detector_index) {
                 std::vector<double> det_coords;
                 for (size_t k = 0; k < op.target_data.args.size(); k++) {
@@ -1394,7 +1395,7 @@ std::string Circuit::describe_instruction_location(size_t instruction_offset) co
     std::stringstream out;
     out << "    at instruction #" << (instruction_offset + 1);
     const auto &op = operations[instruction_offset];
-    if (op.gate->id == gate_name_to_id("REPEAT")) {
+    if (op.gate->id == static_cast<uint8_t>(Gates::REPEAT)) {
         out << " [which is a REPEAT " << op_data_rep_count(op.target_data) << " block]";
     } else {
         out << " [which is " << op << "]";

--- a/src/stim/circuit/circuit.h
+++ b/src/stim/circuit/circuit.h
@@ -212,7 +212,7 @@ struct Circuit {
     void for_each_operation(const CALLBACK &callback) const {
         for (const auto &op : operations) {
             assert(op.gate != nullptr);
-            if (op.gate->id == gate_name_to_id("REPEAT")) {
+            if (op.gate->id == static_cast<uint8_t>(Gates::REPEAT)) {
                 assert(op.target_data.targets.size() == 3);
                 auto b = op.target_data.targets[0].data;
                 assert(b < blocks.size());
@@ -233,7 +233,7 @@ struct Circuit {
         for (size_t p = operations.size(); p-- > 0;) {
             const auto &op = operations[p];
             assert(op.gate != nullptr);
-            if (op.gate->id == gate_name_to_id("REPEAT")) {
+            if (op.gate->id == static_cast<uint8_t>(Gates::REPEAT)) {
                 assert(op.target_data.targets.size() == 3);
                 auto b = op.target_data.targets[0].data;
                 assert(b < blocks.size());
@@ -254,7 +254,7 @@ struct Circuit {
         uint64_t n = 0;
         for (const auto &op : operations) {
             assert(op.gate != nullptr);
-            if (op.gate->id == gate_name_to_id("REPEAT")) {
+            if (op.gate->id == static_cast<uint8_t>(Gates::REPEAT)) {
                 assert(op.target_data.targets.size() == 3);
                 auto b = op.target_data.targets[0].data;
                 assert(b < blocks.size());

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -1201,7 +1201,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
             }
 
             auto &op = self.operations[index];
-            if (op.gate->id == gate_name_to_id("REPEAT")) {
+            if (op.gate->id == static_cast<uint8_t>(Gates::REPEAT)) {
                 return pybind11::cast(
                     CircuitRepeatBlock{op_data_rep_count(op.target_data), op_data_block_body(self, op.target_data)});
             }

--- a/src/stim/circuit/gate_data.cc
+++ b/src/stim/circuit/gate_data.cc
@@ -70,7 +70,7 @@ std::vector<std::vector<std::complex<float>>> Gate::unitary() const {
 
 const Gate &Gate::inverse() const {
     std::string inv_name = name;
-    if ((flags & GATE_IS_UNITARY) || id == gate_name_to_id("TICK")) {
+    if ((flags & GATE_IS_UNITARY) || id == static_cast<uint8_t>(Gates::TICK)) {
         return GATE_DATA.items[best_candidate_inverse_id];
     }
     throw std::out_of_range(inv_name + " has no inverse.");
@@ -81,7 +81,8 @@ Gate::Gate() : name(nullptr) {
 
 Gate::Gate(
     const char *name,
-    const char *best_inverse_name,
+    Gates gate_id,
+    Gates best_inverse_gate,
     uint8_t arg_count,
     void (TableauSimulator::*tableau_simulator_function)(const OperationData &),
     void (FrameSimulator::*frame_simulator_function)(const OperationData &),
@@ -98,8 +99,8 @@ Gate::Gate(
       flags(flags),
       arg_count(arg_count),
       name_len((uint8_t)strlen(name)),
-      id(gate_name_to_id(name)),
-      best_candidate_inverse_id(gate_name_to_id(best_inverse_name)) {
+      id(static_cast<uint8_t>(gate_id)),
+      best_candidate_inverse_id(static_cast<uint8_t>(best_inverse_gate)) {
 }
 
 void GateDataMap::add_gate(bool &failed, const Gate &gate) {

--- a/src/stim/circuit/gate_data.cc
+++ b/src/stim/circuit/gate_data.cc
@@ -103,6 +103,7 @@ Gate::Gate(
 }
 
 void GateDataMap::add_gate(bool &failed, const Gate &gate) {
+    // items[gate.id] = gate;
     const char *c = gate.name;
     uint8_t h = gate_name_to_id(c);
     Gate &loc = items[h];

--- a/src/stim/circuit/gate_data.h
+++ b/src/stim/circuit/gate_data.h
@@ -44,7 +44,46 @@ struct ErrorAnalyzer;
 constexpr uint8_t ARG_COUNT_SYGIL_ANY = uint8_t{0xFF};
 constexpr uint8_t ARG_COUNT_SYGIL_ZERO_OR_ONE = uint8_t{0xFE};
 
-inline uint8_t gate_name_to_id(const char *v, size_t n) {
+enum class Gates : uint8_t {
+    // From gate_data_annotations.cc
+    DETECTOR, OBSERVABLE_INCLUDE, TICK, QUBIT_COORDS, SHIFT_COORDS,
+    // Frome gate_data_blocks.cc
+    REPEAT,
+    // From gate_data_collapsing.cc
+    MX, MY, M, MRX, MRY, MR, RX, RY, R, MPP,
+    // From gate_data_controlled.cc
+    XCX, XCY, XCZ, YCX, YCY, YCZ, CX, CY, CZ,
+    // From gate_data_hada.cc
+    H, H_XY, H_YZ,
+    // From gate_data_noisy.cc
+    DEPOLARIZE1, DEPOLARIZE2, X_ERROR, Y_ERROR, Z_ERROR,
+    PAULI_CHANNEL_1, PAULI_CHANNEL_2,
+    E, ELSE_CORRELATED_ERROR,
+    // From gate_data_pauli.cc
+    I, X, Y, Z,
+    // From gate_data_period_3.cc
+    C_XYZ, C_ZYX,
+    // From gate_data_period_4.cc
+    SQRT_X, SQRT_X_DAG, SQRT_Y, SQRT_Y_DAG, S, S_DAG,
+    // From gate_data_pp.cc
+    SQRT_XX, SQRT_XX_DAG, SQRT_YY, SQRT_YY_DAG, SQRT_ZZ, SQRT_ZZ_DAG,
+    // From gate_data_swaps.cc
+    SWAP, ISWAP, CXSWAP, SWAPCX, ISWAP_DAG,
+
+    /// GATE ALIASES
+
+    // From gate_data_collapsing.cc
+    MZ, MRZ, RZ, ZCX, CNOT, ZCY, ZCZ,
+    // From gate_data_noisy.cc
+    CORRELATED_ERROR,
+    // From gate_data_hada.cc
+    H_XZ,
+    // From gate_data_period_4.cc
+    SQRT_Z, SQRT_Z_DAG,
+};
+
+
+inline uint8_t gate_name_to_hash(const char *v, size_t n) {
     // HACK: A collision is considered to be an error.
     // Just do *anything* that makes all the defined gates have different values.
 
@@ -76,8 +115,162 @@ inline uint8_t gate_name_to_id(const char *v, size_t n) {
     return result;
 }
 
+inline uint8_t gate_hash_to_id(uint8_t hash) noexcept {
+    switch (hash) {
+        case 1:
+            return static_cast<int>(Gates::DEPOLARIZE2);
+        case 13:
+            return static_cast<int>(Gates::SQRT_YY_DAG);
+        case 14:
+            return static_cast<int>(Gates::SQRT_ZZ_DAG);
+        case 16:
+            return static_cast<int>(Gates::SQRT_XX_DAG);
+        case 27:
+            return static_cast<int>(Gates::DEPOLARIZE1);
+        case 29:
+            return static_cast<int>(Gates::SHIFT_COORDS);
+        case 40:
+            return static_cast<int>(Gates::X);
+        case 43:
+            return static_cast<int>(Gates::Y);
+        case 46:
+            return static_cast<int>(Gates::Z);
+        case 47:
+            return static_cast<int>(Gates::E);
+        case 48:
+            return static_cast<int>(Gates::QUBIT_COORDS);
+        case 53:
+            return static_cast<int>(Gates::S);
+        case 54:
+            return static_cast<int>(Gates::R);
+        case 55:
+            return static_cast<int>(Gates::M);
+        case 56:
+            return static_cast<int>(Gates::H);
+        case 59:
+            return static_cast<int>(Gates::I);
+        case 64:
+            return static_cast<int>(Gates::RY);
+        case 65:
+            return static_cast<int>(Gates::ELSE_CORRELATED_ERROR);
+        case 66:
+            return static_cast<int>(Gates::RX);
+        case 70:
+            return static_cast<int>(Gates::RZ);
+        case 73:
+            return static_cast<int>(Gates::MR);
+        case 81:
+            return static_cast<int>(Gates::CY);
+        case 83:
+            return static_cast<int>(Gates::CX);
+        case 87:
+            return static_cast<int>(Gates::CZ);
+        case 89:
+            return static_cast<int>(Gates::MZ);
+        case 93:
+            return static_cast<int>(Gates::MX);
+        case 95:
+            return static_cast<int>(Gates::MY);
+        case 97:
+            return static_cast<int>(Gates::ZCX);
+        case 98:
+            return static_cast<int>(Gates::YCX);
+        case 99:
+            return static_cast<int>(Gates::XCX);
+        case 103:
+            return static_cast<int>(Gates::MRX);
+        case 105:
+            return static_cast<int>(Gates::YCY);
+        case 106:
+            return static_cast<int>(Gates::XCY);
+        case 108:
+            return static_cast<int>(Gates::ZCY);
+        case 109:
+            return static_cast<int>(Gates::MPP);
+        case 110:
+            return static_cast<int>(Gates::MRY);
+        case 117:
+            return static_cast<int>(Gates::MRZ);
+        case 119:
+            return static_cast<int>(Gates::ZCZ);
+        case 120:
+            return static_cast<int>(Gates::YCZ);
+        case 121:
+            return static_cast<int>(Gates::XCZ);
+        case 127:
+            return static_cast<int>(Gates::SQRT_ZZ);
+        case 132:
+            return static_cast<int>(Gates::H_YZ);
+        case 134:
+            return static_cast<int>(Gates::TICK);
+        case 136:
+            return static_cast<int>(Gates::X_ERROR);
+        case 137:
+            return static_cast<int>(Gates::PAULI_CHANNEL_1);
+        case 139:
+            return static_cast<int>(Gates::PAULI_CHANNEL_2);
+        case 140:
+            return static_cast<int>(Gates::CNOT);
+        case 141:
+            return static_cast<int>(Gates::SWAP);
+        case 146:
+            return static_cast<int>(Gates::Z_ERROR);
+        case 147:
+            return static_cast<int>(Gates::Y_ERROR);
+        case 149:
+            return static_cast<int>(Gates::SQRT_XX);
+        case 154:
+            return static_cast<int>(Gates::SQRT_YY);
+        case 155:
+            return static_cast<int>(Gates::H_XZ);
+        case 157:
+            return static_cast<int>(Gates::H_XY);
+        case 160:
+            return static_cast<int>(Gates::C_XYZ);
+        case 166:
+            return static_cast<int>(Gates::S_DAG);
+        case 169:
+            return static_cast<int>(Gates::ISWAP);
+        case 178:
+            return static_cast<int>(Gates::DETECTOR);
+        case 179:
+            return static_cast<int>(Gates::CORRELATED_ERROR);
+        case 182:
+            return static_cast<int>(Gates::C_ZYX);
+        case 194:
+            return static_cast<int>(Gates::SQRT_Z);
+        case 202:
+            return static_cast<int>(Gates::REPEAT);
+        case 205:
+            return static_cast<int>(Gates::CXSWAP);
+        case 213:
+            return static_cast<int>(Gates::SWAPCX);
+        case 216:
+            return static_cast<int>(Gates::SQRT_X);
+        case 219:
+            return static_cast<int>(Gates::ISWAP_DAG);
+        case 221:
+            return static_cast<int>(Gates::SQRT_Y);
+        case 236:
+            return static_cast<int>(Gates::OBSERVABLE_INCLUDE);
+        case 237:
+            return static_cast<int>(Gates::SQRT_Y_DAG);
+        case 238:
+            return static_cast<int>(Gates::SQRT_Z_DAG);
+        case 240:
+            return static_cast<int>(Gates::SQRT_X_DAG);
+        default:
+            std::cerr << "Gate hash not mapped to Gate ID\n";
+            return 0;
+    }
+}
+
+inline uint8_t gate_name_to_id(const char *c, size_t n) {
+    return gate_hash_to_id(gate_name_to_hash(c, n));
+}
+
 inline uint8_t gate_name_to_id(const char *c) {
-    return gate_name_to_id(c, strlen(c));
+    return gate_hash_to_id(gate_name_to_hash(c, strlen(c)));
 }
 
 enum GateFlags : uint16_t {

--- a/src/stim/circuit/gate_data.h
+++ b/src/stim/circuit/gate_data.h
@@ -118,147 +118,147 @@ inline uint8_t gate_name_to_hash(const char *v, size_t n) {
 inline uint8_t gate_hash_to_id(uint8_t hash) noexcept {
     switch (hash) {
         case 1:
-            return static_cast<int>(Gates::DEPOLARIZE2);
+            return static_cast<uint8_t>(Gates::DEPOLARIZE2);
         case 13:
-            return static_cast<int>(Gates::SQRT_YY_DAG);
+            return static_cast<uint8_t>(Gates::SQRT_YY_DAG);
         case 14:
-            return static_cast<int>(Gates::SQRT_ZZ_DAG);
+            return static_cast<uint8_t>(Gates::SQRT_ZZ_DAG);
         case 16:
-            return static_cast<int>(Gates::SQRT_XX_DAG);
+            return static_cast<uint8_t>(Gates::SQRT_XX_DAG);
         case 27:
-            return static_cast<int>(Gates::DEPOLARIZE1);
+            return static_cast<uint8_t>(Gates::DEPOLARIZE1);
         case 29:
-            return static_cast<int>(Gates::SHIFT_COORDS);
+            return static_cast<uint8_t>(Gates::SHIFT_COORDS);
         case 40:
-            return static_cast<int>(Gates::X);
+            return static_cast<uint8_t>(Gates::X);
         case 43:
-            return static_cast<int>(Gates::Y);
+            return static_cast<uint8_t>(Gates::Y);
         case 46:
-            return static_cast<int>(Gates::Z);
+            return static_cast<uint8_t>(Gates::Z);
         case 47:
-            return static_cast<int>(Gates::E);
+            return static_cast<uint8_t>(Gates::E);
         case 48:
-            return static_cast<int>(Gates::QUBIT_COORDS);
+            return static_cast<uint8_t>(Gates::QUBIT_COORDS);
         case 53:
-            return static_cast<int>(Gates::S);
+            return static_cast<uint8_t>(Gates::S);
         case 54:
-            return static_cast<int>(Gates::R);
+            return static_cast<uint8_t>(Gates::R);
         case 55:
-            return static_cast<int>(Gates::M);
+            return static_cast<uint8_t>(Gates::M);
         case 56:
-            return static_cast<int>(Gates::H);
+            return static_cast<uint8_t>(Gates::H);
         case 59:
-            return static_cast<int>(Gates::I);
+            return static_cast<uint8_t>(Gates::I);
         case 64:
-            return static_cast<int>(Gates::RY);
+            return static_cast<uint8_t>(Gates::RY);
         case 65:
-            return static_cast<int>(Gates::ELSE_CORRELATED_ERROR);
+            return static_cast<uint8_t>(Gates::ELSE_CORRELATED_ERROR);
         case 66:
-            return static_cast<int>(Gates::RX);
+            return static_cast<uint8_t>(Gates::RX);
         case 70:
-            return static_cast<int>(Gates::RZ);
+            return static_cast<uint8_t>(Gates::RZ);
         case 73:
-            return static_cast<int>(Gates::MR);
+            return static_cast<uint8_t>(Gates::MR);
         case 81:
-            return static_cast<int>(Gates::CY);
+            return static_cast<uint8_t>(Gates::CY);
         case 83:
-            return static_cast<int>(Gates::CX);
+            return static_cast<uint8_t>(Gates::CX);
         case 87:
-            return static_cast<int>(Gates::CZ);
+            return static_cast<uint8_t>(Gates::CZ);
         case 89:
-            return static_cast<int>(Gates::MZ);
+            return static_cast<uint8_t>(Gates::MZ);
         case 93:
-            return static_cast<int>(Gates::MX);
+            return static_cast<uint8_t>(Gates::MX);
         case 95:
-            return static_cast<int>(Gates::MY);
+            return static_cast<uint8_t>(Gates::MY);
         case 97:
-            return static_cast<int>(Gates::ZCX);
+            return static_cast<uint8_t>(Gates::ZCX);
         case 98:
-            return static_cast<int>(Gates::YCX);
+            return static_cast<uint8_t>(Gates::YCX);
         case 99:
-            return static_cast<int>(Gates::XCX);
+            return static_cast<uint8_t>(Gates::XCX);
         case 103:
-            return static_cast<int>(Gates::MRX);
+            return static_cast<uint8_t>(Gates::MRX);
         case 105:
-            return static_cast<int>(Gates::YCY);
+            return static_cast<uint8_t>(Gates::YCY);
         case 106:
-            return static_cast<int>(Gates::XCY);
+            return static_cast<uint8_t>(Gates::XCY);
         case 108:
-            return static_cast<int>(Gates::ZCY);
+            return static_cast<uint8_t>(Gates::ZCY);
         case 109:
-            return static_cast<int>(Gates::MPP);
+            return static_cast<uint8_t>(Gates::MPP);
         case 110:
-            return static_cast<int>(Gates::MRY);
+            return static_cast<uint8_t>(Gates::MRY);
         case 117:
-            return static_cast<int>(Gates::MRZ);
+            return static_cast<uint8_t>(Gates::MRZ);
         case 119:
-            return static_cast<int>(Gates::ZCZ);
+            return static_cast<uint8_t>(Gates::ZCZ);
         case 120:
-            return static_cast<int>(Gates::YCZ);
+            return static_cast<uint8_t>(Gates::YCZ);
         case 121:
-            return static_cast<int>(Gates::XCZ);
+            return static_cast<uint8_t>(Gates::XCZ);
         case 127:
-            return static_cast<int>(Gates::SQRT_ZZ);
+            return static_cast<uint8_t>(Gates::SQRT_ZZ);
         case 132:
-            return static_cast<int>(Gates::H_YZ);
+            return static_cast<uint8_t>(Gates::H_YZ);
         case 134:
-            return static_cast<int>(Gates::TICK);
+            return static_cast<uint8_t>(Gates::TICK);
         case 136:
-            return static_cast<int>(Gates::X_ERROR);
+            return static_cast<uint8_t>(Gates::X_ERROR);
         case 137:
-            return static_cast<int>(Gates::PAULI_CHANNEL_1);
+            return static_cast<uint8_t>(Gates::PAULI_CHANNEL_1);
         case 139:
-            return static_cast<int>(Gates::PAULI_CHANNEL_2);
+            return static_cast<uint8_t>(Gates::PAULI_CHANNEL_2);
         case 140:
-            return static_cast<int>(Gates::CNOT);
+            return static_cast<uint8_t>(Gates::CNOT);
         case 141:
-            return static_cast<int>(Gates::SWAP);
+            return static_cast<uint8_t>(Gates::SWAP);
         case 146:
-            return static_cast<int>(Gates::Z_ERROR);
+            return static_cast<uint8_t>(Gates::Z_ERROR);
         case 147:
-            return static_cast<int>(Gates::Y_ERROR);
+            return static_cast<uint8_t>(Gates::Y_ERROR);
         case 149:
-            return static_cast<int>(Gates::SQRT_XX);
+            return static_cast<uint8_t>(Gates::SQRT_XX);
         case 154:
-            return static_cast<int>(Gates::SQRT_YY);
+            return static_cast<uint8_t>(Gates::SQRT_YY);
         case 155:
-            return static_cast<int>(Gates::H_XZ);
+            return static_cast<uint8_t>(Gates::H_XZ);
         case 157:
-            return static_cast<int>(Gates::H_XY);
+            return static_cast<uint8_t>(Gates::H_XY);
         case 160:
-            return static_cast<int>(Gates::C_XYZ);
+            return static_cast<uint8_t>(Gates::C_XYZ);
         case 166:
-            return static_cast<int>(Gates::S_DAG);
+            return static_cast<uint8_t>(Gates::S_DAG);
         case 169:
-            return static_cast<int>(Gates::ISWAP);
+            return static_cast<uint8_t>(Gates::ISWAP);
         case 178:
-            return static_cast<int>(Gates::DETECTOR);
+            return static_cast<uint8_t>(Gates::DETECTOR);
         case 179:
-            return static_cast<int>(Gates::CORRELATED_ERROR);
+            return static_cast<uint8_t>(Gates::CORRELATED_ERROR);
         case 182:
-            return static_cast<int>(Gates::C_ZYX);
+            return static_cast<uint8_t>(Gates::C_ZYX);
         case 194:
-            return static_cast<int>(Gates::SQRT_Z);
+            return static_cast<uint8_t>(Gates::SQRT_Z);
         case 202:
-            return static_cast<int>(Gates::REPEAT);
+            return static_cast<uint8_t>(Gates::REPEAT);
         case 205:
-            return static_cast<int>(Gates::CXSWAP);
+            return static_cast<uint8_t>(Gates::CXSWAP);
         case 213:
-            return static_cast<int>(Gates::SWAPCX);
+            return static_cast<uint8_t>(Gates::SWAPCX);
         case 216:
-            return static_cast<int>(Gates::SQRT_X);
+            return static_cast<uint8_t>(Gates::SQRT_X);
         case 219:
-            return static_cast<int>(Gates::ISWAP_DAG);
+            return static_cast<uint8_t>(Gates::ISWAP_DAG);
         case 221:
-            return static_cast<int>(Gates::SQRT_Y);
+            return static_cast<uint8_t>(Gates::SQRT_Y);
         case 236:
-            return static_cast<int>(Gates::OBSERVABLE_INCLUDE);
+            return static_cast<uint8_t>(Gates::OBSERVABLE_INCLUDE);
         case 237:
-            return static_cast<int>(Gates::SQRT_Y_DAG);
+            return static_cast<uint8_t>(Gates::SQRT_Y_DAG);
         case 238:
-            return static_cast<int>(Gates::SQRT_Z_DAG);
+            return static_cast<uint8_t>(Gates::SQRT_Z_DAG);
         case 240:
-            return static_cast<int>(Gates::SQRT_X_DAG);
+            return static_cast<uint8_t>(Gates::SQRT_X_DAG);
         default:
             std::cerr << "Gate hash not mapped to Gate ID\n";
             return 0;
@@ -345,7 +345,8 @@ struct Gate {
     Gate();
     Gate(
         const char *name,
-        const char *best_inverse_name,
+        Gates gate_id,
+        Gates best_inverse_gate,
         uint8_t arg_count,
         void (TableauSimulator::*tableau_simulator_function)(const OperationData &),
         void (FrameSimulator::*frame_simulator_function)(const OperationData &),

--- a/src/stim/circuit/gate_data.test.cc
+++ b/src/stim/circuit/gate_data.test.cc
@@ -71,9 +71,9 @@ bool is_decomposition_correct(const Gate &gate) {
     Circuit circuit2 = epr + Circuit(decomposition);
     auto v2 = circuit_output_eq_val(circuit2);
     for (const auto &op : circuit2.operations) {
-        if (op.gate->id != gate_name_to_id("CX") && op.gate->id != gate_name_to_id("H") &&
-            op.gate->id != gate_name_to_id("S") && op.gate->id != gate_name_to_id("M") &&
-            op.gate->id != gate_name_to_id("R")) {
+        if (op.gate->id != static_cast<uint8_t>(Gates::CX) && op.gate->id != static_cast<uint8_t>(Gates::H) &&
+            op.gate->id != static_cast<uint8_t>(Gates::S) && op.gate->id != static_cast<uint8_t>(Gates::M) &&
+            op.gate->id != static_cast<uint8_t>(Gates::R)) {
             return false;
         }
     }

--- a/src/stim/circuit/gate_data_annotations.cc
+++ b/src/stim/circuit/gate_data_annotations.cc
@@ -28,10 +28,6 @@ void GateDataMap::add_gate_data_annotations(bool &failed) {
             Gates::DETECTOR,
             Gates::DETECTOR,
             ARG_COUNT_SYGIL_ANY,
-            &TableauSimulator::I,
-            &FrameSimulator::I,
-            &ErrorAnalyzer::DETECTOR,
-            &SparseUnsignedRevFrameTracker::undo_DETECTOR,
             (GateFlags)(GATE_ONLY_TARGETS_MEASUREMENT_RECORD | GATE_IS_NOT_FUSABLE | GATE_HAS_NO_EFFECT_ON_QUBITS),
             []() -> ExtraGateData {
                 return {
@@ -120,10 +116,6 @@ Example:
             Gates::OBSERVABLE_INCLUDE,
             Gates::OBSERVABLE_INCLUDE,
             1,
-            &TableauSimulator::I,
-            &FrameSimulator::I,
-            &ErrorAnalyzer::OBSERVABLE_INCLUDE,
-            &SparseUnsignedRevFrameTracker::undo_OBSERVABLE_INCLUDE,
             (GateFlags)(GATE_ONLY_TARGETS_MEASUREMENT_RECORD | GATE_IS_NOT_FUSABLE | GATE_ARGS_ARE_UNSIGNED_INTEGERS | GATE_HAS_NO_EFFECT_ON_QUBITS),
             []() -> ExtraGateData {
                 return {
@@ -198,10 +190,6 @@ Example:
             Gates::TICK,
             Gates::TICK,
             0,
-            &TableauSimulator::I,
-            &FrameSimulator::I,
-            &ErrorAnalyzer::TICK,
-            &SparseUnsignedRevFrameTracker::undo_I,
             (GateFlags)(GATE_IS_NOT_FUSABLE | GATE_TAKES_NO_TARGETS | GATE_HAS_NO_EFFECT_ON_QUBITS),
             []() -> ExtraGateData {
                 return {
@@ -252,10 +240,6 @@ Example:
             Gates::QUBIT_COORDS,
             Gates::QUBIT_COORDS,
             ARG_COUNT_SYGIL_ANY,
-            &TableauSimulator::I,
-            &FrameSimulator::I,
-            &ErrorAnalyzer::I,
-            &SparseUnsignedRevFrameTracker::undo_I,
             (GateFlags)(GATE_IS_NOT_FUSABLE | GATE_HAS_NO_EFFECT_ON_QUBITS),
             []() -> ExtraGateData {
                 return {
@@ -305,10 +289,6 @@ Example:
             Gates::SHIFT_COORDS,
             Gates::SHIFT_COORDS,
             ARG_COUNT_SYGIL_ANY,
-            &TableauSimulator::I,
-            &FrameSimulator::I,
-            &ErrorAnalyzer::SHIFT_COORDS,
-            &SparseUnsignedRevFrameTracker::undo_I,
             (GateFlags)(GATE_IS_NOT_FUSABLE | GATE_TAKES_NO_TARGETS | GATE_HAS_NO_EFFECT_ON_QUBITS),
             []() -> ExtraGateData {
                 return {

--- a/src/stim/circuit/gate_data_annotations.cc
+++ b/src/stim/circuit/gate_data_annotations.cc
@@ -25,7 +25,8 @@ void GateDataMap::add_gate_data_annotations(bool &failed) {
         failed,
         Gate{
             "DETECTOR",
-            "DETECTOR",
+            Gates::DETECTOR,
+            Gates::DETECTOR,
             ARG_COUNT_SYGIL_ANY,
             &TableauSimulator::I,
             &FrameSimulator::I,
@@ -116,7 +117,8 @@ Example:
         failed,
         Gate{
             "OBSERVABLE_INCLUDE",
-            "OBSERVABLE_INCLUDE",
+            Gates::OBSERVABLE_INCLUDE,
+            Gates::OBSERVABLE_INCLUDE,
             1,
             &TableauSimulator::I,
             &FrameSimulator::I,
@@ -193,7 +195,8 @@ Example:
         failed,
         Gate{
             "TICK",
-            "TICK",
+            Gates::TICK,
+            Gates::TICK,
             0,
             &TableauSimulator::I,
             &FrameSimulator::I,
@@ -246,7 +249,8 @@ Example:
         failed,
         Gate{
             "QUBIT_COORDS",
-            "QUBIT_COORDS",
+            Gates::QUBIT_COORDS,
+            Gates::QUBIT_COORDS,
             ARG_COUNT_SYGIL_ANY,
             &TableauSimulator::I,
             &FrameSimulator::I,
@@ -298,7 +302,8 @@ Example:
         failed,
         Gate{
             "SHIFT_COORDS",
-            "SHIFT_COORDS",
+            Gates::SHIFT_COORDS,
+            Gates::SHIFT_COORDS,
             ARG_COUNT_SYGIL_ANY,
             &TableauSimulator::I,
             &FrameSimulator::I,

--- a/src/stim/circuit/gate_data_blocks.cc
+++ b/src/stim/circuit/gate_data_blocks.cc
@@ -25,7 +25,8 @@ void GateDataMap::add_gate_data_blocks(bool &failed) {
         failed,
         Gate{
             "REPEAT",
-            "REPEAT",
+            Gates::REPEAT,
+            Gates::REPEAT,
             0,
             &TableauSimulator::I,
             &FrameSimulator::I,

--- a/src/stim/circuit/gate_data_blocks.cc
+++ b/src/stim/circuit/gate_data_blocks.cc
@@ -28,10 +28,6 @@ void GateDataMap::add_gate_data_blocks(bool &failed) {
             Gates::REPEAT,
             Gates::REPEAT,
             0,
-            &TableauSimulator::I,
-            &FrameSimulator::I,
-            &ErrorAnalyzer::I,
-            &SparseUnsignedRevFrameTracker::undo_I,
             (GateFlags)(GATE_IS_BLOCK | GATE_IS_NOT_FUSABLE),
             []() -> ExtraGateData {
                 return {

--- a/src/stim/circuit/gate_data_collapsing.cc
+++ b/src/stim/circuit/gate_data_collapsing.cc
@@ -29,10 +29,6 @@ void GateDataMap::add_gate_data_collapsing(bool &failed) {
             Gates::MX,
             Gates::MX,
             ARG_COUNT_SYGIL_ZERO_OR_ONE,
-            &TableauSimulator::measure_x,
-            &FrameSimulator::measure_x,
-            &ErrorAnalyzer::MX,
-            &SparseUnsignedRevFrameTracker::undo_MX,
             (GateFlags)(GATE_PRODUCES_NOISY_RESULTS | GATE_ARGS_ARE_DISJOINT_PROBABILITIES),
             []() -> ExtraGateData {
                 return {
@@ -86,10 +82,6 @@ H 0
             Gates::MY,
             Gates::MY,
             ARG_COUNT_SYGIL_ZERO_OR_ONE,
-            &TableauSimulator::measure_y,
-            &FrameSimulator::measure_y,
-            &ErrorAnalyzer::MY,
-            &SparseUnsignedRevFrameTracker::undo_MY,
             (GateFlags)(GATE_PRODUCES_NOISY_RESULTS | GATE_ARGS_ARE_DISJOINT_PROBABILITIES),
             []() -> ExtraGateData {
                 return {
@@ -147,10 +139,6 @@ S 0
             Gates::M,
             Gates::M,
             ARG_COUNT_SYGIL_ZERO_OR_ONE,
-            &TableauSimulator::measure_z,
-            &FrameSimulator::measure_z,
-            &ErrorAnalyzer::MZ,
-            &SparseUnsignedRevFrameTracker::undo_MZ,
             (GateFlags)(GATE_PRODUCES_NOISY_RESULTS | GATE_ARGS_ARE_DISJOINT_PROBABILITIES),
             []() -> ExtraGateData {
                 return {
@@ -208,10 +196,6 @@ M 0
             Gates::MRX,
             Gates::MRX,
             ARG_COUNT_SYGIL_ZERO_OR_ONE,
-            &TableauSimulator::measure_reset_x,
-            &FrameSimulator::measure_reset_x,
-            &ErrorAnalyzer::MRX,
-            &SparseUnsignedRevFrameTracker::undo_MRX,
             (GateFlags)(GATE_PRODUCES_NOISY_RESULTS | GATE_ARGS_ARE_DISJOINT_PROBABILITIES | GATE_IS_RESET),
             []() -> ExtraGateData {
                 return {
@@ -267,10 +251,6 @@ H 0
             Gates::MRY,
             Gates::MRY,
             ARG_COUNT_SYGIL_ZERO_OR_ONE,
-            &TableauSimulator::measure_reset_y,
-            &FrameSimulator::measure_reset_y,
-            &ErrorAnalyzer::MRY,
-            &SparseUnsignedRevFrameTracker::undo_MRY,
             (GateFlags)(GATE_PRODUCES_NOISY_RESULTS | GATE_ARGS_ARE_DISJOINT_PROBABILITIES | GATE_IS_RESET),
             []() -> ExtraGateData {
                 return {
@@ -330,10 +310,6 @@ S 0
             Gates::MR,
             Gates::MR,
             ARG_COUNT_SYGIL_ZERO_OR_ONE,
-            &TableauSimulator::measure_reset_z,
-            &FrameSimulator::measure_reset_z,
-            &ErrorAnalyzer::MRZ,
-            &SparseUnsignedRevFrameTracker::undo_MRZ,
             (GateFlags)(GATE_PRODUCES_NOISY_RESULTS | GATE_ARGS_ARE_DISJOINT_PROBABILITIES | GATE_IS_RESET),
             []() -> ExtraGateData {
                 return {
@@ -393,10 +369,6 @@ R 0
             Gates::RX,
             Gates::MRX,
             0,
-            &TableauSimulator::reset_x,
-            &FrameSimulator::reset_x,
-            &ErrorAnalyzer::RX,
-            &SparseUnsignedRevFrameTracker::undo_RX,
             GATE_IS_RESET,
             []() -> ExtraGateData {
                 return {
@@ -438,10 +410,6 @@ H 0
             Gates::RY,
             Gates::MRY,
             0,
-            &TableauSimulator::reset_y,
-            &FrameSimulator::reset_y,
-            &ErrorAnalyzer::RY,
-            &SparseUnsignedRevFrameTracker::undo_RY,
             GATE_IS_RESET,
             []() -> ExtraGateData {
                 return {
@@ -487,10 +455,6 @@ S 0
             Gates::R,
             Gates::MR,
             0,
-            &TableauSimulator::reset_z,
-            &FrameSimulator::reset_z,
-            &ErrorAnalyzer::RZ,
-            &SparseUnsignedRevFrameTracker::undo_RZ,
             GATE_IS_RESET,
             []() -> ExtraGateData {
                 return {
@@ -535,10 +499,6 @@ R 0
             Gates::MPP,
             Gates::MPP,
             ARG_COUNT_SYGIL_ZERO_OR_ONE,
-            &TableauSimulator::MPP,
-            &FrameSimulator::MPP,
-            &ErrorAnalyzer::MPP,
-            &SparseUnsignedRevFrameTracker::undo_MPP,
             (GateFlags)(GATE_PRODUCES_NOISY_RESULTS | GATE_TARGETS_PAULI_STRING | GATE_TARGETS_COMBINERS |
                         GATE_ARGS_ARE_DISJOINT_PROBABILITIES),
             []() -> ExtraGateData {

--- a/src/stim/circuit/gate_data_collapsing.cc
+++ b/src/stim/circuit/gate_data_collapsing.cc
@@ -26,7 +26,8 @@ void GateDataMap::add_gate_data_collapsing(bool &failed) {
         failed,
         Gate{
             "MX",
-            "MX",
+            Gates::MX,
+            Gates::MX,
             ARG_COUNT_SYGIL_ZERO_OR_ONE,
             &TableauSimulator::measure_x,
             &FrameSimulator::measure_x,
@@ -82,7 +83,8 @@ H 0
         failed,
         Gate{
             "MY",
-            "MY",
+            Gates::MY,
+            Gates::MY,
             ARG_COUNT_SYGIL_ZERO_OR_ONE,
             &TableauSimulator::measure_y,
             &FrameSimulator::measure_y,
@@ -142,7 +144,8 @@ S 0
         failed,
         Gate{
             "M",
-            "M",
+            Gates::M,
+            Gates::M,
             ARG_COUNT_SYGIL_ZERO_OR_ONE,
             &TableauSimulator::measure_z,
             &FrameSimulator::measure_z,
@@ -202,7 +205,8 @@ M 0
         failed,
         Gate{
             "MRX",
-            "MRX",
+            Gates::MRX,
+            Gates::MRX,
             ARG_COUNT_SYGIL_ZERO_OR_ONE,
             &TableauSimulator::measure_reset_x,
             &FrameSimulator::measure_reset_x,
@@ -260,7 +264,8 @@ H 0
         failed,
         Gate{
             "MRY",
-            "MRY",
+            Gates::MRY,
+            Gates::MRY,
             ARG_COUNT_SYGIL_ZERO_OR_ONE,
             &TableauSimulator::measure_reset_y,
             &FrameSimulator::measure_reset_y,
@@ -322,7 +327,8 @@ S 0
         failed,
         Gate{
             "MR",
-            "MR",
+            Gates::MR,
+            Gates::MR,
             ARG_COUNT_SYGIL_ZERO_OR_ONE,
             &TableauSimulator::measure_reset_z,
             &FrameSimulator::measure_reset_z,
@@ -384,7 +390,8 @@ R 0
         failed,
         Gate{
             "RX",
-            "MRX",
+            Gates::RX,
+            Gates::MRX,
             0,
             &TableauSimulator::reset_x,
             &FrameSimulator::reset_x,
@@ -428,7 +435,8 @@ H 0
         failed,
         Gate{
             "RY",
-            "MRY",
+            Gates::RY,
+            Gates::MRY,
             0,
             &TableauSimulator::reset_y,
             &FrameSimulator::reset_y,
@@ -476,7 +484,8 @@ S 0
         failed,
         Gate{
             "R",
-            "MR",
+            Gates::R,
+            Gates::MR,
             0,
             &TableauSimulator::reset_z,
             &FrameSimulator::reset_z,
@@ -523,7 +532,8 @@ R 0
         failed,
         Gate{
             "MPP",
-            "MPP",
+            Gates::MPP,
+            Gates::MPP,
             ARG_COUNT_SYGIL_ZERO_OR_ONE,
             &TableauSimulator::MPP,
             &FrameSimulator::MPP,

--- a/src/stim/circuit/gate_data_controlled.cc
+++ b/src/stim/circuit/gate_data_controlled.cc
@@ -29,7 +29,8 @@ void GateDataMap::add_gate_data_controlled(bool &failed) {
         failed,
         Gate{
             "XCX",
-            "XCX",
+            Gates::XCX,
+            Gates::XCX,
             0,
             &TableauSimulator::XCX,
             &FrameSimulator::XCX,
@@ -73,7 +74,8 @@ H 0
         failed,
         Gate{
             "XCY",
-            "XCY",
+            Gates::XCY,
+            Gates::XCY,
             0,
             &TableauSimulator::XCY,
             &FrameSimulator::XCY,
@@ -121,7 +123,8 @@ S 1
         failed,
         Gate{
             "XCZ",
-            "XCZ",
+            Gates::XCZ,
+            Gates::XCZ,
             0,
             &TableauSimulator::XCZ,
             &FrameSimulator::XCZ,
@@ -179,7 +182,8 @@ CNOT 1 0
         failed,
         Gate{
             "YCX",
-            "YCX",
+            Gates::YCX,
+            Gates::YCX,
             0,
             &TableauSimulator::YCX,
             &FrameSimulator::YCX,
@@ -227,7 +231,8 @@ H 1
         failed,
         Gate{
             "YCY",
-            "YCY",
+            Gates::YCY,
+            Gates::YCY,
             0,
             &TableauSimulator::YCY,
             &FrameSimulator::YCY,
@@ -279,7 +284,8 @@ S 1
         failed,
         Gate{
             "YCZ",
-            "YCZ",
+            Gates::YCZ,
+            Gates::YCZ,
             0,
             &TableauSimulator::YCZ,
             &FrameSimulator::YCZ,
@@ -341,7 +347,8 @@ S 0
         failed,
         Gate{
             "CX",
-            "CX",
+            Gates::CX,
+            Gates::CX,
             0,
             &TableauSimulator::ZCX,
             &FrameSimulator::ZCX,
@@ -400,7 +407,8 @@ CNOT 0 1
         failed,
         Gate{
             "CY",
-            "CY",
+            Gates::CY,
+            Gates::CY,
             0,
             &TableauSimulator::ZCY,
             &FrameSimulator::ZCY,
@@ -462,7 +470,8 @@ S 1
         failed,
         Gate{
             "CZ",
-            "CZ",
+            Gates::CZ,
+            Gates::CZ,
             0,
             &TableauSimulator::ZCZ,
             &FrameSimulator::ZCZ,

--- a/src/stim/circuit/gate_data_controlled.cc
+++ b/src/stim/circuit/gate_data_controlled.cc
@@ -32,10 +32,6 @@ void GateDataMap::add_gate_data_controlled(bool &failed) {
             Gates::XCX,
             Gates::XCX,
             0,
-            &TableauSimulator::XCX,
-            &FrameSimulator::XCX,
-            &ErrorAnalyzer::XCX,
-            &SparseUnsignedRevFrameTracker::undo_XCX,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS),
             []() -> ExtraGateData {
                 return {
@@ -77,10 +73,6 @@ H 0
             Gates::XCY,
             Gates::XCY,
             0,
-            &TableauSimulator::XCY,
-            &FrameSimulator::XCY,
-            &ErrorAnalyzer::XCY,
-            &SparseUnsignedRevFrameTracker::undo_XCY,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS),
             []() -> ExtraGateData {
                 return {
@@ -126,10 +118,6 @@ S 1
             Gates::XCZ,
             Gates::XCZ,
             0,
-            &TableauSimulator::XCZ,
-            &FrameSimulator::XCZ,
-            &ErrorAnalyzer::XCZ,
-            &SparseUnsignedRevFrameTracker::undo_XCZ,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS | GATE_CAN_TARGET_BITS),
             []() -> ExtraGateData {
                 return {
@@ -185,10 +173,6 @@ CNOT 1 0
             Gates::YCX,
             Gates::YCX,
             0,
-            &TableauSimulator::YCX,
-            &FrameSimulator::YCX,
-            &ErrorAnalyzer::YCX,
-            &SparseUnsignedRevFrameTracker::undo_YCX,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS),
             []() -> ExtraGateData {
                 return {
@@ -234,10 +218,6 @@ H 1
             Gates::YCY,
             Gates::YCY,
             0,
-            &TableauSimulator::YCY,
-            &FrameSimulator::YCY,
-            &ErrorAnalyzer::YCY,
-            &SparseUnsignedRevFrameTracker::undo_YCY,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS),
             []() -> ExtraGateData {
                 return {
@@ -287,10 +267,6 @@ S 1
             Gates::YCZ,
             Gates::YCZ,
             0,
-            &TableauSimulator::YCZ,
-            &FrameSimulator::YCZ,
-            &ErrorAnalyzer::YCZ,
-            &SparseUnsignedRevFrameTracker::undo_YCZ,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS | GATE_CAN_TARGET_BITS),
             []() -> ExtraGateData {
                 return {
@@ -350,10 +326,6 @@ S 0
             Gates::CX,
             Gates::CX,
             0,
-            &TableauSimulator::ZCX,
-            &FrameSimulator::ZCX,
-            &ErrorAnalyzer::ZCX,
-            &SparseUnsignedRevFrameTracker::undo_ZCX,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS | GATE_CAN_TARGET_BITS),
             []() -> ExtraGateData {
                 return {
@@ -410,10 +382,6 @@ CNOT 0 1
             Gates::CY,
             Gates::CY,
             0,
-            &TableauSimulator::ZCY,
-            &FrameSimulator::ZCY,
-            &ErrorAnalyzer::ZCY,
-            &SparseUnsignedRevFrameTracker::undo_ZCY,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS | GATE_CAN_TARGET_BITS),
             []() -> ExtraGateData {
                 return {
@@ -473,10 +441,6 @@ S 1
             Gates::CZ,
             Gates::CZ,
             0,
-            &TableauSimulator::ZCZ,
-            &FrameSimulator::ZCZ,
-            &ErrorAnalyzer::ZCZ,
-            &SparseUnsignedRevFrameTracker::undo_ZCZ,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS | GATE_CAN_TARGET_BITS),
             []() -> ExtraGateData {
                 return {

--- a/src/stim/circuit/gate_data_hada.cc
+++ b/src/stim/circuit/gate_data_hada.cc
@@ -30,7 +30,8 @@ void GateDataMap::add_gate_data_hada(bool &failed) {
         failed,
         Gate{
             "H",
-            "H",
+            Gates::H,
+            Gates::H,
             0,
             &TableauSimulator::H_XZ,
             &FrameSimulator::H_XZ,
@@ -66,7 +67,8 @@ H 0
         failed,
         Gate{
             "H_XY",
-            "H_XY",
+            Gates::H_XY,
+            Gates::H_XY,
             0,
             &TableauSimulator::H_XY,
             &FrameSimulator::H_XY,
@@ -104,7 +106,8 @@ S 0
         failed,
         Gate{
             "H_YZ",
-            "H_YZ",
+            Gates::H_YZ,
+            Gates::H_YZ,
             0,
             &TableauSimulator::H_YZ,
             &FrameSimulator::H_YZ,

--- a/src/stim/circuit/gate_data_hada.cc
+++ b/src/stim/circuit/gate_data_hada.cc
@@ -33,10 +33,6 @@ void GateDataMap::add_gate_data_hada(bool &failed) {
             Gates::H,
             Gates::H,
             0,
-            &TableauSimulator::H_XZ,
-            &FrameSimulator::H_XZ,
-            &ErrorAnalyzer::H_XZ,
-            &SparseUnsignedRevFrameTracker::undo_H_XZ,
             GATE_IS_UNITARY,
             []() -> ExtraGateData {
                 return {
@@ -70,10 +66,6 @@ H 0
             Gates::H_XY,
             Gates::H_XY,
             0,
-            &TableauSimulator::H_XY,
-            &FrameSimulator::H_XY,
-            &ErrorAnalyzer::H_XY,
-            &SparseUnsignedRevFrameTracker::undo_H_XY,
             GATE_IS_UNITARY,
             []() -> ExtraGateData {
                 return {
@@ -109,10 +101,6 @@ S 0
             Gates::H_YZ,
             Gates::H_YZ,
             0,
-            &TableauSimulator::H_YZ,
-            &FrameSimulator::H_YZ,
-            &ErrorAnalyzer::H_YZ,
-            &SparseUnsignedRevFrameTracker::undo_H_YZ,
             GATE_IS_UNITARY,
             []() -> ExtraGateData {
                 return {

--- a/src/stim/circuit/gate_data_noisy.cc
+++ b/src/stim/circuit/gate_data_noisy.cc
@@ -25,7 +25,8 @@ void GateDataMap::add_gate_data_noisy(bool &failed) {
         failed,
         Gate{
             "DEPOLARIZE1",
-            "DEPOLARIZE1",
+            Gates::DEPOLARIZE1,
+            Gates::DEPOLARIZE1,
             1,
             &TableauSimulator::DEPOLARIZE1,
             &FrameSimulator::DEPOLARIZE1,
@@ -66,7 +67,8 @@ Pauli Mixture:
         failed,
         Gate{
             "DEPOLARIZE2",
-            "DEPOLARIZE2",
+            Gates::DEPOLARIZE2,
+            Gates::DEPOLARIZE2,
             1,
             &TableauSimulator::DEPOLARIZE2,
             &FrameSimulator::DEPOLARIZE2,
@@ -119,7 +121,8 @@ Pauli Mixture:
         failed,
         Gate{
             "X_ERROR",
-            "X_ERROR",
+            Gates::X_ERROR,
+            Gates::X_ERROR,
             1,
             &TableauSimulator::X_ERROR,
             &FrameSimulator::X_ERROR,
@@ -156,7 +159,8 @@ Pauli Mixture:
         failed,
         Gate{
             "Y_ERROR",
-            "Y_ERROR",
+            Gates::Y_ERROR,
+            Gates::Y_ERROR,
             1,
             &TableauSimulator::Y_ERROR,
             &FrameSimulator::Y_ERROR,
@@ -193,7 +197,8 @@ Pauli Mixture:
         failed,
         Gate{
             "Z_ERROR",
-            "Z_ERROR",
+            Gates::Z_ERROR,
+            Gates::Z_ERROR,
             1,
             &TableauSimulator::Z_ERROR,
             &FrameSimulator::Z_ERROR,
@@ -230,7 +235,8 @@ Pauli Mixture:
         failed,
         Gate{
             "PAULI_CHANNEL_1",
-            "PAULI_CHANNEL_1",
+            Gates::PAULI_CHANNEL_1,
+            Gates::PAULI_CHANNEL_1,
             3,
             &TableauSimulator::PAULI_CHANNEL_1,
             &FrameSimulator::PAULI_CHANNEL_1,
@@ -278,7 +284,8 @@ Pauli Mixture:
         failed,
         Gate{
             "PAULI_CHANNEL_2",
-            "PAULI_CHANNEL_2",
+            Gates::PAULI_CHANNEL_2,
+            Gates::PAULI_CHANNEL_2,
             15,
             &TableauSimulator::PAULI_CHANNEL_2,
             &FrameSimulator::PAULI_CHANNEL_2,
@@ -354,7 +361,8 @@ Pauli Mixture:
         failed,
         Gate{
             "E",
-            "E",
+            Gates::E,
+            Gates::E,
             1,
             &TableauSimulator::CORRELATED_ERROR,
             &FrameSimulator::CORRELATED_ERROR,
@@ -400,7 +408,8 @@ Example:
         failed,
         Gate{
             "ELSE_CORRELATED_ERROR",
-            "ELSE_CORRELATED_ERROR",
+            Gates::ELSE_CORRELATED_ERROR,
+            Gates::ELSE_CORRELATED_ERROR,
             1,
             &TableauSimulator::ELSE_CORRELATED_ERROR,
             &FrameSimulator::ELSE_CORRELATED_ERROR,

--- a/src/stim/circuit/gate_data_noisy.cc
+++ b/src/stim/circuit/gate_data_noisy.cc
@@ -28,10 +28,6 @@ void GateDataMap::add_gate_data_noisy(bool &failed) {
             Gates::DEPOLARIZE1,
             Gates::DEPOLARIZE1,
             1,
-            &TableauSimulator::DEPOLARIZE1,
-            &FrameSimulator::DEPOLARIZE1,
-            &ErrorAnalyzer::DEPOLARIZE1,
-            &SparseUnsignedRevFrameTracker::undo_I,
             (GateFlags)(GATE_IS_NOISE | GATE_ARGS_ARE_DISJOINT_PROBABILITIES),
             []() -> ExtraGateData {
                 return {
@@ -70,10 +66,6 @@ Pauli Mixture:
             Gates::DEPOLARIZE2,
             Gates::DEPOLARIZE2,
             1,
-            &TableauSimulator::DEPOLARIZE2,
-            &FrameSimulator::DEPOLARIZE2,
-            &ErrorAnalyzer::DEPOLARIZE2,
-            &SparseUnsignedRevFrameTracker::undo_I,
             (GateFlags)(GATE_IS_NOISE | GATE_ARGS_ARE_DISJOINT_PROBABILITIES | GATE_TARGETS_PAIRS),
             []() -> ExtraGateData {
                 return {
@@ -124,10 +116,6 @@ Pauli Mixture:
             Gates::X_ERROR,
             Gates::X_ERROR,
             1,
-            &TableauSimulator::X_ERROR,
-            &FrameSimulator::X_ERROR,
-            &ErrorAnalyzer::X_ERROR,
-            &SparseUnsignedRevFrameTracker::undo_I,
             (GateFlags)(GATE_IS_NOISE | GATE_ARGS_ARE_DISJOINT_PROBABILITIES),
             []() -> ExtraGateData {
                 return {
@@ -162,10 +150,6 @@ Pauli Mixture:
             Gates::Y_ERROR,
             Gates::Y_ERROR,
             1,
-            &TableauSimulator::Y_ERROR,
-            &FrameSimulator::Y_ERROR,
-            &ErrorAnalyzer::Y_ERROR,
-            &SparseUnsignedRevFrameTracker::undo_I,
             (GateFlags)(GATE_IS_NOISE | GATE_ARGS_ARE_DISJOINT_PROBABILITIES),
             []() -> ExtraGateData {
                 return {
@@ -200,10 +184,6 @@ Pauli Mixture:
             Gates::Z_ERROR,
             Gates::Z_ERROR,
             1,
-            &TableauSimulator::Z_ERROR,
-            &FrameSimulator::Z_ERROR,
-            &ErrorAnalyzer::Z_ERROR,
-            &SparseUnsignedRevFrameTracker::undo_I,
             (GateFlags)(GATE_IS_NOISE | GATE_ARGS_ARE_DISJOINT_PROBABILITIES),
             []() -> ExtraGateData {
                 return {
@@ -238,10 +218,6 @@ Pauli Mixture:
             Gates::PAULI_CHANNEL_1,
             Gates::PAULI_CHANNEL_1,
             3,
-            &TableauSimulator::PAULI_CHANNEL_1,
-            &FrameSimulator::PAULI_CHANNEL_1,
-            &ErrorAnalyzer::PAULI_CHANNEL_1,
-            &SparseUnsignedRevFrameTracker::undo_I,
             (GateFlags)(GATE_IS_NOISE | GATE_ARGS_ARE_DISJOINT_PROBABILITIES),
             []() -> ExtraGateData {
                 return {
@@ -287,10 +263,6 @@ Pauli Mixture:
             Gates::PAULI_CHANNEL_2,
             Gates::PAULI_CHANNEL_2,
             15,
-            &TableauSimulator::PAULI_CHANNEL_2,
-            &FrameSimulator::PAULI_CHANNEL_2,
-            &ErrorAnalyzer::PAULI_CHANNEL_2,
-            &SparseUnsignedRevFrameTracker::undo_I,
             (GateFlags)(GATE_IS_NOISE | GATE_ARGS_ARE_DISJOINT_PROBABILITIES | GATE_TARGETS_PAIRS),
             []() -> ExtraGateData {
                 return {
@@ -364,10 +336,6 @@ Pauli Mixture:
             Gates::E,
             Gates::E,
             1,
-            &TableauSimulator::CORRELATED_ERROR,
-            &FrameSimulator::CORRELATED_ERROR,
-            &ErrorAnalyzer::CORRELATED_ERROR,
-            &SparseUnsignedRevFrameTracker::undo_I,
             (GateFlags)(GATE_IS_NOISE | GATE_ARGS_ARE_DISJOINT_PROBABILITIES | GATE_TARGETS_PAULI_STRING |
                         GATE_IS_NOT_FUSABLE),
             []() -> ExtraGateData {
@@ -411,10 +379,6 @@ Example:
             Gates::ELSE_CORRELATED_ERROR,
             Gates::ELSE_CORRELATED_ERROR,
             1,
-            &TableauSimulator::ELSE_CORRELATED_ERROR,
-            &FrameSimulator::ELSE_CORRELATED_ERROR,
-            &ErrorAnalyzer::ELSE_CORRELATED_ERROR,
-            &SparseUnsignedRevFrameTracker::undo_I,
             (GateFlags)(GATE_IS_NOISE | GATE_ARGS_ARE_DISJOINT_PROBABILITIES | GATE_TARGETS_PAULI_STRING |
                         GATE_IS_NOT_FUSABLE),
             []() -> ExtraGateData {

--- a/src/stim/circuit/gate_data_pauli.cc
+++ b/src/stim/circuit/gate_data_pauli.cc
@@ -29,7 +29,8 @@ void GateDataMap::add_gate_data_pauli(bool &failed) {
         failed,
         Gate{
             "I",
-            "I",
+            Gates::I,
+            Gates::I,
             0,
             &TableauSimulator::I,
             &FrameSimulator::I,
@@ -64,7 +65,8 @@ Targets:
         failed,
         Gate{
             "X",
-            "X",
+            Gates::X,
+            Gates::X,
             0,
             &TableauSimulator::X,
             &FrameSimulator::I,
@@ -102,7 +104,8 @@ H 0
         failed,
         Gate{
             "Y",
-            "Y",
+            Gates::Y,
+            Gates::Y,
             0,
             &TableauSimulator::Y,
             &FrameSimulator::I,
@@ -141,7 +144,8 @@ H 0
         failed,
         Gate{
             "Z",
-            "Z",
+            Gates::Z,
+            Gates::Z,
             0,
             &TableauSimulator::Z,
             &FrameSimulator::I,

--- a/src/stim/circuit/gate_data_pauli.cc
+++ b/src/stim/circuit/gate_data_pauli.cc
@@ -32,10 +32,6 @@ void GateDataMap::add_gate_data_pauli(bool &failed) {
             Gates::I,
             Gates::I,
             0,
-            &TableauSimulator::I,
-            &FrameSimulator::I,
-            &ErrorAnalyzer::I,
-            &SparseUnsignedRevFrameTracker::undo_I,
             GATE_IS_UNITARY,
             []() -> ExtraGateData {
                 return {
@@ -68,10 +64,6 @@ Targets:
             Gates::X,
             Gates::X,
             0,
-            &TableauSimulator::X,
-            &FrameSimulator::I,
-            &ErrorAnalyzer::I,
-            &SparseUnsignedRevFrameTracker::undo_I,
             GATE_IS_UNITARY,
             []() -> ExtraGateData {
                 return {
@@ -107,10 +99,6 @@ H 0
             Gates::Y,
             Gates::Y,
             0,
-            &TableauSimulator::Y,
-            &FrameSimulator::I,
-            &ErrorAnalyzer::I,
-            &SparseUnsignedRevFrameTracker::undo_I,
             GATE_IS_UNITARY,
             []() -> ExtraGateData {
                 return {
@@ -147,10 +135,6 @@ H 0
             Gates::Z,
             Gates::Z,
             0,
-            &TableauSimulator::Z,
-            &FrameSimulator::I,
-            &ErrorAnalyzer::I,
-            &SparseUnsignedRevFrameTracker::undo_I,
             GATE_IS_UNITARY,
             []() -> ExtraGateData {
                 return {

--- a/src/stim/circuit/gate_data_period_3.cc
+++ b/src/stim/circuit/gate_data_period_3.cc
@@ -29,7 +29,8 @@ void GateDataMap::add_gate_data_period_3(bool &failed) {
         failed,
         Gate{
             "C_XYZ",
-            "C_ZYX",
+            Gates::C_XYZ,
+            Gates::C_ZYX,
             0,
             &TableauSimulator::C_XYZ,
             &FrameSimulator::C_XYZ,
@@ -66,7 +67,8 @@ H 0
         failed,
         Gate{
             "C_ZYX",
-            "C_XYZ",
+            Gates::C_ZYX,
+            Gates::C_XYZ,
             0,
             &TableauSimulator::C_ZYX,
             &FrameSimulator::C_ZYX,

--- a/src/stim/circuit/gate_data_period_3.cc
+++ b/src/stim/circuit/gate_data_period_3.cc
@@ -32,10 +32,6 @@ void GateDataMap::add_gate_data_period_3(bool &failed) {
             Gates::C_XYZ,
             Gates::C_ZYX,
             0,
-            &TableauSimulator::C_XYZ,
-            &FrameSimulator::C_XYZ,
-            &ErrorAnalyzer::C_XYZ,
-            &SparseUnsignedRevFrameTracker::undo_C_XYZ,
             GATE_IS_UNITARY,
             []() -> ExtraGateData {
                 return {
@@ -70,10 +66,6 @@ H 0
             Gates::C_ZYX,
             Gates::C_XYZ,
             0,
-            &TableauSimulator::C_ZYX,
-            &FrameSimulator::C_ZYX,
-            &ErrorAnalyzer::C_ZYX,
-            &SparseUnsignedRevFrameTracker::undo_C_ZYX,
             GATE_IS_UNITARY,
             []() -> ExtraGateData {
                 return {

--- a/src/stim/circuit/gate_data_period_4.cc
+++ b/src/stim/circuit/gate_data_period_4.cc
@@ -29,7 +29,8 @@ void GateDataMap::add_gate_data_period_4(bool &failed) {
         failed,
         Gate{
             "SQRT_X",
-            "SQRT_X_DAG",
+            Gates::SQRT_X,
+            Gates::SQRT_X_DAG,
             0,
             &TableauSimulator::SQRT_X,
             &FrameSimulator::H_YZ,
@@ -66,7 +67,8 @@ H 0
         failed,
         Gate{
             "SQRT_X_DAG",
-            "SQRT_X",
+            Gates::SQRT_X_DAG,
+            Gates::SQRT_X,
             0,
             &TableauSimulator::SQRT_X_DAG,
             &FrameSimulator::H_YZ,
@@ -103,7 +105,8 @@ S 0
         failed,
         Gate{
             "SQRT_Y",
-            "SQRT_Y_DAG",
+            Gates::SQRT_Y,
+            Gates::SQRT_Y_DAG,
             0,
             &TableauSimulator::SQRT_Y,
             &FrameSimulator::H_XZ,
@@ -140,7 +143,8 @@ H 0
         failed,
         Gate{
             "SQRT_Y_DAG",
-            "SQRT_Y",
+            Gates::SQRT_Y_DAG,
+            Gates::SQRT_Y,
             0,
             &TableauSimulator::SQRT_Y_DAG,
             &FrameSimulator::H_XZ,
@@ -177,7 +181,8 @@ S 0
         failed,
         Gate{
             "S",
-            "S_DAG",
+            Gates::S,
+            Gates::S_DAG,
             0,
             &TableauSimulator::SQRT_Z,
             &FrameSimulator::H_XY,
@@ -213,7 +218,8 @@ S 0
         failed,
         Gate{
             "S_DAG",
-            "S",
+            Gates::S_DAG,
+            Gates::S,
             0,
             &TableauSimulator::SQRT_Z_DAG,
             &FrameSimulator::H_XY,

--- a/src/stim/circuit/gate_data_period_4.cc
+++ b/src/stim/circuit/gate_data_period_4.cc
@@ -32,10 +32,6 @@ void GateDataMap::add_gate_data_period_4(bool &failed) {
             Gates::SQRT_X,
             Gates::SQRT_X_DAG,
             0,
-            &TableauSimulator::SQRT_X,
-            &FrameSimulator::H_YZ,
-            &ErrorAnalyzer::H_YZ,
-            &SparseUnsignedRevFrameTracker::undo_H_YZ,
             GATE_IS_UNITARY,
             []() -> ExtraGateData {
                 return {
@@ -70,10 +66,6 @@ H 0
             Gates::SQRT_X_DAG,
             Gates::SQRT_X,
             0,
-            &TableauSimulator::SQRT_X_DAG,
-            &FrameSimulator::H_YZ,
-            &ErrorAnalyzer::H_YZ,
-            &SparseUnsignedRevFrameTracker::undo_H_YZ,
             GATE_IS_UNITARY,
             []() -> ExtraGateData {
                 return {
@@ -108,10 +100,6 @@ S 0
             Gates::SQRT_Y,
             Gates::SQRT_Y_DAG,
             0,
-            &TableauSimulator::SQRT_Y,
-            &FrameSimulator::H_XZ,
-            &ErrorAnalyzer::H_XZ,
-            &SparseUnsignedRevFrameTracker::undo_H_XZ,
             GATE_IS_UNITARY,
             []() -> ExtraGateData {
                 return {
@@ -146,10 +134,6 @@ H 0
             Gates::SQRT_Y_DAG,
             Gates::SQRT_Y,
             0,
-            &TableauSimulator::SQRT_Y_DAG,
-            &FrameSimulator::H_XZ,
-            &ErrorAnalyzer::H_XZ,
-            &SparseUnsignedRevFrameTracker::undo_H_XZ,
             GATE_IS_UNITARY,
             []() -> ExtraGateData {
                 return {
@@ -184,10 +168,6 @@ S 0
             Gates::S,
             Gates::S_DAG,
             0,
-            &TableauSimulator::SQRT_Z,
-            &FrameSimulator::H_XY,
-            &ErrorAnalyzer::H_XY,
-            &SparseUnsignedRevFrameTracker::undo_H_XY,
             GATE_IS_UNITARY,
             []() -> ExtraGateData {
                 return {
@@ -221,10 +201,6 @@ S 0
             Gates::S_DAG,
             Gates::S,
             0,
-            &TableauSimulator::SQRT_Z_DAG,
-            &FrameSimulator::H_XY,
-            &ErrorAnalyzer::H_XY,
-            &SparseUnsignedRevFrameTracker::undo_H_XY,
             GATE_IS_UNITARY,
             []() -> ExtraGateData {
                 return {

--- a/src/stim/circuit/gate_data_pp.cc
+++ b/src/stim/circuit/gate_data_pp.cc
@@ -29,7 +29,8 @@ void GateDataMap::add_gate_data_pp(bool &failed) {
         failed,
         Gate{
             "SQRT_XX",
-            "SQRT_XX_DAG",
+            Gates::SQRT_XX,
+            Gates::SQRT_XX_DAG,
             0,
             &TableauSimulator::SQRT_XX,
             &FrameSimulator::SQRT_XX,
@@ -71,7 +72,8 @@ H 1
         failed,
         Gate{
             "SQRT_XX_DAG",
-            "SQRT_XX",
+            Gates::SQRT_XX_DAG,
+            Gates::SQRT_XX,
             0,
             &TableauSimulator::SQRT_XX_DAG,
             &FrameSimulator::SQRT_XX,
@@ -118,7 +120,8 @@ H 1
         failed,
         Gate{
             "SQRT_YY",
-            "SQRT_YY_DAG",
+            Gates::SQRT_YY,
+            Gates::SQRT_YY_DAG,
             0,
             &TableauSimulator::SQRT_YY,
             &FrameSimulator::SQRT_YY,
@@ -168,7 +171,8 @@ S 1
         failed,
         Gate{
             "SQRT_YY_DAG",
-            "SQRT_YY",
+            Gates::SQRT_YY_DAG,
+            Gates::SQRT_YY,
             0,
             &TableauSimulator::SQRT_YY_DAG,
             &FrameSimulator::SQRT_YY,
@@ -219,7 +223,8 @@ S 1
         failed,
         Gate{
             "SQRT_ZZ",
-            "SQRT_ZZ_DAG",
+            Gates::SQRT_ZZ,
+            Gates::SQRT_ZZ_DAG,
             0,
             &TableauSimulator::SQRT_ZZ,
             &FrameSimulator::SQRT_ZZ,
@@ -256,7 +261,8 @@ S 1
         failed,
         Gate{
             "SQRT_ZZ_DAG",
-            "SQRT_ZZ",
+            Gates::SQRT_ZZ_DAG,
+            Gates::SQRT_ZZ,
             0,
             &TableauSimulator::SQRT_ZZ_DAG,
             &FrameSimulator::SQRT_ZZ,

--- a/src/stim/circuit/gate_data_pp.cc
+++ b/src/stim/circuit/gate_data_pp.cc
@@ -32,10 +32,6 @@ void GateDataMap::add_gate_data_pp(bool &failed) {
             Gates::SQRT_XX,
             Gates::SQRT_XX_DAG,
             0,
-            &TableauSimulator::SQRT_XX,
-            &FrameSimulator::SQRT_XX,
-            &ErrorAnalyzer::SQRT_XX,
-            &SparseUnsignedRevFrameTracker::undo_SQRT_XX,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS),
             []() -> ExtraGateData {
                 return {
@@ -75,10 +71,6 @@ H 1
             Gates::SQRT_XX_DAG,
             Gates::SQRT_XX,
             0,
-            &TableauSimulator::SQRT_XX_DAG,
-            &FrameSimulator::SQRT_XX,
-            &ErrorAnalyzer::SQRT_XX,
-            &SparseUnsignedRevFrameTracker::undo_SQRT_XX,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS),
             []() -> ExtraGateData {
                 return {
@@ -123,10 +115,6 @@ H 1
             Gates::SQRT_YY,
             Gates::SQRT_YY_DAG,
             0,
-            &TableauSimulator::SQRT_YY,
-            &FrameSimulator::SQRT_YY,
-            &ErrorAnalyzer::SQRT_YY,
-            &SparseUnsignedRevFrameTracker::undo_SQRT_YY,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS),
             []() -> ExtraGateData {
                 return {
@@ -174,10 +162,6 @@ S 1
             Gates::SQRT_YY_DAG,
             Gates::SQRT_YY,
             0,
-            &TableauSimulator::SQRT_YY_DAG,
-            &FrameSimulator::SQRT_YY,
-            &ErrorAnalyzer::SQRT_YY,
-            &SparseUnsignedRevFrameTracker::undo_SQRT_YY,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS),
             []() -> ExtraGateData {
                 return {
@@ -226,10 +210,6 @@ S 1
             Gates::SQRT_ZZ,
             Gates::SQRT_ZZ_DAG,
             0,
-            &TableauSimulator::SQRT_ZZ,
-            &FrameSimulator::SQRT_ZZ,
-            &ErrorAnalyzer::SQRT_ZZ,
-            &SparseUnsignedRevFrameTracker::undo_SQRT_ZZ,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS),
             []() -> ExtraGateData {
                 return {
@@ -264,10 +244,6 @@ S 1
             Gates::SQRT_ZZ_DAG,
             Gates::SQRT_ZZ,
             0,
-            &TableauSimulator::SQRT_ZZ_DAG,
-            &FrameSimulator::SQRT_ZZ,
-            &ErrorAnalyzer::SQRT_ZZ,
-            &SparseUnsignedRevFrameTracker::undo_SQRT_ZZ,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS),
             []() -> ExtraGateData {
                 return {

--- a/src/stim/circuit/gate_data_swaps.cc
+++ b/src/stim/circuit/gate_data_swaps.cc
@@ -32,10 +32,6 @@ void GateDataMap::add_gate_data_swaps(bool &failed) {
             Gates::SWAP,
             Gates::SWAP,
             0,
-            &TableauSimulator::SWAP,
-            &FrameSimulator::SWAP,
-            &ErrorAnalyzer::SWAP,
-            &SparseUnsignedRevFrameTracker::undo_SWAP,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS),
             []() -> ExtraGateData {
                 return {
@@ -69,10 +65,6 @@ CNOT 0 1
             Gates::ISWAP,
             Gates::ISWAP_DAG,
             0,
-            &TableauSimulator::ISWAP,
-            &FrameSimulator::ISWAP,
-            &ErrorAnalyzer::ISWAP,
-            &SparseUnsignedRevFrameTracker::undo_ISWAP,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS),
             []() -> ExtraGateData {
                 return {
@@ -110,10 +102,6 @@ S 0
             Gates::ISWAP_DAG,
             Gates::ISWAP,
             0,
-            &TableauSimulator::ISWAP_DAG,
-            &FrameSimulator::ISWAP,
-            &ErrorAnalyzer::ISWAP,
-            &SparseUnsignedRevFrameTracker::undo_ISWAP,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS),
             []() -> ExtraGateData {
                 return {
@@ -155,10 +143,6 @@ H 0
             Gates::CXSWAP,
             Gates::SWAPCX,
             0,
-            &TableauSimulator::CXSWAP,
-            &FrameSimulator::CXSWAP,
-            &ErrorAnalyzer::CXSWAP,
-            &SparseUnsignedRevFrameTracker::undo_CXSWAP,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS),
             []() -> ExtraGateData {
                 return {
@@ -192,10 +176,6 @@ CNOT 0 1
             Gates::SWAPCX,
             Gates::CXSWAP,
             0,
-            &TableauSimulator::SWAPCX,
-            &FrameSimulator::SWAPCX,
-            &ErrorAnalyzer::SWAPCX,
-            &SparseUnsignedRevFrameTracker::undo_SWAPCX,
             (GateFlags)(GATE_IS_UNITARY | GATE_TARGETS_PAIRS),
             []() -> ExtraGateData {
                 return {

--- a/src/stim/circuit/gate_data_swaps.cc
+++ b/src/stim/circuit/gate_data_swaps.cc
@@ -29,7 +29,8 @@ void GateDataMap::add_gate_data_swaps(bool &failed) {
         failed,
         Gate{
             "SWAP",
-            "SWAP",
+            Gates::SWAP,
+            Gates::SWAP,
             0,
             &TableauSimulator::SWAP,
             &FrameSimulator::SWAP,
@@ -65,7 +66,8 @@ CNOT 0 1
         failed,
         Gate{
             "ISWAP",
-            "ISWAP_DAG",
+            Gates::ISWAP,
+            Gates::ISWAP_DAG,
             0,
             &TableauSimulator::ISWAP,
             &FrameSimulator::ISWAP,
@@ -105,7 +107,8 @@ S 0
         failed,
         Gate{
             "ISWAP_DAG",
-            "ISWAP",
+            Gates::ISWAP_DAG,
+            Gates::ISWAP,
             0,
             &TableauSimulator::ISWAP_DAG,
             &FrameSimulator::ISWAP,
@@ -149,7 +152,8 @@ H 0
         failed,
         Gate{
             "CXSWAP",
-            "SWAPCX",
+            Gates::CXSWAP,
+            Gates::SWAPCX,
             0,
             &TableauSimulator::CXSWAP,
             &FrameSimulator::CXSWAP,
@@ -185,7 +189,8 @@ CNOT 0 1
         failed,
         Gate{
             "SWAPCX",
-            "CXSWAP",
+            Gates::SWAPCX,
+            Gates::CXSWAP,
             0,
             &TableauSimulator::SWAPCX,
             &FrameSimulator::SWAPCX,

--- a/src/stim/diagram/circuit_timeline_helper.cc
+++ b/src/stim/diagram/circuit_timeline_helper.cc
@@ -179,21 +179,21 @@ void CircuitTimelineHelper::do_record_measure_result(uint32_t target_qubit) {
 }
 
 void CircuitTimelineHelper::do_next_operation(const Circuit &circuit, const Operation &op) {
-    if (op.gate->id == gate_name_to_id("REPEAT")) {
+    if (op.gate->id == static_cast<uint8_t>(Gates::REPEAT)) {
         do_repeat_block(circuit, op);
-    } else if (op.gate->id == gate_name_to_id("MPP")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::MPP)) {
         do_operation_with_target_combiners(op);
-    } else if (op.gate->id == gate_name_to_id("DETECTOR")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::DETECTOR)) {
         do_detector(op);
-    } else if (op.gate->id == gate_name_to_id("OBSERVABLE_INCLUDE")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::OBSERVABLE_INCLUDE)) {
         do_observable_include(op);
-    } else if (op.gate->id == gate_name_to_id("SHIFT_COORDS")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::SHIFT_COORDS)) {
         do_shift_coords(op);
-    } else if (op.gate->id == gate_name_to_id("E") || op.gate->id == gate_name_to_id("ELSE_CORRELATED_ERROR")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::E) || op.gate->id == static_cast<uint8_t>(Gates::ELSE_CORRELATED_ERROR)) {
         do_multi_qubit_atomic_operation(op);
-    } else if (op.gate->id == gate_name_to_id("QUBIT_COORDS")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::QUBIT_COORDS)) {
         do_qubit_coords(op);
-    } else if (op.gate->id == gate_name_to_id("TICK")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::TICK)) {
         do_atomic_operation(op.gate, {}, {});
         num_ticks_seen += 1;
     } else if (op.gate->flags & GATE_TARGETS_PAIRS) {

--- a/src/stim/diagram/detector_slice/detector_slice_set.cc
+++ b/src/stim/diagram/detector_slice/detector_slice_set.cc
@@ -47,9 +47,9 @@ bool DetectorSliceSetComputer::process_tick() {
 }
 
 bool DetectorSliceSetComputer::process_op_rev(const Circuit &parent, const Operation &op) {
-    if (op.gate->id == gate_name_to_id("TICK")) {
+    if (op.gate->id == static_cast<uint8_t>(Gates::TICK)) {
         return process_tick();
-    } else if (op.gate->id == gate_name_to_id("REPEAT")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::REPEAT)) {
         const auto &loop_body = op_data_block_body(parent, op.target_data);
         uint64_t stop_iter = first_yield_tick + num_yield_ticks;
         uint64_t max_skip = std::max(tick_cur, stop_iter) - stop_iter;

--- a/src/stim/diagram/detector_slice/detector_slice_set.cc
+++ b/src/stim/diagram/detector_slice/detector_slice_set.cc
@@ -75,7 +75,7 @@ bool DetectorSliceSetComputer::process_op_rev(const Circuit &parent, const Opera
                 used_qubits.insert(t.qubit_value());
             }
         }
-        (tracker.*(op.gate->sparse_unsigned_rev_frame_tracker_function))(op.target_data);
+        tracker.invoke(op.gate->id, op.target_data);
         return false;
     }
 }

--- a/src/stim/diagram/timeline/timeline_3d_drawer.cc
+++ b/src/stim/diagram/timeline/timeline_3d_drawer.cc
@@ -293,19 +293,19 @@ void DiagramTimeline3DDrawer::do_observable_include(const ResolvedTimelineOperat
 }
 
 void DiagramTimeline3DDrawer::do_resolved_operation(const ResolvedTimelineOperation &op) {
-    if (op.gate->id == gate_name_to_id("MPP")) {
+    if (op.gate->id == static_cast<uint8_t>(Gates::MPP)) {
         do_mpp(op);
-    } else if (op.gate->id == gate_name_to_id("DETECTOR")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::DETECTOR)) {
         do_detector(op);
-    } else if (op.gate->id == gate_name_to_id("OBSERVABLE_INCLUDE")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::OBSERVABLE_INCLUDE)) {
         do_observable_include(op);
-    } else if (op.gate->id == gate_name_to_id("QUBIT_COORDS")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::QUBIT_COORDS)) {
         do_qubit_coords(op);
-    } else if (op.gate->id == gate_name_to_id("E")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::E)) {
         do_correlated_error(op);
-    } else if (op.gate->id == gate_name_to_id("ELSE_CORRELATED_ERROR")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::ELSE_CORRELATED_ERROR)) {
         do_else_correlated_error(op);
-    } else if (op.gate->id == gate_name_to_id("TICK")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::TICK)) {
         do_tick();
     } else if (op.gate->flags & GATE_TARGETS_PAIRS) {
         do_two_qubit_gate_instance(op);
@@ -321,7 +321,7 @@ DiagramTimeline3DDrawer::DiagramTimeline3DDrawer(size_t num_qubits, bool has_tic
 
 void add_used_qubits(const Circuit &circuit, std::set<uint64_t> &out) {
     for (const auto &op : circuit.operations) {
-        if (op.gate->id == gate_name_to_id("REPEAT")) {
+        if (op.gate->id == static_cast<uint8_t>(Gates::REPEAT)) {
             add_used_qubits(op_data_block_body(circuit, op.target_data), out);
         } else {
             for (const auto &t : op.target_data.targets) {

--- a/src/stim/diagram/timeline/timeline_ascii_drawer.cc
+++ b/src/stim/diagram/timeline/timeline_ascii_drawer.cc
@@ -58,7 +58,7 @@ void DiagramTimelineAsciiDrawer::do_two_qubit_gate_instance(const ResolvedTimeli
     first << (ends.first == "Z" ? "@" : ends.first);
     second << (ends.second == "Z" ? "@" : ends.second);
     if (!op.args.empty()) {
-        if (op.gate->id == gate_name_to_id("PAULI_CHANNEL_2")) {
+        if (op.gate->id == static_cast<uint8_t>(Gates::PAULI_CHANNEL_2)) {
             first << "[0]";
             second << "[1]";
         }
@@ -430,19 +430,19 @@ void DiagramTimelineAsciiDrawer::do_observable_include(const ResolvedTimelineOpe
 }
 
 void DiagramTimelineAsciiDrawer::do_resolved_operation(const ResolvedTimelineOperation &op) {
-    if (op.gate->id == gate_name_to_id("MPP")) {
+    if (op.gate->id == static_cast<uint8_t>(Gates::MPP)) {
         do_mpp(op);
-    } else if (op.gate->id == gate_name_to_id("DETECTOR")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::DETECTOR)) {
         do_detector(op);
-    } else if (op.gate->id == gate_name_to_id("OBSERVABLE_INCLUDE")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::OBSERVABLE_INCLUDE)) {
         do_observable_include(op);
-    } else if (op.gate->id == gate_name_to_id("QUBIT_COORDS")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::QUBIT_COORDS)) {
         do_qubit_coords(op);
-    } else if (op.gate->id == gate_name_to_id("E")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::E)) {
         do_correlated_error(op);
-    } else if (op.gate->id == gate_name_to_id("ELSE_CORRELATED_ERROR")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::ELSE_CORRELATED_ERROR)) {
         do_else_correlated_error(op);
-    } else if (op.gate->id == gate_name_to_id("TICK")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::TICK)) {
         do_tick();
     } else if (op.gate->flags & GATE_TARGETS_PAIRS) {
         do_two_qubit_gate_instance(op);

--- a/src/stim/diagram/timeline/timeline_svg_drawer.cc
+++ b/src/stim/diagram/timeline/timeline_svg_drawer.cc
@@ -313,7 +313,7 @@ void DiagramTimelineSvgDrawer::do_two_qubit_gate_instance(const ResolvedTimeline
     }
 
     auto pieces = two_qubit_gate_pieces(op.gate->name);
-    if (op.gate->id == gate_name_to_id("PAULI_CHANNEL_2")) {
+    if (op.gate->id == static_cast<uint8_t>(Gates::PAULI_CHANNEL_2)) {
         pieces.first.append("[0]");
         pieces.second.append("[1]");
     }
@@ -743,19 +743,19 @@ void DiagramTimelineSvgDrawer::do_resolved_operation(const ResolvedTimelineOpera
     if (resolver.num_ticks_seen < min_tick || resolver.num_ticks_seen > max_tick) {
         return;
     }
-    if (op.gate->id == gate_name_to_id("MPP")) {
+    if (op.gate->id == static_cast<uint8_t>(Gates::MPP)) {
         do_mpp(op);
-    } else if (op.gate->id == gate_name_to_id("DETECTOR")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::DETECTOR)) {
         do_detector(op);
-    } else if (op.gate->id == gate_name_to_id("OBSERVABLE_INCLUDE")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::OBSERVABLE_INCLUDE)) {
         do_observable_include(op);
-    } else if (op.gate->id == gate_name_to_id("QUBIT_COORDS")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::QUBIT_COORDS)) {
         do_qubit_coords(op);
-    } else if (op.gate->id == gate_name_to_id("E")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::E)) {
         do_correlated_error(op);
-    } else if (op.gate->id == gate_name_to_id("ELSE_CORRELATED_ERROR")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::ELSE_CORRELATED_ERROR)) {
         do_else_correlated_error(op);
-    } else if (op.gate->id == gate_name_to_id("TICK")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::TICK)) {
         do_tick();
     } else if (op.gate->flags & GATE_TARGETS_PAIRS) {
         do_two_qubit_gate_instance(op);
@@ -782,7 +782,7 @@ void DiagramTimelineSvgDrawer::make_diagram_write_to(
     std::stringstream buffer;
     DiagramTimelineSvgDrawer obj(buffer, num_qubits, circuit_has_ticks);
     tick_slice_num = std::min(tick_slice_num, circuit_num_ticks - tick_slice_start + 1);
-    if (!circuit.operations.empty() && circuit.operations.back().gate->id == gate_name_to_id("TICK")) {
+    if (!circuit.operations.empty() && circuit.operations.back().gate->id == static_cast<uint8_t>(Gates::TICK)) {
         tick_slice_num = std::min(tick_slice_num, circuit_num_ticks - tick_slice_start);
     }
     if (mode != SVG_MODE_TIMELINE) {

--- a/src/stim/simulators/detection_simulator.cc
+++ b/src/stim/simulators/detection_simulator.cc
@@ -111,7 +111,7 @@ void detector_sample_out_helper_stream(
                 }
             }
         } else {
-            (sim.*op.gate->frame_simulator_function)(op.target_data);
+            sim.invoke(op.gate->id, op.target_data);
             sim.m_record.mark_all_as_written();
         }
     });

--- a/src/stim/simulators/detection_simulator.cc
+++ b/src/stim/simulators/detection_simulator.cc
@@ -85,7 +85,7 @@ void detector_sample_out_helper_stream(
     simd_bit_table<MAX_BITWORD_WIDTH> detector_buffer(1024, num_samples);
     size_t buffered_detectors = 0;
     circuit.for_each_operation([&](const Operation &op) {
-        if (op.gate->id == gate_name_to_id("DETECTOR")) {
+        if (op.gate->id == static_cast<uint8_t>(Gates::DETECTOR)) {
             simd_bits_range_ref<MAX_BITWORD_WIDTH> result = detector_buffer[buffered_detectors];
             result.clear();
             for (auto t : op.target_data.targets) {
@@ -97,7 +97,7 @@ void detector_sample_out_helper_stream(
                 writer.batch_write_bytes(detector_buffer, 1024 >> 6);
                 buffered_detectors = 0;
             }
-        } else if (op.gate->id == gate_name_to_id("OBSERVABLE_INCLUDE")) {
+        } else if (op.gate->id == static_cast<uint8_t>(Gates::OBSERVABLE_INCLUDE)) {
             if (append_observables) {
                 size_t id = (size_t)op.target_data.args[0];
                 while (observables.size() <= id) {

--- a/src/stim/simulators/error_analyzer.cc
+++ b/src/stim/simulators/error_analyzer.cc
@@ -411,7 +411,7 @@ void ErrorAnalyzer::run_circuit(const Circuit &circuit) {
                 uint64_t repeats = op_data_rep_count(op.target_data);
                 run_loop(loop_body, repeats);
             } else {
-                (this->*op.gate->reverse_error_analyzer_function)(op.target_data);
+                invoke(op.gate->id, op.target_data);
             }
         } catch (std::invalid_argument &ex) {
             std::stringstream error_msg;

--- a/src/stim/simulators/error_analyzer.cc
+++ b/src/stim/simulators/error_analyzer.cc
@@ -397,16 +397,16 @@ void ErrorAnalyzer::run_circuit(const Circuit &circuit) {
         const auto &op = circuit.operations[k];
         assert(op.gate != nullptr);
         try {
-            if (op.gate->id == gate_name_to_id("ELSE_CORRELATED_ERROR")) {
+            if (op.gate->id == static_cast<uint8_t>(Gates::ELSE_CORRELATED_ERROR)) {
                 stacked_else_correlated_errors.push_back(op.target_data);
-            } else if (op.gate->id == gate_name_to_id("E")) {
+            } else if (op.gate->id == static_cast<uint8_t>(Gates::E)) {
                 stacked_else_correlated_errors.push_back(op.target_data);
                 correlated_error_block(stacked_else_correlated_errors);
                 stacked_else_correlated_errors.clear();
             } else if (!stacked_else_correlated_errors.empty()) {
                 throw std::invalid_argument(
                     "ELSE_CORRELATED_ERROR wasn't preceded by ELSE_CORRELATED_ERROR or CORRELATED_ERROR (E)");
-            } else if (op.gate->id == gate_name_to_id("REPEAT")) {
+            } else if (op.gate->id == static_cast<uint8_t>(Gates::REPEAT)) {
                 const auto &loop_body = op_data_block_body(circuit, op.target_data);
                 uint64_t repeats = op_data_rep_count(op.target_data);
                 run_loop(loop_body, repeats);

--- a/src/stim/simulators/error_analyzer.h
+++ b/src/stim/simulators/error_analyzer.h
@@ -228,6 +228,10 @@ struct ErrorAnalyzer {
     /// with the implicit Z basis initialization at the start of a circuit.
     void post_check_initialization();
 
+    inline void invoke(uint8_t gate_id, const OperationData& data) {
+        (this->*(ERROR_ANALYZER_VTABLE[gate_id]))(data);
+    }
+
     /// Returns a PauliString indicating the current error sensitivity of a detector or observable.
     ///
     /// The observable or detector is sensitive to the Pauli error P at q if the Pauli sensitivity

--- a/src/stim/simulators/error_analyzer.test.cc
+++ b/src/stim/simulators/error_analyzer.test.cc
@@ -317,8 +317,8 @@ TEST(ErrorAnalyzer, unitary_gates_match_frame_simulator) {
     OperationData targets = {{}, data};
     for (const auto &gate : GATE_DATA.gates()) {
         if (gate.flags & GATE_IS_UNITARY) {
-            (e.*gate.reverse_error_analyzer_function)(targets);
-            (f.*gate.inverse().frame_simulator_function)(targets);
+            e.invoke(gate.id, targets);
+            f.invoke(gate.inverse().id, targets);
             for (size_t q = 0; q < 16; q++) {
                 bool xs[2]{};
                 bool zs[2]{};

--- a/src/stim/simulators/error_matcher.cc
+++ b/src/stim/simulators/error_matcher.cc
@@ -214,7 +214,7 @@ void ErrorMatcher::rev_process_instruction(const Operation &op) {
     cur_loc.tick_offset = error_analyzer.num_ticks_in_past;
     cur_op = &op;
 
-    if (op.gate->id == gate_name_to_id("DETECTOR")) {
+    if (op.gate->id == static_cast<uint8_t>(Gates::DETECTOR)) {
         error_analyzer.DETECTOR(op.target_data);
         if (!op.target_data.args.empty()) {
             auto id = error_analyzer.tracker.num_detectors_in_past;
@@ -227,44 +227,44 @@ void ErrorMatcher::rev_process_instruction(const Operation &op) {
                 entry->second.push_back(d);
             }
         }
-    } else if (op.gate->id == gate_name_to_id("SHIFT_COORDS")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::SHIFT_COORDS)) {
         error_analyzer.SHIFT_COORDS(op.target_data);
         for (size_t k = 0; k < op.target_data.args.size(); k++) {
             cur_coord_offset[k] -= op.target_data.args[k];
         }
     } else if (!(op.gate->flags & (GATE_IS_NOISE | GATE_PRODUCES_NOISY_RESULTS))) {
         (error_analyzer.*op.gate->reverse_error_analyzer_function)(op.target_data);
-    } else if (op.gate->id == gate_name_to_id("E") || op.gate->id == gate_name_to_id("ELSE_CORRELATED_ERROR")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::E) || op.gate->id == static_cast<uint8_t>(Gates::ELSE_CORRELATED_ERROR)) {
         cur_loc.instruction_targets.target_range_start = 0;
         cur_loc.instruction_targets.target_range_end = op.target_data.targets.size();
         resolve_paulis_into(op.target_data.targets, 0, cur_loc.flipped_pauli_product);
         err_atom(op);
         cur_loc.flipped_pauli_product.clear();
-    } else if (op.gate->id == gate_name_to_id("X_ERROR")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::X_ERROR)) {
         err_xyz(op, TARGET_PAULI_X_BIT);
-    } else if (op.gate->id == gate_name_to_id("Y_ERROR")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::Y_ERROR)) {
         err_xyz(op, TARGET_PAULI_X_BIT | TARGET_PAULI_Z_BIT);
-    } else if (op.gate->id == gate_name_to_id("Z_ERROR")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::Z_ERROR)) {
         err_xyz(op, TARGET_PAULI_Z_BIT);
-    } else if (op.gate->id == gate_name_to_id("PAULI_CHANNEL_1")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::PAULI_CHANNEL_1)) {
         err_pauli_channel_1(op);
-    } else if (op.gate->id == gate_name_to_id("DEPOLARIZE1")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::DEPOLARIZE1)) {
         float p = op.target_data.args[0];
         std::array<double, 3> spread{p, p, p};
         err_pauli_channel_1({op.gate, {spread, op.target_data.targets}});
-    } else if (op.gate->id == gate_name_to_id("PAULI_CHANNEL_2")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::PAULI_CHANNEL_2)) {
         err_pauli_channel_2(op);
-    } else if (op.gate->id == gate_name_to_id("DEPOLARIZE2")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::DEPOLARIZE2)) {
         float p = op.target_data.args[0];
         std::array<double, 15> spread{p, p, p, p, p, p, p, p, p, p, p, p, p, p, p};
         err_pauli_channel_2({op.gate, {spread, op.target_data.targets}});
-    } else if (op.gate->id == gate_name_to_id("MPP")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::MPP)) {
         err_m(op, 0);
-    } else if (op.gate->id == gate_name_to_id("MX") || op.gate->id == gate_name_to_id("MRX")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::MX) || op.gate->id == static_cast<uint8_t>(Gates::MRX)) {
         err_m(op, TARGET_PAULI_X_BIT);
-    } else if (op.gate->id == gate_name_to_id("MY") || op.gate->id == gate_name_to_id("MRY")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::MY) || op.gate->id == static_cast<uint8_t>(Gates::MRY)) {
         err_m(op, TARGET_PAULI_X_BIT | TARGET_PAULI_Z_BIT);
-    } else if (op.gate->id == gate_name_to_id("M") || op.gate->id == gate_name_to_id("MR")) {
+    } else if (op.gate->id == static_cast<uint8_t>(Gates::M) || op.gate->id == static_cast<uint8_t>(Gates::MR)) {
         err_m(op, TARGET_PAULI_Z_BIT);
     } else {
         throw std::invalid_argument("Not implemented: " + std::string(op.gate->name));
@@ -280,7 +280,7 @@ void ErrorMatcher::rev_process_circuit(uint64_t reps, const Circuit &block) {
             cur_loc.stack_frames.back().instruction_offset = k;
 
             const auto &op = block.operations[k];
-            if (op.gate->id == gate_name_to_id("REPEAT")) {
+            if (op.gate->id == static_cast<uint8_t>(Gates::REPEAT)) {
                 auto rep_count = op_data_rep_count(op.target_data);
                 cur_loc.stack_frames.back().instruction_repetitions_arg = op_data_rep_count(op.target_data);
                 rev_process_circuit(rep_count, op_data_block_body(block, op.target_data));

--- a/src/stim/simulators/error_matcher.cc
+++ b/src/stim/simulators/error_matcher.cc
@@ -62,7 +62,7 @@ ErrorMatcher::ErrorMatcher(
 
 void ErrorMatcher::err_atom(const Operation &effect) {
     assert(error_analyzer.error_class_probabilities.empty());
-    (error_analyzer.*effect.gate->reverse_error_analyzer_function)(effect.target_data);
+    error_analyzer.invoke(effect.gate->id, effect.target_data);
     if (error_analyzer.error_class_probabilities.empty()) {
         /// Maybe there were no detectors or observables nearby? Or the noise probability was zero?
         return;
@@ -233,7 +233,7 @@ void ErrorMatcher::rev_process_instruction(const Operation &op) {
             cur_coord_offset[k] -= op.target_data.args[k];
         }
     } else if (!(op.gate->flags & (GATE_IS_NOISE | GATE_PRODUCES_NOISY_RESULTS))) {
-        (error_analyzer.*op.gate->reverse_error_analyzer_function)(op.target_data);
+        error_analyzer.invoke(op.gate->id, op.target_data);
     } else if (op.gate->id == static_cast<uint8_t>(Gates::E) || op.gate->id == static_cast<uint8_t>(Gates::ELSE_CORRELATED_ERROR)) {
         cur_loc.instruction_targets.target_range_start = 0;
         cur_loc.instruction_targets.target_range_end = op.target_data.targets.size();

--- a/src/stim/simulators/frame_simulator.cc
+++ b/src/stim/simulators/frame_simulator.cc
@@ -84,7 +84,7 @@ void FrameSimulator::reset_all() {
 void FrameSimulator::reset_all_and_run(const Circuit &circuit) {
     reset_all();
     circuit.for_each_operation([&](const Operation &op) {
-        (this->*op.gate->frame_simulator_function)(op.target_data);
+        invoke(op.gate->id, op.target_data);
     });
 }
 
@@ -603,14 +603,14 @@ void sample_out_helper(
         // Results getting quite large. Stream them (with buffering to disk) instead of trying to store them all.
         MeasureRecordBatchWriter writer(out, num_shots, format);
         circuit.for_each_operation([&](const Operation &op) {
-            (sim.*op.gate->frame_simulator_function)(op.target_data);
+            sim.invoke(op.gate->id, op.target_data);
             sim.m_record.intermediate_write_unwritten_results_to(writer, ref_sample);
         });
         sim.m_record.final_write_unwritten_results_to(writer, ref_sample);
     } else {
         // Small case. Just do everything in memory.
         circuit.for_each_operation([&](const Operation &op) {
-            (sim.*op.gate->frame_simulator_function)(op.target_data);
+            sim.invoke(op.gate->id, op.target_data);
         });
         write_table_data(
             out, num_shots, circuit.count_measurements(), ref_sample, sim.m_record.storage, format, 'M', 'M', 0);

--- a/src/stim/simulators/frame_simulator.h
+++ b/src/stim/simulators/frame_simulator.h
@@ -97,6 +97,10 @@ struct FrameSimulator {
     void reset_all_and_run(const Circuit &circuit);
     void reset_all();
 
+    inline void invoke(uint8_t gate_id, const OperationData& data) {
+        (this->*(FRAME_SIM_VTABLE[gate_id]))(data);
+    }
+
     void measure_x(const OperationData &target_data);
     void measure_y(const OperationData &target_data);
     void measure_z(const OperationData &target_data);

--- a/src/stim/simulators/frame_simulator.test.cc
+++ b/src/stim/simulators/frame_simulator.test.cc
@@ -49,7 +49,6 @@ TEST(FrameSimulator, get_set_frame) {
 
 bool is_bulk_frame_operation_consistent_with_tableau(const Gate &gate) {
     Tableau tableau = gate.tableau();
-    const auto &bulk_func = gate.frame_simulator_function;
 
     size_t num_qubits = 500;
     size_t num_samples = 1000;
@@ -66,7 +65,7 @@ bool is_bulk_frame_operation_consistent_with_tableau(const Gate &gate) {
         PauliString test_value = PauliString::random(num_qubits, SHARED_TEST_RNG());
         PauliStringRef test_value_ref(test_value);
         sim.set_frame(k, test_value);
-        (sim.*bulk_func)(op_data);
+        sim.invoke(gate.id, op_data);
         for (size_t k2 = 0; k2 < targets.size(); k2 += num_targets) {
             size_t target_buf[2];
             if (num_targets == 1) {
@@ -110,7 +109,7 @@ bool is_output_possible_promising_no_bare_resets(
                 out_p++;
             }
         } else {
-            (tableau_sim.*op.gate->tableau_simulator_function)(op.target_data);
+            tableau_sim.invoke(op.gate->id, op.target_data);
         }
     });
     return pass;

--- a/src/stim/simulators/measurements_to_detection_events.cc
+++ b/src/stim/simulators/measurements_to_detection_events.cc
@@ -82,7 +82,7 @@ void stim::measurements_to_detection_events_helper(
             out_index = num_detectors + (uint64_t)op.target_data.args[0];
         } else {
             measure_count_so_far += op.count_measurement_results();
-            (frame_sim.*op.gate->frame_simulator_function)(op.target_data);
+            frame_sim.invoke(op.gate->id, op.target_data);
             return;
         }
 

--- a/src/stim/simulators/measurements_to_detection_events.cc
+++ b/src/stim/simulators/measurements_to_detection_events.cc
@@ -68,8 +68,8 @@ void stim::measurements_to_detection_events_helper(
 
     uint64_t measure_count_so_far = 0;
     uint64_t detector_offset = 0;
-    const auto det_id = gate_name_to_id("DETECTOR");
-    const auto obs_id = gate_name_to_id("OBSERVABLE_INCLUDE");
+    const auto det_id = static_cast<uint8_t>(Gates::DETECTOR);
+    const auto obs_id = static_cast<uint8_t>(Gates::OBSERVABLE_INCLUDE);
     noiseless_circuit.for_each_operation([&](const Operation &op) {
         uint64_t out_index;
         if (op.gate->id == det_id) {

--- a/src/stim/simulators/sparse_rev_frame_tracker.cc
+++ b/src/stim/simulators/sparse_rev_frame_tracker.cc
@@ -549,7 +549,7 @@ void SparseUnsignedRevFrameTracker::undo_OBSERVABLE_INCLUDE(const OperationData 
 }
 
 void SparseUnsignedRevFrameTracker::undo_operation(const Operation &op, const Circuit &parent) {
-    if (op.gate->id == gate_name_to_id("REPEAT")) {
+    if (op.gate->id == static_cast<uint8_t>(Gates::REPEAT)) {
         const auto &loop_body = op_data_block_body(parent, op.target_data);
         uint64_t repeats = op_data_rep_count(op.target_data);
         undo_loop(loop_body, repeats);
@@ -559,7 +559,7 @@ void SparseUnsignedRevFrameTracker::undo_operation(const Operation &op, const Ci
 }
 
 void SparseUnsignedRevFrameTracker::undo_operation(const Operation &op) {
-    assert(op.gate->id != gate_name_to_id("REPEAT"));
+    assert(op.gate->id != static_cast<uint8_t>(Gates::REPEAT));
     (this->*op.gate->sparse_unsigned_rev_frame_tracker_function)(op.target_data);
 }
 

--- a/src/stim/simulators/sparse_rev_frame_tracker.cc
+++ b/src/stim/simulators/sparse_rev_frame_tracker.cc
@@ -554,13 +554,13 @@ void SparseUnsignedRevFrameTracker::undo_operation(const Operation &op, const Ci
         uint64_t repeats = op_data_rep_count(op.target_data);
         undo_loop(loop_body, repeats);
     } else {
-        (this->*op.gate->sparse_unsigned_rev_frame_tracker_function)(op.target_data);
+        invoke(op.gate->id, op.target_data);
     }
 }
 
 void SparseUnsignedRevFrameTracker::undo_operation(const Operation &op) {
     assert(op.gate->id != static_cast<uint8_t>(Gates::REPEAT));
-    (this->*op.gate->sparse_unsigned_rev_frame_tracker_function)(op.target_data);
+    invoke(op.gate->id, op.target_data);
 }
 
 void SparseUnsignedRevFrameTracker::undo_circuit(const Circuit &circuit) {

--- a/src/stim/simulators/sparse_rev_frame_tracker.h
+++ b/src/stim/simulators/sparse_rev_frame_tracker.h
@@ -43,6 +43,10 @@ struct SparseUnsignedRevFrameTracker {
 
     PauliString current_error_sensitivity_for(DemTarget target) const;
 
+    inline void invoke(uint8_t gate_id, const OperationData& data) {
+        (this->*(SPARSE_UNSIGNED_REV_FRAME_TRACKER_VTABLE[gate_id]))(data);
+    }
+
     void handle_xor_gauge(ConstPointerRange<DemTarget> sorted1, ConstPointerRange<DemTarget> sorted2);
     void handle_gauge(ConstPointerRange<DemTarget> sorted);
     void undo_classical_pauli(GateTarget classical_control, GateTarget target);

--- a/src/stim/simulators/sparse_rev_frame_tracker.test.cc
+++ b/src/stim/simulators/sparse_rev_frame_tracker.test.cc
@@ -156,7 +156,7 @@ TEST(SparseUnsignedRevFrameTracker, fuzz_all_unitary_gates_vs_tableau) {
             for (size_t k = 0; k < n; k++) {
                 targets.push_back(n - k + 1);
             }
-            (tracker_gate.*gate.sparse_unsigned_rev_frame_tracker_function)(OpDat{targets});
+            tracker_gate.invoke(gate.id, OpDat{targets});
             tracker_tableau.undo_tableau(gate.tableau(), targets);
             EXPECT_EQ(tracker_gate, tracker_tableau) << gate.name;
         }

--- a/src/stim/simulators/tableau_simulator.cc
+++ b/src/stim/simulators/tableau_simulator.cc
@@ -824,7 +824,7 @@ void TableauSimulator::sample_stream(FILE *in, FILE *out, SampleFormat format, b
         sim.ensure_large_enough_for_qubits(unprocessed.count_qubits());
 
         unprocessed.for_each_operation([&](const Operation &op) {
-            (sim.*op.gate->tableau_simulator_function)(op.target_data);
+            sim.invoke(op.gate->id, op.target_data);
             sim.measurement_record.write_unwritten_results_to(*writer);
             if (interactive && op.count_measurement_results()) {
                 putc('\n', out);
@@ -1013,7 +1013,7 @@ void TableauSimulator::expand_do_circuit(const Circuit &circuit, uint64_t reps) 
     ensure_large_enough_for_qubits(circuit.count_qubits());
     for (uint64_t k = 0; k < reps; k++) {
         circuit.for_each_operation([&](const Operation &op) {
-            ((*this).*op.gate->tableau_simulator_function)(op.target_data);
+            invoke(op.gate->id, op.target_data);
         });
     }
 }
@@ -1037,7 +1037,7 @@ void TableauSimulator::do_operation_ensure_size(const Operation &operation) {
         }
     }
     ensure_large_enough_for_qubits(n);
-    ((*this).*operation.gate->tableau_simulator_function)(operation.target_data);
+    invoke(operation.gate->id, operation.target_data);
 }
 
 void TableauSimulator::set_num_qubits(size_t new_num_qubits) {

--- a/src/stim/simulators/tableau_simulator.h
+++ b/src/stim/simulators/tableau_simulator.h
@@ -156,6 +156,10 @@ struct TableauSimulator {
 
     std::vector<PauliString> canonical_stabilizers() const;
 
+    inline void invoke(uint8_t gate_id, const OperationData& data) {
+        (this->*(TABLEAU_SIM_VTABLE[gate_id]))(data);
+    }
+
     /// === SPECIALIZED VECTORIZED OPERATION IMPLEMENTATIONS ===
     void I(const OperationData &target_data);
     void H_XZ(const OperationData &target_data);

--- a/src/stim/simulators/tableau_simulator.test.cc
+++ b/src/stim/simulators/tableau_simulator.test.cc
@@ -295,13 +295,12 @@ TEST(TableauSimulator, unitary_gates_consistent_with_tableau_data) {
         }
         sim.inv_state = t;
 
-        const auto &action = gate.tableau_simulator_function;
         const auto &inverse_op_tableau = gate.inverse().tableau();
         if (inverse_op_tableau.num_qubits == 2) {
-            (sim.*action)(OpDat({7, 4}));
+            sim.invoke(gate.id, OpDat({7, 4}));
             t.inplace_scatter_prepend(inverse_op_tableau, {7, 4});
         } else {
-            (sim.*action)(OpDat(5));
+            sim.invoke(gate.id, OpDat(5));
             t.inplace_scatter_prepend(inverse_op_tableau, {5});
         }
         EXPECT_EQ(sim.inv_state, t) << gate.name;
@@ -387,7 +386,7 @@ TEST(TableauSimulator, to_vector_sim) {
     sim_vec = sim_tab.to_vector_sim();
     ASSERT_TRUE(sim_tab.to_vector_sim().approximate_equals(sim_vec, true));
 
-    (sim_tab.*GATE_DATA.at("XCX").tableau_simulator_function)(OpDat({4, 7}));
+    sim_tab.invoke(static_cast<uint8_t>(Gates::XCX), OpDat({4, 7}));
     sim_vec.apply("XCX", 4, 7);
     ASSERT_TRUE(sim_tab.to_vector_sim().approximate_equals(sim_vec, true));
 }

--- a/src/stim/simulators/transform_without_feedback.cc
+++ b/src/stim/simulators/transform_without_feedback.cc
@@ -68,21 +68,21 @@ struct WithoutFeedbackHelper {
             auto b1 = t1.is_measurement_record_target();
             auto b2 = t2.is_measurement_record_target();
             if (b1 > b2) {
-                if (op.gate->id == gate_name_to_id("CX")) {
+                if (op.gate->id == static_cast<uint8_t>(Gates::CX)) {
                     do_single_feedback(t1, t2.qubit_value(), true, false);
-                } else if (op.gate->id == gate_name_to_id("CY")) {
+                } else if (op.gate->id == static_cast<uint8_t>(Gates::CY)) {
                     do_single_feedback(t1, t2.qubit_value(), true, true);
-                } else if (op.gate->id == gate_name_to_id("CZ")) {
+                } else if (op.gate->id == static_cast<uint8_t>(Gates::CZ)) {
                     do_single_feedback(t1, t2.qubit_value(), false, true);
                 } else {
                     throw std::invalid_argument("Unknown feedback gate.");
                 }
             } else if (b2 > b1) {
-                if (op.gate->id == gate_name_to_id("CX")) {
+                if (op.gate->id == static_cast<uint8_t>(Gates::CX)) {
                     do_single_feedback(t2, t1.qubit_value(), true, false);
-                } else if (op.gate->id == gate_name_to_id("CY")) {
+                } else if (op.gate->id == static_cast<uint8_t>(Gates::CY)) {
                     do_single_feedback(t2, t1.qubit_value(), true, true);
-                } else if (op.gate->id == gate_name_to_id("CZ")) {
+                } else if (op.gate->id == static_cast<uint8_t>(Gates::CZ)) {
                     do_single_feedback(t2, t1.qubit_value(), false, true);
                 } else {
                     throw std::invalid_argument("Unknown feedback gate.");
@@ -124,7 +124,7 @@ struct WithoutFeedbackHelper {
     void undo_circuit(const Circuit &circuit) {
         for (size_t k = circuit.operations.size(); k--;) {
             const auto &op = circuit.operations[k];
-            if (op.gate->id == gate_name_to_id("REPEAT")) {
+            if (op.gate->id == static_cast<uint8_t>(Gates::REPEAT)) {
                 undo_repeat_block(circuit, op);
             } else if (op.gate->flags & GATE_CAN_TARGET_BITS) {
                 undo_feedback_capable_operation(op);
@@ -142,13 +142,13 @@ struct WithoutFeedbackHelper {
             const auto &op = reversed.operations[k];
             tracker.num_measurements_in_past += op.count_measurement_results();
 
-            if (op.gate->id == gate_name_to_id("REPEAT")) {
+            if (op.gate->id == static_cast<uint8_t>(Gates::REPEAT)) {
                 result.append_repeat_block(
                     op_data_rep_count(op.target_data), build_output(op_data_block_body(reversed, op.target_data)));
                 continue;
             }
 
-            if (op.gate->id == gate_name_to_id("DETECTOR")) {
+            if (op.gate->id == static_cast<uint8_t>(Gates::DETECTOR)) {
                 auto p = det_changes.find(tracker.num_detectors_in_past);
                 tracker.num_detectors_in_past++;
                 if (p != det_changes.end()) {
@@ -192,7 +192,7 @@ Circuit circuit_with_identical_adjacent_loops_fused(const Circuit &circuit) {
         loop_reps = 0;
     };
     for (const auto &op : circuit.operations) {
-        bool is_loop = op.gate->id == gate_name_to_id("REPEAT");
+        bool is_loop = op.gate->id == static_cast<uint8_t>(Gates::REPEAT);
 
         // Grow the growing loop or flush it if needed.
         if (loop_reps > 0) {

--- a/src/stim/stabilizers/conversions.cc
+++ b/src/stim/stabilizers/conversions.cc
@@ -178,7 +178,7 @@ Tableau stim::circuit_to_tableau(
 
     circuit.for_each_operation([&](const Operation &op) {
         if (op.gate->flags & GATE_IS_UNITARY) {
-            (sim.*op.gate->tableau_simulator_function)(op.target_data);
+            sim.invoke(op.gate->id, op.target_data);
         } else if (op.gate->flags & GATE_IS_NOISE) {
             if (!ignore_noise) {
                 throw std::invalid_argument(
@@ -217,7 +217,7 @@ std::vector<std::complex<float>> stim::circuit_to_output_state_vector(const Circ
 
     circuit.for_each_operation([&](const Operation &op) {
         if (op.gate->flags & GATE_IS_UNITARY) {
-            (sim.*op.gate->tableau_simulator_function)(op.target_data);
+            sim.invoke(op.gate->id, op.target_data);
         } else if (op.gate->flags & (GATE_IS_NOISE | GATE_IS_RESET | GATE_PRODUCES_NOISY_RESULTS)) {
             throw std::invalid_argument(
                 "The circuit has no well-defined tableau because it contains noisy or dissipative operations.\n"

--- a/src/stim/stabilizers/pauli_string_ref.cc
+++ b/src/stim/stabilizers/pauli_string_ref.cc
@@ -162,7 +162,7 @@ void PauliStringRef::after_inplace_broadcast(const Tableau &tableau, ConstPointe
 
 void PauliStringRef::after_inplace(const Circuit &circuit) {
     for (const auto &op : circuit.operations) {
-        if (op.gate->id == gate_name_to_id("REPEAT")) {
+        if (op.gate->id == static_cast<uint8_t>(Gates::REPEAT)) {
             const auto &body = op_data_block_body(circuit, op.target_data);
             auto reps = op_data_rep_count(op.target_data);
             for (size_t k = 0; k < reps; k++) {
@@ -202,7 +202,7 @@ void PauliStringRef::after_inplace(const Operation &operation, bool inverse) {
                 throw std::invalid_argument(ss.str());
             }
         }
-    } else if (operation.gate->id == gate_name_to_id("MPP")) {
+    } else if (operation.gate->id == static_cast<uint8_t>(Gates::MPP)) {
         size_t start = 0;
         const auto &targets = operation.target_data.targets;
         while (start < targets.size()) {
@@ -229,13 +229,13 @@ void PauliStringRef::after_inplace(const Operation &operation, bool inverse) {
         }
     } else if (operation.gate->flags & GATE_PRODUCES_NOISY_RESULTS) {
         bool x_dep, z_dep;
-        if (operation.gate->id == gate_name_to_id("M")) {
+        if (operation.gate->id == static_cast<uint8_t>(Gates::M)) {
             x_dep = true;
             z_dep = false;
-        } else if (operation.gate->id == gate_name_to_id("MX")) {
+        } else if (operation.gate->id == static_cast<uint8_t>(Gates::MX)) {
             x_dep = false;
             z_dep = true;
-        } else if (operation.gate->id == gate_name_to_id("MY")) {
+        } else if (operation.gate->id == static_cast<uint8_t>(Gates::MY)) {
             x_dep = true;
             z_dep = true;
         } else {


### PR DESCRIPTION
Addresses initial steps implicated by #509 by disassociating simulator function pointers from gates and introducing independent function vtables for each simulator.

Key features
 - Gate name hashing should now only happen when parsing circuits.
 - Introduces a new `Gates` enum and a mechanism for moving from a gate name's hash to a gate's ID. Consequently, fewer places in the code now do a parsing step.
 - Gates no longer store function pointers to simulator functions. Instead this PR introduces compile time vtables for each simulator.
- The vtables are currently global. In the next step when simulators are templatised we probably wouldn’t want that, but I felt it would be better to deal with that while templatising the simulators.
