### PR TITLE
Add a `custom_counts` column to sinter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,6 +315,7 @@ jobs:
       - run: diff <(python dev/gen_stim_api_reference.py -dev) doc/python_api_reference_vDev.md
       - run: diff <(python dev/gen_stim_stub_file.py -dev) glue/python/src/stim/__init__.pyi
       - run: diff <(python dev/gen_stim_stub_file.py -dev) doc/stim.pyi
+      - run: diff <(python dev/gen_sinter_api_reference.py -dev) doc/sinter_api.md
       - run: diff <(python -c "import stim; stim.main(command_line_args=['help', 'gates_markdown'])") doc/gates.md
       - run: diff <(python -c "import stim; stim.main(command_line_args=['help', 'formats_markdown'])") doc/result_formats.md
       - run: diff <(python -c "import stim; stim.main(command_line_args=['help', 'commands_markdown'])") doc/usage_command_line.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,7 +315,6 @@ jobs:
       - run: diff <(python dev/gen_stim_api_reference.py -dev) doc/python_api_reference_vDev.md
       - run: diff <(python dev/gen_stim_stub_file.py -dev) glue/python/src/stim/__init__.pyi
       - run: diff <(python dev/gen_stim_stub_file.py -dev) doc/stim.pyi
-      - run: diff <(python dev/gen_sinter_api_reference.py -dev) doc/sinter_api.md
       - run: diff <(python -c "import stim; stim.main(command_line_args=['help', 'gates_markdown'])") doc/gates.md
       - run: diff <(python -c "import stim; stim.main(command_line_args=['help', 'formats_markdown'])") doc/result_formats.md
       - run: diff <(python -c "import stim; stim.main(command_line_args=['help', 'commands_markdown'])") doc/usage_command_line.md

--- a/dev/gen_sinter_api_reference.py
+++ b/dev/gen_sinter_api_reference.py
@@ -38,7 +38,7 @@ def main():
     print(f'''
 ```python
 # Types used by the method definitions.
-from typing import overload, TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Union
+from typing import overload, TYPE_CHECKING, Any, Counter, Dict, Iterable, List, Optional, Tuple, Union
 import abc
 import dataclasses
 import io

--- a/glue/sample/README.md
+++ b/glue/sample/README.md
@@ -288,10 +288,7 @@ For example:
 The columns are:
 
 - `shots` (unsigned int): How many times the circuit was sampled.
-  - `errors` (unsigned int): How many times the decoder failed to predict the logical observable.
-      The errors field may also have type `Dict[str, int]`, with a value like `{"E_":100,"EE":300}`.
-      In this case the keys correspond to types of error that occurred and the values are how often that
-      specific type of error occurred.
+- `errors` (unsigned int): How many times the decoder failed to predict any logical observable.
 - `discards` (unsigned int): How many times a shot was discarded because a postselected detector fired or because the decoder incorrectly predicted the value of a postselected observable. Discarded shots never count as errors.
 - `seconds` (non-negative float): How many CPU core seconds it took to simulate and decode these shots.
 - `decoder` (str): Which decoder was used.
@@ -310,6 +307,12 @@ shots that were from separate circuits or separate versions of a circuit.
 dictionary with helpful keys like "noise_level" or "circuit_name". The json
 value is serialized into JSON and then escaped so that it can be put into the
 CSV data (e.g. quotes get doubled up).
+- `custom_counts` (json[Dict[str, int]]): A field that can store a dictionary
+from string keys to integer counts represented in
+[Java Script Object Notation](https://json.org).
+The counts can be a huge variety of things, ranging from per-observable error
+counts to detection event counts. In general, any value that should be added
+when merging rows could be in these counters.
 
 Note shots may be spread across multiple rows.
 For example, this data:

--- a/glue/sample/src/sinter/_anon_task_stats_test.py
+++ b/glue/sample/src/sinter/_anon_task_stats_test.py
@@ -24,12 +24,12 @@ def test_add():
     assert a0 + b0 == sinter.AnonTaskStats(shots=270, errors=34, discards=43, seconds=52)
     assert a0 + sinter.AnonTaskStats() == a0
 
-    a = sinter.AnonTaskStats(shots=220, errors=30, discards=40, seconds=50, classified_errors=collections.Counter({'a': 10, 'b': 20}))
-    b = sinter.AnonTaskStats(shots=50, errors=4, discards=3, seconds=2, classified_errors=collections.Counter({'a': 1, 'c': 3}))
-    assert a + b == sinter.AnonTaskStats(shots=270, errors=34, discards=43, seconds=52, classified_errors=collections.Counter({'a': 11, 'b': 20, 'c': 3}))
+    a = sinter.AnonTaskStats(shots=220, errors=30, discards=40, seconds=50, custom_counts=collections.Counter({'a': 10, 'b': 20}))
+    b = sinter.AnonTaskStats(shots=50, errors=4, discards=3, seconds=2, custom_counts=collections.Counter({'a': 1, 'c': 3}))
+    assert a + b == sinter.AnonTaskStats(shots=270, errors=34, discards=43, seconds=52, custom_counts=collections.Counter({'a': 11, 'b': 20, 'c': 3}))
 
     assert a + sinter.AnonTaskStats() == a
     assert sinter.AnonTaskStats() + b == b
 
-    assert a + b0 == sinter.AnonTaskStats(shots=270, errors=34, discards=43, seconds=52, classified_errors=collections.Counter({'a': 10, 'b': 20, '': 4}))
-    assert a0 + b == sinter.AnonTaskStats(shots=270, errors=34, discards=43, seconds=52, classified_errors=collections.Counter({'a': 1, 'c': 3, '': 30}))
+    assert a + b0 == sinter.AnonTaskStats(shots=270, errors=34, discards=43, seconds=52, custom_counts=collections.Counter({'a': 10, 'b': 20}))
+    assert a0 + b == sinter.AnonTaskStats(shots=270, errors=34, discards=43, seconds=52, custom_counts=collections.Counter({'a': 1, 'c': 3}))

--- a/glue/sample/src/sinter/_collection.py
+++ b/glue/sample/src/sinter/_collection.py
@@ -49,7 +49,8 @@ def iter_collect(*,
                  max_batch_seconds: Optional[int] = None,
                  max_batch_size: Optional[int] = None,
                  start_batch_size: Optional[int] = None,
-                 split_errors: bool = False,
+                 count_observable_error_combos: bool = False,
+                 count_detection_events: bool = False,
                  custom_decoders: Optional[Dict[str, 'sinter.Decoder']] = None,
                  ) -> Iterator['sinter.Progress']:
     """Iterates error correction statistics collected from worker processes.
@@ -81,10 +82,16 @@ def iter_collect(*,
             after this many errors have been seen in samples taken from the
             circuit. The actual number sampled errors may be larger due to
             batching.
-        split_errors: Defaults to False. When set to to True, the returned
-            TaskStats instances will have a non-None `classified_errors` field
-            where keys are bitmasks identifying which observables flipped and
-            values are the number of errors where that happened.
+        count_observable_error_combos: Defaults to False. When set to to True,
+            the returned stats will have a custom counts field with keys
+            like `obs_mistake_mask=E_E__` counting how many times specific
+            combinations of observables were mispredicted by the decoder.
+        count_detection_events: Defaults to False. When set to True, the
+            returned stats will have a custom counts field withs the
+            key `detection_events` counting the number of times a detector fired
+            and also `detectors_checked` counting the number of detectors that
+            were executed. The detection fraction is the ratio of these two
+            numbers.
         start_batch_size: Defaults to None (collector's choice). The very
             first shots taken from the circuit will use a batch of this
             size, and no other batches will be taken in parallel. Once this
@@ -162,7 +169,8 @@ def iter_collect(*,
                 max_batch_size=max_batch_size,
             ),
             decoders=decoders,
-            split_errors=split_errors,
+            count_observable_error_combos=count_observable_error_combos,
+            count_detection_events=count_detection_events,
             additional_existing_data=additional_existing_data,
             custom_decoders=custom_decoders) as manager:
         try:
@@ -208,7 +216,8 @@ def collect(*,
             progress_callback: Optional[Callable[['sinter.Progress'], None]] = None,
             max_shots: Optional[int] = None,
             max_errors: Optional[int] = None,
-            split_errors: bool = False,
+            count_observable_error_combos: bool = False,
+            count_detection_events: bool = False,
             decoders: Optional[Iterable[str]] = None,
             max_batch_seconds: Optional[int] = None,
             max_batch_size: Optional[int] = None,
@@ -235,7 +244,7 @@ def collect(*,
             max_shots and max_errors.
         progress_callback: Defaults to None (unused). If specified, then each
             time new sample statistics are acquired from a worker this method
-            will be invoked with the new sinter.SamplerStats.
+            will be invoked with the new `sinter.TaskStats`.
         hint_num_tasks: If `tasks` is an iterator or a generator, its length
             can be given here so that progress printouts can say how many cases
             are left.
@@ -243,10 +252,16 @@ def collect(*,
             decoders to use on each Task. It must either be the case that each
             Task specifies a decoder and this is set to None, or this is an
             iterable and each Task has its decoder set to None.
-        split_errors: Defaults to False. When set to to True, the returned
-            TaskStats instances will have a non-None `classified_errors` field
-            where keys are bitmasks identifying which observables flipped and
-            values are the number of errors where that happened.
+        count_observable_error_combos: Defaults to False. When set to to True,
+            the returned stats will have a custom counts field with keys
+            like `obs_mistake_mask=E_E__` counting how many times specific
+            combinations of observables were mispredicted by the decoder.
+        count_detection_events: Defaults to False. When set to True, the
+            returned stats will have a custom counts field withs the
+            key `detection_events` counting the number of times a detector fired
+            and also `detectors_checked` counting the number of detectors that
+            were executed. The detection fraction is the ratio of these two
+            numbers.
         max_shots: Defaults to None (unused). Stops the sampling process
             after this many samples have been taken from the circuit.
         max_errors: Defaults to None (unused). Stops the sampling process
@@ -352,7 +367,8 @@ def collect(*,
             max_batch_seconds=max_batch_seconds,
             start_batch_size=start_batch_size,
             max_batch_size=max_batch_size,
-            split_errors=split_errors,
+            count_observable_error_combos=count_observable_error_combos,
+            count_detection_events=count_detection_events,
             decoders=decoders,
             tasks=tasks,
             hint_num_tasks=hint_num_tasks,

--- a/glue/sample/src/sinter/_collection_tracker_for_single_task.py
+++ b/glue/sample/src/sinter/_collection_tracker_for_single_task.py
@@ -19,12 +19,14 @@ class CollectionTrackerForSingleTask:
             self,
             *,
             task: Task,
-            split_errors: bool,
+            count_observable_error_combos: bool,
+            count_detection_events: bool,
             circuit_path: str,
             dem_path: str,
             existing_data: ExistingData):
         self.unfilled_task = task
-        self.split_errors = split_errors
+        self.count_observable_error_combos = count_observable_error_combos
+        self.count_detection_events = count_detection_events
         self.task_strong_id = None
         self.circuit_path = circuit_path
         self.dem_path = dem_path
@@ -162,7 +164,8 @@ class CollectionTrackerForSingleTask:
                 json_metadata=self.unfilled_task.json_metadata,
                 strong_id=None,
                 num_shots=-1,
-                split_errors=self.split_errors,
+                count_observable_error_combos=self.count_observable_error_combos,
+                count_detection_events=self.count_detection_events,
             )
 
         # Wait to have *some* data before starting to sample in parallel.
@@ -182,7 +185,8 @@ class CollectionTrackerForSingleTask:
             postselected_observables_mask=self.unfilled_task.postselected_observables_mask,
             json_metadata=self.unfilled_task.json_metadata,
             num_shots=num_shots,
-            split_errors=self.split_errors,
+            count_observable_error_combos=self.count_observable_error_combos,
+            count_detection_events=self.count_detection_events,
         )
 
     def status(self) -> str:

--- a/glue/sample/src/sinter/_collection_work_manager.py
+++ b/glue/sample/src/sinter/_collection_work_manager.py
@@ -21,7 +21,8 @@ class CollectionWorkManager:
                  tasks_iter: Iterator[Task],
                  global_collection_options: CollectionOptions,
                  additional_existing_data: Optional[ExistingData],
-                 split_errors: bool,
+                 count_observable_error_combos: bool,
+                 count_detection_events: bool,
                  decoders: Optional[Iterable[str]],
                  custom_decoders: Dict[str, Decoder]):
         self.custom_decoders = custom_decoders
@@ -41,7 +42,8 @@ class CollectionWorkManager:
         self.finished_count = 0
         self.deployed_jobs: Dict[int, WorkIn] = {}
         self.next_job_id = 0
-        self.split_errors = split_errors
+        self.count_observable_error_combos = count_observable_error_combos
+        self.count_detection_events = count_detection_events
 
         self.tasks_with_decoder_iter: Iterator[Task] = _iter_tasks_with_assigned_decoders(
             tasks_iter=tasks_iter,
@@ -139,7 +141,7 @@ class CollectionWorkManager:
                 json_metadata=work_in.json_metadata,
                 shots=stats.shots,
                 errors=stats.errors,
-                classified_errors=stats.classified_errors,
+                custom_counts=stats.custom_counts,
                 discards=stats.discards,
                 seconds=stats.seconds,
             )
@@ -158,7 +160,8 @@ class CollectionWorkManager:
                 circuit_path=str((self.tmp_dir / f'circuit_{self.next_collector_key}.stim').absolute()),
                 dem_path=str((self.tmp_dir / f'dem_{self.next_collector_key}.dem').absolute()),
                 existing_data=self.additional_existing_data,
-                split_errors=self.split_errors,
+                count_detection_events=self.count_detection_events,
+                count_observable_error_combos=self.count_observable_error_combos,
             )
             if collector.is_done():
                 self.finished_count += 1

--- a/glue/sample/src/sinter/_csv_out.py
+++ b/glue/sample/src/sinter/_csv_out.py
@@ -24,6 +24,7 @@ def csv_line(*,
              decoder: Any,
              strong_id: Any,
              json_metadata: JSON_TYPE,
+             custom_counts: JSON_TYPE,
              is_header: bool = False) -> str:
     if isinstance(seconds, float):
         if seconds < 1:
@@ -36,6 +37,14 @@ def csv_line(*,
         json_metadata = json.dumps(json_metadata,
                                    separators=(',', ':'),
                                    sort_keys=True)
+        if custom_counts:
+            custom_counts = escape_csv(
+                json.dumps(custom_counts,
+                           separators=(',', ':'),
+                           sort_keys=True), None)
+        else:
+            custom_counts = ''
+
 
     shots = escape_csv(shots, 10)
     if isinstance(errors, (dict, collections.Counter)):
@@ -52,7 +61,8 @@ def csv_line(*,
             f'{seconds},'
             f'{decoder},'
             f'{strong_id},'
-            f'{json_metadata}')
+            f'{json_metadata},'
+            f'{custom_counts}')
 
 
 CSV_HEADER = csv_line(shots='shots',
@@ -62,4 +72,5 @@ CSV_HEADER = csv_line(shots='shots',
                       strong_id='strong_id',
                       decoder='decoder',
                       json_metadata='json_metadata',
+                      custom_counts='custom_counts',
                       is_header=True)

--- a/glue/sample/src/sinter/_decoding.py
+++ b/glue/sample/src/sinter/_decoding.py
@@ -81,18 +81,34 @@ def _streaming_count_mistakes(
         *,
         num_shots: int,
         num_obs: int,
+        num_det: int,
         postselected_observable_mask: Optional[np.ndarray] = None,
+        dets_in: pathlib.Path,
         obs_in: pathlib.Path,
         predictions_in: pathlib.Path,
-        out_obs_to_num_errors: Optional[collections.Counter],
-) -> Tuple[int, int]:
+        count_detection_events: bool,
+        count_observable_error_combos: bool,
+) -> Tuple[int, int, collections.Counter]:
 
+    num_det_bytes = math.ceil(num_det / 8)
     num_obs_bytes = math.ceil(num_obs / 8)
-    num_shots_left = num_shots
     num_errors = 0
     num_discards = 0
+    custom_counts = collections.Counter()
+    if count_detection_events:
+        with open(dets_in, 'rb') as dets_in_f:
+            num_shots_left = num_shots
+            while num_shots_left:
+                batch_size = min(num_shots_left, math.ceil(10**6 / max(num_obs, 1)))
+                det_data = np.fromfile(dets_in_f, dtype=np.uint8, count=num_det_bytes * batch_size)
+                for b in range(8):
+                    custom_counts['detection_events'] += np.count_nonzero(det_data & (1 << b))
+                num_shots_left -= batch_size
+        custom_counts['detectors_checked'] += num_shots * num_det
+
     with open(obs_in, 'rb') as obs_in_f:
         with open(predictions_in, 'rb') as predictions_in_f:
+            num_shots_left = num_shots
             while num_shots_left:
                 batch_size = min(num_shots_left, math.ceil(10**6 / max(num_obs, 1)))
 
@@ -108,14 +124,14 @@ def _streaming_count_mistakes(
                     err_mask &= ~discard_mask
                     num_discards += np.count_nonzero(discard_mask)
 
-                if out_obs_to_num_errors is not None:
+                if count_observable_error_combos:
                     for misprediction_arr in cmp_table[err_mask]:
-                        err_key = ''.join('_E'[b] for b in np.unpackbits(misprediction_arr, count=num_obs, bitorder='little'))
-                        out_obs_to_num_errors[err_key] += 1
+                        err_key = "obs_mistake_mask=" + ''.join('_E'[b] for b in np.unpackbits(misprediction_arr, count=num_obs, bitorder='little'))
+                        custom_counts[err_key] += 1
 
                 num_errors += np.count_nonzero(err_mask)
                 num_shots_left -= batch_size
-    return num_discards, num_errors
+    return num_discards, num_errors, custom_counts
 
 
 def sample_decode(*,
@@ -125,7 +141,8 @@ def sample_decode(*,
                   dem_path: Union[None, str, pathlib.Path],
                   post_mask: Optional[np.ndarray] = None,
                   postselected_observable_mask: Optional[np.ndarray] = None,
-                  split_errors: bool = False,
+                  count_observable_error_combos: bool = False,
+                  count_detection_events: bool = False,
                   num_shots: int,
                   decoder: str,
                   tmp_dir: Union[str, pathlib.Path, None] = None,
@@ -149,10 +166,16 @@ def sample_decode(*,
         postselected_observable_mask: Bit packed mask indicating which observables to
             postselect on. If the decoder incorrectly predicts any of these observables, the
             shot is discarded instead of counted as an error.
-        split_errors: Defaults to False. When set to to True, the returned
-            AnonTaskStats will have a non-None `classified_errors` field where
-            keys are an integer with the k'th bit set to 1 if the k'th
-            observable was mispredicted.
+        count_observable_error_combos: Defaults to False. When set to to True,
+            the returned AnonTaskStats will have a custom counts field with keys
+            like `obs_mistake_mask=E_E__` counting how many times specific
+            combinations of observables were mispredicted by the decoder.
+        count_detection_events: Defaults to False. When set to True, the
+            returned AnonTaskStats will have a custom counts field withs the
+            key `detection_events` counting the number of times a detector fired
+            and also `detectors_checked` counting the number of detectors that
+            were executed. The detection fraction is the ratio of these two
+            numbers.
         num_shots: The number of sample shots to take from the circuit.
         decoder: The name of the decoder to use. Allowed values are:
             "pymatching":
@@ -206,10 +229,12 @@ def sample_decode(*,
             postselected_observable_mask=postselected_observable_mask,
             compiled_decoder=compiled_decoder,
             total_num_shots=num_shots,
+            num_det=circuit.num_detectors,
             mini_batch_size=1024,
             start_time_monotonic=start_time,
-            split_errors=split_errors,
             num_obs=circuit.num_observables,
+            count_observable_error_combos=count_observable_error_combos,
+            count_detection_events=count_detection_events,
         )
     except NotImplementedError:
         assert __private__unstable__force_decode_on_disk or __private__unstable__force_decode_on_disk is None
@@ -223,7 +248,8 @@ def sample_decode(*,
             decoder_obj=decoder_obj,
             tmp_dir=tmp_dir,
             start_time_monotonic=start_time,
-            split_errors=split_errors,
+            count_observable_error_combos=count_observable_error_combos,
+            count_detection_events=count_detection_events,
         )
 
 
@@ -233,18 +259,20 @@ def _sample_decode_helper_using_memory(
     post_mask: Optional[np.ndarray],
     postselected_observable_mask: Optional[np.ndarray],
     num_obs: int,
+    num_det: int,
     total_num_shots: int,
     mini_batch_size: int,
     compiled_decoder: CompiledDecoder,
     start_time_monotonic: float,
-    split_errors: bool,
+    count_observable_error_combos: bool,
+    count_detection_events: bool,
 ) -> AnonTaskStats:
     sampler: stim.CompiledDetectorSampler = circuit.compile_detector_sampler()
 
     out_num_discards = 0
     out_num_errors = 0
     shots_left = total_num_shots
-    out_obs_to_num_errors = collections.Counter() if split_errors else None
+    custom_counts = collections.Counter()
     while shots_left > 0:
         cur_num_shots = min(shots_left, mini_batch_size)
         dets_data, obs_data = sampler.sample(shots=cur_num_shots, separate_observables=True, bit_packed=True)
@@ -273,19 +301,24 @@ def _sample_decode_helper_using_memory(
         # Count how many mistakes the decoder made on non-discarded shots.
         mispredictions = obs_data ^ predict_data
         err_mask = np.any(mispredictions, axis=1)
-        if split_errors:
+        if count_detection_events:
+            for b in range(8):
+                custom_counts['detection_events'] += np.count_nonzero(dets_data & (1 << b))
+        if count_observable_error_combos:
             for misprediction_arr in mispredictions[err_mask]:
-                err_key = ''.join('_E'[b] for b in np.unpackbits(misprediction_arr, count=num_obs, bitorder='little'))
-                out_obs_to_num_errors[err_key] += 1
+                err_key = "obs_mistake_mask=" + ''.join('_E'[b] for b in np.unpackbits(misprediction_arr, count=num_obs, bitorder='little'))
+                custom_counts[err_key] += 1
         out_num_errors += np.count_nonzero(err_mask)
         shots_left -= cur_num_shots
 
+    if count_detection_events:
+        custom_counts['detectors_checked'] += num_det * total_num_shots
     return AnonTaskStats(
         shots=total_num_shots,
         errors=out_num_errors,
         discards=out_num_discards,
         seconds=time.monotonic() - start_time_monotonic,
-        classified_errors=out_obs_to_num_errors,
+        custom_counts=custom_counts,
     )
 
 
@@ -300,7 +333,8 @@ def _sample_decode_helper_using_disk(
     decoder_obj: Decoder,
     tmp_dir: Union[str, pathlib.Path, None],
     start_time_monotonic: float,
-    split_errors: bool,
+    count_observable_error_combos: bool,
+    count_detection_events: bool,
 ) -> AnonTaskStats:
     with contextlib.ExitStack() as exit_stack:
         if tmp_dir is None:
@@ -363,14 +397,16 @@ def _sample_decode_helper_using_disk(
         )
 
         # Count how many predictions matched the actual observable data.
-        out_obs_to_num_errors = collections.Counter() if split_errors else None
-        num_obs_discards, num_errors = _streaming_count_mistakes(
+        num_obs_discards, num_errors, custom_counts = _streaming_count_mistakes(
             num_shots=num_kept_shots,
             num_obs=num_obs,
+            num_det=num_dets,
+            dets_in=dets_all_path,
             obs_in=obs_used_path,
             predictions_in=predictions_path,
             postselected_observable_mask=postselected_observable_mask,
-            out_obs_to_num_errors=out_obs_to_num_errors,
+            count_detection_events=count_detection_events,
+            count_observable_error_combos=count_observable_error_combos,
         )
 
         return AnonTaskStats(
@@ -378,5 +414,5 @@ def _sample_decode_helper_using_disk(
             errors=num_errors,
             discards=num_obs_discards + num_det_discards,
             seconds=time.monotonic() - start_time_monotonic,
-            classified_errors=out_obs_to_num_errors,
+            custom_counts=custom_counts,
         )

--- a/glue/sample/src/sinter/_existing_data.py
+++ b/glue/sample/src/sinter/_existing_data.py
@@ -55,27 +55,30 @@ class ExistingData:
         reader = csv.DictReader(path_or_file)
         reader.fieldnames = [e.strip() for e in reader.fieldnames]
         actual_fields = set(reader.fieldnames)
-        if actual_fields != expected_fields:
+        if not (expected_fields <= actual_fields):
             raise ValueError(
                 f"Bad CSV data. "
                 f"Got columns {sorted(actual_fields)!r} "
                 f"but expected columns {sorted(expected_fields)!r}")
+        has_custom_counts = 'custom_counts' in actual_fields
         result = ExistingData()
         for row in reader:
-            errs = json.loads(row['errors'])
-            if isinstance(errs, int):
-                num_errors = errs
-                classified_errors = None
-            elif isinstance(errs, dict):
-                num_errors = sum(errs.values())
-                classified_errors = collections.Counter(errs)
+            if has_custom_counts:
+                custom_counts = row['custom_counts']
+                if custom_counts is None or custom_counts == '':
+                    custom_counts = collections.Counter()
+                else:
+                    custom_counts = json.loads(custom_counts)
+                    if not isinstance(custom_counts, dict) or not all(isinstance(k, str) or not isinstance(v, int) for k, v in custom_counts.items()):
+                        raise ValueError(f"{row['custom_counts']=} isn't empty or a dictionary from string keys to integer values.")
+                    custom_counts = collections.Counter(custom_counts)
             else:
-                raise NotImplementedError(f"{row['errors']=}")
+                custom_counts = collections.Counter()
             result.add_sample(TaskStats(
                 shots=int(row['shots']),
                 discards=int(row['discards']),
-                errors=num_errors,
-                classified_errors=classified_errors,
+                errors=int(row['errors']),
+                custom_counts=custom_counts,
                 seconds=float(row['seconds']),
                 strong_id=row['strong_id'],
                 decoder=row['decoder'],

--- a/glue/sample/src/sinter/_existing_data.py
+++ b/glue/sample/src/sinter/_existing_data.py
@@ -122,8 +122,8 @@ def stats_from_csv_files(*paths_or_files: Any) -> List['sinter.TaskStats']:
         >>> stats = sinter.stats_from_csv_files(in_memory_file)
         >>> for stat in stats:
         ...     print(repr(stat))
-        sinter.TaskStats(strong_id='9c31908e2b', decoder='pymatching', json_metadata={'d': 9}, shots=4000, errors=66, discards=0, seconds=0.25)
-        sinter.TaskStats(strong_id='deadbeef08', decoder='pymatching', json_metadata={'d': 7}, shots=1000, errors=250, discards=0, seconds=0.125)
+        sinter.TaskStats(strong_id='9c31908e2b', decoder='pymatching', json_metadata={'d': 9}, shots=4000, errors=66, seconds=0.25)
+        sinter.TaskStats(strong_id='deadbeef08', decoder='pymatching', json_metadata={'d': 7}, shots=1000, errors=250, seconds=0.125)
     """
     result = ExistingData()
     for p in paths_or_files:
@@ -163,8 +163,8 @@ def read_stats_from_csv_files(*paths_or_files: Any) -> List['sinter.TaskStats']:
         >>> stats = sinter.read_stats_from_csv_files(in_memory_file)
         >>> for stat in stats:
         ...     print(repr(stat))
-        sinter.TaskStats(strong_id='9c31908e2b', decoder='pymatching', json_metadata={'d': 9}, shots=4000, errors=66, discards=0, seconds=0.25)
-        sinter.TaskStats(strong_id='deadbeef08', decoder='pymatching', json_metadata={'d': 7}, shots=1000, errors=250, discards=0, seconds=0.125)
+        sinter.TaskStats(strong_id='9c31908e2b', decoder='pymatching', json_metadata={'d': 9}, shots=4000, errors=66, seconds=0.25)
+        sinter.TaskStats(strong_id='deadbeef08', decoder='pymatching', json_metadata={'d': 7}, shots=1000, errors=250, seconds=0.125)
     """
     result = ExistingData()
     for p in paths_or_files:

--- a/glue/sample/src/sinter/_existing_data_test.py
+++ b/glue/sample/src/sinter/_existing_data_test.py
@@ -1,0 +1,41 @@
+import collections
+import pathlib
+import tempfile
+
+import sinter
+
+
+def test_read_stats_from_csv_files():
+    with tempfile.TemporaryDirectory() as d:
+        d = pathlib.Path(d)
+
+        with open(d / 'tmp.csv', 'w') as f:
+            print("""
+shots,errors,discards,seconds,decoder,strong_id,json_metadata
+  300,     1,      20,    1.0,pymatching,abc123,"{""d"":3}"
+ 1000,     3,      40,    3.0,pymatching,abc123,"{""d"":3}"
+ 2000,     0,      10,    2.0,pymatching,def456,"{""d"":5}"
+    """.strip(), file=f)
+
+        assert sinter.read_stats_from_csv_files(d / 'tmp.csv') == [
+            sinter.TaskStats(strong_id='abc123', decoder='pymatching', json_metadata={'d': 3}, shots=1300, errors=4, discards=60, seconds=4.0),
+            sinter.TaskStats(strong_id='def456', decoder='pymatching', json_metadata={'d': 5}, shots=2000, errors=0, discards=10, seconds=2.0),
+        ]
+
+        with open(d / 'tmp2.csv', 'w') as f:
+            print("""
+shots,errors,discards,seconds,decoder,strong_id,json_metadata,custom_counts
+  300,     1,      20,    1.0,pymatching,abc123,"{""d"":3}","{""dets"":1234}"
+ 1000,     3,      40,    3.0,pymatching,abc123,"{""d"":3}",
+ 2000,     0,      10,    2.0,pymatching,def456,"{""d"":5}"
+    """.strip(), file=f)
+
+        assert sinter.read_stats_from_csv_files(d / 'tmp2.csv') == [
+            sinter.TaskStats(strong_id='abc123', decoder='pymatching', json_metadata={'d': 3}, shots=1300, errors=4, discards=60, seconds=4.0, custom_counts=collections.Counter({'dets': 1234})),
+            sinter.TaskStats(strong_id='def456', decoder='pymatching', json_metadata={'d': 5}, shots=2000, errors=0, discards=10, seconds=2.0),
+        ]
+
+        assert sinter.read_stats_from_csv_files(d / 'tmp.csv', d / 'tmp2.csv') == [
+            sinter.TaskStats(strong_id='abc123', decoder='pymatching', json_metadata={'d': 3}, shots=2600, errors=8, discards=120, seconds=8.0, custom_counts=collections.Counter({'dets': 1234})),
+            sinter.TaskStats(strong_id='def456', decoder='pymatching', json_metadata={'d': 5}, shots=4000, errors=0, discards=20, seconds=4.0),
+        ]

--- a/glue/sample/src/sinter/_main_collect.py
+++ b/glue/sample/src/sinter/_main_collect.py
@@ -141,8 +141,17 @@ def parse_args(args: List[str]) -> Any:
                              'Examples:\n'
                              '''    --postselected_observables_predicate "False"\n'''
                              '''    --postselected_observables_predicate "metadata['d'] == 5 and index >= 2"\n''')
-    parser.add_argument('--split_errors',
-                        help='Causes errors to be grouped by the observable mispredictions that caused the error.',
+    parser.add_argument('--count_observable_error_combos',
+                        help='When set, the returned stats will include custom '
+                             'counts like `obs_mistake_mask=E_E__` counting '
+                             'how many times the decoder made each pattern of '
+                             'observable mistakes.',
+                        action='store_true')
+    parser.add_argument('--count_detection_events',
+                        help='When set, the returned stats will include custom '
+                             'counts `detectors_checked` and '
+                             '`detection_events`. The detection fraction is '
+                             'the ratio of these two numbers.',
                         action='store_true')
     parser.add_argument('--quiet',
                         help='Disables writing progress to stderr.',
@@ -281,7 +290,8 @@ def main_collect(*, command_line_args: List[str]):
             progress_callback=on_progress,
             max_errors=args.max_errors,
             max_shots=args.max_shots,
-            split_errors=args.split_errors,
+            count_detection_events=args.count_detection_events,
+            count_observable_error_combos=args.count_observable_error_combos,
             decoders=args.decoders,
             max_batch_seconds=args.max_batch_seconds,
             max_batch_size=args.max_batch_size,

--- a/glue/sample/src/sinter/_main_collect_test.py
+++ b/glue/sample/src/sinter/_main_collect_test.py
@@ -257,7 +257,7 @@ def test_main_collect_comma_separated_key_values():
         ])
 
 
-def test_main_collect_split_observables():
+def test_main_collect_count_observable_error_combos():
     with tempfile.TemporaryDirectory() as d:
         d = pathlib.Path(d)
         with open(d / 'a=3.stim', 'w') as f:
@@ -282,7 +282,7 @@ def test_main_collect_split_observables():
             "10000",
             "--decoders",
             "pymatching",
-            "--split_errors",
+            "--count_observable_error_combos",
             "--processes",
             "4",
             "--quiet",
@@ -292,9 +292,46 @@ def test_main_collect_split_observables():
         data = sinter.stats_from_csv_files(d / "out.csv")
         assert len(data) == 1
         item, = data
-        assert isinstance(item.classified_errors, collections.Counter)
-        assert set(item.classified_errors.keys()) == {"E_", "_E", "EE"}
-        assert 0.1*0.8 - 0.01 < item.classified_errors['_E'] / item.shots < 0.1*0.8 + 0.01
-        assert 0.9*0.2 - 0.01 < item.classified_errors['E_'] / item.shots < 0.9*0.2 + 0.01
-        assert 0.1*0.2 - 0.01 < item.classified_errors['EE'] / item.shots < 0.1*0.2 + 0.01
+        assert set(item.custom_counts.keys()) == {"obs_mistake_mask=E_", "obs_mistake_mask=_E", "obs_mistake_mask=EE"}
+        assert 0.1*0.8 - 0.01 < item.custom_counts['obs_mistake_mask=_E'] / item.shots < 0.1*0.8 + 0.01
+        assert 0.9*0.2 - 0.01 < item.custom_counts['obs_mistake_mask=E_'] / item.shots < 0.9*0.2 + 0.01
+        assert 0.1*0.2 - 0.01 < item.custom_counts['obs_mistake_mask=EE'] / item.shots < 0.1*0.2 + 0.01
 
+
+def test_main_collect_count_detection_events():
+    with tempfile.TemporaryDirectory() as d:
+        d = pathlib.Path(d)
+        with open(d / 'a=3.stim', 'w') as f:
+            print("""
+                X_ERROR(0.1) 0
+                X_ERROR(0.2) 1
+                M 0 1
+                OBSERVABLE_INCLUDE(0) rec[-1]
+                OBSERVABLE_INCLUDE(1) rec[-2]
+                DETECTOR rec[-2]
+            """, file=f)
+
+        # Collects requested stats.
+        main(command_line_args=[
+            "collect",
+            "--circuits",
+            str(d / 'a=3.stim'),
+            "--max_shots",
+            "100000",
+            "--metadata_func",
+            "sinter.comma_separated_key_values(path)",
+            "--decoders",
+            "pymatching",
+            "--count_detection_events",
+            "--processes",
+            "4",
+            "--quiet",
+            "--save_resume_filepath",
+            str(d / "out.csv"),
+        ])
+        data = sinter.stats_from_csv_files(d / "out.csv")
+        assert len(data) == 1
+        item, = data
+        assert set(item.custom_counts.keys()) == {"detection_events", "detectors_checked"}
+        assert item.custom_counts['detectors_checked'] == 100000
+        assert 100000 * 0.1 * 0.5 < item.custom_counts['detection_events'] < 100000 * 0.1 * 1.5

--- a/glue/sample/src/sinter/_main_combine_test.py
+++ b/glue/sample/src/sinter/_main_combine_test.py
@@ -23,9 +23,9 @@ shots,errors,discards,seconds,decoder,strong_id,json_metadata
                 "combine",
                 str(d / "input.csv"),
             ])
-        assert out.getvalue() == """     shots,    errors,  discards, seconds,decoder,strong_id,json_metadata
-       600,       101,       220,    3.00,pymatching,f256bab362f516ebe4d59a08ae67330ff7771ff738757cd738f4b30605ddccf6,"{""path"":""a.stim""}"
-         9,         5,         4,    6.00,pymatching,5fe5a6cd4226b1a910d57e5479d1ba6572e0b3115983c9516360916d1670000f,"{""path"":""b.stim""}"
+        assert out.getvalue() == """     shots,    errors,  discards, seconds,decoder,strong_id,json_metadata,custom_counts
+       600,       101,       220,    3.00,pymatching,f256bab362f516ebe4d59a08ae67330ff7771ff738757cd738f4b30605ddccf6,"{""path"":""a.stim""}",
+         9,         5,         4,    6.00,pymatching,5fe5a6cd4226b1a910d57e5479d1ba6572e0b3115983c9516360916d1670000f,"{""path"":""b.stim""}",
 """
 
         out = io.StringIO()
@@ -35,9 +35,36 @@ shots,errors,discards,seconds,decoder,strong_id,json_metadata
                 str(d / "input.csv"),
                 str(d / "input.csv"),
             ])
-        assert out.getvalue() == """     shots,    errors,  discards, seconds,decoder,strong_id,json_metadata
-      1200,       202,       440,    6.00,pymatching,f256bab362f516ebe4d59a08ae67330ff7771ff738757cd738f4b30605ddccf6,"{""path"":""a.stim""}"
-        18,        10,         8,    12.0,pymatching,5fe5a6cd4226b1a910d57e5479d1ba6572e0b3115983c9516360916d1670000f,"{""path"":""b.stim""}"
+        assert out.getvalue() == """     shots,    errors,  discards, seconds,decoder,strong_id,json_metadata,custom_counts
+      1200,       202,       440,    6.00,pymatching,f256bab362f516ebe4d59a08ae67330ff7771ff738757cd738f4b30605ddccf6,"{""path"":""a.stim""}",
+        18,        10,         8,    12.0,pymatching,5fe5a6cd4226b1a910d57e5479d1ba6572e0b3115983c9516360916d1670000f,"{""path"":""b.stim""}",
+"""
+
+
+def test_main_combine_legacy_custom_counts():
+    with tempfile.TemporaryDirectory() as d:
+        d = pathlib.Path(d)
+        with open(d / f'old.csv', 'w') as f:
+            print("""
+shots,errors,discards,seconds,decoder,strong_id,json_metadata
+100,1,20,1.0,pymatching,abc123,"{""path"":""a.stim""}"
+            """.strip(), file=f)
+        with open(d / f'new.csv', 'w') as f:
+            print("""
+shots,errors,discards,seconds,decoder,strong_id,json_metadata,custom_counts
+300,1,20,1.0,pymatching,abc123,"{""path"":""a.stim""}","{""x"":2}"
+300,1,20,1.0,pymatching,abc123,"{""path"":""a.stim""}","{""y"":3}"
+            """.strip(), file=f)
+
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            main(command_line_args=[
+                "combine",
+                str(d / "old.csv"),
+                str(d / "new.csv"),
+            ])
+        assert out.getvalue() == """     shots,    errors,  discards, seconds,decoder,strong_id,json_metadata,custom_counts
+       700,         3,        60,    3.00,pymatching,abc123,"{""path"":""a.stim""}","{""x"":2,""y"":3}"
 """
 
 
@@ -63,12 +90,12 @@ shots,errors,discards,seconds,decoder,   strong_id,json_metadata
                 str(d / "input.csv"),
                 str(d / "input.csv"),
             ])
-        assert out.getvalue() == """     shots,    errors,  discards, seconds,decoder,strong_id,json_metadata
-      2000,       200,         8,    4.00,pymatching,deadbeef0,"{""d"":19}"
-      4000,       600,         6,    6.00,pymatching,deadbeef1,"{""d"":9}"
-      6000,       400,      4000,    10.0,pymatching,deadbeef2,"{""d"":200}"
-      8000,       200,         2,    14.0,pymatching,deadbeef3,"{""d"":3}"
-     10000,       200,         0,    22.0,pymatching,deadbeef4,"{""d"":5}"
+        assert out.getvalue() == """     shots,    errors,  discards, seconds,decoder,strong_id,json_metadata,custom_counts
+      2000,       200,         8,    4.00,pymatching,deadbeef0,"{""d"":19}",
+      4000,       600,         6,    6.00,pymatching,deadbeef1,"{""d"":9}",
+      6000,       400,      4000,    10.0,pymatching,deadbeef2,"{""d"":200}",
+      8000,       200,         2,    14.0,pymatching,deadbeef3,"{""d"":3}",
+     10000,       200,         0,    22.0,pymatching,deadbeef4,"{""d"":5}",
 """
 
         out = io.StringIO()
@@ -80,12 +107,12 @@ shots,errors,discards,seconds,decoder,   strong_id,json_metadata
                 str(d / "input.csv"),
                 str(d / "input.csv"),
             ])
-        assert out.getvalue() == """     shots,    errors,  discards, seconds,decoder,strong_id,json_metadata
-      8000,       200,         2,    14.0,pymatching,deadbeef3,"{""d"":3}"
-     10000,       200,         0,    22.0,pymatching,deadbeef4,"{""d"":5}"
-      4000,       600,         6,    6.00,pymatching,deadbeef1,"{""d"":9}"
-      2000,       200,         8,    4.00,pymatching,deadbeef0,"{""d"":19}"
-      6000,       400,      4000,    10.0,pymatching,deadbeef2,"{""d"":200}"
+        assert out.getvalue() == """     shots,    errors,  discards, seconds,decoder,strong_id,json_metadata,custom_counts
+      8000,       200,         2,    14.0,pymatching,deadbeef3,"{""d"":3}",
+     10000,       200,         0,    22.0,pymatching,deadbeef4,"{""d"":5}",
+      4000,       600,         6,    6.00,pymatching,deadbeef1,"{""d"":9}",
+      2000,       200,         8,    4.00,pymatching,deadbeef0,"{""d"":19}",
+      6000,       400,      4000,    10.0,pymatching,deadbeef2,"{""d"":200}",
 """
 
         out = io.StringIO()
@@ -97,10 +124,10 @@ shots,errors,discards,seconds,decoder,   strong_id,json_metadata
                 str(d / "input.csv"),
                 str(d / "input.csv"),
             ])
-        assert out.getvalue() == """     shots,    errors,  discards, seconds,decoder,strong_id,json_metadata
-     10000,       200,         0,    22.0,pymatching,deadbeef4,"{""d"":5}"
-      8000,       200,         2,    14.0,pymatching,deadbeef3,"{""d"":3}"
-      2000,       200,         8,    4.00,pymatching,deadbeef0,"{""d"":19}"
-      4000,       600,         6,    6.00,pymatching,deadbeef1,"{""d"":9}"
-      6000,       400,      4000,    10.0,pymatching,deadbeef2,"{""d"":200}"
+        assert out.getvalue() == """     shots,    errors,  discards, seconds,decoder,strong_id,json_metadata,custom_counts
+     10000,       200,         0,    22.0,pymatching,deadbeef4,"{""d"":5}",
+      8000,       200,         2,    14.0,pymatching,deadbeef3,"{""d"":3}",
+      2000,       200,         8,    4.00,pymatching,deadbeef0,"{""d"":19}",
+      4000,       600,         6,    6.00,pymatching,deadbeef1,"{""d"":9}",
+      6000,       400,      4000,    10.0,pymatching,deadbeef2,"{""d"":200}",
 """

--- a/glue/sample/src/sinter/_main_plot.py
+++ b/glue/sample/src/sinter/_main_plot.py
@@ -1,4 +1,3 @@
-import collections
 import math
 from typing import Any, Callable, Iterable, List, Optional, TYPE_CHECKING, Tuple, Union, Dict, Sequence, cast
 import argparse
@@ -196,9 +195,9 @@ def parse_args(args: List[str]) -> Any:
                         help='Customize the Y axis label. '
                              'Prefix [log] for logarithmic scale. '
                              'Prefix [sqrt] for square root scale.')
-    parser.add_argument('--split_errors',
+    parser.add_argument('--split_custom_counts',
                         action='store_true',
-                        help='When a stat has classified errors, this causes each classification to be a separate statistic.\n')
+                        help='When a stat has custom counts, this splits it into multiple copies of the stat with each one having exactly one of the custom counts.\n')
     parser.add_argument('--show',
                         action='store_true',
                         help='Displays the plot in a window.\n'
@@ -649,11 +648,11 @@ def main_plot(*, command_line_args: List[str]):
     for file in getattr(args, 'in'):
         total += ExistingData.from_file(file)
 
-    if args.split_errors:
+    if args.split_custom_counts:
         total.data = {
             s.strong_id: s
             for v in total.data.values()
-            for s in v._split_errors()
+            for s in v._split_custom_counts()
         }
 
     fig, _ = _plot_helper(

--- a/glue/sample/src/sinter/_main_plot_test.py
+++ b/glue/sample/src/sinter/_main_plot_test.py
@@ -379,3 +379,34 @@ def test_m_fields():
             "test",
         ])
         assert (d / "output.png").exists()
+
+
+def test_split_custom_counts():
+    with tempfile.TemporaryDirectory() as d:
+        d = pathlib.Path(d)
+        with open(d / f'input.csv', 'w') as f:
+            print("""
+                shots,errors,discards,seconds,decoder,strong_id,json_metadata,custom_counts
+                 1000,   400,       0,   1.00,magical,000000001,"{""f"":1}",
+                 1000,   400,       0,   1.00,magical,000000002,"{""f"":2}","{""a"":3}"
+                 1000,   400,       0,   1.00,magical,000000003,"{""f"":3}","{""b"":3,""c"":4}"
+                 1000,   400,       0,   1.00,magical,000000005,"{""f"":5}",
+            """.strip(), file=f)
+
+        main(command_line_args=[
+            "plot",
+            "--in",
+            str(d / "input.csv"),
+            "--out",
+            str(d / "output.png"),
+            "--xaxis",
+            "values",
+            "--x_func",
+            "m.f",
+            "--group_func",
+            "m.g",
+            "--subtitle",
+            "test",
+            "--split_custom_counts",
+        ])
+        assert (d / "output.png").exists()

--- a/glue/sample/src/sinter/_task_stats.py
+++ b/glue/sample/src/sinter/_task_stats.py
@@ -123,13 +123,12 @@ class TaskStats:
             ...     decoder='pymatching',
             ...     shots=22,
             ...     errors=3,
-            ...     discards=4,
             ...     seconds=5,
             ... )
             >>> print(sinter.CSV_HEADER)
-                 shots,    errors,  discards, seconds,decoder,strong_id,json_metadata
+                 shots,    errors,  discards, seconds,decoder,strong_id,json_metadata,custom_counts
             >>> print(stat.to_csv_line())
-                    22,         3,         4,       5,pymatching,test,"{""a"":[1,2,3]}"
+                    22,         3,         0,       5,pymatching,test,"{""a"":[1,2,3]}",
         """
         return csv_line(
             shots=self.shots,
@@ -159,7 +158,7 @@ class TaskStats:
             ))
         return result
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.to_csv_line()
 
     def __repr__(self) -> str:

--- a/glue/sample/src/sinter/_task_stats_test.py
+++ b/glue/sample/src/sinter/_task_stats_test.py
@@ -28,7 +28,7 @@ def test_to_csv_line():
         discards=4,
         seconds=5,
     )
-    assert v.to_csv_line() == str(v) == '        22,         3,         4,       5,pymatching,test,"{""a"":[1,2,3]}"'
+    assert v.to_csv_line() == str(v) == '        22,         3,         4,       5,pymatching,test,"{""a"":[1,2,3]}",'
 
 
 def test_to_anon_stats():
@@ -53,7 +53,7 @@ def test_add():
         errors=30,
         discards=40,
         seconds=50,
-        classified_errors=collections.Counter({'a': 10, 'b': 20}),
+        custom_counts=collections.Counter({'a': 10, 'b': 20}),
     )
     b = sinter.TaskStats(
         decoder='pymatching',
@@ -63,7 +63,7 @@ def test_add():
         errors=4,
         discards=3,
         seconds=2,
-        classified_errors=collections.Counter({'a': 1, 'c': 3}),
+        custom_counts=collections.Counter({'a': 1, 'c': 3}),
     )
     c = sinter.TaskStats(
         decoder='pymatching',
@@ -73,7 +73,7 @@ def test_add():
         errors=34,
         discards=43,
         seconds=52,
-        classified_errors=collections.Counter({'a': 11, 'b': 20, 'c': 3}),
+        custom_counts=collections.Counter({'a': 11, 'b': 20, 'c': 3}),
     )
     assert a + b == c
     with pytest.raises(ValueError):
@@ -85,5 +85,5 @@ def test_add():
             errors=34,
             discards=43,
             seconds=52,
-            classified_errors=collections.Counter({'a': 11, 'b': 20, 'c': 3}),
+            custom_counts=collections.Counter({'a': 11, 'b': 20, 'c': 3}),
         )

--- a/glue/sample/src/sinter/_worker.py
+++ b/glue/sample/src/sinter/_worker.py
@@ -24,7 +24,8 @@ class WorkIn:
             postselection_mask: 'Optional[np.ndarray]',
             postselected_observables_mask: 'Optional[np.ndarray]',
             json_metadata: 'JSON_TYPE',
-            split_errors: bool,
+            count_observable_error_combos: bool,
+            count_detection_events: bool,
             num_shots: int):
         self.work_key = work_key
         self.circuit_path = circuit_path
@@ -34,7 +35,8 @@ class WorkIn:
         self.postselection_mask = postselection_mask
         self.postselected_observables_mask = postselected_observables_mask
         self.json_metadata = json_metadata
-        self.split_errors = split_errors
+        self.count_observable_error_combos = count_observable_error_combos
+        self.count_detection_events = count_detection_events
         self.num_shots = num_shots
 
     def with_work_key(self, work_key: Any) -> 'WorkIn':
@@ -48,7 +50,8 @@ class WorkIn:
             json_metadata=self.json_metadata,
             strong_id=self.strong_id,
             num_shots=self.num_shots,
-            split_errors=self.split_errors,
+            count_observable_error_combos=self.count_observable_error_combos,
+            count_detection_events=self.count_detection_events,
         )
 
 
@@ -150,7 +153,8 @@ def do_work(work: WorkIn, child_dir: str, custom_decoders: Dict[str, 'sinter.Dec
         post_mask=work.postselection_mask,
         postselected_observable_mask=work.postselected_observables_mask,
         decoder=work.decoder,
-        split_errors=work.split_errors,
+        count_observable_error_combos=work.count_observable_error_combos,
+        count_detection_events=work.count_detection_events,
         tmp_dir=child_dir,
         custom_decoders=custom_decoders,
     )

--- a/glue/sample/src/sinter/_worker_test.py
+++ b/glue/sample/src/sinter/_worker_test.py
@@ -30,7 +30,8 @@ def test_worker_loop_infers_dem():
             num_shots=-1,
             postselected_observables_mask=None,
             postselection_mask=None,
-            split_errors=False,
+            count_detection_events=False,
+            count_observable_error_combos=False,
         ))
         inp.put(None)
         worker_loop(tmp_dir, inp, out, None, 0)
@@ -70,7 +71,8 @@ def test_worker_loop_does_not_recompute_dem():
             num_shots=1000,
             postselected_observables_mask=None,
             postselection_mask=None,
-            split_errors=False,
+            count_detection_events=False,
+            count_observable_error_combos=False,
         ))
         inp.put(None)
         worker_loop(tmp_dir, inp, out, None, 0)


### PR DESCRIPTION
- Obsoletes the multi-value error column option; so drop it
- Replace `sinter collect --split_errors` option with `--count_observable_error_combos`
- Add `sinter collect --count_detection_events` option
- Replace `sinter plot --split_errors` option with `--count_observable_error_combos`

Fixes https://github.com/quantumlib/Stim/issues/406