### PR TITLE
Allow reference_sample to be passed as an argument to sampler.

### DIFF
--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -41,6 +41,7 @@ API references for stable versions are kept on the [stim github wiki](https://gi
     - [`stim.Circuit.num_qubits`](#stim.Circuit.num_qubits)
     - [`stim.Circuit.num_sweep_bits`](#stim.Circuit.num_sweep_bits)
     - [`stim.Circuit.num_ticks`](#stim.Circuit.num_ticks)
+    - [`stim.Circuit.reference_sample`](#stim.Circuit.reference_sample)
     - [`stim.Circuit.search_for_undetectable_logical_errors`](#stim.Circuit.search_for_undetectable_logical_errors)
     - [`stim.Circuit.shortest_graphlike_error`](#stim.Circuit.shortest_graphlike_error)
     - [`stim.Circuit.to_file`](#stim.Circuit.to_file)
@@ -1040,6 +1041,7 @@ def compile_sampler(
     *,
     skip_reference_sample: bool = False,
     seed: object = None,
+    reference_sample: object = None,
 ) -> stim.CompiledMeasurementSampler:
     """Returns an object that can quickly batch sample measurements from the circuit.
 
@@ -1083,6 +1085,18 @@ def compile_sampler(
             CAUTION: simulation results *MAY NOT* be consistent if you vary how many
             shots are taken. For example, taking 10 shots and then 90 shots will
             give different results from taking 100 shots in one call.
+        reference_sample: The data to xor into the measurement flips produced by the
+            frame simulator, in order to produce proper measurement results.
+            This can either be specified as an `np.bool_` array or a bit packed
+            `np.uint8` array (little endian). Under normal conditions, the reference
+            sample should be a valid noiseless sample of the circuit, such as the
+            one returned by `circuit.reference_sample()`. If this argument is not
+            provided, the reference sample will be set to
+            `circuit.reference_sample()`, unless `skip_reference_sample=True`
+            is used, in which case it will be set to all-zeros.
+
+    Raises:
+        ValueError: skip_reference_sample is True and reference_sample is not None.
 
     Examples:
         >>> import stim
@@ -1979,6 +1993,30 @@ def num_ticks(
         ...    }
         ... ''').num_ticks
         101
+    """
+```
+
+<a name="stim.Circuit.reference_sample"></a>
+```python
+# stim.Circuit.reference_sample
+
+# (in class stim.Circuit)
+def reference_sample(
+    self,
+    bit_packed: bool = False,
+) -> np.ndarray:
+    """Samples the given circuit in a deterministic fashion.
+
+    Discards all noisy operations, and biases all collapse events
+    towards +Z instead of randomly +Z/-Z.
+
+    Args:
+        circuit: The circuit to "sample" from.
+        bit_packed: Defaults to False. Determines whether the output numpy arrays
+            use dtype=bool_ or dtype=uint8 with 8 bools packed into each byte.
+
+    Returns:
+        reference_sample: reference sample sampled from the given circuit.
     """
 ```
 
@@ -3391,6 +3429,7 @@ def __init__(
     *,
     skip_reference_sample: bool = False,
     seed: object = None,
+    reference_sample: object = None,
 ) -> None:
     """Creates a measurement sampler for the given circuit.
 
@@ -3439,6 +3478,15 @@ def __init__(
             CAUTION: simulation results *MAY NOT* be consistent if you vary how many
             shots are taken. For example, taking 10 shots and then 90 shots will
             give different results from taking 100 shots in one call.
+        reference_sample: The data to xor into the measurement flips produced by the
+            frame simulator, in order to produce proper measurement results.
+            This can either be specified as an `np.bool_` array or a bit packed
+            `np.uint8` array (little endian). Under normal conditions, the reference
+            sample should be a valid noiseless sample of the circuit, such as the
+            one returned by `circuit.reference_sample()`. If this argument is not
+            provided, the reference sample will be set to
+            `circuit.reference_sample()`, unless `skip_reference_sample=True`
+            is used, in which case it will be set to all-zeros.
 
     Returns:
         An initialized stim.CompiledMeasurementSampler.

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -1040,8 +1040,8 @@ def compile_sampler(
     self,
     *,
     skip_reference_sample: bool = False,
-    seed: object = None,
-    reference_sample: object = None,
+    seed: Optional[int] = None,
+    reference_sample: Optional[np.ndarray] = None,
 ) -> stim.CompiledMeasurementSampler:
     """Returns an object that can quickly batch sample measurements from the circuit.
 
@@ -2003,6 +2003,7 @@ def num_ticks(
 # (in class stim.Circuit)
 def reference_sample(
     self,
+    *,
     bit_packed: bool = False,
 ) -> np.ndarray:
     """Samples the given circuit in a deterministic fashion.

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -564,8 +564,8 @@ class Circuit:
         self,
         *,
         skip_reference_sample: bool = False,
-        seed: object = None,
-        reference_sample: object = None,
+        seed: Optional[int] = None,
+        reference_sample: Optional[np.ndarray] = None,
     ) -> stim.CompiledMeasurementSampler:
         """Returns an object that can quickly batch sample measurements from the circuit.
 
@@ -1433,6 +1433,7 @@ class Circuit:
         """
     def reference_sample(
         self,
+        *,
         bit_packed: bool = False,
     ) -> np.ndarray:
         """Samples the given circuit in a deterministic fashion.

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -565,6 +565,7 @@ class Circuit:
         *,
         skip_reference_sample: bool = False,
         seed: object = None,
+        reference_sample: object = None,
     ) -> stim.CompiledMeasurementSampler:
         """Returns an object that can quickly batch sample measurements from the circuit.
 
@@ -608,6 +609,18 @@ class Circuit:
                 CAUTION: simulation results *MAY NOT* be consistent if you vary how many
                 shots are taken. For example, taking 10 shots and then 90 shots will
                 give different results from taking 100 shots in one call.
+            reference_sample: The data to xor into the measurement flips produced by the
+                frame simulator, in order to produce proper measurement results.
+                This can either be specified as an `np.bool_` array or a bit packed
+                `np.uint8` array (little endian). Under normal conditions, the reference
+                sample should be a valid noiseless sample of the circuit, such as the
+                one returned by `circuit.reference_sample()`. If this argument is not
+                provided, the reference sample will be set to
+                `circuit.reference_sample()`, unless `skip_reference_sample=True`
+                is used, in which case it will be set to all-zeros.
+
+        Raises:
+            ValueError: skip_reference_sample is True and reference_sample is not None.
 
         Examples:
             >>> import stim
@@ -1417,6 +1430,23 @@ class Circuit:
             ...    }
             ... ''').num_ticks
             101
+        """
+    def reference_sample(
+        self,
+        bit_packed: bool = False,
+    ) -> np.ndarray:
+        """Samples the given circuit in a deterministic fashion.
+
+        Discards all noisy operations, and biases all collapse events
+        towards +Z instead of randomly +Z/-Z.
+
+        Args:
+            circuit: The circuit to "sample" from.
+            bit_packed: Defaults to False. Determines whether the output numpy arrays
+                use dtype=bool_ or dtype=uint8 with 8 bools packed into each byte.
+
+        Returns:
+            reference_sample: reference sample sampled from the given circuit.
         """
     def search_for_undetectable_logical_errors(
         self,
@@ -2507,6 +2537,7 @@ class CompiledMeasurementSampler:
         *,
         skip_reference_sample: bool = False,
         seed: object = None,
+        reference_sample: object = None,
     ) -> None:
         """Creates a measurement sampler for the given circuit.
 
@@ -2555,6 +2586,15 @@ class CompiledMeasurementSampler:
                 CAUTION: simulation results *MAY NOT* be consistent if you vary how many
                 shots are taken. For example, taking 10 shots and then 90 shots will
                 give different results from taking 100 shots in one call.
+            reference_sample: The data to xor into the measurement flips produced by the
+                frame simulator, in order to produce proper measurement results.
+                This can either be specified as an `np.bool_` array or a bit packed
+                `np.uint8` array (little endian). Under normal conditions, the reference
+                sample should be a valid noiseless sample of the circuit, such as the
+                one returned by `circuit.reference_sample()`. If this argument is not
+                provided, the reference sample will be set to
+                `circuit.reference_sample()`, unless `skip_reference_sample=True`
+                is used, in which case it will be set to all-zeros.
 
         Returns:
             An initialized stim.CompiledMeasurementSampler.

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -564,8 +564,8 @@ class Circuit:
         self,
         *,
         skip_reference_sample: bool = False,
-        seed: object = None,
-        reference_sample: object = None,
+        seed: Optional[int] = None,
+        reference_sample: Optional[np.ndarray] = None,
     ) -> stim.CompiledMeasurementSampler:
         """Returns an object that can quickly batch sample measurements from the circuit.
 
@@ -1433,6 +1433,7 @@ class Circuit:
         """
     def reference_sample(
         self,
+        *,
         bit_packed: bool = False,
     ) -> np.ndarray:
         """Samples the given circuit in a deterministic fashion.

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -565,6 +565,7 @@ class Circuit:
         *,
         skip_reference_sample: bool = False,
         seed: object = None,
+        reference_sample: object = None,
     ) -> stim.CompiledMeasurementSampler:
         """Returns an object that can quickly batch sample measurements from the circuit.
 
@@ -608,6 +609,18 @@ class Circuit:
                 CAUTION: simulation results *MAY NOT* be consistent if you vary how many
                 shots are taken. For example, taking 10 shots and then 90 shots will
                 give different results from taking 100 shots in one call.
+            reference_sample: The data to xor into the measurement flips produced by the
+                frame simulator, in order to produce proper measurement results.
+                This can either be specified as an `np.bool_` array or a bit packed
+                `np.uint8` array (little endian). Under normal conditions, the reference
+                sample should be a valid noiseless sample of the circuit, such as the
+                one returned by `circuit.reference_sample()`. If this argument is not
+                provided, the reference sample will be set to
+                `circuit.reference_sample()`, unless `skip_reference_sample=True`
+                is used, in which case it will be set to all-zeros.
+
+        Raises:
+            ValueError: skip_reference_sample is True and reference_sample is not None.
 
         Examples:
             >>> import stim
@@ -1417,6 +1430,23 @@ class Circuit:
             ...    }
             ... ''').num_ticks
             101
+        """
+    def reference_sample(
+        self,
+        bit_packed: bool = False,
+    ) -> np.ndarray:
+        """Samples the given circuit in a deterministic fashion.
+
+        Discards all noisy operations, and biases all collapse events
+        towards +Z instead of randomly +Z/-Z.
+
+        Args:
+            circuit: The circuit to "sample" from.
+            bit_packed: Defaults to False. Determines whether the output numpy arrays
+                use dtype=bool_ or dtype=uint8 with 8 bools packed into each byte.
+
+        Returns:
+            reference_sample: reference sample sampled from the given circuit.
         """
     def search_for_undetectable_logical_errors(
         self,
@@ -2507,6 +2537,7 @@ class CompiledMeasurementSampler:
         *,
         skip_reference_sample: bool = False,
         seed: object = None,
+        reference_sample: object = None,
     ) -> None:
         """Creates a measurement sampler for the given circuit.
 
@@ -2555,6 +2586,15 @@ class CompiledMeasurementSampler:
                 CAUTION: simulation results *MAY NOT* be consistent if you vary how many
                 shots are taken. For example, taking 10 shots and then 90 shots will
                 give different results from taking 100 shots in one call.
+            reference_sample: The data to xor into the measurement flips produced by the
+                frame simulator, in order to produce proper measurement results.
+                This can either be specified as an `np.bool_` array or a bit packed
+                `np.uint8` array (little endian). Under normal conditions, the reference
+                sample should be a valid noiseless sample of the circuit, such as the
+                one returned by `circuit.reference_sample()`. If this argument is not
+                provided, the reference sample will be set to
+                `circuit.reference_sample()`, unless `skip_reference_sample=True`
+                is used, in which case it will be set to all-zeros.
 
         Returns:
             An initialized stim.CompiledMeasurementSampler.

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -415,6 +415,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
         pybind11::kw_only(),
         pybind11::arg("skip_reference_sample") = false,
         pybind11::arg("seed") = pybind11::none(),
+        pybind11::arg("reference_sample") = pybind11::none(),
         clean_doc_string(R"DOC(
             Returns an object that can quickly batch sample measurements from the circuit.
 
@@ -458,6 +459,12 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
                     CAUTION: simulation results *MAY NOT* be consistent if you vary how many
                     shots are taken. For example, taking 10 shots and then 90 shots will
                     give different results from taking 100 shots in one call.
+                reference_sample: Reference sample used by the sampler. If None
+                    then the reference sample is constructed on the fly
+                    according to skip_reference_sample.
+
+            Raises:
+                ValueError: skip_reference_sample is True and reference_sample is not None.
 
             Examples:
                 >>> import stim

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -419,7 +419,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
         pybind11::arg("seed") = pybind11::none(),
         pybind11::arg("reference_sample") = pybind11::none(),
         clean_doc_string(R"DOC(
-            @signature def compile_sampler(self, *, skip_reference_sample: bool = False, seed: Optional[int] = None, reference_sample: Optional[np.ndarray] = None) -> stim.CompiledMeasurementSampler
+            @signature def compile_sampler(self, *, skip_reference_sample: bool = False, seed: Optional[int] = None, reference_sample: Optional[np.ndarray] = None) -> stim.CompiledMeasurementSampler:
             Returns an object that can quickly batch sample measurements from the circuit.
 
             Args:

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -459,9 +459,15 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
                     CAUTION: simulation results *MAY NOT* be consistent if you vary how many
                     shots are taken. For example, taking 10 shots and then 90 shots will
                     give different results from taking 100 shots in one call.
-                reference_sample: Reference sample used by the sampler. If None
-                    then the reference sample is constructed on the fly
-                    according to skip_reference_sample.
+                reference_sample: The data to xor into the measurement flips produced by the
+                    frame simulator, in order to produce proper measurement results.
+                    This can either be specified as an `np.bool_` array or a bit packed
+                    `np.uint8` array (little endian). Under normal conditions, the reference
+                    sample should be a valid noiseless sample of the circuit, such as the
+                    one returned by `circuit.reference_sample()`. If this argument is not
+                    provided, the reference sample will be set to
+                    `circuit.reference_sample()`, unless `skip_reference_sample=True`
+                    is used, in which case it will be set to all-zeros.
 
             Raises:
                 ValueError: skip_reference_sample is True and reference_sample is not None.

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -30,10 +30,12 @@
 #include "stim/py/base.pybind.h"
 #include "stim/py/compiled_detector_sampler.pybind.h"
 #include "stim/py/compiled_measurement_sampler.pybind.h"
+#include "stim/py/numpy.pybind.h"
 #include "stim/search/search.h"
 #include "stim/simulators/error_analyzer.h"
 #include "stim/simulators/error_matcher.h"
 #include "stim/simulators/measurements_to_detection_events.pybind.h"
+#include "stim/simulators/tableau_simulator.h"
 #include "stim/simulators/transform_without_feedback.h"
 
 using namespace stim;
@@ -481,6 +483,33 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
                 >>> s = c.compile_sampler()
                 >>> s.sample(shots=1)
                 array([[False, False,  True]])
+        )DOC")
+            .data());
+
+    c.def(
+        "reference_sample",
+        [](const Circuit self, bool bit_packed) {
+            simd_bits<MAX_BITWORD_WIDTH> ref = TableauSimulator::reference_sample_circuit(self);
+            simd_bits_range_ref<MAX_BITWORD_WIDTH> reference_sample(ref.ptr_simd, ref.num_simd_words);
+            size_t num_measure = self.count_measurements();
+            return simd_bits_to_numpy(reference_sample, num_measure, bit_packed);
+        },
+        pybind11::kw_only(),
+        pybind11::arg("bit_packed") = false,
+        clean_doc_string(R"DOC(
+            @signature def reference_sample(self, bit_packed: bool = False) -> np.ndarray:
+            Samples the given circuit in a deterministic fashion.
+
+            Discards all noisy operations, and biases all collapse events
+            towards +Z instead of randomly +Z/-Z.
+
+            Args:
+                circuit: The circuit to "sample" from.
+                bit_packed: Defaults to False. Determines whether the output numpy arrays
+                    use dtype=bool_ or dtype=uint8 with 8 bools packed into each byte.
+
+            Returns:
+                reference_sample: reference sample sampled from the given circuit.
         )DOC")
             .data());
 

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -488,7 +488,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
 
     c.def(
         "reference_sample",
-        [](const Circuit self, bool bit_packed) {
+        [](const Circuit &self, bool bit_packed) {
             simd_bits<MAX_BITWORD_WIDTH> ref = TableauSimulator::reference_sample_circuit(self);
             simd_bits_range_ref<MAX_BITWORD_WIDTH> reference_sample(ref.ptr_simd, ref.num_simd_words);
             size_t num_measure = self.count_measurements();

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -419,6 +419,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
         pybind11::arg("seed") = pybind11::none(),
         pybind11::arg("reference_sample") = pybind11::none(),
         clean_doc_string(R"DOC(
+            @signature def compile_sampler(self, *, skip_reference_sample: bool = False, seed: Optional[int] = None, reference_sample: Optional[np.ndarray] = None) -> stim.CompiledMeasurementSampler
             Returns an object that can quickly batch sample measurements from the circuit.
 
             Args:
@@ -497,7 +498,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
         pybind11::kw_only(),
         pybind11::arg("bit_packed") = false,
         clean_doc_string(R"DOC(
-            @signature def reference_sample(self, bit_packed: bool = False) -> np.ndarray:
+            @signature def reference_sample(self, *, bit_packed: bool = False) -> np.ndarray:
             Samples the given circuit in a deterministic fashion.
 
             Discards all noisy operations, and biases all collapse events

--- a/src/stim/circuit/circuit_pybind_test.py
+++ b/src/stim/circuit/circuit_pybind_test.py
@@ -1345,3 +1345,23 @@ def test_num_ticks():
         CX 0 1
         TICK
     """).num_ticks == 2
+
+
+def test_reference_sample():
+    circuit = stim.Circuit(
+        """
+        H 0
+        CNOT 0 1
+    """
+    )
+    ref = circuit.reference_sample()
+    assert len(ref) == 0
+    circuit = stim.Circuit(
+        """
+        H 0
+        M 0
+        M 1
+    """
+    )
+    ref = circuit.reference_sample()
+    assert ref[0] == ref[1]

--- a/src/stim/circuit/circuit_pybind_test.py
+++ b/src/stim/circuit/circuit_pybind_test.py
@@ -1365,3 +1365,12 @@ def test_reference_sample():
     )
     ref = circuit.reference_sample()
     assert ref[0] == ref[1]
+    circuit = stim.Circuit()
+    circuit.append("X", (i for i in range(0, 100, 2)))
+    circuit.append("M", (i for i in range(100)))
+    ref_sample = circuit.reference_sample(bit_packed=False)
+    expected = np.zeros((len(ref_sample) // 8 + 1), dtype=np.uint8)
+    for bit_indx, bit in enumerate(ref_sample):
+        expected[bit_indx//8] |= (bit << (bit_indx % 8))
+    ref_sample = circuit.reference_sample(bit_packed=True)
+    np.testing.assert_array_equal(ref_sample, expected)

--- a/src/stim/py/compiled_measurement_sampler.pybind.cc
+++ b/src/stim/py/compiled_measurement_sampler.pybind.cc
@@ -142,9 +142,15 @@ void stim_pybind::pybind_compiled_measurement_sampler_methods(
                     CAUTION: simulation results *MAY NOT* be consistent if you vary how many
                     shots are taken. For example, taking 10 shots and then 90 shots will
                     give different results from taking 100 shots in one call.
-                reference_sample: Reference sample used by the sampler. If None
-                    then the reference sample is constructed on the fly
-                    according to skip_reference_sample.
+                reference_sample: The data to xor into the measurement flips produced by the
+                    frame simulator, in order to produce proper measurement results.
+                    This can either be specified as an `np.bool_` array or a bit packed
+                    `np.uint8` array (little endian). Under normal conditions, the reference
+                    sample should be a valid noiseless sample of the circuit, such as the
+                    one returned by `circuit.reference_sample()`. If this argument is not
+                    provided, the reference sample will be set to
+                    `circuit.reference_sample()`, unless `skip_reference_sample=True`
+                    is used, in which case it will be set to all-zeros.
 
             Returns:
                 An initialized stim.CompiledMeasurementSampler.

--- a/src/stim/py/compiled_measurement_sampler.pybind.h
+++ b/src/stim/py/compiled_measurement_sampler.pybind.h
@@ -45,7 +45,10 @@ struct CompiledMeasurementSampler {
 pybind11::class_<CompiledMeasurementSampler> pybind_compiled_measurement_sampler(pybind11::module &m);
 void pybind_compiled_measurement_sampler_methods(pybind11::module &m, pybind11::class_<CompiledMeasurementSampler> &c);
 CompiledMeasurementSampler py_init_compiled_sampler(
-    const stim::Circuit &circuit, bool skip_reference_sample, const pybind11::object &seed);
+    const stim::Circuit &circuit,
+    bool skip_reference_sample,
+    const pybind11::object &seed,
+    const pybind11::object &reference_sample);
 
 }  // namespace stim_pybind
 

--- a/src/stim/py/compiled_measurement_sampler_pybind_test.py
+++ b/src/stim/py/compiled_measurement_sampler_pybind_test.py
@@ -148,7 +148,7 @@ def test_reference_sample_init():
         [[True]],
     )
     with pytest.raises(ValueError):
-        circuit.compile_sampler(reference_sample=ref_sample, skip_reference_sample=True).sample(1)
+        circuit.compile_sampler(reference_sample=ref_sample, skip_reference_sample=True)
 
 
 def test_repr():

--- a/src/stim/py/compiled_measurement_sampler_pybind_test.py
+++ b/src/stim/py/compiled_measurement_sampler_pybind_test.py
@@ -125,13 +125,12 @@ def test_reference_sample_init():
         [[True]],
     )
     circuit = stim.Circuit("X 0\nM 0")
-    s = stim.TableauSimulator()
     ref_sample = np.array([False])
     np.testing.assert_array_equal(
         circuit.compile_sampler(reference_sample=ref_sample).sample(1),
         [[False]],
     )
-    ref_sample = s.reference_sample(circuit)
+    ref_sample = circuit.reference_sample()
     np.testing.assert_array_equal(
         circuit.compile_sampler(reference_sample=ref_sample).sample(1),
         [[True]],
@@ -142,13 +141,25 @@ def test_reference_sample_init():
         circuit.compile_sampler(reference_sample=ref_sample).sample(1),
         [[True]],
     )
-    ref_sample = s.reference_sample(circuit)
+    ref_sample = circuit.reference_sample()
     np.testing.assert_array_equal(
         circuit.compile_sampler(reference_sample=ref_sample).sample(1),
         [[True]],
     )
     with pytest.raises(ValueError):
         circuit.compile_sampler(reference_sample=ref_sample, skip_reference_sample=True)
+    circuit = stim.Circuit("H 0\n X 1\n CNOT 0 1\n H 0 1\n MPP X0*X1")
+    ref_sample = circuit.reference_sample()
+    np.testing.assert_array_equal(
+        circuit.compile_sampler(reference_sample=ref_sample, seed=0).sample(10),
+        circuit.compile_sampler(reference_sample=None, seed=0).sample(10),
+    )
+    circuit = stim.Circuit("H 0\n X 1\n CNOT 0 1\n H 0 1 2\n MPP Y1*Y2 X1*X2 Z1*Z2")
+    ref_sample = circuit.reference_sample()
+    np.testing.assert_array_equal(
+        circuit.compile_sampler(reference_sample=ref_sample, seed=0).sample(11),
+        circuit.compile_sampler(seed=0).sample(11),
+    )
 
 
 def test_repr():

--- a/src/stim/py/compiled_measurement_sampler_pybind_test.py
+++ b/src/stim/py/compiled_measurement_sampler_pybind_test.py
@@ -14,6 +14,7 @@
 import tempfile
 
 import numpy as np
+import pytest
 import stim
 
 
@@ -117,6 +118,37 @@ def test_skip_reference_sample():
         stim.Circuit("X_ERROR(1) 0\nM 0").compile_sampler(skip_reference_sample=True).sample(1),
         [[True]],
     )
+
+def test_reference_sample_init():
+    np.testing.assert_array_equal(
+        stim.Circuit("X 0\nM 0").compile_sampler(reference_sample=None).sample(1),
+        [[True]],
+    )
+    circuit = stim.Circuit("X 0\nM 0")
+    s = stim.TableauSimulator()
+    ref_sample = np.array([False])
+    np.testing.assert_array_equal(
+        circuit.compile_sampler(reference_sample=ref_sample).sample(1),
+        [[False]],
+    )
+    ref_sample = s.reference_sample(circuit)
+    np.testing.assert_array_equal(
+        circuit.compile_sampler(reference_sample=ref_sample).sample(1),
+        [[True]],
+    )
+    circuit = stim.Circuit("X_ERROR(1) 0\n M 0")
+    ref_sample = np.array([False])
+    np.testing.assert_array_equal(
+        circuit.compile_sampler(reference_sample=ref_sample).sample(1),
+        [[True]],
+    )
+    ref_sample = s.reference_sample(circuit)
+    np.testing.assert_array_equal(
+        circuit.compile_sampler(reference_sample=ref_sample).sample(1),
+        [[True]],
+    )
+    with pytest.raises(ValueError):
+        circuit.compile_sampler(reference_sample=ref_sample, skip_reference_sample=True).sample(1)
 
 
 def test_repr():

--- a/src/stim/simulators/tableau_simulator.pybind.cc
+++ b/src/stim/simulators/tableau_simulator.pybind.cc
@@ -18,7 +18,6 @@
 #include "stim/circuit/circuit_repeat_block.pybind.h"
 #include "stim/probability_util.h"
 #include "stim/py/base.pybind.h"
-#include "stim/py/numpy.pybind.h"
 #include "stim/simulators/tableau_simulator.h"
 #include "stim/stabilizers/conversions.h"
 #include "stim/stabilizers/pauli_string.pybind.h"
@@ -2018,33 +2017,6 @@ void stim_pybind::pybind_tableau_simulator_methods(pybind11::module &m, pybind11
                         stim.PauliString("+ZZ"),
                     ],
                 )
-        )DOC")
-            .data());
-    c.def(
-        "reference_sample",
-        [](const TableauSimulator self, const Circuit &circuit, bool bit_packed) {
-            simd_bits<MAX_BITWORD_WIDTH> ref = self.reference_sample_circuit(circuit);
-            simd_bits_range_ref<MAX_BITWORD_WIDTH> reference_sample(ref.ptr_simd, ref.num_simd_words);
-            size_t num_measure = circuit.count_measurements();
-            return simd_bits_to_numpy(reference_sample, num_measure, bit_packed);
-        },
-        pybind11::arg("circuit"),
-        pybind11::kw_only(),
-        pybind11::arg("bit_packed") = false,
-        clean_doc_string(R"DOC(
-            @signature def reference_sample(self, circuit: stim.Circuit, *, bit_packed: bool = False) -> np.ndarray:
-            Samples the given circuit in a deterministic fashion.
-
-            Discards all noisy operations, and biases all collapse events
-            towards +Z instead of randomly +Z/-Z.
-
-            Args:
-                circuit: The circuit to "sample" from.
-                bit_packed: Defaults to False. Determines whether the output numpy arrays
-                    use dtype=bool_ or dtype=uint8 with 8 bools packed into each byte.
-
-            Returns:
-                reference_sample: reference sample sampled from the given circuit.
         )DOC")
             .data());
 }

--- a/src/stim/simulators/tableau_simulator_pybind_test.py
+++ b/src/stim/simulators/tableau_simulator_pybind_test.py
@@ -697,3 +697,27 @@ def test_depolarize2_error():
 
     with pytest.raises(ValueError, match='Unexpected argument'):
         s.depolarize2(1, p=1, q=2)
+
+
+
+def test_reference_sample():
+    s = stim.TableauSimulator(seed=1)
+    s.h(*range(0, 10, 2))
+    s.cnot(*range(10))
+    circuit = stim.Circuit("""H 0
+                CNOT 0 1
+                """
+                )
+    ref = s.reference_sample(circuit)
+    assert len(ref) == 0
+    circuit = stim.Circuit("""H 0
+        CNOT 0 1
+        M 0
+        R 0
+        M 1
+        DEPOLARIZE1(0.01) 0 1 2 3
+        DEPOLARIZE2(0.01) 0 1 2 3
+        """)
+    ref = s.reference_sample(circuit)
+    assert len(ref) == 2
+    assert not np.all(ref)

--- a/src/stim/simulators/tableau_simulator_pybind_test.py
+++ b/src/stim/simulators/tableau_simulator_pybind_test.py
@@ -697,27 +697,3 @@ def test_depolarize2_error():
 
     with pytest.raises(ValueError, match='Unexpected argument'):
         s.depolarize2(1, p=1, q=2)
-
-
-
-def test_reference_sample():
-    s = stim.TableauSimulator(seed=1)
-    s.h(*range(0, 10, 2))
-    s.cnot(*range(10))
-    circuit = stim.Circuit("""H 0
-                CNOT 0 1
-                """
-                )
-    ref = s.reference_sample(circuit)
-    assert len(ref) == 0
-    circuit = stim.Circuit("""H 0
-        CNOT 0 1
-        M 0
-        R 0
-        M 1
-        DEPOLARIZE1(0.01) 0 1 2 3
-        DEPOLARIZE2(0.01) 0 1 2 3
-        """)
-    ref = s.reference_sample(circuit)
-    assert len(ref) == 2
-    assert not np.all(ref)


### PR DESCRIPTION
Addresses #531 and #532. compile_sampler now accepts reference_sample keyword argument which defaults to None. Also exposes the TableauSimulator::reference_sample method to pybind which is useful for checking that passing in this reference sample reproduces to current behaviour when skip_reference_sample is False.