### PR TITLE
Remove hardcoded SIMD width from `stim/circuit` directory

### DIFF
--- a/file_lists/source_files_no_main
+++ b/file_lists/source_files_no_main
@@ -1,6 +1,7 @@
 src/stim.cc
 src/stim/arg_parse.cc
 src/stim/circuit/circuit.cc
+src/stim/circuit/circuit_instruction.cc
 src/stim/circuit/gate_data.cc
 src/stim/circuit/gate_data_annotations.cc
 src/stim/circuit/gate_data_blocks.cc

--- a/src/stim/circuit/circuit_instruction.cc
+++ b/src/stim/circuit/circuit_instruction.cc
@@ -1,0 +1,222 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "stim/circuit/circuit_instruction.h"
+
+#include <utility>
+
+#include "stim/circuit/gate_data.h"
+#include "stim/circuit/gate_target.h"
+#include "stim/circuit/circuit.h"
+
+using namespace stim;
+
+uint64_t CircuitInstruction::repeat_block_rep_count() const {
+    assert(targets.size() == 3);
+    uint64_t low = targets[1].data;
+    uint64_t high = targets[2].data;
+    return low | (high << 32);
+}
+
+Circuit &CircuitInstruction::repeat_block_body(Circuit &host) const {
+    assert(targets.size() == 3);
+    auto b = targets[0].data;
+    assert(b < host.blocks.size());
+    return host.blocks[b];
+}
+
+const Circuit &CircuitInstruction::repeat_block_body(const Circuit &host) const {
+    assert(targets.size() == 3);
+    auto b = targets[0].data;
+    assert(b < host.blocks.size());
+    return host.blocks[b];
+}
+
+CircuitInstruction::CircuitInstruction(
+    GateType gate_type, SpanRef<const double> args, SpanRef<const GateTarget> targets)
+    : gate_type(gate_type), args(args), targets(targets) {
+}
+
+void CircuitInstruction::validate() const {
+    const Gate &gate = GATE_DATA.items[gate_type];
+
+    if (gate.flags == GateFlags::NO_GATE_FLAG) {
+        throw std::invalid_argument("Unrecognized gate_type. Associated flag is NO_GATE_FLAG.");
+    }
+
+    if (gate.flags & GATE_TARGETS_PAIRS) {
+        if (targets.size() & 1) {
+            throw std::invalid_argument(
+                "Two qubit gate " + std::string(gate.name) +
+                " requires an even number of targets but was given "
+                "(" +
+                comma_sep(args).str() + ").");
+        }
+        for (size_t k = 0; k < targets.size(); k += 2) {
+            if (targets[k] == targets[k + 1]) {
+                throw std::invalid_argument(
+                    "The two qubit gate " + std::string(gate.name) +
+                    " was applied to a target pair with the same target (" + target_str(targets[k]) +
+                    ") twice. Gates can't interact targets with themselves.");
+            }
+        }
+    }
+
+    if (gate.arg_count == ARG_COUNT_SYGIL_ZERO_OR_ONE) {
+        if (args.size() > 1) {
+            throw std::invalid_argument(
+                "Gate " + std::string(gate.name) + " was given " + std::to_string(args.size()) + " parens arguments (" +
+                comma_sep(args).str() + ") but takes 0 or 1 parens arguments.");
+        }
+    } else if (args.size() != gate.arg_count && gate.arg_count != ARG_COUNT_SYGIL_ANY) {
+        throw std::invalid_argument(
+            "Gate " + std::string(gate.name) + " was given " + std::to_string(args.size()) + " parens arguments (" +
+            comma_sep(args).str() + ") but takes " + std::to_string(gate.arg_count) + " parens arguments.");
+    }
+
+    if ((gate.flags & GATE_TAKES_NO_TARGETS) && !targets.empty()) {
+        throw std::invalid_argument(
+            "Gate " + std::string(gate.name) + " takes no targets but was given targets" + targets_str(targets) + ".");
+    }
+
+    if (gate.flags & GATE_ARGS_ARE_DISJOINT_PROBABILITIES) {
+        double total = 0;
+        for (const auto p : args) {
+            if (!(p >= 0 && p <= 1)) {
+                throw std::invalid_argument(
+                    "Gate " + std::string(gate.name) + " only takes probability arguments, but one of its arguments (" +
+                    comma_sep(args).str() + ") wasn't a probability.");
+            }
+            total += p;
+        }
+        if (total > 1.0000001) {
+            throw std::invalid_argument(
+                "The disjoint probability arguments (" + comma_sep(args).str() + ") given to gate " +
+                std::string(gate.name) + " sum to more than 1.");
+        }
+    } else if (gate.flags & GATE_ARGS_ARE_UNSIGNED_INTEGERS) {
+        for (const auto p : args) {
+            if (p < 0 || p != round(p)) {
+                throw std::invalid_argument(
+                    "Gate " + std::string(gate.name) +
+                    " only takes non-negative integer arguments, but one of its arguments (" + comma_sep(args).str() +
+                    ") wasn't a non-negative integer.");
+            }
+        }
+    }
+
+    uint32_t valid_target_mask = TARGET_VALUE_MASK;
+
+    // Check combiners.
+    if (gate.flags & GATE_TARGETS_COMBINERS) {
+        bool combiner_allowed = false;
+        bool just_saw_combiner = false;
+        bool failed = false;
+        for (const auto p : targets) {
+            if (p.is_combiner()) {
+                failed |= !combiner_allowed;
+                combiner_allowed = false;
+                just_saw_combiner = true;
+            } else {
+                combiner_allowed = true;
+                just_saw_combiner = false;
+            }
+        }
+        failed |= just_saw_combiner;
+        if (failed) {
+            throw std::invalid_argument(
+                "Gate " + std::string(gate.name) +
+                " given combiners ('*') that aren't between other targets: " + targets_str(targets) + ".");
+        }
+        valid_target_mask |= TARGET_COMBINER;
+    }
+
+    // Check that targets are in range.
+    if (gate.flags & GATE_PRODUCES_NOISY_RESULTS) {
+        valid_target_mask |= TARGET_INVERTED_BIT;
+    }
+    if (gate.flags & GATE_CAN_TARGET_BITS) {
+        valid_target_mask |= TARGET_RECORD_BIT | TARGET_SWEEP_BIT;
+    }
+    if (gate.flags & GATE_ONLY_TARGETS_MEASUREMENT_RECORD) {
+        for (GateTarget q : targets) {
+            if (!(q.data & TARGET_RECORD_BIT)) {
+                throw std::invalid_argument("Gate " + std::string(gate.name) + " only takes rec[-k] targets.");
+            }
+        }
+    } else if (gate.flags & GATE_TARGETS_PAULI_STRING) {
+        for (GateTarget q : targets) {
+            if (!(q.data & (TARGET_PAULI_X_BIT | TARGET_PAULI_Z_BIT | TARGET_COMBINER))) {
+                throw std::invalid_argument(
+                    "Gate " + std::string(gate.name) + " only takes Pauli targets ('X2', 'Y3', 'Z5', etc).");
+            }
+        }
+    } else {
+        for (GateTarget q : targets) {
+            if (q.data != (q.data & valid_target_mask)) {
+                std::stringstream ss;
+                ss << "Target ";
+                q.write_succinct(ss);
+                ss << " has invalid modifiers for gate type '" << gate.name << "'.";
+                throw std::invalid_argument(ss.str());
+            }
+        }
+    }
+}
+
+uint64_t CircuitInstruction::count_measurement_results() const {
+    auto flags = GATE_DATA.items[gate_type].flags;
+    if (!(flags & GATE_PRODUCES_NOISY_RESULTS)) {
+        return 0;
+    }
+    uint64_t n = (uint64_t)targets.size();
+    if (flags & GATE_TARGETS_COMBINERS) {
+        for (auto e : targets) {
+            if (e.is_combiner()) {
+                n -= 2;
+            }
+        }
+    }
+    return n;
+}
+
+bool CircuitInstruction::can_fuse(const CircuitInstruction &other) const {
+    auto flags = GATE_DATA.items[gate_type].flags;
+    return gate_type == other.gate_type && args == other.args && !(flags & GATE_IS_NOT_FUSABLE);
+}
+
+bool CircuitInstruction::operator==(const CircuitInstruction &other) const {
+    return gate_type == other.gate_type && args == other.args && targets == other.targets;
+}
+bool CircuitInstruction::approx_equals(const CircuitInstruction &other, double atol) const {
+    if (gate_type != other.gate_type || targets != other.targets || args.size() != other.args.size()) {
+        return false;
+    }
+    for (size_t k = 0; k < args.size(); k++) {
+        if (fabs(args[k] - other.args[k]) > atol) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool CircuitInstruction::operator!=(const CircuitInstruction &other) const {
+    return !(*this == other);
+}
+
+std::string CircuitInstruction::str() const {
+    std::stringstream s;
+    s << *this;
+    return s.str();
+}

--- a/src/stim/circuit/circuit_instruction.h
+++ b/src/stim/circuit/circuit_instruction.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _STIM_CIRCUIT_INSTRUCTION_H
+#define _STIM_CIRCUIT_INSTRUCTION_H
+
+#include "stim/circuit/gate_target.h"
+#include "stim/mem/span_ref.h"
+
+
+namespace stim {
+
+struct Circuit;
+
+/// The data that describes how a gate is being applied to qubits (or other targets).
+///
+/// A gate applied to targets.
+///
+/// This struct is not self-sufficient. It points into data stored elsewhere (e.g. in a Circuit's jagged_data).
+struct CircuitInstruction {
+    /// The gate applied by the operation.
+    GateType gate_type;
+
+    /// Numeric arguments varying the functionality of the gate.
+    ///
+    /// The meaning of the numbers varies from gate to gate.
+    /// Examples:
+    ///     X_ERROR(p) has a single argument: probability of X.
+    ///     PAULI_CHANNEL_1(px,py,pz) has multiple probability arguments.
+    ///     DETECTOR(c1,c2) has variable arguments: coordinate data.
+    ///     OBSERVABLE_INCLUDE(k) has a single argument: the observable index.
+    SpanRef<const double> args;
+
+    /// Encoded data indicating the qubits and other targets acted on by the gate.
+    SpanRef<const GateTarget> targets;
+
+    CircuitInstruction() = delete;
+    CircuitInstruction(GateType gate_type, SpanRef<const double> args, SpanRef<const GateTarget> targets);
+
+    /// Determines if two operations can be combined into one operation (with combined targeting data).
+    ///
+    /// For example, `H 1` then `H 2 1` is equivalent to `H 1 2 1` so those instructions are fusable.
+    bool can_fuse(const CircuitInstruction &other) const;
+    /// Equality.
+    bool operator==(const CircuitInstruction &other) const;
+    /// Inequality.
+    bool operator!=(const CircuitInstruction &other) const;
+    /// Approximate equality.
+    bool approx_equals(const CircuitInstruction &other, double atol) const;
+    /// Returns a text description of the instruction, as would appear in a STIM circuit file.
+    std::string str() const;
+
+    /// Determines the number of entries added to the measurement record by the operation.
+    ///
+    /// Note: invalid to use this on REPEAT blocks.
+    uint64_t count_measurement_results() const;
+
+    uint64_t repeat_block_rep_count() const;
+    Circuit &repeat_block_body(Circuit &host) const;
+    const Circuit &repeat_block_body(const Circuit &host) const;
+
+    /// Verifies complex invariants that circuit instructions are supposed to follow.
+    ///
+    /// For example: CNOT gates should have an even number of targets.
+    /// For example: X_ERROR should have a single float argument between 0 and 1 inclusive.
+    ///
+    /// Raises:
+    ///     std::invalid_argument: Validation failed.
+    void validate() const;
+};
+
+}  // namespace stim
+
+#endif

--- a/src/stim/circuit/circuit_instruction.pybind.h
+++ b/src/stim/circuit/circuit_instruction.pybind.h
@@ -17,6 +17,7 @@
 
 #include <pybind11/pybind11.h>
 
+#include "stim/circuit/circuit_instruction.h"
 #include "stim/circuit/gate_data.h"
 #include "stim/circuit/gate_target.h"
 

--- a/src/stim/circuit/gate_data.h
+++ b/src/stim/circuit/gate_data.h
@@ -33,7 +33,6 @@
 
 namespace stim {
 
-struct CircuitInstruction;
 struct Tableau;
 
 constexpr uint8_t ARG_COUNT_SYGIL_ANY = uint8_t{0xFF};
@@ -364,15 +363,6 @@ struct GateDataMap {
 };
 
 extern const GateDataMap GATE_DATA;
-
-void decompose_mpp_operation(
-    const CircuitInstruction &target_data,
-    size_t num_qubits,
-    const std::function<void(
-        const CircuitInstruction &h_xz,
-        const CircuitInstruction &h_yz,
-        const CircuitInstruction &cnot,
-        const CircuitInstruction &meas)> &callback);
 
 }  // namespace stim
 

--- a/src/stim/circuit/gate_data_collapsing.cc
+++ b/src/stim/circuit/gate_data_collapsing.cc
@@ -15,8 +15,6 @@
 #include "stim/circuit/circuit.h"
 #include "stim/circuit/gate_data.h"
 #include "stim/circuit/gate_target.h"
-#include "stim/mem/simd_bits.h"
-#include "stim/mem/simd_word.h"
 
 using namespace stim;
 
@@ -540,85 +538,4 @@ Examples:
                 };
             },
         });
-}
-
-void stim::decompose_mpp_operation(
-    const CircuitInstruction &mpp_op,
-    size_t num_qubits,
-    const std::function<void(
-        const CircuitInstruction &h_xz,
-        const CircuitInstruction &h_yz,
-        const CircuitInstruction &cnot,
-        const CircuitInstruction &meas)> &callback) {
-    simd_bits<MAX_BITWORD_WIDTH> used(num_qubits);
-    simd_bits<MAX_BITWORD_WIDTH> inner_used(num_qubits);
-    std::vector<GateTarget> h_xz;
-    std::vector<GateTarget> h_yz;
-    std::vector<GateTarget> cnot;
-    std::vector<GateTarget> meas;
-
-    size_t start = 0;
-    while (start < mpp_op.targets.size()) {
-        size_t end = start + 1;
-        while (end < mpp_op.targets.size() && mpp_op.targets[end].is_combiner()) {
-            end += 2;
-        }
-
-        // Determine which qubits are being touched by the next group.
-        inner_used.clear();
-        for (size_t i = start; i < end; i += 2) {
-            auto t = mpp_op.targets[i];
-            if (inner_used[t.qubit_value()]) {
-                throw std::invalid_argument(
-                    "A pauli product specified the same qubit twice.\n"
-                    "The operation: " +
-                    mpp_op.str());
-            }
-            inner_used[t.qubit_value()] = true;
-        }
-
-        // If there's overlap with previous groups, the previous groups have to be flushed first.
-        if (inner_used.intersects(used)) {
-            callback(
-                CircuitInstruction{GateType::H, {}, h_xz},
-                CircuitInstruction{GateType::H_YZ, {}, h_yz},
-                CircuitInstruction{GateType::CX, {}, cnot},
-                CircuitInstruction{GateType::M, mpp_op.args, meas});
-            h_xz.clear();
-            h_yz.clear();
-            cnot.clear();
-            meas.clear();
-            used.clear();
-        }
-        used |= inner_used;
-
-        // Append operations that are equivalent to the desired measurement.
-        for (size_t i = start; i < end; i += 2) {
-            auto t = mpp_op.targets[i];
-            auto q = t.qubit_value();
-            if (t.data & TARGET_PAULI_X_BIT) {
-                if (t.data & TARGET_PAULI_Z_BIT) {
-                    h_yz.push_back({q});
-                } else {
-                    h_xz.push_back({q});
-                }
-            }
-            if (i == start) {
-                meas.push_back({q});
-            } else {
-                cnot.push_back({q});
-                cnot.push_back({meas.back().qubit_value()});
-            }
-            meas.back().data ^= t.data & TARGET_INVERTED_BIT;
-        }
-
-        start = end;
-    }
-
-    // Flush remaining groups.
-    callback(
-        CircuitInstruction{GateType::H, {}, h_xz},
-        CircuitInstruction{GateType::H_YZ, {}, h_yz},
-        CircuitInstruction{GateType::CX, {}, cnot},
-        CircuitInstruction{GateType::M, mpp_op.args, meas});
 }

--- a/src/stim/circuit/gate_decomposition.h
+++ b/src/stim/circuit/gate_decomposition.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _STIM_GATE_DECOMPOSITION_H
+#define _STIM_GATE_DECOMPOSITION_H
+
+#include "stim/circuit/gate_data.h"
+#include "stim/circuit/gate_target.h"
+#include "stim/circuit/circuit_instruction.h"
+#include "stim/mem/simd_bits.h"
+
+
+namespace stim {
+
+template <size_t W>
+void decompose_mpp_operation(
+    const CircuitInstruction &mpp_op,
+    size_t num_qubits,
+    const std::function<void(
+        const CircuitInstruction &h_xz,
+        const CircuitInstruction &h_yz,
+        const CircuitInstruction &cnot,
+        const CircuitInstruction &meas)> &callback) {
+    simd_bits<W> used(num_qubits);
+    simd_bits<W> inner_used(num_qubits);
+    std::vector<GateTarget> h_xz;
+    std::vector<GateTarget> h_yz;
+    std::vector<GateTarget> cnot;
+    std::vector<GateTarget> meas;
+
+    size_t start = 0;
+    while (start < mpp_op.targets.size()) {
+        size_t end = start + 1;
+        while (end < mpp_op.targets.size() && mpp_op.targets[end].is_combiner()) {
+            end += 2;
+        }
+
+        // Determine which qubits are being touched by the next group.
+        inner_used.clear();
+        for (size_t i = start; i < end; i += 2) {
+            auto t = mpp_op.targets[i];
+            if (inner_used[t.qubit_value()]) {
+                throw std::invalid_argument(
+                    "A pauli product specified the same qubit twice.\n"
+                    "The operation: " +
+                    mpp_op.str());
+            }
+            inner_used[t.qubit_value()] = true;
+        }
+
+        // If there's overlap with previous groups, the previous groups have to be flushed first.
+        if (inner_used.intersects(used)) {
+            callback(
+                CircuitInstruction{GateType::H, {}, h_xz},
+                CircuitInstruction{GateType::H_YZ, {}, h_yz},
+                CircuitInstruction{GateType::CX, {}, cnot},
+                CircuitInstruction{GateType::M, mpp_op.args, meas});
+            h_xz.clear();
+            h_yz.clear();
+            cnot.clear();
+            meas.clear();
+            used.clear();
+        }
+        used |= inner_used;
+
+        // Append operations that are equivalent to the desired measurement.
+        for (size_t i = start; i < end; i += 2) {
+            auto t = mpp_op.targets[i];
+            auto q = t.qubit_value();
+            if (t.data & TARGET_PAULI_X_BIT) {
+                if (t.data & TARGET_PAULI_Z_BIT) {
+                    h_yz.push_back({q});
+                } else {
+                    h_xz.push_back({q});
+                }
+            }
+            if (i == start) {
+                meas.push_back({q});
+            } else {
+                cnot.push_back({q});
+                cnot.push_back({meas.back().qubit_value()});
+            }
+            meas.back().data ^= t.data & TARGET_INVERTED_BIT;
+        }
+
+        start = end;
+    }
+
+    // Flush remaining groups.
+    callback(
+        CircuitInstruction{GateType::H, {}, h_xz},
+        CircuitInstruction{GateType::H_YZ, {}, h_yz},
+        CircuitInstruction{GateType::CX, {}, cnot},
+        CircuitInstruction{GateType::M, mpp_op.args, meas});
+}
+
+}  // namespace stim
+
+#endif

--- a/src/stim/circuit/gate_target.cc
+++ b/src/stim/circuit/gate_target.cc
@@ -180,3 +180,29 @@ void GateTarget::write_succinct(std::ostream &out) const {
         out << (data & TARGET_VALUE_MASK);
     }
 }
+
+void stim::write_targets(std::ostream &out, SpanRef<const GateTarget> targets) {
+    bool skip_space = false;
+    for (auto t : targets) {
+        if (t.is_combiner()) {
+            skip_space = true;
+        } else if (!skip_space) {
+            out << ' ';
+        } else {
+            skip_space = false;
+        }
+        t.write_succinct(out);
+    }
+}
+
+std::string stim::targets_str(SpanRef<const GateTarget> targets) {
+    std::stringstream out;
+    stim::write_targets(out, targets);
+    return out.str();
+}
+
+std::string stim::target_str(GateTarget t) {
+    std::stringstream out;
+    t.write_succinct(out);
+    return out.str();
+}

--- a/src/stim/circuit/gate_target.h
+++ b/src/stim/circuit/gate_target.h
@@ -20,6 +20,7 @@
 #include <iostream>
 
 #include "stim/circuit/gate_data.h"
+#include "stim/mem/span_ref.h"
 
 namespace stim {
 
@@ -62,6 +63,10 @@ struct GateTarget {
 
     void write_succinct(std::ostream &out) const;
 };
+
+void write_targets(std::ostream &out, SpanRef<const GateTarget> targets);
+std::string targets_str(SpanRef<const GateTarget> targets);
+std::string target_str(GateTarget t);
 
 std::ostream &operator<<(std::ostream &out, const GateTarget &t);
 

--- a/src/stim/io/measure_record_reader.inl
+++ b/src/stim/io/measure_record_reader.inl
@@ -175,9 +175,9 @@ bool MeasureRecordReaderFormat01<W>::start_and_read_entire_record_helper(SAW0 sa
                 if (k == 0) {
                     return false;
                 }
-                // intentional fall through.
+                [[fallthrough]];
             case '\r':
-                // intentional fall through.
+                [[fallthrough]];
             case '\n':
                 throw std::invalid_argument(
                     "01 data ended in middle of record at byte position " + std::to_string(k) +

--- a/src/stim/simulators/error_analyzer.cc
+++ b/src/stim/simulators/error_analyzer.cc
@@ -18,6 +18,7 @@
 #include <queue>
 #include <sstream>
 
+#include "stim/circuit/gate_decomposition.h"
 #include "stim/stabilizers/pauli_string.h"
 
 using namespace stim;
@@ -1385,7 +1386,7 @@ void ErrorAnalyzer::MPP(const CircuitInstruction &target_data) {
     for (size_t k = 0; k < n; k++) {
         reversed_targets[k] = target_data.targets[n - k - 1];
     }
-    decompose_mpp_operation(
+    decompose_mpp_operation<MAX_BITWORD_WIDTH>(
         CircuitInstruction{GateType::MPP, target_data.args, reversed_targets},
         tracker.xs.size(),
         [&](const CircuitInstruction &h_xz,

--- a/src/stim/simulators/frame_simulator.cc
+++ b/src/stim/simulators/frame_simulator.cc
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <cstring>
 
+#include "stim/circuit/gate_decomposition.h"
 #include "stim/probability_util.h"
 #include "stim/simulators/tableau_simulator.h"
 
@@ -543,7 +544,7 @@ void FrameSimulator::do_Z_ERROR(const CircuitInstruction &target_data) {
 }
 
 void FrameSimulator::do_MPP(const CircuitInstruction &target_data) {
-    decompose_mpp_operation(
+    decompose_mpp_operation<MAX_BITWORD_WIDTH>(
         target_data,
         num_qubits,
         [&](const CircuitInstruction &h_xz,

--- a/src/stim/simulators/sparse_rev_frame_tracker.cc
+++ b/src/stim/simulators/sparse_rev_frame_tracker.cc
@@ -14,6 +14,8 @@
 
 #include "stim/simulators/sparse_rev_frame_tracker.h"
 
+#include "stim/circuit/gate_decomposition.h"
+
 using namespace stim;
 
 constexpr GateVTable<void (SparseUnsignedRevFrameTracker::*)(const CircuitInstruction &)> rev_tracker_vtable_data() {
@@ -202,7 +204,7 @@ void SparseUnsignedRevFrameTracker::undo_MPP(const CircuitInstruction &target_da
     for (size_t k = 0; k < n; k++) {
         reversed_targets[k] = target_data.targets[n - k - 1];
     }
-    decompose_mpp_operation(
+    decompose_mpp_operation<MAX_BITWORD_WIDTH>(
         CircuitInstruction{target_data.gate_type, target_data.args, reversed_targets},
         xs.size(),
         [&](const CircuitInstruction &h_xz,

--- a/src/stim/simulators/tableau_simulator.cc
+++ b/src/stim/simulators/tableau_simulator.cc
@@ -17,6 +17,7 @@
 #include <set>
 
 #include "stim/circuit/gate_data.h"
+#include "stim/circuit/gate_decomposition.h"
 #include "stim/probability_util.h"
 
 using namespace stim;
@@ -117,7 +118,7 @@ bool TableauSimulator::is_deterministic_z(size_t target) const {
 }
 
 void TableauSimulator::MPP(const CircuitInstruction &target_data) {
-    decompose_mpp_operation(
+    decompose_mpp_operation<MAX_BITWORD_WIDTH>(
         target_data,
         inv_state.num_qubits,
         [&](const CircuitInstruction &h_xz,


### PR DESCRIPTION
This PR removes the dependency of all Circuit components on `MAX_BITWORD_WIDTH`. It does this via templatisation of `decompose_mpp_operation` (the only place where `MAX_BITWORD_WIDTH` is used in `src/circuit` outside the benchmarks, pybind etc). I had to do some light splitting-up of files (notably `circuit.h`) to facilitate this.

As before, happy to make any changes.