### PR TITLE
Don't rely on types module to supply NoneType

### DIFF
--- a/glue/sample/src/sinter/_task_stats.py
+++ b/glue/sample/src/sinter/_task_stats.py
@@ -8,9 +8,6 @@ from sinter._anon_task_stats import AnonTaskStats
 from sinter._json_type import JSON_TYPE
 from sinter._csv_out import csv_line
 
-# Don't rely on types module for NoneType since it depends on python version.
-NoneType = type(None)
-
 
 @dataclasses.dataclass(frozen=True)
 class TaskStats:
@@ -66,7 +63,8 @@ class TaskStats:
         assert isinstance(self.custom_counts, collections.Counter)
         assert isinstance(self.decoder, str)
         assert isinstance(self.strong_id, str)
-        assert isinstance(self.json_metadata, (NoneType, int, float, str, dict, list, tuple))
+        # Don't rely on types module for NoneType since its presence depends on python version.
+        assert self.json_metadata is None or isinstance(self.json_metadata, (int, float, str, dict, list, tuple))
         assert self.errors >= 0
         assert self.discards >= 0
         assert self.seconds >= 0

--- a/glue/sample/src/sinter/_task_stats.py
+++ b/glue/sample/src/sinter/_task_stats.py
@@ -1,6 +1,5 @@
 import collections
 import dataclasses
-from types import NoneType
 from typing import Counter
 from typing import List
 from typing import Optional
@@ -64,7 +63,7 @@ class TaskStats:
         assert isinstance(self.custom_counts, collections.Counter)
         assert isinstance(self.decoder, str)
         assert isinstance(self.strong_id, str)
-        assert isinstance(self.json_metadata, (NoneType, int, float, str, dict, list, tuple))
+        assert isinstance(self.json_metadata, (type(None), int, float, str, dict, list, tuple))
         assert self.errors >= 0
         assert self.discards >= 0
         assert self.seconds >= 0

--- a/glue/sample/src/sinter/_task_stats.py
+++ b/glue/sample/src/sinter/_task_stats.py
@@ -8,6 +8,9 @@ from sinter._anon_task_stats import AnonTaskStats
 from sinter._json_type import JSON_TYPE
 from sinter._csv_out import csv_line
 
+# Don't rely on types module for NoneType since it depends on python version.
+NoneType = type(None)
+
 
 @dataclasses.dataclass(frozen=True)
 class TaskStats:
@@ -63,7 +66,7 @@ class TaskStats:
         assert isinstance(self.custom_counts, collections.Counter)
         assert isinstance(self.decoder, str)
         assert isinstance(self.strong_id, str)
-        assert isinstance(self.json_metadata, (type(None), int, float, str, dict, list, tuple))
+        assert isinstance(self.json_metadata, (NoneType, int, float, str, dict, list, tuple))
         assert self.errors >= 0
         assert self.discards >= 0
         assert self.seconds >= 0


### PR DESCRIPTION
[Old python](https://stackoverflow.com/questions/15844714/why-am-i-getting-an-error-message-in-python-cannot-import-name-nonetype) used to have `NoneType = type(None)` definition in the `types` module. In python 3 the module doesn't provide `NoneType` anymore until python 3.10 when it's back again...

```console
$ python3.8
Python 3.8.7 (default, Dec 22 2020, 10:37:26) 
[GCC 10.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from types import NoneType
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'NoneType' from 'types' (/usr/lib/python3.8/types.py)
>>> 
$ python3.10
Python 3.10.9 (main, Dec  7 2022, 13:47:07) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from types import NoneType
>>> 
```

Since the definition is so simple, we can make the code a little more robust by just saying `type(None)` in the one place it uses `NoneType`.