### PR TITLE
add support for avx512 and allow users to choose the Stim architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY out)
 # Convert desired SIMD_WIDTH into machine architecture flags.
 if(NOT(SIMD_WIDTH))
     set(MACHINE_FLAG "-march=native")
+elseif(SIMD_WIDTH EQUAL 512)
+    set(MACHINE_FLAG "-mavx512" "-mavx2" "-msse2")
 elseif(SIMD_WIDTH EQUAL 256)
     set(MACHINE_FLAG "-mavx2" "-msse2")
 elseif(SIMD_WIDTH EQUAL 128)

--- a/glue/python/src/stim/__init__.py
+++ b/glue/python/src/stim/__init__.py
@@ -6,13 +6,28 @@
 # compatible instructions. Importing a different one can result in runtime segfaults that crash the python interpreter.
 
 import stim._detect_machine_architecture as _tmp
+import os
 
+# Autodetec arch
 _tmp = _tmp._UNSTABLE_detect_march()
 # NOTE: avx2 disabled until https://github.com/quantumlib/Stim/issues/432 is fixed
-# if _tmp == 'avx2':
-#     from stim._stim_avx2 import *
-#     from stim._stim_avx2 import _UNSTABLE_raw_gate_data, _UNSTABLE_raw_format_data, __version__
-if _tmp == 'avx2' or _tmp == 'sse2':
+if _tmp == "avx2" or _tmp == "avx512":
+    _tmp = "sse2"
+# Or enforce with environment variable STIM_ARCH
+if "STIM_ARCH" in os.environ:
+    _tmp = os.environ["STIM_ARCH"].lower()
+    if _tmp not in ['avx512', 'avx2', 'sse2', 'polyfill']:
+        print("Warning! STIM_ARCH is defined but is not one of the expected Stim architecture. Please select either avx512, avx2, ss2 or polyfill")
+        exit(1)
+
+# Load arch
+if _tmp == 'avx512':
+    from stim._stim_avx512 import *
+    from stim._stim_avx512 import _UNSTABLE_raw_gate_data, _UNSTABLE_raw_format_data, __version__
+elif _tmp == 'avx2':
+    from stim._stim_avx2 import *
+    from stim._stim_avx2 import _UNSTABLE_raw_gate_data, _UNSTABLE_raw_format_data, __version__
+elif _tmp == 'sse2':
     from stim._stim_sse2 import *
     from stim._stim_sse2 import _UNSTABLE_raw_gate_data, _UNSTABLE_raw_format_data, __version__
 else:

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ if sys.platform.startswith('win'):
         '/O2',
         f'/DVERSION_INFO={version}',
     ]
+    arch_sse = ['/arch:AVX512']
     arch_avx = ['/arch:AVX2']
     arch_sse = ['/arch:SSE2']
     arch_basic = []
@@ -44,6 +45,7 @@ else:
         '-g0',
         f'-DVERSION_INFO={version}',
     ]
+    arch_avx512 = ['-mavx512f']
     arch_avx = ['-mavx2']
     arch_sse = ['-msse2', '-mno-avx2']
     arch_basic = []
@@ -81,18 +83,29 @@ stim_sse2 = Extension(
     ],
 )
 
-# NOTE: disabled until https://github.com/quantumlib/Stim/issues/432 is fixed
-# stim_avx2 = Extension(
-#     'stim._stim_avx2',
-#     sources=RELEVANT_SOURCE_FILES,
-#     include_dirs=[pybind11.get_include(), "src"],
-#     language='c++',
-#     extra_compile_args=[
-#         *common_compile_args,
-#         *arch_avx,
-#         '-DSTIM_PYBIND11_MODULE_NAME=_stim_avx2',
-#     ],
-# )
+stim_avx2 = Extension(
+    'stim._stim_avx2',
+    sources=RELEVANT_SOURCE_FILES,
+    include_dirs=[pybind11.get_include(), "src"],
+    language='c++',
+    extra_compile_args=[
+        *common_compile_args,
+        *arch_avx,
+        '-DSTIM_PYBIND11_MODULE_NAME=_stim_avx2',
+    ],
+)
+
+stim_avx512 = Extension(
+    'stim._stim_avx512',
+    sources=RELEVANT_SOURCE_FILES,
+    include_dirs=[pybind11.get_include(), "src"],
+    language='c++',
+    extra_compile_args=[
+        *common_compile_args,
+        *arch_avx512,
+        '-DSTIM_PYBIND11_MODULE_NAME=_stim_avx512',
+    ],
+)
 
 with open('glue/python/README.md', encoding='UTF-8') as f:
     long_description = f.read()
@@ -111,8 +124,8 @@ setup(
         stim_detect_machine_architecture,
         stim_polyfill,
         stim_sse2,
-        # NOTE: disabled until https://github.com/quantumlib/Stim/issues/432 is fixed
-        # stim_avx2,
+        stim_avx2,
+        stim_avx512,
     ],
     python_requires='>=3.6.0',
     packages=['stim'],

--- a/src/stim/mem/simd_word.h
+++ b/src/stim/mem/simd_word.h
@@ -36,7 +36,16 @@ struct bitword;
 
 }  // namespace stim
 
-#if __AVX2__
+
+#if __AVX512__
+#include "stim/mem/simd_word_128_sse.h"
+#include "stim/mem/simd_word_256_avx.h"
+#include "stim/mem/simd_word_512_avx512.h"
+#include "stim/mem/simd_word_64_std.h"
+namespace stim {
+constexpr size_t MAX_BITWORD_WIDTH = 512;
+}  // namespace stim
+#elif __AVX2__
 #include "stim/mem/simd_word_128_sse.h"
 #include "stim/mem/simd_word_256_avx.h"
 #include "stim/mem/simd_word_64_std.h"

--- a/src/stim/mem/simd_word_512_avx512.h
+++ b/src/stim/mem/simd_word_512_avx512.h
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _STIM_MEM_SIMD_WORD_512_AVX512_H
+#define _STIM_MEM_SIMD_WORD_512_AVX512_H
+
+/// Implements `simd_word` using AVX512 intrinsic instructions.
+/// For example, `_mm256_xor_si256` is AVX2.
+
+#include <immintrin.h>
+#include <iostream>
+
+#include "stim/mem/simd_util.h"
+
+namespace stim {
+
+template <size_t bit_size>
+struct bitword;
+
+#if __AVX512__
+
+/// Implements a 512 bit bitword using AVX instructions.
+template <>
+struct bitword<512> {
+    constexpr static size_t BIT_SIZE = 512;
+    constexpr static size_t BIT_POW = 9; 
+
+    union {
+        __m512i val;
+        uint64_t u64[8];
+        uint8_t u8[64];
+    };
+
+    static void *aligned_malloc(size_t bytes) {
+        return _mm_malloc(bytes, sizeof(__m512i));
+    }
+    static void aligned_free(void *ptr) {
+        _mm_free(ptr);
+    }
+
+    inline bitword<512>() : val(__m512i{}) {
+    }
+    inline bitword<512>(__m512i val) : val(val) {
+    }
+
+    inline static bitword<512> tile8(uint8_t pattern) {
+        return {_mm512_set1_epi8(pattern)};
+    }
+
+    inline static bitword<512> tile16(uint16_t pattern) {
+        return {_mm512_set1_epi16(pattern)};
+    }
+
+    inline static bitword<512> tile32(uint32_t pattern) {
+        return {_mm512_set1_epi32(pattern)};
+    }
+
+    inline static bitword<512> tile64(uint64_t pattern) {
+        return {_mm512_set1_epi64x(pattern)};
+    }
+
+    inline operator bool() const {  // NOLINT(hicpp-explicit-conversions)
+        return u64[0] | u64[1] | u64[2] | u64[3] | u64[4] | u64[5] | u64[6] | u64[7];
+    }
+
+    inline bitword<512> &operator^=(const bitword<512> &other) {
+        val = _mm512_xor_si512(val, other.val);
+        return *this;
+    }
+
+    inline bitword<512> &operator&=(const bitword<512> &other) {
+        val = _mm512_and_si512(val, other.val);
+        return *this;
+    }
+
+    inline bitword<512> &operator|=(const bitword<512> &other) {
+        val = _mm512_or_si512(val, other.val);
+        return *this;
+    }
+
+    inline bitword<512> operator^(const bitword<512> &other) const {
+        return {_mm512_xor_si512(val, other.val)};
+    }
+
+    inline bitword<512> operator&(const bitword<512> &other) const {
+        return {_mm512_and_si512(val, other.val)};
+    }
+
+    inline bitword<512> operator|(const bitword<512> &other) const {
+        return {_mm512_or_si512(val, other.val)};
+    }
+
+    inline bitword<512> andnot(const bitword<512> &other) const {
+        return {_mm512_andnot_si512(val, other.val)};
+    }
+
+    inline uint16_t popcount() const {
+        return stim::popcnt64(u64[0]) + stim::popcnt64(u64[1]) + stim::popcnt64(u64[2]) +
+               stim::popcnt64(u64[3]) + stim::popcnt64(u64[4]) + stim::popcnt64(u64[5]) +
+               stim::popcnt64(u64[6]) + (uint16_t)stim::popcnt64(u64[7]);
+    }
+
+    template <uint64_t shift>
+    static void inplace_transpose_block_pass(bitword<512> *data, size_t stride, __m512i mask) {
+        for (size_t k = 0; k < 512; k++) {
+            if (k & shift) {
+                continue;
+            }
+            bitword<512> &x = data[stride * k];
+            bitword<512> &y = data[stride * (k + shift)];
+            bitword<512> a = x & mask;
+            bitword<512> b = x & ~mask;
+            bitword<512> c = y & mask;
+            bitword<512> d = y & ~mask;
+            x = a | bitword<512>(_mm512_slli_epi64(c.val, shift));
+            y = bitword<512>(_mm512_srli_epi64(b.val, shift)) | d;
+        }
+    }
+
+    //TODO: this is just a copy of the same function of avx2
+    static void inplace_transpose_block_pass_64_and_128_and_256(bitword<512> *data, size_t stride) {
+        uint64_t *ptr = (uint64_t *)data;
+        stride <<= 2;
+
+        for (size_t k = 0; k < 64; k++) {
+            std::swap(ptr[stride * (k + 64 * 0) + 1], ptr[stride * (k + 64 * 1) + 0]);
+            std::swap(ptr[stride * (k + 64 * 0) + 2], ptr[stride * (k + 64 * 2) + 0]);
+            std::swap(ptr[stride * (k + 64 * 0) + 3], ptr[stride * (k + 64 * 3) + 0]);
+            std::swap(ptr[stride * (k + 64 * 1) + 2], ptr[stride * (k + 64 * 2) + 1]);
+            std::swap(ptr[stride * (k + 64 * 1) + 3], ptr[stride * (k + 64 * 3) + 1]);
+            std::swap(ptr[stride * (k + 64 * 2) + 3], ptr[stride * (k + 64 * 3) + 2]);
+        }
+    }
+
+    static void inplace_transpose_square(bitword<512> *data, size_t stride) {
+        inplace_transpose_block_pass<1>(data, stride, _mm512_set1_epi8(0x55));
+        inplace_transpose_block_pass<2>(data, stride, _mm512_set1_epi8(0x33));
+        inplace_transpose_block_pass<4>(data, stride, _mm512_set1_epi8(0xF));
+        inplace_transpose_block_pass<8>(data, stride, _mm512_set1_epi16(0xFF));
+        inplace_transpose_block_pass<16>(data, stride, _mm512_set1_epi32(0xFFFF));
+        inplace_transpose_block_pass<32>(data, stride, _mm512_set1_epi64x(0xFFFFFFFF));
+        inplace_transpose_block_pass_64_and_128(data, stride);
+    }
+};
+#endif
+
+}  // namespace stim
+
+#endif

--- a/src/stim/py/march.pybind.cc
+++ b/src/stim/py/march.pybind.cc
@@ -37,6 +37,12 @@ std::string detect_march() {
     cpuid(regs, INFO_HIGHEST_FUNCTION_PARAMETER);
     auto max_info_param = regs[EAX];
 
+#if defined(__x86_64__)   
+    if (__builtin_cpu_supports("avx512f")) {
+        return "avx512";
+    }
+#endif
+
     if (max_info_param >= INFO_EXTENDED_FEATURES) {
         cpuid(regs, INFO_EXTENDED_FEATURES);
         if (regs[EBX] & avx2_bit_in_ebx) {


### PR DESCRIPTION
Hi!

I started implementing the AVX512F instructions for code vectorization, which is more recent and is available on newer AMD Zen4 and on some Intel processors. This can give up to 4% improved performance over AVX2 version on my very limited testing. 

Also, I added in the Python binding the possibility to the user to specify the architecture he/she wants to use with the STIM_ARCHITECTURE environment variable. The default behavior is still SSE2 because of https://github.com/quantumlib/Stim/issues/432.

Below some basic benchmark (1% improvement in this case):
```
(env_dev) moise@moise-HP-EliteBook-840:~/Program/Stim/examples$ export STIM_ARCH=avx512 && time python surface_code.py 
real	0m32.448s
user	0m26.335s
sys	0m6.786s

(env_dev) moise@moise-HP-EliteBook-840:~/Program/Stim/examples$ export STIM_ARCH=avx2 && time python surface_code.py 
real	0m32.787s
user	0m26.680s
sys	0m6.782s

(env_dev) moise@moise-HP-EliteBook-840:~/Program/Stim/examples$ export STIM_ARCH=sse2 && time python surface_code.py 
real	0m35.860s
user	0m29.884s
sys	0m6.656s
```
with the code:
```
(env_dev) moise@moise-HP-EliteBook-840:~/Program/Stim/examples$ cat surface_code.py 
import stim 

c = stim.Circuit.generated(
"surface_code:rotated_memory_z",
rounds=20,
distance=40,
after_clifford_depolarization=0.001,
after_reset_flip_probability=0.001,
before_measure_flip_probability=0.001,
before_round_data_depolarization=0.001)

sampler = c.compile_sampler()
samples = sampler.sample(300000)
```

TODO: correct the function `inplace_transpose_block_pass_64_and_128_and_256` line 234 in `[src/stim/mem/simd_word_512_avx512.h](https://github.com/quantumlib/Stim/compare/main...MoiseRousseau:Stim:Moise/arch_avx512?expand=1#diff-75e1a1cb88702d8bf8b9f964584cababa9c07f6868db23d08a5b1015b3410ae3)`. However, it seems this function is not called in the code..

Let me know what you think,
Moise
