### PR TITLE
Keep stim.CompiledDetectorSampler's FrameSim cached

### DIFF
--- a/glue/sample/src/sinter/_decoding_pymatching_v2.py
+++ b/glue/sample/src/sinter/_decoding_pymatching_v2.py
@@ -18,7 +18,12 @@ def decode_using_pymatching_v2(*,
             f.write(b'\0' * (num_obs * num_shots))
         return
 
-    result = pymatching._cpp_pymatching.main(command_line_args=[
+    cli_method = getattr(pymatching, 'cli')
+    if cli_method is None:
+        # Backwards compat for pymatching 2.0.0
+        cli_method = pymatching._cpp_pymatching.main
+
+    result = cli_method(command_line_args=[
         "predict",
         "--dem", str(dem_path),
         "--in", str(dets_b8_in_path),

--- a/src/stim/io/measure_record_batch.cc
+++ b/src/stim/io/measure_record_batch.cc
@@ -24,7 +24,7 @@
 using namespace stim;
 
 MeasureRecordBatch::MeasureRecordBatch(size_t num_shots, size_t max_lookback)
-    : max_lookback(max_lookback), unwritten(0), stored(0), written(0), shot_mask(num_shots), storage(1, num_shots) {
+    : num_shots(num_shots), max_lookback(max_lookback), unwritten(0), stored(0), written(0), shot_mask(num_shots), storage(1, num_shots) {
     for (size_t k = 0; k < num_shots; k++) {
         shot_mask[k] = true;
     }
@@ -134,4 +134,18 @@ void MeasureRecordBatch::final_write_unwritten_results_to(
 void MeasureRecordBatch::clear() {
     stored = 0;
     unwritten = 0;
+}
+void MeasureRecordBatch::destructive_resize(size_t new_num_shots, size_t new_max_lookback) {
+    unwritten = 0;
+    stored = 0;
+    written = 0;
+    max_lookback = new_max_lookback;
+    if (new_num_shots != num_shots) {
+        num_shots = new_num_shots;
+        shot_mask = simd_bits<MAX_BITWORD_WIDTH>(num_shots);
+        for (size_t k = 0; k < num_shots; k++) {
+            shot_mask[k] = true;
+        }
+        storage.destructive_resize(1, num_shots);
+    }
 }

--- a/src/stim/io/measure_record_batch.h
+++ b/src/stim/io/measure_record_batch.h
@@ -25,6 +25,7 @@ namespace stim {
 ///
 /// Results that have been written and are further back than `max_lookback` may be discarded from memory.
 struct MeasureRecordBatch {
+    size_t num_shots;
     /// How far back into the measurement record a circuit being simulated may look.
     /// Results younger than this cannot be discarded.
     size_t max_lookback;
@@ -74,6 +75,8 @@ struct MeasureRecordBatch {
     void reserve_space_for_results(size_t count);
     /// Resets the record to an empty state.
     void clear();
+
+    void destructive_resize(size_t new_num_shots, size_t new_max_lookback);
 };
 
 }  // namespace stim

--- a/src/stim/mem/simd_bit_table.h
+++ b/src/stim/mem/simd_bit_table.h
@@ -66,6 +66,9 @@ struct simd_bit_table {
     ///     A simd_bit_table with cell contents corresponding to the text.
     static simd_bit_table from_text(const char *text, size_t min_rows = 0, size_t min_cols = 0);
 
+    /// Resizes the table. Doesn't clear to zero. Does nothing if already the target size.
+    void destructive_resize(size_t new_min_bits_major, size_t new_min_bits_minor);
+
     /// Equality.
     bool operator==(const simd_bit_table &other) const;
     /// Inequality.

--- a/src/stim/mem/simd_bit_table.inl
+++ b/src/stim/mem/simd_bit_table.inl
@@ -101,6 +101,13 @@ void exchange_low_indices(simd_bit_table<W> &table) {
 }
 
 template <size_t W>
+void simd_bit_table<W>::destructive_resize(size_t new_min_bits_major, size_t new_min_bits_minor) {
+    num_simd_words_minor = min_bits_to_num_simd_words<W>(new_min_bits_minor);
+    num_simd_words_major = min_bits_to_num_simd_words<W>(new_min_bits_major);
+    data.destructive_resize(num_simd_words_minor * num_simd_words_major * W * W);
+}
+
+template <size_t W>
 void simd_bit_table<W>::do_square_transpose() {
     assert(num_simd_words_minor == num_simd_words_major);
 

--- a/src/stim/mem/simd_bit_table.test.cc
+++ b/src/stim/mem/simd_bit_table.test.cc
@@ -289,3 +289,14 @@ TEST(simd_bit_table, lg) {
     ASSERT_EQ(lg(8), 3);
     ASSERT_EQ(lg(9), 3);
 }
+
+TEST_EACH_WORD_SIZE_W(simd_bit_table, destructive_resize, {
+    simd_bit_table<W> table = table.random(5, 7, SHARED_TEST_RNG());
+    const uint8_t *prev_pointer = table.data.u8;
+    table.destructive_resize(5, 7);
+    ASSERT_EQ(table.data.u8, prev_pointer);
+    table.destructive_resize(1025, 7);
+    ASSERT_NE(table.data.u8, prev_pointer);
+    ASSERT_GE(table.num_major_bits_padded(), 1025);
+    ASSERT_GE(table.num_minor_bits_padded(), 7);
+})

--- a/src/stim/mem/simd_bits.h
+++ b/src/stim/mem/simd_bits.h
@@ -78,6 +78,8 @@ struct simd_bits {
     /// Determines whether or not any of the bits in the simd_bits are non-zero.
     bool not_zero() const;
 
+    void destructive_resize(size_t new_min_bits);
+
     /// Returns a reference to the bit at offset k.
     bit_ref operator[](size_t k);
     /// Returns a const reference to the bit at offset k.

--- a/src/stim/mem/simd_bits.inl
+++ b/src/stim/mem/simd_bits.inl
@@ -194,6 +194,14 @@ simd_bits<W> &simd_bits<W>::swap_with(simd_bits_range_ref<W> other) {
 }
 
 template <size_t W>
+void simd_bits<W>::destructive_resize(size_t new_min_bits) {
+    if (min_bits_to_num_bits_padded<W>(new_min_bits) == num_bits_padded()) {
+        return;
+    }
+    *this = std::move(simd_bits<W>(new_min_bits));
+}
+
+template <size_t W>
 size_t simd_bits<W>::popcnt() const {
     return simd_bits_range_ref<W>(*this).popcnt();
 }

--- a/src/stim/py/compiled_detector_sampler.pybind.h
+++ b/src/stim/py/compiled_detector_sampler.pybind.h
@@ -19,6 +19,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include "stim/simulators/frame_simulator.h"
 #include "stim/circuit/circuit.h"
 #include "stim/mem/simd_bits.h"
 
@@ -28,6 +29,7 @@ struct CompiledDetectorSampler {
     stim::CircuitStats circuit_stats;
     stim::Circuit circuit;
     std::shared_ptr<std::mt19937_64> prng;
+    stim::FrameSimulator frame_sim;
 
     CompiledDetectorSampler() = delete;
     CompiledDetectorSampler(const CompiledDetectorSampler &) = delete;

--- a/src/stim/py/compiled_detector_sampler_pybind_test.py
+++ b/src/stim/py/compiled_detector_sampler_pybind_test.py
@@ -19,18 +19,31 @@ import numpy as np
 import stim
 
 
+def test_compiled_detector_sampler_trivial():
+    c = stim.Circuit("""
+        X_ERROR(1) 0
+        M 0
+        DETECTOR rec[-1]
+    """)
+    np.testing.assert_array_equal(
+        c.compile_detector_sampler().sample(shots=2),
+        np.array([
+            [1],
+            [1],
+        ], dtype=np.bool_))
+
+
 def test_compiled_detector_sampler_sample():
-    c = stim.Circuit()
-    c.append_operation("X_ERROR", [0], 1)
-    c.append_operation("M", [0, 1, 2])
-    c.append_operation("DETECTOR", [stim.target_rec(-3), stim.target_rec(-2)])
-    c.append_operation("DETECTOR", [stim.target_rec(-3), stim.target_rec(-1)])
-    c.append_operation("DETECTOR", [stim.target_rec(-1), stim.target_rec(-2)])
-    c.append_from_stim_program_text("""
+    c = stim.Circuit("""
+        X_ERROR(1) 0
+        M 0 1 2
+        DETECTOR rec[-3] rec[-2]
+        DETECTOR rec[-3] rec[-1]
+        DETECTOR rec[-1] rec[-2]
         OBSERVABLE_INCLUDE(0) rec[-3]
         OBSERVABLE_INCLUDE(3) rec[-2] rec[-1]
+        OBSERVABLE_INCLUDE(0) rec[-2]
     """)
-    c.append_operation("OBSERVABLE_INCLUDE", [stim.target_rec(-2)], 0)
     np.testing.assert_array_equal(
         c.compile_detector_sampler().sample(5),
         np.array([
@@ -39,7 +52,7 @@ def test_compiled_detector_sampler_sample():
             [1, 1, 0],
             [1, 1, 0],
             [1, 1, 0],
-        ], dtype=np.uint8))
+        ], dtype=np.bool_))
     np.testing.assert_array_equal(
         c.compile_detector_sampler().sample(5, prepend_observables=True),
         np.array([
@@ -48,7 +61,7 @@ def test_compiled_detector_sampler_sample():
             [1, 0, 0, 0, 1, 1, 0],
             [1, 0, 0, 0, 1, 1, 0],
             [1, 0, 0, 0, 1, 1, 0],
-        ], dtype=np.uint8))
+        ], dtype=np.bool_))
     np.testing.assert_array_equal(
         c.compile_detector_sampler().sample(5, append_observables=True),
         np.array([
@@ -57,7 +70,7 @@ def test_compiled_detector_sampler_sample():
             [1, 1, 0, 1, 0, 0, 0],
             [1, 1, 0, 1, 0, 0, 0],
             [1, 1, 0, 1, 0, 0, 0],
-        ], dtype=np.uint8))
+        ], dtype=np.bool_))
 
     dets, obs = c.compile_detector_sampler().sample(5, separate_observables=True)
     np.testing.assert_array_equal(
@@ -68,7 +81,7 @@ def test_compiled_detector_sampler_sample():
             [1, 1, 0],
             [1, 1, 0],
             [1, 1, 0],
-        ], dtype=np.uint8))
+        ], dtype=np.bool_))
     np.testing.assert_array_equal(
         obs,
         np.array([
@@ -106,7 +119,7 @@ def test_compiled_detector_sampler_sample():
             [1, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0],
             [1, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0],
             [1, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0],
-        ], dtype=np.uint8))
+        ], dtype=np.bool_))
     np.testing.assert_array_equal(
         c.compile_detector_sampler().sample_bit_packed(5),
         np.array([

--- a/src/stim/simulators/frame_simulator.h
+++ b/src/stim/simulators/frame_simulator.h
@@ -76,6 +76,7 @@ struct FrameSimulator {
 
     PauliString get_frame(size_t sample_index) const;
     void set_frame(size_t sample_index, const PauliStringRef &new_frame);
+    void configure_for(CircuitStats new_circuit_stats, FrameSimulatorMode new_mode, size_t new_batch_size);
 
     void reset_all_and_run(const Circuit &circuit);
     void reset_all();

--- a/src/stim/simulators/frame_simulator.test.cc
+++ b/src/stim/simulators/frame_simulator.test.cc
@@ -1439,3 +1439,16 @@ TEST(FrameSimulator, ignores_sweep_controls_when_given_no_sweep_data) {
                  .popcnt();
     ASSERT_EQ(n, 0);
 }
+
+TEST(FrameSimulator, reconfigure_for) {
+    auto circuit = Circuit(R"CIRCUIT(
+        X_ERROR(1) 0
+        M 0
+        DETECTOR rec[-1]
+    )CIRCUIT");
+
+    FrameSimulator frame_sim(circuit.compute_stats(), FrameSimulatorMode::STORE_DETECTIONS_TO_MEMORY, 0, SHARED_TEST_RNG());
+    frame_sim.configure_for(circuit.compute_stats(), FrameSimulatorMode::STORE_DETECTIONS_TO_MEMORY, 256);
+    frame_sim.reset_all_and_run(circuit);
+    ASSERT_EQ(frame_sim.det_record.storage[0].popcnt(), 256);
+}


### PR DESCRIPTION
- Time to re-sample 2^14 shots from a d=13 r=39 surface code improved from ~1.8s to ~1.2s
- Add stim::FrameSimulator::configure_for
- Add stim::{simd_bits,simd_bit_table,etc}::destructive_resize