### PR TITLE
Refactor `sinter plot --split_custom_counts` into `--custom_error_count_keys`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@ googletest-download/*
 googletest-src
 cmake_install.cmake
 Makefile
-lib/*
-out/*
+lib
+out
 stim.cbp
 data/*
 _deps/*
@@ -19,16 +19,16 @@ bazel-*
 python_build_stim/*
 *.egg-*
 stim.cpython*
-**/dist/*
+dist
 MANIFEST
 *.whl
 *.swp
-**/__pycache__/**
+__pycache__
 pip-wheel-metadata/*
 wheelhouse/*
 *.pyd
-venv/*
-.venv/*
+venv
+.venv
 **/LastTest.log
 *.so
 .clwb/*
@@ -37,7 +37,9 @@ coverage/*
 cmake-build-debug-coverage/*
 # clangd generated files
 compile_commands.json
-.cache/*
+.cache
 build.ninja
 .ninja_deps
 .ninja_log
+.pytest_cache
+node_modules

--- a/BUILD
+++ b/BUILD
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@rules_python//python:packaging.bzl", "py_wheel")
-load("@pybind11_bazel//:build_defs.bzl", "pybind_extension")
 
 SOURCE_FILES_NO_MAIN = glob(
     [

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,27 +9,29 @@ http_archive(
 )
 
 http_archive(
-    name = "pybind11_bazel",
-    strip_prefix = "pybind11_bazel-faf56fb3df11287f26dbc66fdedf60a2fc2c6631",
-    urls = ["https://github.com/pybind/pybind11_bazel/archive/faf56fb3df11287f26dbc66fdedf60a2fc2c6631.zip"],
-    sha256 = "a185aa68c93b9f62c80fcb3aadc3c83c763854750dc3f38be1dadcb7be223837",
+    name = "pybind11",
+    build_file = "@pybind11_bazel//:pybind11.BUILD",
+    sha256 = "832e2f309c57da9c1e6d4542dedd34b24e4192ecb4d62f6f4866a737454c9970",
+    strip_prefix = "pybind11-2.10.4",
+    urls = ["https://github.com/pybind/pybind11/archive/v2.10.4.tar.gz"],
 )
 
 http_archive(
-    name = "pybind11",
-    build_file = "@pybind11_bazel//:pybind11.BUILD",
-    sha256 = "6bd528c4dbe2276635dc787b6b1f2e5316cf6b49ee3e150264e455a0d68d19c1",
-    strip_prefix = "pybind11-2.9.2",
-    urls = ["https://github.com/pybind/pybind11/archive/v2.9.2.tar.gz"],
+    name = "pybind11_bazel",
+    sha256 = "b72c5b44135b90d1ffaba51e08240be0b91707ac60bea08bb4d84b47316211bb",
+    strip_prefix = "pybind11_bazel-b162c7c88a253e3f6b673df0c621aca27596ce6b",
+    urls = ["https://github.com/pybind/pybind11_bazel/archive/b162c7c88a253e3f6b673df0c621aca27596ce6b.zip"],
 )
 
 http_archive(
     name = "rules_python",
-    sha256 = "5fa3c738d33acca3b97622a13a741129f67ef43f5fdfcec63b29374cc0574c29",
-    strip_prefix = "rules_python-0.9.0",
-    url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.9.0.tar.gz",
+    sha256 = "84aec9e21cc56fbc7f1335035a71c850d1b9b5cc6ff497306f84cced9a769841",
+    strip_prefix = "rules_python-0.23.1",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.23.1/rules_python-0.23.1.tar.gz",
 )
 
-load("@pybind11_bazel//:python_configure.bzl", "python_configure")
+load("@rules_python//python:repositories.bzl", "py_repositories")
+py_repositories()
 
+load("@pybind11_bazel//:python_configure.bzl", "python_configure")
 python_configure(name = "local_config_python")

--- a/doc/sinter_api.md
+++ b/doc/sinter_api.md
@@ -240,6 +240,10 @@ def decode_shots_bit_packed(
             where `num_shots` is the number of shots to decoder and `dem` is
             the detector error model this instance was compiled to decode.
 
+            It's guaranteed that the data will be laid out in memory so that
+            detection events within a shot are contiguous in memory (i.e.
+            that bit_packed_detection_event_data.strides[1] == 1).
+
     Returns:
         Bit packed observable flip data stored as a bit packed numpy array.
         The numpy array must have the following dtype/shape:

--- a/doc/sinter_command_line.md
+++ b/doc/sinter_command_line.md
@@ -35,7 +35,9 @@ SYNOPSIS
         [--quiet] \
         [--count_detection_events] \
         [--count_observable_error_combos] \
-        [--start_batch_size int]
+        [--start_batch_size int] \
+        [--custom_error_count_key NAME] \
+        [--allowed_cpu_affinity_ids PYTHON_EXPRESSION [ANOTHER_PYTHON_EXPRESSION ...]]
 
 DESCRIPTION
     Uses python multiprocessing to collect shots from the given circuit, decode
@@ -270,7 +272,7 @@ SYNOPSIS
         [--fig_size float float] \
         [--highlight_max_likelihood_factor float] \
         [--plot_args_func PYTHON_EXPRESSION] \
-        [--split_custom_counts] \
+        [--custom_error_count_keys] \
         [--subtitle "{common}"|text] \
         [--title text] \
         [--type "error_rate"|"discard_rate"|"custom_y" [...] \

--- a/glue/sample/src/sinter/_decoding.py
+++ b/glue/sample/src/sinter/_decoding.py
@@ -238,19 +238,20 @@ def sample_decode(*,
         )
     except NotImplementedError:
         assert __private__unstable__force_decode_on_disk or __private__unstable__force_decode_on_disk is None
-        return _sample_decode_helper_using_disk(
-            circuit=circuit,
-            dem=dem,
-            dem_path=dem_path,
-            post_mask=post_mask,
-            postselected_observable_mask=postselected_observable_mask,
-            num_shots=num_shots,
-            decoder_obj=decoder_obj,
-            tmp_dir=tmp_dir,
-            start_time_monotonic=start_time,
-            count_observable_error_combos=count_observable_error_combos,
-            count_detection_events=count_detection_events,
-        )
+        pass
+    return _sample_decode_helper_using_disk(
+        circuit=circuit,
+        dem=dem,
+        dem_path=dem_path,
+        post_mask=post_mask,
+        postselected_observable_mask=postselected_observable_mask,
+        num_shots=num_shots,
+        decoder_obj=decoder_obj,
+        tmp_dir=tmp_dir,
+        start_time_monotonic=start_time,
+        count_observable_error_combos=count_observable_error_combos,
+        count_detection_events=count_detection_events,
+    )
 
 
 def _sample_decode_helper_using_memory(

--- a/glue/sample/src/sinter/_decoding_decoder_class.py
+++ b/glue/sample/src/sinter/_decoding_decoder_class.py
@@ -37,6 +37,10 @@ class CompiledDecoder(metaclass=abc.ABCMeta):
                 where `num_shots` is the number of shots to decoder and `dem` is
                 the detector error model this instance was compiled to decode.
 
+                It's guaranteed that the data will be laid out in memory so that
+                detection events within a shot are contiguous in memory (i.e.
+                that bit_packed_detection_event_data.strides[1] == 1).
+
         Returns:
             Bit packed observable flip data stored as a bit packed numpy array.
             The numpy array must have the following dtype/shape:

--- a/glue/sample/src/sinter/_decoding_test.py
+++ b/glue/sample/src/sinter/_decoding_test.py
@@ -4,6 +4,8 @@ from typing import Optional
 
 import numpy as np
 import pytest
+
+import sinter
 import stim
 
 from sinter._collection import post_selection_mask_from_4th_coord
@@ -353,3 +355,17 @@ def test_decode_fails_correctly(decoder: str, required_import: str, force_stream
                     obs_predictions_b8_out_path=d / 'predict.b8',
                     tmp_dir=d,
                 )
+
+
+@pytest.mark.parametrize('decoder,required_import,force_streaming', DECODER_CASES)
+def test_full_scale(decoder: str, required_import: str, force_streaming: Optional[bool]):
+    pytest.importorskip(required_import)
+    result, = sinter.collect(
+        num_workers=2,
+        tasks=[sinter.Task(circuit=stim.Circuit())],
+        decoders=[decoder],
+        max_shots=1000,
+    )
+    assert result.discards == 0
+    assert result.shots == 1000
+    assert result.errors == 0

--- a/glue/sample/src/sinter/_main_plot.py
+++ b/glue/sample/src/sinter/_main_plot.py
@@ -1,4 +1,5 @@
 import math
+import sys
 from typing import Any, Callable, Iterable, List, Optional, TYPE_CHECKING, Tuple, Union, Dict, Sequence, cast
 import argparse
 
@@ -195,9 +196,15 @@ def parse_args(args: List[str]) -> Any:
                         help='Customize the Y axis label. '
                              'Prefix [log] for logarithmic scale. '
                              'Prefix [sqrt] for square root scale.')
-    parser.add_argument('--split_custom_counts',
-                        action='store_true',
-                        help='When a stat has custom counts, this splits it into multiple copies of the stat with each one having exactly one of the custom counts.\n')
+    parser.add_argument('--custom_error_count_keys',
+                        type=str,
+                        nargs='+',
+                        default=None,
+                        help="Replaces the stat's error count with one of its custom counts. Stats "
+                             "without this count end up with an error count of 0. Adds the json "
+                             "metadata field 'custom_error_count_key' to identify the custom count "
+                             "used. Specifying multiple values turns each stat into multiple "
+                             "stats.")
     parser.add_argument('--show',
                         action='store_true',
                         help='Displays the plot in a window.\n'
@@ -648,11 +655,24 @@ def main_plot(*, command_line_args: List[str]):
     for file in getattr(args, 'in'):
         total += ExistingData.from_file(file)
 
-    if args.split_custom_counts:
+    if args.custom_error_count_keys:
+        seen_keys = {k for stat in total.data.values() for k in stat.custom_counts}
+        missing = []
+        for k in args.custom_error_count_keys:
+            if k not in seen_keys:
+                missing.append(k)
+        if missing:
+            print("Warning: the following custom error count keys didn't appear in any statistic:", file=sys.stderr)
+            for k in sorted(missing):
+                print(f'    {k!r}', file=sys.stderr)
+            print("Here are the keys that do appear:", file=sys.stderr)
+            for k in sorted(seen_keys):
+                print(f'    {k!r}', file=sys.stderr)
+
         total.data = {
             s.strong_id: s
             for v in total.data.values()
-            for s in v._split_custom_counts()
+            for s in v._split_custom_counts(args.custom_error_count_keys)
         }
 
     fig, _ = _plot_helper(

--- a/glue/sample/src/sinter/_main_plot_test.py
+++ b/glue/sample/src/sinter/_main_plot_test.py
@@ -407,6 +407,8 @@ def test_split_custom_counts():
             "m.g",
             "--subtitle",
             "test",
-            "--split_custom_counts",
+            "--custom_error_count_keys",
+            "a",
+            "b",
         ])
         assert (d / "output.png").exists()

--- a/glue/sample/src/sinter/_task_stats.py
+++ b/glue/sample/src/sinter/_task_stats.py
@@ -137,20 +137,23 @@ class TaskStats:
             custom_counts=self.custom_counts,
         )
 
-    def _split_custom_counts(self) -> List['TaskStats']:
-        if not self.custom_counts:
-            return [self]
+    def _split_custom_counts(self, custom_keys: List[str]) -> List['TaskStats']:
         result = []
-        for k, v in self.custom_counts.items():
+        for k in custom_keys:
+            m = self.json_metadata
+            if isinstance(m, dict):
+                m = dict(m)
+                m.setdefault('custom_error_count_key', k)
+                m.setdefault('original_error_count', self.errors)
             result.append(TaskStats(
                 strong_id=f'{self.strong_id}:{k}',
                 decoder=self.decoder,
-                json_metadata=self.json_metadata,
+                json_metadata=m,
                 shots=self.shots,
-                errors=v,
+                errors=self.custom_counts[k],
                 discards=self.discards,
                 seconds=self.seconds,
-                custom_counts=collections.Counter({k: v}),
+                custom_counts=self.custom_counts,
             ))
         return result
 


### PR DESCRIPTION
- Bump versions of dependencies in WORKSPACE
- Fix disk decoding fallback being within an except block, complicating error messages
- Change splitting to keep all custom counts but highlight the one that replaced errors with extra properties
- Require user to list the custom counts they want
- Allow multiple custom decoder module functions