### PR TITLE
Add `split_errors` options to sinter

### DIFF
--- a/doc/sinter_command_line.md
+++ b/doc/sinter_command_line.md
@@ -1,4 +1,4 @@
-# Stim command line reference
+# Sinter command line reference
 
 ## Index
 
@@ -25,7 +25,7 @@ SYNOPSIS
         [--save_resume_filepath FILEPATH] \
         [--metadata_func auto|PYTHON_EXPRESSION] \
         \
-        [--also_print_results_to_stdout]
+        [--also_print_results_to_stdout] \
         [--custom_decoders_module_function PYTHON_EXPRESSION] \
         [--existing_data_filepaths FILEPATH [...]] \
         [--max_batch_size int] \
@@ -42,55 +42,110 @@ DESCRIPTION
 
 OPTIONS
     --circuits CIRCUITS [CIRCUITS ...]
-                          Circuit files to sample from and decode. This parameter can be given multiple arguments.
+        Circuit files to sample from and decode. This parameter can be given
+        multiple arguments.
     --decoders DECODERS [DECODERS ...]
-                          The decoder to use to predict observables from detection events.
+        The decoder to use to predict observables from detection events.
     --custom_decoders_module_function CUSTOM_DECODERS_MODULE_FUNCTION
-                          Use the syntax "module:function" to "import function from module" and use the result of "function()" as the custom_decoders dictionary. The dictionary must map strings to stim.Decoder
-                          instances.
+        Use the syntax "module:function" to "import function from module" and
+        use the result of "function()" as the custom_decoders dictionary. The
+        dictionary must map strings to stim.Decoder instances.
     --max_shots MAX_SHOTS
-                          Sampling of a circuit will stop if this many shots have been taken.
+        Sampling of a circuit will stop if this many shots have been taken.
     --max_errors MAX_ERRORS
-                          Sampling of a circuit will stop if this many errors have been seen.
+        Sampling of a circuit will stop if this many errors have been seen.
     --processes PROCESSES
-                          Number of processes to use for simultaneous sampling and decoding.
+        Number of processes to use for simultaneous sampling and decoding.
     --save_resume_filepath SAVE_RESUME_FILEPATH
-                          Activates MERGE mode. If save_resume_filepath doesn't exist, initializes it with a CSV header. CSV data already at save_resume_filepath counts towards max_shots and max_errors.
-                          Collected data is appended to save_resume_filepath. Note that MERGE mode is tolerant to failures: if the process is killed, it can simply be restarted and it will pick up where it left
-                          off. Note that MERGE mode is idempotent: if sufficient data has been collected, no additional work is done when run again.
+        Activates MERGE mode. If save_resume_filepath doesn't exist, initializes
+        it with a CSV header. CSV data already at save_resume_filepath counts
+        towards max_shots and max_errors.
+        Collected data is appended to save_resume_filepath. Note that MERGE mode
+        is tolerant to failures: if the process is killed, it can simply be
+        restarted and it will pick up where it left off. Note that MERGE mode is
+        idempotent: if sufficient data has been collected, no additional work is
+        done when run again.
     --start_batch_size START_BATCH_SIZE
-                          Initial number of samples to batch together into one job. Starting small prevents over-sampling of circuits above threshold. The allowed batch size increases exponentially from this
-                          starting point.
+        Initial number of samples to batch together into one job. Starting small
+        prevents over-sampling of circuits above threshold. The allowed batch
+        size increases exponentially from this starting point.
     --max_batch_size MAX_BATCH_SIZE
-                          Maximum number of samples to batch together into one job. Bigger values increase the delay between jobs finishing. Smaller values decrease the amount of aggregation of results,
-                          increasing the amount of output information.
+        Maximum number of samples to batch together into one job. Bigger values
+        increase the delay between jobs finishing. Smaller values decrease the
+        amount of aggregation of results, increasing the amount of output
+        information.
     --max_batch_seconds MAX_BATCH_SECONDS
-                          Limits number of shots in a batch so that the estimated runtime of the batch is below this amount.
+        Limits number of shots in a batch so that the estimated runtime of the
+        batch is below this amount.
     --postselect_detectors_with_non_zero_4th_coord
-                          Turns on detector postselection. If any detector with a non-zero 4th coordinate fires, the shot is discarded.
+        Turns on detector postselection. If any detector with a non-zero 4th
+        coordinate fires, the shot is discarded.
     --postselected_detectors_predicate POSTSELECTED_DETECTORS_PREDICATE
-                          Specifies a predicate used to decide which detectors to postselect. When a postselected detector produces a detection event, the shot is discarded instead of being given to the
-                          decoder.The number of discarded shots is tracked as a statistic.Available values: index: The unique number identifying the detector, determined by the order of detectors in the circuit
-                          file. coords: The coordinate data associated with the detector. An empty tuple, if the circuit file did not specify detector coordinates. metadata: The metadata associated with the task
-                          being sampled. Expected expression type: Something that can be given to `bool` to get False (do not postselect) or True (yes postselect). Examples: --postselected_detectors_predicate
-                          "coords[2] == 0" --postselected_observables_predicate "coords[3] < metadata['postselection_level']"
+        Specifies a predicate used to decide which detectors to postselect. When
+        a postselected detector produces a detection event, the shot is
+        discarded instead of being given to the decoder. The number of discarded
+        shots is tracked as a statistic.
+        
+        Available values:
+            index: The unique number identifying the detector, determined by the
+                order of detectors in the circuit file.
+            coords: The coordinate data associated with the detector. An empty
+                tuple, if the circuit file did not specify detector coordinates.
+            metadata: The metadata associated with the task being sampled.
+
+        Expected expression type: Something that can be given to `bool` to get
+            False (do not postselect) or True (yes postselect).
+
+        Examples:
+            --postselected_detectors_predicate "coords[2] == 0"
+            --postselected_detectors_predicate "coords[3] < metadata['postselection_level']"
     --postselected_observables_predicate POSTSELECTED_OBSERVABLES_PREDICATE
-                          Specifies a predicate used to decide which observables to postselect. When a decoder mispredicts a postselected observable, the shot is discarded instead of counting as an
-                          error.Available values: index: The index of the observable to postselect or not. metadata: The metadata associated with the task. Expected expression type: Something that can be given
-                          to `bool` to get False (do not postselect) or True (yes postselect). Examples: --postselected_observables_predicate "False" --postselected_observables_predicate "metadata['d'] == 5 and
-                          index >= 2"
-    --split_errors        Causes errors to be grouped by the observable mispredictions that caused the error.
-    --quiet               Disables writing progress to stderr.
+        Specifies a predicate used to decide which observables to postselect.
+        When a decoder mispredicts a postselected observable, the shot is
+        discarded instead of counting as an error.
+        
+        Available values:
+            index: The index of the observable to postselect or not.
+            metadata: The metadata associated with the task.
+
+        Expected expression type:
+            Something that can be given to `bool` to get False (do not
+            postselect) or True (yes postselect).
+
+        Examples:
+            --postselected_observables_predicate "False"
+            --postselected_observables_predicate "metadata['d'] == 5 and index >= 2"
+    --split_errors
+        Causes errors to be grouped by the observable mispredictions that caused
+        the error.
+    --quiet
+        Disables writing progress to stderr.
     --also_print_results_to_stdout
-                          Even if writing to a file, also write results to stdout.
+        Even if writing to a file, also write results to stdout.
     --existing_data_filepaths [EXISTING_DATA_FILEPATHS ...]
-                          CSV data from these files counts towards max_shots and max_errors. This parameter can be given multiple arguments.
+        CSV data from these files counts towards max_shots and max_errors. This
+        parameter can be given multiple arguments.
     --metadata_func METADATA_FUNC
-                          A python expression that associates json metadata with a circuit's results. Set to "auto" to use "sinter.comma_separated_key_values(path)" Values available to the expression: path:
-                          Relative path to the circuit file, from the command line arguments. circuit: The circuit itself, parsed from the file, as a stim.Circuit. Expected type: A value that can be serialized
-                          into JSON, like a Dict[str, int]. Note that the decoder field is already recorded separately, so storing it in the metadata as well would be redundant. But something like decoder
-                          version could be usefully added. Examples: --metadata_func "{'path': path}" --metadata_func "auto" --metadata_func "{'n': circuit.num_qubits, 'p':
-                          float(path.split('/')[-1].split('.')[0])}"
+        A python expression that associates json metadata with a circuit's
+        results. Set to "auto" to use "sinter.comma_separated_key_values(path)".
+        
+        Values available to the expression:
+            path: Relative path to the circuit file, from the command line
+                arguments.
+            circuit: The circuit itself, parsed from the file, as a
+                stim.Circuit.
+        
+        Expected type:
+            A value that can be serialized into JSON, like a Dict[str, int].
+
+        Note that the decoder field is already recorded separately, so storing
+        it in the metadata as well would be redundant. But something like
+        decoder version could be usefully added.
+        
+        Examples:
+            --metadata_func "{'path': path}"
+            --metadata_func "auto"
+            --metadata_func "{'n': circuit.num_qubits, 'p': float(path.split('/')[-1].split('.')[0])}"
 
 EXAMPLES
     Example #1
@@ -119,7 +174,7 @@ NAME
 
 SYNOPSIS
     sinter combine \
-        filepath [...]
+        FILEPATH [...]
 
 DESCRIPTION
     Loads sample statistics from one or more CSV statistics files (produced by
@@ -176,10 +231,10 @@ NAME
 
 SYNOPSIS
     sinter plot \
-        --in filepath [...] \
+        --in FILEPATH [...] \
         [--x_func PYTHON_EXPRESSION] \
         [--group_func PYTHON_EXPRESSION] \
-        [--out filepath] \
+        [--out FILEPATH] \
         [--show] \
         \
         [--filter_func PYTHON_EXPRESSION] \
@@ -206,54 +261,160 @@ DESCRIPTION
     `--y_func`.
 
 OPTIONS
-    --filter_func FILTER_FUNC
-                          A python expression that determines whether a case is kept or not. Values available to the python expression: metadata: The parsed value from the json_metadata for the data point. m:
-                          `m.key` is a shorthand for `metadata.get("key", None)`. decoder: The decoder that decoded the data for the data point. strong_id: The cryptographic hash of the case that was sampled for
-                          the data point. stat: The sinter.TaskStats object for the data point. Expected expression type: Something that can be given to `bool` to get True or False. Examples: --filter_func
-                          "decoder=='pymatching'" --filter_func "0.001 < metadata['p'] < 0.005"
-    --x_func X_FUNC       A python expression that determines where points go on the x axis. Values available to the python expression: metadata: The parsed value from the json_metadata for the data point. m:
-                          `m.key` is a shorthand for `metadata.get("key", None)`. decoder: The decoder that decoded the data for the data point. strong_id: The cryptographic hash of the case that was sampled for
-                          the data point. stat: The sinter.TaskStats object for the data point. Expected expression type: Something that can be given to `float` to get a float. Examples: --x_func "metadata['p']"
-                          --x_func m.p --x_func "metadata['path'].split('/')[-1].split('.')[0]"
-    --y_func Y_FUNC       A python expression that determines where points go on the y axis. This argument is not used by error rate or discard rate plots; only by the "custom_y" type plot.Values available to
-                          the python expression: metadata: The parsed value from the json_metadata for the data point. m: `m.key` is a shorthand for `metadata.get("key", None)`. decoder: The decoder that decoded
-                          the data for the data point. strong_id: The cryptographic hash of the case that was sampled for the data point. stat: The sinter.TaskStats object for the data point. Expected expression
-                          type: Something that can be given to `float` to get a float. Examples: --x_func "metadata['p']" --x_func "metadata['path'].split('/')[-1].split('.')[0]"
-    --fig_size FIG_SIZE FIG_SIZE
-                          Desired figure width in pixels.
-    --fig_height FIG_HEIGHT
-                          Desired figure height in pixels.
-    --group_func GROUP_FUNC
-                          A python expression that determines how points are grouped into curves. Values available to the python expression: metadata: The parsed value from the json_metadata for the data point.
-                          m: `m.key` is a shorthand for `metadata.get("key", None)`. decoder: The decoder that decoded the data for the data point. strong_id: The cryptographic hash of the case that was sampled
-                          for the data point. stat: The sinter.TaskStats object for the data point. Expected expression type: Something that can be given to `str` to get a useful string. Examples: --group_func
-                          "(decoder, metadata['d'])" --group_func m.d --group_func "metadata['path'].split('/')[-2]"
+    --filter_func PYTHON_EXPRESSION
+        A python expression that determines whether a case is kept or not.
+        
+        Values available to the python expression:
+            metadata: The parsed value from the json_metadata for the data
+                point.
+            m: `m.key` is a shorthand for `metadata.get("key", None)`.
+            decoder: The decoder that decoded the data for the data point.
+            strong_id: The cryptographic hash of the case that was sampled for
+                the data point.
+            stat: The sinter.TaskStats object for the data point.
+            
+        Expected expression type: Something that can be given to `bool` to get
+            True or False.
+            
+        Examples:
+            --filter_func "decoder=='pymatching'"
+            --filter_func "0.001 < metadata['p'] < 0.005"
+    --x_func PYTHON_EXPRESSION
+        A python expression that determines where points go on the x axis.
+        
+        Values available to the python expression:
+            metadata: The parsed value from the json_metadata for the data
+                point.
+            m: `m.key` is a shorthand for `metadata.get("key", None)`.
+            decoder: The decoder that decoded the data for the data point.
+            strong_id: The cryptographic hash of the case that was sampled for
+                the data point.
+            stat: The sinter.TaskStats object for the data point.
+
+        Expected expression type: Something that can be given to `float` to get
+            a float.
+
+        Examples:
+            --x_func "metadata['p']"
+            --x_func m.p
+            --x_func "metadata['path'].split('/')[-1].split('.')[0]"
+    --y_func PYTHON_EXPRESSION
+        A python expression that determines where points go on the y axis. This
+        argument is not used by error rate or discard rate plots; only by the
+        "custom_y" type plot.
+
+        Values available to the python expression:
+            metadata: The parsed value from the json_metadata for the data
+                point.
+            m: `m.key` is a shorthand for `metadata.get("key", None)`.
+            decoder: The decoder that decoded the data for the data point.
+            strong_id: The cryptographic hash of the case that was sampled for
+                the data point.
+            stat: The sinter.TaskStats object for the data point.
+
+        Expected expression type: Something that can be given to `float` to get
+            a float.
+
+        Examples:
+            --y_func "metadata['p']"
+            --y_func m.p
+            --y_func "metadata['path'].split('/')[-1].split('.')[0]"
+    --fig_size WIDTH HEIGHT
+        Desired figure width and height in pixels.
+    --group_func PYTHON_EXPRESSION
+        A python expression that determines how points are grouped into curves.
+        
+        Values available to the python expression:
+            metadata: The parsed value from the json_metadata for the data
+                point.
+            m: `m.key` is a shorthand for `metadata.get("key", None)`.
+            decoder: The decoder that decoded the data for the data point.
+            strong_id: The cryptographic hash of the case that was sampled for
+                the data point.
+            stat: The sinter.TaskStats object for the data point.
+
+        Expected expression type:
+            Something that can be given to `str` to get a useful string.
+            
+        Examples:
+            --group_func "(decoder, metadata['d'])"
+            --group_func m.d
+            --group_func "metadata['path'].split('/')[-2]"
     --failure_unit_name FAILURE_UNIT_NAME
-                          The unit of failure, typically either "shot" (the default) or "round". If this argument is specified, --failure_units_per_shot_func must also be specified.
-    --failure_units_per_shot_func FAILURE_UNITS_PER_SHOT_FUNC
-                          A python expression that evaluates to the number of failure units there are per shot. For example, if the failure unit is rounds, this should be an expression that returns the number of
-                          rounds in a shot. Sinter has no way of knowing what you consider a round to be, otherwise. This value is used to rescale the logical error rate plots. For example, if there are 4
-                          failure units per shot then a shot error rate of 10% corresponds to a unit failure rate of 2.7129%. The conversion formula (assuming less than 50% error rates) is: P_unit = 0.5 - 0.5 *
-                          (1 - 2 * P_shot)**(1/units_per_shot) Values available to the python expression: metadata: The parsed value from the json_metadata for the data point. m: `m.key` is a shorthand for
-                          `metadata.get("key", None)`. decoder: The decoder that decoded the data for the data point. strong_id: The cryptographic hash of the case that was sampled for the data point. stat: The
-                          sinter.TaskStats object for the data point. Expected expression type: float. Examples: --failure_units_per_shot_func "metadata['rounds']" --failure_units_per_shot_func m.r
-                          --failure_units_per_shot_func "m.distance * 3" --failure_units_per_shot_func "10"
+        The unit of failure, typically either "shot" (the default) or "round".
+        If this argument is specified, --failure_units_per_shot_func must also
+        be specified.
+    --failure_units_per_shot_func PYTHON_EXPRESSION
+        A python expression that evaluates to the number of failure units there
+        are per shot. For example, if the failure unit is rounds, this should be
+        an expression that returns the number of rounds in a shot. Sinter has no
+        way of knowing what you consider a round to be, otherwise. This value is
+        used to rescale the logical error rate plots. For example, if there are 4
+        failure units per shot then a shot error rate of 10% corresponds to a
+        unit failure rate of 2.7129%. The conversion formula (assuming less than
+        50% error rates) is:
+        
+            P_unit = 0.5 - 0.5 * (1 - 2 * P_shot)**(1/units_per_shot)
+
+        Values available to the python expression:
+            metadata: The parsed value from the json_metadata for the data
+                point.
+            m: `m.key` is a shorthand for `metadata.get("key", None)`.
+            decoder: The decoder that decoded the data for the data point.
+            strong_id: The cryptographic hash of the case that was sampled for
+                the data point.
+            stat: The sinter.TaskStats object for the data point.
+        
+        Expected expression type: float.
+        
+        Examples:
+            --failure_units_per_shot_func "metadata['rounds']"
+            --failure_units_per_shot_func m.r
+            --failure_units_per_shot_func "m.distance * 3"
+            --failure_units_per_shot_func "10"
     --failure_values_func FAILURE_VALUES_FUNC
-                          A python expression that evaluates to the number of independent ways a shot can fail. For example, if a shot corresponds to a memory experiment preserving two observables, then the
-                          failure unions is 2. This value is necessary to correctly rescale the logical error rate plots when using --failure_values_func. By default it is assumed to be 1. Values available to
-                          the python expression: metadata: The parsed value from the json_metadata for the data point. m: `m.key` is a shorthand for `metadata.get("key", None)`. decoder: The decoder that decoded
-                          the data for the data point. strong_id: The cryptographic hash of the case that was sampled for the data point. stat: The sinter.TaskStats object for the data point. Expected expression
-                          type: float. Examples: --failure_values_func "metadata['num_obs']" --failure_values_func "2"
+        A python expression that evaluates to the number of independent ways a
+        shot can fail. For example, if a shot corresponds to a memory experiment
+        preserving two observables, then the failure unions is 2. This value is
+        necessary to correctly rescale the logical error rate plots when using
+        --failure_values_func. By default it is assumed to be 1.
+        
+        Values available to the python expression:
+            metadata: The parsed value from the json_metadata for the data
+                point.
+            m: `m.key` is a shorthand for `metadata.get("key", None)`.
+            decoder: The decoder that decoded the data for the data point.
+            strong_id: The cryptographic hash of the case that was sampled for
+                the data point.
+            stat: The sinter.TaskStats object for the data point.
+
+        Expected expression type: float.
+        
+        Examples:
+            --failure_values_func "metadata['num_obs']"
+            --failure_values_func "2"
     --plot_args_func PLOT_ARGS_FUNC
-                          A python expression used to customize the look of curves. Values available to the python expression: index: A unique integer identifying the curve. key: The group key (returned from
-                          --group_func) identifying the curve. stats: The list of sinter.TaskStats object in the group. metadata: (From one arbitrary data point in the group.) The parsed value from the
-                          json_metadata for the data point. m: `m.key` is a shorthand for `metadata.get("key", None)`. decoder: (From one arbitrary data point in the group.) The decoder that decoded the data for
-                          the data point. strong_id: (From one arbitrary data point in the group.) The cryptographic hash of the case that was sampled for the data point. stat: (From one arbitrary data point in
-                          the group.) The sinter.TaskStats object for the data point. Expected expression type: A dictionary to give to matplotlib plotting functions as a **kwargs argument. Examples:
-                          --plot_args_func "'''{'label': 'curve #' + str(index), 'linewidth': 5}'''" --plot_args_func "'''{'marker': 'ov*sp^<>8PhH+xXDd|'[index % 18]}'''"
+        A python expression used to customize the look of curves.
+        
+        Values available to the python expression:
+            index: A unique integer identifying the curve.
+            key: The group key (returned from --group_func) identifying the curve.
+            stats: The list of sinter.TaskStats object in the group.
+            metadata: (From one arbitrary data point in the group.) The parsed value from the json_metadata for the data point.
+            m: `m.key` is a shorthand for `metadata.get("key", None)`.
+            decoder: (From one arbitrary data point in the group.) The decoder that decoded the data for the data point.
+            strong_id: (From one arbitrary data point in the group.) The cryptographic hash of the case that was sampled for the data point.
+            stat: (From one arbitrary data point in the group.) The sinter.TaskStats object for the data point.
+
+        Expected expression type:
+            A dictionary to give to matplotlib plotting functions as a **kwargs argument.
+
+        Examples:
+            --plot_args_func "{'label': 'curve #' + str(index), 'linewidth': 5}"
+            --plot_args_func "{'marker': 'ov*sp^<>8PhH+xXDd|'[index % 18]}"
     --in IN [IN ...]      Input files to get data from.
     --type {error_rate,discard_rate,custom_y} [{error_rate,discard_rate,custom_y} ...]
-                          Picks the figures to include.
+        Picks the figures to include.
     --out OUT             Output file to write the plot to. The file extension determines the type of image. Either this or --show must be specified.
     --xaxis XAXIS         Customize the X axis label. Prefix [log] for logarithmic scale. Prefix [sqrt] for square root scale.
     --yaxis YAXIS         Customize the Y axis label. Prefix [log] for logarithmic scale. Prefix [sqrt] for square root scale.
@@ -263,7 +424,7 @@ OPTIONS
     --title TITLE         Sets the title of the plot.
     --subtitle SUBTITLE   Sets the subtitle of the plot. Note: The pattern "{common}" will expand to text including all json metadata values that are the same across all stats.
     --highlight_max_likelihood_factor HIGHLIGHT_MAX_LIKELIHOOD_FACTOR
-                          The relative likelihood ratio that determines the color highlights around curves. Set this to 1 or larger. Set to 1 to disable highlighting.
+        The relative likelihood ratio that determines the color highlights around curves. Set this to 1 or larger. Set to 1 to disable highlighting.
 
 
 EXAMPLES

--- a/doc/sinter_command_line.md
+++ b/doc/sinter_command_line.md
@@ -1,0 +1,281 @@
+# Stim command line reference
+
+## Index
+
+- [sinter collect](#collect)
+- [sinter combine](#combine)
+- [sinter plot](#plot)
+
+## Commands
+
+<a name="collect"></a>
+### sinter collect
+
+```
+NAME
+    sinter collect
+
+SYNOPSIS
+    sinter collect \
+        --circuits FILEPATH [...] \
+        --decoders pymatching|fusion_blossom|...  [...] \
+        --processes int \
+        [--max_shots int] \
+        [--max_errors int] \
+        [--save_resume_filepath FILEPATH] \
+        [--metadata_func auto|PYTHON_EXPRESSION] \
+        \
+        [--also_print_results_to_stdout]
+        [--custom_decoders_module_function PYTHON_EXPRESSION] \
+        [--existing_data_filepaths FILEPATH [...]] \
+        [--max_batch_size int] \
+        [--max_batch_seconds int] \
+        [--postselected_detectors_predicate PYTHON_EXPRESSION] \
+        [--postselected_observables_predicate PYTHON_EXPRESSION] \
+        [--quiet] \
+        [--split_errors] \
+        [--start_batch_size int]
+
+DESCRIPTION
+    Uses python multiprocessing to collect shots from the given circuit, decode
+    them using the given decoders, and report CSV statistics on error rates.
+
+OPTIONS
+    --circuits CIRCUITS [CIRCUITS ...]
+                          Circuit files to sample from and decode. This parameter can be given multiple arguments.
+    --decoders DECODERS [DECODERS ...]
+                          The decoder to use to predict observables from detection events.
+    --custom_decoders_module_function CUSTOM_DECODERS_MODULE_FUNCTION
+                          Use the syntax "module:function" to "import function from module" and use the result of "function()" as the custom_decoders dictionary. The dictionary must map strings to stim.Decoder
+                          instances.
+    --max_shots MAX_SHOTS
+                          Sampling of a circuit will stop if this many shots have been taken.
+    --max_errors MAX_ERRORS
+                          Sampling of a circuit will stop if this many errors have been seen.
+    --processes PROCESSES
+                          Number of processes to use for simultaneous sampling and decoding.
+    --save_resume_filepath SAVE_RESUME_FILEPATH
+                          Activates MERGE mode. If save_resume_filepath doesn't exist, initializes it with a CSV header. CSV data already at save_resume_filepath counts towards max_shots and max_errors.
+                          Collected data is appended to save_resume_filepath. Note that MERGE mode is tolerant to failures: if the process is killed, it can simply be restarted and it will pick up where it left
+                          off. Note that MERGE mode is idempotent: if sufficient data has been collected, no additional work is done when run again.
+    --start_batch_size START_BATCH_SIZE
+                          Initial number of samples to batch together into one job. Starting small prevents over-sampling of circuits above threshold. The allowed batch size increases exponentially from this
+                          starting point.
+    --max_batch_size MAX_BATCH_SIZE
+                          Maximum number of samples to batch together into one job. Bigger values increase the delay between jobs finishing. Smaller values decrease the amount of aggregation of results,
+                          increasing the amount of output information.
+    --max_batch_seconds MAX_BATCH_SECONDS
+                          Limits number of shots in a batch so that the estimated runtime of the batch is below this amount.
+    --postselect_detectors_with_non_zero_4th_coord
+                          Turns on detector postselection. If any detector with a non-zero 4th coordinate fires, the shot is discarded.
+    --postselected_detectors_predicate POSTSELECTED_DETECTORS_PREDICATE
+                          Specifies a predicate used to decide which detectors to postselect. When a postselected detector produces a detection event, the shot is discarded instead of being given to the
+                          decoder.The number of discarded shots is tracked as a statistic.Available values: index: The unique number identifying the detector, determined by the order of detectors in the circuit
+                          file. coords: The coordinate data associated with the detector. An empty tuple, if the circuit file did not specify detector coordinates. metadata: The metadata associated with the task
+                          being sampled. Expected expression type: Something that can be given to `bool` to get False (do not postselect) or True (yes postselect). Examples: --postselected_detectors_predicate
+                          "coords[2] == 0" --postselected_observables_predicate "coords[3] < metadata['postselection_level']"
+    --postselected_observables_predicate POSTSELECTED_OBSERVABLES_PREDICATE
+                          Specifies a predicate used to decide which observables to postselect. When a decoder mispredicts a postselected observable, the shot is discarded instead of counting as an
+                          error.Available values: index: The index of the observable to postselect or not. metadata: The metadata associated with the task. Expected expression type: Something that can be given
+                          to `bool` to get False (do not postselect) or True (yes postselect). Examples: --postselected_observables_predicate "False" --postselected_observables_predicate "metadata['d'] == 5 and
+                          index >= 2"
+    --split_errors        Causes errors to be grouped by the observable mispredictions that caused the error.
+    --quiet               Disables writing progress to stderr.
+    --also_print_results_to_stdout
+                          Even if writing to a file, also write results to stdout.
+    --existing_data_filepaths [EXISTING_DATA_FILEPATHS ...]
+                          CSV data from these files counts towards max_shots and max_errors. This parameter can be given multiple arguments.
+    --metadata_func METADATA_FUNC
+                          A python expression that associates json metadata with a circuit's results. Set to "auto" to use "sinter.comma_separated_key_values(path)" Values available to the expression: path:
+                          Relative path to the circuit file, from the command line arguments. circuit: The circuit itself, parsed from the file, as a stim.Circuit. Expected type: A value that can be serialized
+                          into JSON, like a Dict[str, int]. Note that the decoder field is already recorded separately, so storing it in the metadata as well would be redundant. But something like decoder
+                          version could be usefully added. Examples: --metadata_func "{'path': path}" --metadata_func "auto" --metadata_func "{'n': circuit.num_qubits, 'p':
+                          float(path.split('/')[-1].split('.')[0])}"
+
+EXAMPLES
+    Example #1
+        >>> stim gen --out "d=5,r=5,p=0.01.stim" --code repetition_code --task memory --distance 5 --rounds 5 --before_round_data_depolarization 0.01
+        >>> stim gen --out "d=7,r=5,p=0.01.stim" --code repetition_code --task memory --distance 7 --rounds 5 --before_round_data_depolarization 0.01
+        >>> sinter collect \
+                --processes 4 \
+                --circuits *.stim \
+                --metadata_func auto \
+                --decoders pymatching \
+                --max_shots 1_000_000 \
+                --max_errors 1_000 \
+                --save_resume_filepath stats.csv
+        >>> sinter combine stats.csv
+             shots,    errors,  discards, seconds,decoder,strong_id,json_metadata
+           1000000,        12,         0,   0.716,pymatching,41fe89ff6c51e598d51846cb7a2b626fbfcaa76adcd1be9e0f1e2dff1fe87f1c,"{""d"":5,""p"":0.01,""r"":5}"
+           1000000,         1,         0,   0.394,pymatching,639d47a421d2a7661bb5b19255295767fc7cf0be7592fe4bcbc2639068e21349,"{""d"":7,""p"":0.01,""r"":5}"
+```
+
+<a name="combine"></a>
+### sinter combine
+
+```
+NAME
+    sinter combine
+
+SYNOPSIS
+    sinter combine \
+        filepath [...]
+
+DESCRIPTION
+    Loads sample statistics from one or more CSV statistics files (produced by
+    `sinter collect`), and aggregates rows corresponding to the same circuit
+    together.
+
+OPTIONS
+    filepaths
+        The locations of statistics files with rows aggregate together.
+
+
+EXAMPLES
+    Example #1
+        >>> sinter combine stats.csv
+             shots,    errors,  discards, seconds,decoder,strong_id,json_metadata
+           1000000,        12,         0,   0.716,pymatching,41fe89ff6c51e598d51846cb7a2b626fbfcaa76adcd1be9e0f1e2dff1fe87f1c,"{""d"":5,""p"":0.01,""r"":5}"
+           1000000,         1,         0,   0.394,pymatching,639d47a421d2a7661bb5b19255295767fc7cf0be7592fe4bcbc2639068e21349,"{""d"":7,""p"":0.01,""r"":5}"
+        >>> cat stats.csv
+             shots,    errors,  discards, seconds,decoder,strong_id,json_metadata
+               100,         0,         0,   0.174,pymatching,41fe89ff6c51e598d51846cb7a2b626fbfcaa76adcd1be9e0f1e2dff1fe87f1c,"{""d"":5,""p"":0.01,""r"":5}"
+               100,         0,         0,   0.000,pymatching,41fe89ff6c51e598d51846cb7a2b626fbfcaa76adcd1be9e0f1e2dff1fe87f1c,"{""d"":5,""p"":0.01,""r"":5}"
+               400,         0,         0,   0.000,pymatching,41fe89ff6c51e598d51846cb7a2b626fbfcaa76adcd1be9e0f1e2dff1fe87f1c,"{""d"":5,""p"":0.01,""r"":5}"
+              1200,         0,         0,   0.000,pymatching,41fe89ff6c51e598d51846cb7a2b626fbfcaa76adcd1be9e0f1e2dff1fe87f1c,"{""d"":5,""p"":0.01,""r"":5}"
+               100,         0,         0,   0.178,pymatching,639d47a421d2a7661bb5b19255295767fc7cf0be7592fe4bcbc2639068e21349,"{""d"":7,""p"":0.01,""r"":5}"
+              3600,         0,         0,   0.001,pymatching,41fe89ff6c51e598d51846cb7a2b626fbfcaa76adcd1be9e0f1e2dff1fe87f1c,"{""d"":5,""p"":0.01,""r"":5}"
+              3600,         0,         0,   0.001,pymatching,41fe89ff6c51e598d51846cb7a2b626fbfcaa76adcd1be9e0f1e2dff1fe87f1c,"{""d"":5,""p"":0.01,""r"":5}"
+             10800,         0,         0,   0.002,pymatching,41fe89ff6c51e598d51846cb7a2b626fbfcaa76adcd1be9e0f1e2dff1fe87f1c,"{""d"":5,""p"":0.01,""r"":5}"
+             18000,         0,         0,   0.003,pymatching,41fe89ff6c51e598d51846cb7a2b626fbfcaa76adcd1be9e0f1e2dff1fe87f1c,"{""d"":5,""p"":0.01,""r"":5}"
+             39600,         0,         0,   0.007,pymatching,41fe89ff6c51e598d51846cb7a2b626fbfcaa76adcd1be9e0f1e2dff1fe87f1c,"{""d"":5,""p"":0.01,""r"":5}"
+             75600,         0,         0,   0.012,pymatching,41fe89ff6c51e598d51846cb7a2b626fbfcaa76adcd1be9e0f1e2dff1fe87f1c,"{""d"":5,""p"":0.01,""r"":5}"
+            154800,         2,         0,   0.028,pymatching,41fe89ff6c51e598d51846cb7a2b626fbfcaa76adcd1be9e0f1e2dff1fe87f1c,"{""d"":5,""p"":0.01,""r"":5}"
+            306000,         5,         0,   0.051,pymatching,41fe89ff6c51e598d51846cb7a2b626fbfcaa76adcd1be9e0f1e2dff1fe87f1c,"{""d"":5,""p"":0.01,""r"":5}"
+               200,         0,         0,   0.000,pymatching,639d47a421d2a7661bb5b19255295767fc7cf0be7592fe4bcbc2639068e21349,"{""d"":7,""p"":0.01,""r"":5}"
+               600,         0,         0,   0.001,pymatching,639d47a421d2a7661bb5b19255295767fc7cf0be7592fe4bcbc2639068e21349,"{""d"":7,""p"":0.01,""r"":5}"
+              1800,         0,         0,   0.001,pymatching,639d47a421d2a7661bb5b19255295767fc7cf0be7592fe4bcbc2639068e21349,"{""d"":7,""p"":0.01,""r"":5}"
+              5400,         0,         0,   0.002,pymatching,639d47a421d2a7661bb5b19255295767fc7cf0be7592fe4bcbc2639068e21349,"{""d"":7,""p"":0.01,""r"":5}"
+             16200,         0,         0,   0.004,pymatching,639d47a421d2a7661bb5b19255295767fc7cf0be7592fe4bcbc2639068e21349,"{""d"":7,""p"":0.01,""r"":5}"
+             48600,         1,         0,   0.010,pymatching,639d47a421d2a7661bb5b19255295767fc7cf0be7592fe4bcbc2639068e21349,"{""d"":7,""p"":0.01,""r"":5}"
+            385800,         5,         0,   0.071,pymatching,41fe89ff6c51e598d51846cb7a2b626fbfcaa76adcd1be9e0f1e2dff1fe87f1c,"{""d"":5,""p"":0.01,""r"":5}"
+            145800,         0,         0,   0.030,pymatching,639d47a421d2a7661bb5b19255295767fc7cf0be7592fe4bcbc2639068e21349,"{""d"":7,""p"":0.01,""r"":5}"
+            145800,         0,         0,   0.032,pymatching,639d47a421d2a7661bb5b19255295767fc7cf0be7592fe4bcbc2639068e21349,"{""d"":7,""p"":0.01,""r"":5}"
+               200,         0,         0,   0.178,pymatching,41fe89ff6c51e598d51846cb7a2b626fbfcaa76adcd1be9e0f1e2dff1fe87f1c,"{""d"":5,""p"":0.01,""r"":5}"
+               200,         0,         0,   0.188,pymatching,41fe89ff6c51e598d51846cb7a2b626fbfcaa76adcd1be9e0f1e2dff1fe87f1c,"{""d"":5,""p"":0.01,""r"":5}"
+            198100,         0,         0,   0.044,pymatching,639d47a421d2a7661bb5b19255295767fc7cf0be7592fe4bcbc2639068e21349,"{""d"":7,""p"":0.01,""r"":5}"
+            437400,         0,         0,   0.092,pymatching,639d47a421d2a7661bb5b19255295767fc7cf0be7592fe4bcbc2639068e21349,"{""d"":7,""p"":0.01,""r"":5}"
+```
+
+<a name="plot"></a>
+### sinter plot
+
+```
+NAME
+    sinter plot
+
+SYNOPSIS
+    sinter plot \
+        --in filepath [...] \
+        [--x_func PYTHON_EXPRESSION] \
+        [--group_func PYTHON_EXPRESSION] \
+        [--out filepath] \
+        [--show] \
+        \
+        [--filter_func PYTHON_EXPRESSION] \
+        [--y_func PYTHON_EXPRESSION] \
+        [--failure_unit_name string] \
+        [--failure_units_per_shot_func PYTHON_EXPRESSION] \
+        [--failure_values_func PYTHON_EXPRESSION] \
+        [--fig_size float float] \
+        [--highlight_max_likelihood_factor float] \
+        [--plot_args_func PYTHON_EXPRESSION] \
+        [--split_errors] \
+        [--subtitle "{common}"|text] \
+        [--title text] \
+        [--type "error_rate"|"discard_rate"|"custom_y" [...] \
+        [--xaxis "text"|"[log]text"|"[sqrt]text"] \
+        [--yaxis "text"|"[log]text"|"[sqrt]text"] \
+        [--ymin float]
+
+DESCRIPTION
+    Creates a plot of statistics collected by `sinter collect` by grouping data
+    into curves according to `--group_func`, and laying out points along that
+    curve according to `--x_func`. Plots error rates by default, and also
+    discard rates if there are any discards, but this can be customized by using
+    `--y_func`.
+
+OPTIONS
+    --filter_func FILTER_FUNC
+                          A python expression that determines whether a case is kept or not. Values available to the python expression: metadata: The parsed value from the json_metadata for the data point. m:
+                          `m.key` is a shorthand for `metadata.get("key", None)`. decoder: The decoder that decoded the data for the data point. strong_id: The cryptographic hash of the case that was sampled for
+                          the data point. stat: The sinter.TaskStats object for the data point. Expected expression type: Something that can be given to `bool` to get True or False. Examples: --filter_func
+                          "decoder=='pymatching'" --filter_func "0.001 < metadata['p'] < 0.005"
+    --x_func X_FUNC       A python expression that determines where points go on the x axis. Values available to the python expression: metadata: The parsed value from the json_metadata for the data point. m:
+                          `m.key` is a shorthand for `metadata.get("key", None)`. decoder: The decoder that decoded the data for the data point. strong_id: The cryptographic hash of the case that was sampled for
+                          the data point. stat: The sinter.TaskStats object for the data point. Expected expression type: Something that can be given to `float` to get a float. Examples: --x_func "metadata['p']"
+                          --x_func m.p --x_func "metadata['path'].split('/')[-1].split('.')[0]"
+    --y_func Y_FUNC       A python expression that determines where points go on the y axis. This argument is not used by error rate or discard rate plots; only by the "custom_y" type plot.Values available to
+                          the python expression: metadata: The parsed value from the json_metadata for the data point. m: `m.key` is a shorthand for `metadata.get("key", None)`. decoder: The decoder that decoded
+                          the data for the data point. strong_id: The cryptographic hash of the case that was sampled for the data point. stat: The sinter.TaskStats object for the data point. Expected expression
+                          type: Something that can be given to `float` to get a float. Examples: --x_func "metadata['p']" --x_func "metadata['path'].split('/')[-1].split('.')[0]"
+    --fig_size FIG_SIZE FIG_SIZE
+                          Desired figure width in pixels.
+    --fig_height FIG_HEIGHT
+                          Desired figure height in pixels.
+    --group_func GROUP_FUNC
+                          A python expression that determines how points are grouped into curves. Values available to the python expression: metadata: The parsed value from the json_metadata for the data point.
+                          m: `m.key` is a shorthand for `metadata.get("key", None)`. decoder: The decoder that decoded the data for the data point. strong_id: The cryptographic hash of the case that was sampled
+                          for the data point. stat: The sinter.TaskStats object for the data point. Expected expression type: Something that can be given to `str` to get a useful string. Examples: --group_func
+                          "(decoder, metadata['d'])" --group_func m.d --group_func "metadata['path'].split('/')[-2]"
+    --failure_unit_name FAILURE_UNIT_NAME
+                          The unit of failure, typically either "shot" (the default) or "round". If this argument is specified, --failure_units_per_shot_func must also be specified.
+    --failure_units_per_shot_func FAILURE_UNITS_PER_SHOT_FUNC
+                          A python expression that evaluates to the number of failure units there are per shot. For example, if the failure unit is rounds, this should be an expression that returns the number of
+                          rounds in a shot. Sinter has no way of knowing what you consider a round to be, otherwise. This value is used to rescale the logical error rate plots. For example, if there are 4
+                          failure units per shot then a shot error rate of 10% corresponds to a unit failure rate of 2.7129%. The conversion formula (assuming less than 50% error rates) is: P_unit = 0.5 - 0.5 *
+                          (1 - 2 * P_shot)**(1/units_per_shot) Values available to the python expression: metadata: The parsed value from the json_metadata for the data point. m: `m.key` is a shorthand for
+                          `metadata.get("key", None)`. decoder: The decoder that decoded the data for the data point. strong_id: The cryptographic hash of the case that was sampled for the data point. stat: The
+                          sinter.TaskStats object for the data point. Expected expression type: float. Examples: --failure_units_per_shot_func "metadata['rounds']" --failure_units_per_shot_func m.r
+                          --failure_units_per_shot_func "m.distance * 3" --failure_units_per_shot_func "10"
+    --failure_values_func FAILURE_VALUES_FUNC
+                          A python expression that evaluates to the number of independent ways a shot can fail. For example, if a shot corresponds to a memory experiment preserving two observables, then the
+                          failure unions is 2. This value is necessary to correctly rescale the logical error rate plots when using --failure_values_func. By default it is assumed to be 1. Values available to
+                          the python expression: metadata: The parsed value from the json_metadata for the data point. m: `m.key` is a shorthand for `metadata.get("key", None)`. decoder: The decoder that decoded
+                          the data for the data point. strong_id: The cryptographic hash of the case that was sampled for the data point. stat: The sinter.TaskStats object for the data point. Expected expression
+                          type: float. Examples: --failure_values_func "metadata['num_obs']" --failure_values_func "2"
+    --plot_args_func PLOT_ARGS_FUNC
+                          A python expression used to customize the look of curves. Values available to the python expression: index: A unique integer identifying the curve. key: The group key (returned from
+                          --group_func) identifying the curve. stats: The list of sinter.TaskStats object in the group. metadata: (From one arbitrary data point in the group.) The parsed value from the
+                          json_metadata for the data point. m: `m.key` is a shorthand for `metadata.get("key", None)`. decoder: (From one arbitrary data point in the group.) The decoder that decoded the data for
+                          the data point. strong_id: (From one arbitrary data point in the group.) The cryptographic hash of the case that was sampled for the data point. stat: (From one arbitrary data point in
+                          the group.) The sinter.TaskStats object for the data point. Expected expression type: A dictionary to give to matplotlib plotting functions as a **kwargs argument. Examples:
+                          --plot_args_func "'''{'label': 'curve #' + str(index), 'linewidth': 5}'''" --plot_args_func "'''{'marker': 'ov*sp^<>8PhH+xXDd|'[index % 18]}'''"
+    --in IN [IN ...]      Input files to get data from.
+    --type {error_rate,discard_rate,custom_y} [{error_rate,discard_rate,custom_y} ...]
+                          Picks the figures to include.
+    --out OUT             Output file to write the plot to. The file extension determines the type of image. Either this or --show must be specified.
+    --xaxis XAXIS         Customize the X axis label. Prefix [log] for logarithmic scale. Prefix [sqrt] for square root scale.
+    --yaxis YAXIS         Customize the Y axis label. Prefix [log] for logarithmic scale. Prefix [sqrt] for square root scale.
+    --split_errors        When a stat has classified errors, this causes each classification to be a separate statistic.
+    --show                Displays the plot in a window. Either this or --out must be specified.
+    --ymin YMIN           Sets the minimum value of the y axis (max always 1).
+    --title TITLE         Sets the title of the plot.
+    --subtitle SUBTITLE   Sets the subtitle of the plot. Note: The pattern "{common}" will expand to text including all json metadata values that are the same across all stats.
+    --highlight_max_likelihood_factor HIGHLIGHT_MAX_LIKELIHOOD_FACTOR
+                          The relative likelihood ratio that determines the color highlights around curves. Set this to 1 or larger. Set to 1 to disable highlighting.
+
+
+EXAMPLES
+    Example #1
+        >>> cat stats.csv
+             shots,    errors,  discards, seconds,decoder,strong_id,json_metadata
+           1000000,        12,         0,   0.716,pymatching,41fe89ff6c51e598d51846cb7a2b626fbfcaa76adcd1be9e0f1e2dff1fe87f1c,"{""d"":5,""p"":0.01,""r"":5}"
+           1000000,         1,         0,   0.394,pymatching,639d47a421d2a7661bb5b19255295767fc7cf0be7592fe4bcbc2639068e21349,"{""d"":7,""p"":0.01,""r"":5}"
+        >>> sinter plot \
+            --in stats.csv \
+            --show \
+            --x_func m.d \
+            --group_func "f'''rounds={m.r}'''" \
+            --xaxis "[log]distance"
+```

--- a/glue/sample/README.md
+++ b/glue/sample/README.md
@@ -6,7 +6,9 @@ quantum error correction circuits.
 - [How it works](#how_it_works)
 - [How to install](#how_to_install)
 - [How to use: Python API](#how_to_use_python)
+    - [Sinter Python API Reference](doc/sinter_api.md)
 - [How to use: Linux Command Line](#how_to_use_linux)
+    - [Sinter Command Line Reference](doc/sinter_command_line.md)
 - [The csv format for sample statistics](#csv_format)
 
 <a name="how_to_works"></a>
@@ -286,7 +288,10 @@ For example:
 The columns are:
 
 - `shots` (unsigned int): How many times the circuit was sampled.
-- `errors` (unsigned int): How many times the decoder failed to predict the logical observable.
+  - `errors` (unsigned int): How many times the decoder failed to predict the logical observable.
+      The errors field may also have type `Dict[str, int]`, with a value like `{"E_":100,"EE":300}`.
+      In this case the keys correspond to types of error that occurred and the values are how often that
+      specific type of error occurred.
 - `discards` (unsigned int): How many times a shot was discarded because a postselected detector fired or because the decoder incorrectly predicted the value of a postselected observable. Discarded shots never count as errors.
 - `seconds` (non-negative float): How many CPU core seconds it took to simulate and decode these shots.
 - `decoder` (str): Which decoder was used.

--- a/glue/sample/src/sinter/_collection.py
+++ b/glue/sample/src/sinter/_collection.py
@@ -49,6 +49,7 @@ def iter_collect(*,
                  max_batch_seconds: Optional[int] = None,
                  max_batch_size: Optional[int] = None,
                  start_batch_size: Optional[int] = None,
+                 split_errors: bool = False,
                  custom_decoders: Optional[Dict[str, 'sinter.Decoder']] = None,
                  ) -> Iterator['sinter.Progress']:
     """Iterates error correction statistics collected from worker processes.
@@ -80,6 +81,10 @@ def iter_collect(*,
             after this many errors have been seen in samples taken from the
             circuit. The actual number sampled errors may be larger due to
             batching.
+        split_errors: Defaults to False. When set to to True, the returned
+            TaskStats instances will have a non-None `classified_errors` field
+            where keys are bitmasks identifying which observables flipped and
+            values are the number of errors where that happened.
         start_batch_size: Defaults to None (collector's choice). The very
             first shots taken from the circuit will use a batch of this
             size, and no other batches will be taken in parallel. Once this
@@ -157,6 +162,7 @@ def iter_collect(*,
                 max_batch_size=max_batch_size,
             ),
             decoders=decoders,
+            split_errors=split_errors,
             additional_existing_data=additional_existing_data,
             custom_decoders=custom_decoders) as manager:
         try:
@@ -202,6 +208,7 @@ def collect(*,
             progress_callback: Optional[Callable[['sinter.Progress'], None]] = None,
             max_shots: Optional[int] = None,
             max_errors: Optional[int] = None,
+            split_errors: bool = False,
             decoders: Optional[Iterable[str]] = None,
             max_batch_seconds: Optional[int] = None,
             max_batch_size: Optional[int] = None,
@@ -236,6 +243,10 @@ def collect(*,
             decoders to use on each Task. It must either be the case that each
             Task specifies a decoder and this is set to None, or this is an
             iterable and each Task has its decoder set to None.
+        split_errors: Defaults to False. When set to to True, the returned
+            TaskStats instances will have a non-None `classified_errors` field
+            where keys are bitmasks identifying which observables flipped and
+            values are the number of errors where that happened.
         max_shots: Defaults to None (unused). Stops the sampling process
             after this many samples have been taken from the circuit.
         max_errors: Defaults to None (unused). Stops the sampling process
@@ -341,6 +352,7 @@ def collect(*,
             max_batch_seconds=max_batch_seconds,
             start_batch_size=start_batch_size,
             max_batch_size=max_batch_size,
+            split_errors=split_errors,
             decoders=decoders,
             tasks=tasks,
             hint_num_tasks=hint_num_tasks,

--- a/glue/sample/src/sinter/_collection_tracker_for_single_task.py
+++ b/glue/sample/src/sinter/_collection_tracker_for_single_task.py
@@ -19,10 +19,12 @@ class CollectionTrackerForSingleTask:
             self,
             *,
             task: Task,
+            split_errors: bool,
             circuit_path: str,
             dem_path: str,
             existing_data: ExistingData):
         self.unfilled_task = task
+        self.split_errors = split_errors
         self.task_strong_id = None
         self.circuit_path = circuit_path
         self.dem_path = dem_path
@@ -160,6 +162,7 @@ class CollectionTrackerForSingleTask:
                 json_metadata=self.unfilled_task.json_metadata,
                 strong_id=None,
                 num_shots=-1,
+                split_errors=self.split_errors,
             )
 
         # Wait to have *some* data before starting to sample in parallel.
@@ -179,6 +182,7 @@ class CollectionTrackerForSingleTask:
             postselected_observables_mask=self.unfilled_task.postselected_observables_mask,
             json_metadata=self.unfilled_task.json_metadata,
             num_shots=num_shots,
+            split_errors=self.split_errors,
         )
 
     def status(self) -> str:

--- a/glue/sample/src/sinter/_collection_work_manager.py
+++ b/glue/sample/src/sinter/_collection_work_manager.py
@@ -21,6 +21,7 @@ class CollectionWorkManager:
                  tasks_iter: Iterator[Task],
                  global_collection_options: CollectionOptions,
                  additional_existing_data: Optional[ExistingData],
+                 split_errors: bool,
                  decoders: Optional[Iterable[str]],
                  custom_decoders: Dict[str, Decoder]):
         self.custom_decoders = custom_decoders
@@ -40,6 +41,7 @@ class CollectionWorkManager:
         self.finished_count = 0
         self.deployed_jobs: Dict[int, WorkIn] = {}
         self.next_job_id = 0
+        self.split_errors = split_errors
 
         self.tasks_with_decoder_iter: Iterator[Task] = _iter_tasks_with_assigned_decoders(
             tasks_iter=tasks_iter,
@@ -137,6 +139,7 @@ class CollectionWorkManager:
                 json_metadata=work_in.json_metadata,
                 shots=stats.shots,
                 errors=stats.errors,
+                classified_errors=stats.classified_errors,
                 discards=stats.discards,
                 seconds=stats.seconds,
             )
@@ -155,6 +158,7 @@ class CollectionWorkManager:
                 circuit_path=str((self.tmp_dir / f'circuit_{self.next_collector_key}.stim').absolute()),
                 dem_path=str((self.tmp_dir / f'dem_{self.next_collector_key}.dem').absolute()),
                 existing_data=self.additional_existing_data,
+                split_errors=self.split_errors,
             )
             if collector.is_done():
                 self.finished_count += 1

--- a/glue/sample/src/sinter/_csv_out.py
+++ b/glue/sample/src/sinter/_csv_out.py
@@ -1,3 +1,4 @@
+import collections
 import csv
 import io
 import json
@@ -37,6 +38,8 @@ def csv_line(*,
                                    sort_keys=True)
 
     shots = escape_csv(shots, 10)
+    if isinstance(errors, (dict, collections.Counter)):
+        errors = json.dumps(errors, separators=(',', ':'), sort_keys=True)
     errors = escape_csv(errors, 10)
     discards = escape_csv(discards, 10)
     seconds = escape_csv(seconds, 8)

--- a/glue/sample/src/sinter/_existing_data.py
+++ b/glue/sample/src/sinter/_existing_data.py
@@ -1,3 +1,4 @@
+import collections
 import json
 import pathlib
 from typing import Any, Dict, List, TYPE_CHECKING
@@ -61,10 +62,20 @@ class ExistingData:
                 f"but expected columns {sorted(expected_fields)!r}")
         result = ExistingData()
         for row in reader:
+            errs = json.loads(row['errors'])
+            if isinstance(errs, int):
+                num_errors = errs
+                classified_errors = None
+            elif isinstance(errs, dict):
+                num_errors = sum(errs.values())
+                classified_errors = collections.Counter(errs)
+            else:
+                raise NotImplementedError(f"{row['errors']=}")
             result.add_sample(TaskStats(
                 shots=int(row['shots']),
                 discards=int(row['discards']),
-                errors=int(row['errors']),
+                errors=num_errors,
+                classified_errors=classified_errors,
                 seconds=float(row['seconds']),
                 strong_id=row['strong_id'],
                 decoder=row['decoder'],

--- a/glue/sample/src/sinter/_main_collect.py
+++ b/glue/sample/src/sinter/_main_collect.py
@@ -127,7 +127,7 @@ def parse_args(args: List[str]) -> Any:
                              '    Something that can be given to `bool` to get False (do not postselect) or True (yes postselect).\n'
                              'Examples:\n'
                              '''    --postselected_detectors_predicate "coords[2] == 0"\n'''
-                             '''    --postselected_observables_predicate "coords[3] < metadata['postselection_level']"\n''')
+                             '''    --postselected_detectors_predicate "coords[3] < metadata['postselection_level']"\n''')
     parser.add_argument('--postselected_observables_predicate',
                         type=str,
                         default='''False''',

--- a/glue/sample/src/sinter/_main_collect.py
+++ b/glue/sample/src/sinter/_main_collect.py
@@ -141,6 +141,9 @@ def parse_args(args: List[str]) -> Any:
                              'Examples:\n'
                              '''    --postselected_observables_predicate "False"\n'''
                              '''    --postselected_observables_predicate "metadata['d'] == 5 and index >= 2"\n''')
+    parser.add_argument('--split_errors',
+                        help='Causes errors to be grouped by the observable mispredictions that caused the error.',
+                        action='store_true')
     parser.add_argument('--quiet',
                         help='Disables writing progress to stderr.',
                         action='store_true')
@@ -278,6 +281,7 @@ def main_collect(*, command_line_args: List[str]):
             progress_callback=on_progress,
             max_errors=args.max_errors,
             max_shots=args.max_shots,
+            split_errors=args.split_errors,
             decoders=args.decoders,
             max_batch_seconds=args.max_batch_seconds,
             max_batch_size=args.max_batch_size,

--- a/glue/sample/src/sinter/_main_collect_test.py
+++ b/glue/sample/src/sinter/_main_collect_test.py
@@ -1,3 +1,4 @@
+import collections
 import pathlib
 import tempfile
 
@@ -143,7 +144,7 @@ def test_main_collect_with_custom_decoder():
                 "--decoders",
                 "NOTEXIST",
                 "--custom_decoders_module_function",
-                "sinter._main_test:_make_custom_decoders",
+                "sinter._main_collect_test:_make_custom_decoders",
                 "--processes",
                 "2",
                 "--quiet",
@@ -161,7 +162,7 @@ def test_main_collect_with_custom_decoder():
             "--decoders",
             "alternate",
             "--custom_decoders_module_function",
-            "sinter._main_test:_make_custom_decoders",
+            "sinter._main_collect_test:_make_custom_decoders",
             "--processes",
             "2",
             "--quiet",
@@ -256,33 +257,44 @@ def test_main_collect_comma_separated_key_values():
         ])
 
 
-def test_main_predict():
+def test_main_collect_split_observables():
     with tempfile.TemporaryDirectory() as d:
         d = pathlib.Path(d)
-        with open(d / f'input.dets', 'w') as f:
+        with open(d / 'a=3.stim', 'w') as f:
             print("""
-shot D0
-shot
-            """, file=f)
-        with open(d / f'input.dem', 'w') as f:
-            print("""
-error(0.1) D0 L0
+                X_ERROR(0.1) 0
+                X_ERROR(0.2) 1
+                M 0 1
+                OBSERVABLE_INCLUDE(0) rec[-1]
+                OBSERVABLE_INCLUDE(1) rec[-2]
             """, file=f)
 
+        # Collects requested stats.
         main(command_line_args=[
-            "predict",
-            "--dets",
-            str(d / "input.dets"),
-            "--dem",
-            str(d / "input.dem"),
-            "--decoder",
+            "collect",
+            "--circuits",
+            str(d / 'a=3.stim'),
+            "--max_shots",
+            "100000",
+            "--metadata_func",
+            "sinter.comma_separated_key_values(path)",
+            "--max_errors",
+            "10000",
+            "--decoders",
             "pymatching",
-            "--dets_format",
-            "dets",
-            "--obs_out",
-            str(d / "output.01"),
-            "--obs_out_format",
-            "01",
+            "--split_errors",
+            "--processes",
+            "4",
+            "--quiet",
+            "--save_resume_filepath",
+            str(d / "out.csv"),
         ])
-        with open(d / 'output.01') as f:
-            assert f.read() == '1\n0\n'
+        data = sinter.stats_from_csv_files(d / "out.csv")
+        assert len(data) == 1
+        item, = data
+        assert isinstance(item.classified_errors, collections.Counter)
+        assert set(item.classified_errors.keys()) == {"E_", "_E", "EE"}
+        assert 0.1*0.8 - 0.01 < item.classified_errors['_E'] / item.shots < 0.1*0.8 + 0.01
+        assert 0.9*0.2 - 0.01 < item.classified_errors['E_'] / item.shots < 0.9*0.2 + 0.01
+        assert 0.1*0.2 - 0.01 < item.classified_errors['EE'] / item.shots < 0.1*0.2 + 0.01
+

--- a/glue/sample/src/sinter/_main_plot.py
+++ b/glue/sample/src/sinter/_main_plot.py
@@ -23,6 +23,7 @@ def parse_args(args: List[str]) -> Any:
                         help='A python expression that determines whether a case is kept or not.\n'
                              'Values available to the python expression:\n'
                              '    metadata: The parsed value from the json_metadata for the data point.\n'
+                             '    m: `m.key` is a shorthand for `metadata.get("key", None)`.\n'
                              '    decoder: The decoder that decoded the data for the data point.\n'
                              '    strong_id: The cryptographic hash of the case that was sampled for the data point.\n'
                              '    stat: The sinter.TaskStats object for the data point.\n'
@@ -37,6 +38,7 @@ def parse_args(args: List[str]) -> Any:
                         help='A python expression that determines where points go on the x axis.\n'
                              'Values available to the python expression:\n'
                              '    metadata: The parsed value from the json_metadata for the data point.\n'
+                             '    m: `m.key` is a shorthand for `metadata.get("key", None)`.\n'
                              '    decoder: The decoder that decoded the data for the data point.\n'
                              '    strong_id: The cryptographic hash of the case that was sampled for the data point.\n'
                              '    stat: The sinter.TaskStats object for the data point.\n'
@@ -44,6 +46,7 @@ def parse_args(args: List[str]) -> Any:
                              '    Something that can be given to `float` to get a float.\n'
                              'Examples:\n'
                              '''    --x_func "metadata['p']"\n'''
+                             '''    --x_func m.p\n'''
                              '''    --x_func "metadata['path'].split('/')[-1].split('.')[0]"\n'''
                         )
     parser.add_argument('--y_func',
@@ -54,6 +57,7 @@ def parse_args(args: List[str]) -> Any:
                              'by the "custom_y" type plot.'
                              'Values available to the python expression:\n'
                              '    metadata: The parsed value from the json_metadata for the data point.\n'
+                             '    m: `m.key` is a shorthand for `metadata.get("key", None)`.\n'
                              '    decoder: The decoder that decoded the data for the data point.\n'
                              '    strong_id: The cryptographic hash of the case that was sampled for the data point.\n'
                              '    stat: The sinter.TaskStats object for the data point.\n'
@@ -68,16 +72,13 @@ def parse_args(args: List[str]) -> Any:
                         nargs=2,
                         default=None,
                         help='Desired figure width in pixels.')
-    parser.add_argument('--fig_height',
-                        type=int,
-                        default=None,
-                        help='Desired figure height in pixels.')
     parser.add_argument('--group_func',
                         type=str,
                         default="'all data (use -group_func and -x_func to group into curves)'",
                         help='A python expression that determines how points are grouped into curves.\n'
                              'Values available to the python expression:\n'
                              '    metadata: The parsed value from the json_metadata for the data point.\n'
+                             '    m: `m.key` is a shorthand for `metadata.get("key", None)`.\n'
                              '    decoder: The decoder that decoded the data for the data point.\n'
                              '    strong_id: The cryptographic hash of the case that was sampled for the data point.\n'
                              '    stat: The sinter.TaskStats object for the data point.\n'
@@ -85,6 +86,7 @@ def parse_args(args: List[str]) -> Any:
                              '    Something that can be given to `str` to get a useful string.\n'
                              'Examples:\n'
                              '''    --group_func "(decoder, metadata['d'])"\n'''
+                             '''    --group_func m.d\n'''
                              '''    --group_func "metadata['path'].split('/')[-2]"\n'''
                         )
     parser.add_argument('--failure_unit_name',
@@ -102,13 +104,14 @@ def parse_args(args: List[str]) -> Any:
                              'to be, otherwise.\n'
                              '\n'
                              'This value is used to rescale the logical error rate plots. For example, if there are 4\n'
-                             'failure units per shot then a shot error rate of 10% corresponds to a unit failure rate\n'
-                             'of 2.7129%. The conversion formula (assuming <50% error rates) is:\n'
+                             'failure units per shot then a shot error rate of 10%% corresponds to a unit failure rate\n'
+                             'of 2.7129%%. The conversion formula (assuming less than 50%% error rates) is:\n'
                              '\n'
                              '    P_unit = 0.5 - 0.5 * (1 - 2 * P_shot)**(1/units_per_shot)\n'
                              '\n'
                              'Values available to the python expression:\n'
                              '    metadata: The parsed value from the json_metadata for the data point.\n'
+                             '    m: `m.key` is a shorthand for `metadata.get("key", None)`.\n'
                              '    decoder: The decoder that decoded the data for the data point.\n'
                              '    strong_id: The cryptographic hash of the case that was sampled for the data point.\n'
                              '    stat: The sinter.TaskStats object for the data point.\n'
@@ -118,7 +121,8 @@ def parse_args(args: List[str]) -> Any:
                              '\n'
                              'Examples:\n'
                              '''    --failure_units_per_shot_func "metadata['rounds']"\n'''
-                             '''    --failure_units_per_shot_func "metadata['distance'] * 3"\n'''
+                             '''    --failure_units_per_shot_func m.r\n'''
+                             '''    --failure_units_per_shot_func "m.distance * 3"\n'''
                              '''    --failure_units_per_shot_func "10"\n'''
                         )
     parser.add_argument('--failure_values_func',
@@ -133,6 +137,7 @@ def parse_args(args: List[str]) -> Any:
                              '\n'
                              'Values available to the python expression:\n'
                              '    metadata: The parsed value from the json_metadata for the data point.\n'
+                             '    m: `m.key` is a shorthand for `metadata.get("key", None)`.\n'
                              '    decoder: The decoder that decoded the data for the data point.\n'
                              '    strong_id: The cryptographic hash of the case that was sampled for the data point.\n'
                              '    stat: The sinter.TaskStats object for the data point.\n'
@@ -153,6 +158,7 @@ def parse_args(args: List[str]) -> Any:
                              '    key: The group key (returned from --group_func) identifying the curve.\n'
                              '    stats: The list of sinter.TaskStats object in the group.\n'
                              '    metadata: (From one arbitrary data point in the group.) The parsed value from the json_metadata for the data point.\n'
+                             '    m: `m.key` is a shorthand for `metadata.get("key", None)`.\n'
                              '    decoder: (From one arbitrary data point in the group.) The decoder that decoded the data for the data point.\n'
                              '    strong_id: (From one arbitrary data point in the group.) The cryptographic hash of the case that was sampled for the data point.\n'
                              '    stat: (From one arbitrary data point in the group.) The sinter.TaskStats object for the data point.\n'
@@ -160,7 +166,7 @@ def parse_args(args: List[str]) -> Any:
                              '    A dictionary to give to matplotlib plotting functions as a **kwargs argument.\n'
                              'Examples:\n'
                              """    --plot_args_func "'''{'label': 'curve #' + str(index), 'linewidth': 5}'''"\n"""
-                             """    --plot_args_func "'''{'marker': 'ov*sp^<>8PhH+xXDd|'[index % 18]}'''"\n"""
+                             """    --plot_args_func "'''{'marker': 'ov*sp^<>8PhH+xXDd|'[index %% 18]}'''"\n"""
                         )
     parser.add_argument('--in',
                         type=str,
@@ -190,6 +196,9 @@ def parse_args(args: List[str]) -> Any:
                         help='Customize the Y axis label. '
                              'Prefix [log] for logarithmic scale. '
                              'Prefix [sqrt] for square root scale.')
+    parser.add_argument('--split_errors',
+                        action='store_true',
+                        help='When a stat has classified errors, this causes each classification to be a separate statistic.\n')
     parser.add_argument('--show',
                         action='store_true',
                         help='Displays the plot in a window.\n'
@@ -236,32 +245,32 @@ def parse_args(args: List[str]) -> Any:
     if a.failure_unit_name is None:
         a.failure_unit_name = 'shot'
     a.x_func = eval(compile(
-        f'lambda *, stat, decoder, metadata, strong_id: {a.x_func}',
+        f'lambda *, stat, decoder, metadata, m, strong_id: {a.x_func}',
         filename='x_func:command_line_arg',
         mode='eval'))
     if a.y_func is not None:
         a.y_func = eval(compile(
-            f'lambda *, stat, decoder, metadata, strong_id: {a.y_func}',
+            f'lambda *, stat, decoder, metadata, m, strong_id: {a.y_func}',
             filename='x_func:command_line_arg',
             mode='eval'))
     a.group_func = eval(compile(
-        f'lambda *, stat, decoder, metadata, strong_id: {a.group_func}',
+        f'lambda *, stat, decoder, metadata, m, strong_id: {a.group_func}',
         filename='group_func:command_line_arg',
         mode='eval'))
     a.filter_func = eval(compile(
-        f'lambda *, stat, decoder, metadata, strong_id: {a.filter_func}',
+        f'lambda *, stat, decoder, metadata, m, strong_id: {a.filter_func}',
         filename='filter_func:command_line_arg',
         mode='eval'))
     a.failure_units_per_shot_func = eval(compile(
-        f'lambda *, stat, decoder, metadata, strong_id: {a.failure_units_per_shot_func}',
+        f'lambda *, stat, decoder, metadata, m, strong_id: {a.failure_units_per_shot_func}',
         filename='failure_units_per_shot_func:command_line_arg',
         mode='eval'))
     a.failure_values_func = eval(compile(
-        f'lambda *, stat, decoder, metadata, strong_id: {a.failure_values_func}',
+        f'lambda *, stat, decoder, metadata, m, strong_id: {a.failure_values_func}',
         filename='failure_values_func:command_line_arg',
         mode='eval'))
     a.plot_args_func = eval(compile(
-        f'lambda *, index, key, stats, stat, decoder, metadata, strong_id: {a.plot_args_func}',
+        f'lambda *, index, key, stats, stat, decoder, metadata, m, strong_id: {a.plot_args_func}',
         filename='plot_args_func:command_line_arg',
         mode='eval'))
     return a
@@ -624,11 +633,28 @@ def _plot_helper(
     return fig, axs
 
 
+class _FieldToMetadataWrapper:
+    def __init__(self, d: Dict):
+        self.__private_d = d
+
+    def __getattr__(self, item):
+        if isinstance(self.__private_d, dict):
+            return self.__private_d.get(item, None)
+        return None
+
+
 def main_plot(*, command_line_args: List[str]):
     args = parse_args(command_line_args)
     total = ExistingData()
     for file in getattr(args, 'in'):
         total += ExistingData.from_file(file)
+
+    if args.split_errors:
+        total.data = {
+            s.strong_id: s
+            for v in total.data.values()
+            for s in v._split_errors()
+        }
 
     fig, _ = _plot_helper(
         samples=total,
@@ -636,31 +662,37 @@ def main_plot(*, command_line_args: List[str]):
             stat=stat,
             decoder=stat.decoder,
             metadata=stat.json_metadata,
+            m=_FieldToMetadataWrapper(stat.json_metadata),
             strong_id=stat.strong_id),
         x_func=lambda stat: args.x_func(
             stat=stat,
             decoder=stat.decoder,
             metadata=stat.json_metadata,
+            m=_FieldToMetadataWrapper(stat.json_metadata),
             strong_id=stat.strong_id),
         y_func=None if args.y_func is None else lambda stat: args.y_func(
             stat=stat,
             decoder=stat.decoder,
             metadata=stat.json_metadata,
+            m=_FieldToMetadataWrapper(stat.json_metadata),
             strong_id=stat.strong_id),
         filter_func=lambda stat: args.filter_func(
             stat=stat,
             decoder=stat.decoder,
             metadata=stat.json_metadata,
+            m=_FieldToMetadataWrapper(stat.json_metadata),
             strong_id=stat.strong_id),
         failure_units_per_shot_func=lambda stat: args.failure_units_per_shot_func(
             stat=stat,
             decoder=stat.decoder,
             metadata=stat.json_metadata,
+            m=_FieldToMetadataWrapper(stat.json_metadata),
             strong_id=stat.strong_id),
         failure_values_func=lambda stat: args.failure_values_func(
             stat=stat,
             decoder=stat.decoder,
             metadata=stat.json_metadata,
+            m=_FieldToMetadataWrapper(stat.json_metadata),
             strong_id=stat.strong_id),
         plot_args_func=lambda index, group_key, stats: args.plot_args_func(
             index=index,
@@ -669,6 +701,7 @@ def main_plot(*, command_line_args: List[str]):
             stat=stats[0],
             decoder=stats[0].decoder,
             metadata=stats[0].json_metadata,
+            m=_FieldToMetadataWrapper(stats[0].json_metadata),
             strong_id=stats[0].strong_id),
         failure_unit=args.failure_unit_name,
         plot_types=args.type,

--- a/glue/sample/src/sinter/_main_plot.py
+++ b/glue/sample/src/sinter/_main_plot.py
@@ -71,7 +71,7 @@ def parse_args(args: List[str]) -> Any:
                         type=int,
                         nargs=2,
                         default=None,
-                        help='Desired figure width in pixels.')
+                        help='Desired figure width and height in pixels.')
     parser.add_argument('--group_func',
                         type=str,
                         default="'all data (use -group_func and -x_func to group into curves)'",

--- a/glue/sample/src/sinter/_main_plot_test.py
+++ b/glue/sample/src/sinter/_main_plot_test.py
@@ -349,3 +349,33 @@ def test_failure_values_func():
             "rounds",
         ])
         assert (d / "output.png").exists()
+
+
+def test_m_fields():
+    with tempfile.TemporaryDirectory() as d:
+        d = pathlib.Path(d)
+        with open(d / f'input.csv', 'w') as f:
+            print("""
+                shots,errors,discards,seconds,decoder,strong_id,json_metadata
+                 1000,   400,       0,   1.00,magical,000000001,"{""f"":1}"
+                 1000,   400,       0,   1.00,magical,000000002,"{""f"":2}"
+                 1000,   400,       0,   1.00,magical,000000003,"{""f"":3}"
+                 1000,   400,       0,   1.00,magical,000000005,"{""f"":5}"
+            """.strip(), file=f)
+
+        main(command_line_args=[
+            "plot",
+            "--in",
+            str(d / "input.csv"),
+            "--out",
+            str(d / "output.png"),
+            "--xaxis",
+            "values",
+            "--x_func",
+            "m.f",
+            "--group_func",
+            "m.g",
+            "--subtitle",
+            "test",
+        ])
+        assert (d / "output.png").exists()

--- a/glue/sample/src/sinter/_main_predict_test.py
+++ b/glue/sample/src/sinter/_main_predict_test.py
@@ -1,0 +1,36 @@
+import pathlib
+import tempfile
+
+from sinter._main import main
+
+
+def test_main_predict():
+    with tempfile.TemporaryDirectory() as d:
+        d = pathlib.Path(d)
+        with open(d / f'input.dets', 'w') as f:
+            print("""
+shot D0
+shot
+            """, file=f)
+        with open(d / f'input.dem', 'w') as f:
+            print("""
+error(0.1) D0 L0
+            """, file=f)
+
+        main(command_line_args=[
+            "predict",
+            "--dets",
+            str(d / "input.dets"),
+            "--dem",
+            str(d / "input.dem"),
+            "--decoder",
+            "pymatching",
+            "--dets_format",
+            "dets",
+            "--obs_out",
+            str(d / "output.01"),
+            "--obs_out_format",
+            "01",
+        ])
+        with open(d / 'output.01') as f:
+            assert f.read() == '1\n0\n'

--- a/glue/sample/src/sinter/_worker.py
+++ b/glue/sample/src/sinter/_worker.py
@@ -24,6 +24,7 @@ class WorkIn:
             postselection_mask: 'Optional[np.ndarray]',
             postselected_observables_mask: 'Optional[np.ndarray]',
             json_metadata: 'JSON_TYPE',
+            split_errors: bool,
             num_shots: int):
         self.work_key = work_key
         self.circuit_path = circuit_path
@@ -33,6 +34,7 @@ class WorkIn:
         self.postselection_mask = postselection_mask
         self.postselected_observables_mask = postselected_observables_mask
         self.json_metadata = json_metadata
+        self.split_errors = split_errors
         self.num_shots = num_shots
 
     def with_work_key(self, work_key: Any) -> 'WorkIn':
@@ -46,6 +48,7 @@ class WorkIn:
             json_metadata=self.json_metadata,
             strong_id=self.strong_id,
             num_shots=self.num_shots,
+            split_errors=self.split_errors,
         )
 
 
@@ -147,6 +150,7 @@ def do_work(work: WorkIn, child_dir: str, custom_decoders: Dict[str, 'sinter.Dec
         post_mask=work.postselection_mask,
         postselected_observable_mask=work.postselected_observables_mask,
         decoder=work.decoder,
+        split_errors=work.split_errors,
         tmp_dir=child_dir,
         custom_decoders=custom_decoders,
     )

--- a/glue/sample/src/sinter/_worker_test.py
+++ b/glue/sample/src/sinter/_worker_test.py
@@ -30,6 +30,7 @@ def test_worker_loop_infers_dem():
             num_shots=-1,
             postselected_observables_mask=None,
             postselection_mask=None,
+            split_errors=False,
         ))
         inp.put(None)
         worker_loop(tmp_dir, inp, out, None, 0)
@@ -69,6 +70,7 @@ def test_worker_loop_does_not_recompute_dem():
             num_shots=1000,
             postselected_observables_mask=None,
             postselection_mask=None,
+            split_errors=False,
         ))
         inp.put(None)
         worker_loop(tmp_dir, inp, out, None, 0)


### PR DESCRIPTION
- Add `--split_errors` option to `sinter collect` to store errors keyed by obs symptom instead of just recording if anything failed at all
- Add `--split_errors` option to `sinter plot` to split compound errors into multiple separate rows
- Add `sinter.{AnonTaskStats,TaskStats}classified_errors` field
- Add `split_errors=False` argument to `sinter.{collect,iter_collect}
- Modify CSV reading and writing to expand errors column into classified errors when needed
- Add `m` value to sinter plot command line lambdas
- Add sinter command line usage documentation

In stats files split errors look like this, with what would have been an integer number of errors expanded into a dictionary of failed observable to count like `{"EE":3,"E_":41,"_E":27}`:

```
4124,"{""EE"":3,""E_"":41,""_E"":27}",0,   1.1,pymatching,7b7cca5e5e25fad7c792496fe58880654149c903e3198c2822f203c602aedcb2,"{""d"":5,""r"":15,p:0.001}"
```

Fixes https://github.com/quantumlib/Stim/issues/417
Fixes https://github.com/quantumlib/Stim/issues/560