### PR TITLE
Test conversions on all SIMD widths

### DIFF
--- a/src/stim/cmd/command_gen.test.cc
+++ b/src/stim/cmd/command_gen.test.cc
@@ -20,12 +20,13 @@
 #include "stim/gen/gen_rep_code.h"
 #include "stim/gen/gen_surface_code.h"
 #include "stim/main_namespaced.test.h"
+#include "stim/mem/simd_word.test.h"
 #include "stim/simulators/frame_simulator_util.h"
 #include "stim/test_util.test.h"
 
 using namespace stim;
 
-TEST(command_gen, no_noise_no_detections) {
+TEST_EACH_WORD_SIZE_W(command_gen, no_noise_no_detections, {
     std::vector<uint32_t> distances{2, 3, 4, 5, 6, 7, 15};
     std::vector<uint32_t> rounds{1, 2, 3, 4, 5, 6, 20};
     std::map<std::string, std::pair<std::string, GeneratedCircuit (*)(const CircuitGenParameters &)>> funcs{
@@ -45,13 +46,13 @@ TEST(command_gen, no_noise_no_detections) {
                 CircuitGenParameters params(r, d, func.second.first);
                 auto circuit = func.second.second(params).circuit;
                 auto [det_samples, obs_samples] =
-                    sample_batch_detection_events<MAX_BITWORD_WIDTH>(circuit, 256, SHARED_TEST_RNG());
+                    sample_batch_detection_events<W>(circuit, 256, SHARED_TEST_RNG());
                 EXPECT_FALSE(det_samples.data.not_zero() || obs_samples.data.not_zero())
                     << "d=" << d << ", r=" << r << ", task=" << func.second.first << ", func=" << func.first;
             }
         }
     }
-}
+})
 
 TEST(command_gen, execute) {
     ASSERT_TRUE(matches(

--- a/src/stim/probability_util.test.cc
+++ b/src/stim/probability_util.test.cc
@@ -17,6 +17,7 @@
 #include "gtest/gtest.h"
 
 #include "stim/mem/simd_bits.h"
+#include "stim/mem/simd_word.test.h"
 #include "stim/test_util.test.h"
 
 using namespace stim;
@@ -46,9 +47,9 @@ TEST(probability_util, sample_hit_indices) {
     }
 }
 
-TEST(probability_util, biased_random) {
+TEST_EACH_WORD_SIZE_W(probability_util, biased_random, {
     std::vector<float> probs{0, 0.01, 0.03, 0.1, 0.4, 0.49, 0.5, 0.6, 0.9, 0.99, 0.999, 1};
-    simd_bits<MAX_BITWORD_WIDTH> data(1000000);
+    simd_bits<W> data(1000000);
     size_t n = data.num_bits_padded();
     for (auto p : probs) {
         biased_randomize_bits(p, data.u64, data.u64 + data.num_u64_padded(), SHARED_TEST_RNG());
@@ -63,4 +64,4 @@ TEST(probability_util, biased_random) {
         EXPECT_TRUE(min_expected <= t && t <= max_expected)
             << min_expected / n << " < " << t / (float)n << " < " << max_expected / n << " for p=" << p;
     }
-}
+})

--- a/src/stim/stabilizers/conversions.test.cc
+++ b/src/stim/stabilizers/conversions.test.cc
@@ -214,23 +214,23 @@ TEST_EACH_WORD_SIZE_W(conversions, stabilizer_state_vector_to_circuit_basic, {
     )CIRCUIT"));
 })
 
-TEST(conversions, stabilizer_state_vector_to_circuit_fuzz_round_trip) {
+TEST_EACH_WORD_SIZE_W(conversions, stabilizer_state_vector_to_circuit_fuzz_round_trip, {
     for (const auto &little_endian : std::vector<bool>{false, true}) {
         for (size_t n = 0; n < 10; n++) {
             // Pick a random stabilizer state.
-            TableauSimulator<MAX_BITWORD_WIDTH> sim(SHARED_TEST_RNG(), n);
-            sim.inv_state = Tableau<MAX_BITWORD_WIDTH>::random(n, SHARED_TEST_RNG());
+            TableauSimulator<W> sim(SHARED_TEST_RNG(), n);
+            sim.inv_state = Tableau<W>::random(n, SHARED_TEST_RNG());
             auto desired_vec = sim.to_state_vector(little_endian);
 
             // Round trip through a circuit.
-            auto circuit = stabilizer_state_vector_to_circuit<MAX_BITWORD_WIDTH>(desired_vec, little_endian);
-            auto actual_vec = circuit_to_output_state_vector<MAX_BITWORD_WIDTH>(circuit, little_endian);
+            auto circuit = stabilizer_state_vector_to_circuit<W>(desired_vec, little_endian);
+            auto actual_vec = circuit_to_output_state_vector<W>(circuit, little_endian);
             ASSERT_EQ(actual_vec, desired_vec) << "little_endian=" << little_endian << ", n=" << n;
         }
     }
-}
+})
 
-TEST(conversions, circuit_to_tableau_ignoring_gates) {
+TEST_EACH_WORD_SIZE_W(conversions, circuit_to_tableau_ignoring_gates, {
     Circuit unitary(R"CIRCUIT(
         I 0
         X 0
@@ -315,46 +315,46 @@ TEST(conversions, circuit_to_tableau_ignoring_gates) {
         TICK
     )CIRCUIT");
 
-    ASSERT_EQ(circuit_to_tableau<MAX_BITWORD_WIDTH>(unitary, false, false, false).num_qubits, 2);
+    ASSERT_EQ(circuit_to_tableau<W>(unitary, false, false, false).num_qubits, 2);
 
-    ASSERT_THROW({ circuit_to_tableau<MAX_BITWORD_WIDTH>(noise, false, false, false); }, std::invalid_argument);
-    ASSERT_THROW({ circuit_to_tableau<MAX_BITWORD_WIDTH>(noise, false, true, true); }, std::invalid_argument);
-    ASSERT_EQ(circuit_to_tableau<MAX_BITWORD_WIDTH>(noise, true, false, false), Tableau<MAX_BITWORD_WIDTH>(2));
+    ASSERT_THROW({ circuit_to_tableau<W>(noise, false, false, false); }, std::invalid_argument);
+    ASSERT_THROW({ circuit_to_tableau<W>(noise, false, true, true); }, std::invalid_argument);
+    ASSERT_EQ(circuit_to_tableau<W>(noise, true, false, false), Tableau<W>(2));
 
-    ASSERT_THROW({ circuit_to_tableau<MAX_BITWORD_WIDTH>(measure, false, false, false); }, std::invalid_argument);
-    ASSERT_THROW({ circuit_to_tableau<MAX_BITWORD_WIDTH>(measure, true, false, true); }, std::invalid_argument);
-    ASSERT_EQ(circuit_to_tableau<MAX_BITWORD_WIDTH>(measure, false, true, false), Tableau<MAX_BITWORD_WIDTH>(1));
+    ASSERT_THROW({ circuit_to_tableau<W>(measure, false, false, false); }, std::invalid_argument);
+    ASSERT_THROW({ circuit_to_tableau<W>(measure, true, false, true); }, std::invalid_argument);
+    ASSERT_EQ(circuit_to_tableau<W>(measure, false, true, false), Tableau<W>(1));
 
-    ASSERT_THROW({ circuit_to_tableau<MAX_BITWORD_WIDTH>(reset, false, false, false); }, std::invalid_argument);
-    ASSERT_THROW({ circuit_to_tableau<MAX_BITWORD_WIDTH>(reset, true, true, false); }, std::invalid_argument);
-    ASSERT_EQ(circuit_to_tableau<MAX_BITWORD_WIDTH>(reset, false, false, true), Tableau<MAX_BITWORD_WIDTH>(1));
+    ASSERT_THROW({ circuit_to_tableau<W>(reset, false, false, false); }, std::invalid_argument);
+    ASSERT_THROW({ circuit_to_tableau<W>(reset, true, true, false); }, std::invalid_argument);
+    ASSERT_EQ(circuit_to_tableau<W>(reset, false, false, true), Tableau<W>(1));
 
-    ASSERT_THROW({ circuit_to_tableau<MAX_BITWORD_WIDTH>(measure_reset, false, false, false); }, std::invalid_argument);
-    ASSERT_THROW({ circuit_to_tableau<MAX_BITWORD_WIDTH>(measure_reset, true, false, true); }, std::invalid_argument);
-    ASSERT_THROW({ circuit_to_tableau<MAX_BITWORD_WIDTH>(measure_reset, true, true, false); }, std::invalid_argument);
-    ASSERT_EQ(circuit_to_tableau<MAX_BITWORD_WIDTH>(measure_reset, false, true, true), Tableau<MAX_BITWORD_WIDTH>(1));
+    ASSERT_THROW({ circuit_to_tableau<W>(measure_reset, false, false, false); }, std::invalid_argument);
+    ASSERT_THROW({ circuit_to_tableau<W>(measure_reset, true, false, true); }, std::invalid_argument);
+    ASSERT_THROW({ circuit_to_tableau<W>(measure_reset, true, true, false); }, std::invalid_argument);
+    ASSERT_EQ(circuit_to_tableau<W>(measure_reset, false, true, true), Tableau<W>(1));
 
-    ASSERT_EQ(circuit_to_tableau<MAX_BITWORD_WIDTH>(annotations, false, false, false), Tableau<MAX_BITWORD_WIDTH>(1));
+    ASSERT_EQ(circuit_to_tableau<W>(annotations, false, false, false), Tableau<W>(1));
 
     ASSERT_EQ(
-        circuit_to_tableau<MAX_BITWORD_WIDTH>(
+        circuit_to_tableau<W>(
             annotations + measure_reset + measure + reset + unitary + noise, true, true, true)
             .num_qubits,
         2);
-}
+})
 
-TEST(conversions, circuit_to_tableau) {
+TEST_EACH_WORD_SIZE_W(conversions, circuit_to_tableau, {
     ASSERT_EQ(
-        circuit_to_tableau<MAX_BITWORD_WIDTH>(
+        circuit_to_tableau<W>(
             Circuit(R"CIRCUIT(
         )CIRCUIT"),
             false,
             false,
             false),
-        Tableau<MAX_BITWORD_WIDTH>(0));
+        Tableau<W>(0));
 
     ASSERT_EQ(
-        circuit_to_tableau<MAX_BITWORD_WIDTH>(
+        circuit_to_tableau<W>(
             Circuit(R"CIRCUIT(
             REPEAT 10 {
                 X 0
@@ -364,10 +364,10 @@ TEST(conversions, circuit_to_tableau) {
             false,
             false,
             false),
-        Tableau<MAX_BITWORD_WIDTH>(1));
+        Tableau<W>(1));
 
     ASSERT_EQ(
-        circuit_to_tableau<MAX_BITWORD_WIDTH>(
+        circuit_to_tableau<W>(
             Circuit(R"CIRCUIT(
             REPEAT 11 {
                 X 0
@@ -377,20 +377,20 @@ TEST(conversions, circuit_to_tableau) {
             false,
             false,
             false),
-        GATE_DATA.at("X").tableau<MAX_BITWORD_WIDTH>());
+        GATE_DATA.at("X").tableau<W>());
 
     ASSERT_EQ(
-        circuit_to_tableau<MAX_BITWORD_WIDTH>(
+        circuit_to_tableau<W>(
             Circuit(R"CIRCUIT(
             S 0
         )CIRCUIT"),
             false,
             false,
             false),
-        GATE_DATA.at("S").tableau<MAX_BITWORD_WIDTH>());
+        GATE_DATA.at("S").tableau<W>());
 
     ASSERT_EQ(
-        circuit_to_tableau<MAX_BITWORD_WIDTH>(
+        circuit_to_tableau<W>(
             Circuit(R"CIRCUIT(
             SQRT_Y_DAG 1
             CZ 0 1
@@ -399,10 +399,10 @@ TEST(conversions, circuit_to_tableau) {
             false,
             false,
             false),
-        GATE_DATA.at("CX").tableau<MAX_BITWORD_WIDTH>());
+        GATE_DATA.at("CX").tableau<W>());
 
     ASSERT_EQ(
-        circuit_to_tableau<MAX_BITWORD_WIDTH>(
+        circuit_to_tableau<W>(
             Circuit(R"CIRCUIT(
             R 0
             X_ERROR(0.1) 0
@@ -414,28 +414,28 @@ TEST(conversions, circuit_to_tableau) {
             true,
             true,
             true),
-        GATE_DATA.at("CX").tableau<MAX_BITWORD_WIDTH>());
-}
+        GATE_DATA.at("CX").tableau<W>());
+})
 
-TEST(conversions, circuit_to_output_state_vector) {
+TEST_EACH_WORD_SIZE_W(conversions, circuit_to_output_state_vector, {
     ASSERT_EQ(
-        circuit_to_output_state_vector<MAX_BITWORD_WIDTH>(Circuit(""), false), (std::vector<std::complex<float>>{{1}}));
+        circuit_to_output_state_vector<W>(Circuit(""), false), (std::vector<std::complex<float>>{{1}}));
     ASSERT_EQ(
-        circuit_to_output_state_vector<MAX_BITWORD_WIDTH>(Circuit("H 0 1"), false),
+        circuit_to_output_state_vector<W>(Circuit("H 0 1"), false),
         (std::vector<std::complex<float>>{{0.5}, {0.5}, {0.5}, {0.5}}));
     ASSERT_EQ(
-        circuit_to_output_state_vector<MAX_BITWORD_WIDTH>(Circuit("X 1"), false),
+        circuit_to_output_state_vector<W>(Circuit("X 1"), false),
         (std::vector<std::complex<float>>{{0}, {1}, {0}, {0}}));
     ASSERT_EQ(
-        circuit_to_output_state_vector<MAX_BITWORD_WIDTH>(Circuit("X 1"), true),
+        circuit_to_output_state_vector<W>(Circuit("X 1"), true),
         (std::vector<std::complex<float>>{{0}, {0}, {1}, {0}}));
-}
+})
 
-TEST(conversions, tableau_to_circuit_fuzz_vs_circuit_to_tableau) {
+TEST_EACH_WORD_SIZE_W(conversions, tableau_to_circuit_fuzz_vs_circuit_to_tableau, {
     for (size_t n = 0; n < 10; n++) {
-        auto desired = Tableau<MAX_BITWORD_WIDTH>::random(n, SHARED_TEST_RNG());
-        Circuit circuit = tableau_to_circuit<MAX_BITWORD_WIDTH>(desired, "elimination");
-        auto actual = circuit_to_tableau<MAX_BITWORD_WIDTH>(circuit, false, false, false);
+        auto desired = Tableau<W>::random(n, SHARED_TEST_RNG());
+        Circuit circuit = tableau_to_circuit<W>(desired, "elimination");
+        auto actual = circuit_to_tableau<W>(circuit, false, false, false);
         ASSERT_EQ(actual, desired);
 
         for (const auto &op : circuit.operations) {
@@ -443,7 +443,7 @@ TEST(conversions, tableau_to_circuit_fuzz_vs_circuit_to_tableau) {
                 << op;
         }
     }
-}
+})
 
 TEST_EACH_WORD_SIZE_W(conversions, tableau_to_circuit, {
     ASSERT_EQ(tableau_to_circuit<W>(GATE_DATA.at("I").tableau<W>(), "elimination"), Circuit(R"CIRCUIT(
@@ -472,14 +472,14 @@ TEST_EACH_WORD_SIZE_W(conversions, tableau_to_circuit, {
         )CIRCUIT"));
 })
 
-TEST(conversions, unitary_to_tableau_vs_gate_data) {
+TEST_EACH_WORD_SIZE_W(conversions, unitary_to_tableau_vs_gate_data, {
     for (const auto &gate : GATE_DATA.items) {
         if (gate.flags & GATE_IS_UNITARY) {
-            EXPECT_EQ(unitary_to_tableau<MAX_BITWORD_WIDTH>(gate.unitary(), true), gate.tableau<MAX_BITWORD_WIDTH>())
+            EXPECT_EQ(unitary_to_tableau<W>(gate.unitary(), true), gate.tableau<W>())
                 << gate.name;
         }
     }
-}
+})
 
 TEST_EACH_WORD_SIZE_W(conversions, tableau_to_unitary_vs_gate_data, {
     VectorSimulator v1(2);
@@ -507,54 +507,54 @@ TEST_EACH_WORD_SIZE_W(conversions, tableau_to_unitary_vs_gate_data, {
     }
 })
 
-TEST(conversions, unitary_vs_tableau_basic) {
+TEST_EACH_WORD_SIZE_W(conversions, unitary_vs_tableau_basic, {
     ASSERT_EQ(
-        unitary_to_tableau<MAX_BITWORD_WIDTH>(GATE_DATA.at("XCZ").unitary(), false),
-        GATE_DATA.at("ZCX").tableau<MAX_BITWORD_WIDTH>());
+        unitary_to_tableau<W>(GATE_DATA.at("XCZ").unitary(), false),
+        GATE_DATA.at("ZCX").tableau<W>());
     ASSERT_EQ(
-        unitary_to_tableau<MAX_BITWORD_WIDTH>(GATE_DATA.at("XCZ").unitary(), true),
-        GATE_DATA.at("XCZ").tableau<MAX_BITWORD_WIDTH>());
+        unitary_to_tableau<W>(GATE_DATA.at("XCZ").unitary(), true),
+        GATE_DATA.at("XCZ").tableau<W>());
     ASSERT_EQ(
-        unitary_to_tableau<MAX_BITWORD_WIDTH>(GATE_DATA.at("ZCX").unitary(), false),
-        GATE_DATA.at("XCZ").tableau<MAX_BITWORD_WIDTH>());
+        unitary_to_tableau<W>(GATE_DATA.at("ZCX").unitary(), false),
+        GATE_DATA.at("XCZ").tableau<W>());
     ASSERT_EQ(
-        unitary_to_tableau<MAX_BITWORD_WIDTH>(GATE_DATA.at("ZCX").unitary(), true),
-        GATE_DATA.at("ZCX").tableau<MAX_BITWORD_WIDTH>());
+        unitary_to_tableau<W>(GATE_DATA.at("ZCX").unitary(), true),
+        GATE_DATA.at("ZCX").tableau<W>());
 
     ASSERT_EQ(
-        unitary_to_tableau<MAX_BITWORD_WIDTH>(GATE_DATA.at("XCY").unitary(), false),
-        GATE_DATA.at("YCX").tableau<MAX_BITWORD_WIDTH>());
+        unitary_to_tableau<W>(GATE_DATA.at("XCY").unitary(), false),
+        GATE_DATA.at("YCX").tableau<W>());
     ASSERT_EQ(
-        unitary_to_tableau<MAX_BITWORD_WIDTH>(GATE_DATA.at("XCY").unitary(), true),
-        GATE_DATA.at("XCY").tableau<MAX_BITWORD_WIDTH>());
+        unitary_to_tableau<W>(GATE_DATA.at("XCY").unitary(), true),
+        GATE_DATA.at("XCY").tableau<W>());
     ASSERT_EQ(
-        unitary_to_tableau<MAX_BITWORD_WIDTH>(GATE_DATA.at("YCX").unitary(), false),
-        GATE_DATA.at("XCY").tableau<MAX_BITWORD_WIDTH>());
+        unitary_to_tableau<W>(GATE_DATA.at("YCX").unitary(), false),
+        GATE_DATA.at("XCY").tableau<W>());
     ASSERT_EQ(
-        unitary_to_tableau<MAX_BITWORD_WIDTH>(GATE_DATA.at("YCX").unitary(), true),
-        GATE_DATA.at("YCX").tableau<MAX_BITWORD_WIDTH>());
-}
+        unitary_to_tableau<W>(GATE_DATA.at("YCX").unitary(), true),
+        GATE_DATA.at("YCX").tableau<W>());
+})
 
-TEST(conversions, unitary_to_tableau_fuzz_vs_tableau_to_unitary) {
+TEST_EACH_WORD_SIZE_W(conversions, unitary_to_tableau_fuzz_vs_tableau_to_unitary, {
     for (bool little_endian : std::vector<bool>{false, true}) {
         for (size_t n = 0; n < 6; n++) {
-            auto desired = Tableau<MAX_BITWORD_WIDTH>::random(n, SHARED_TEST_RNG());
-            auto unitary = tableau_to_unitary<MAX_BITWORD_WIDTH>(desired, little_endian);
-            auto actual = unitary_to_tableau<MAX_BITWORD_WIDTH>(unitary, little_endian);
+            auto desired = Tableau<W>::random(n, SHARED_TEST_RNG());
+            auto unitary = tableau_to_unitary<W>(desired, little_endian);
+            auto actual = unitary_to_tableau<W>(unitary, little_endian);
             ASSERT_EQ(actual, desired) << "little_endian=" << little_endian << ", n=" << n;
         }
     }
-}
+})
 
-TEST(conversions, unitary_to_tableau_fail) {
+TEST_EACH_WORD_SIZE_W(conversions, unitary_to_tableau_fail, {
     ASSERT_THROW(
         {
-            unitary_to_tableau<MAX_BITWORD_WIDTH>({{{1}, {0}}, {{0}, {sqrtf(0.5), sqrtf(0.5)}}}, false);
+            unitary_to_tableau<W>({{{1}, {0}}, {{0}, {sqrtf(0.5), sqrtf(0.5)}}}, false);
         },
         std::invalid_argument);
     ASSERT_THROW(
         {
-            unitary_to_tableau<MAX_BITWORD_WIDTH>(
+            unitary_to_tableau<W>(
                 {
                     {1, 0, 0, 0},
                     {0, 1, 0, 0},
@@ -566,7 +566,7 @@ TEST(conversions, unitary_to_tableau_fail) {
         std::invalid_argument);
     ASSERT_THROW(
         {
-            unitary_to_tableau<MAX_BITWORD_WIDTH>(
+            unitary_to_tableau<W>(
                 {
                     {1, 0, 0, 0, 0, 0, 0, 0},
                     {0, 1, 0, 0, 0, 0, 0, 0},
@@ -580,7 +580,7 @@ TEST(conversions, unitary_to_tableau_fail) {
                 false);
         },
         std::invalid_argument);
-}
+})
 
 TEST_EACH_WORD_SIZE_W(conversions, stabilizers_to_tableau_fuzz, {
     for (size_t n = 0; n < 10; n++) {


### PR DESCRIPTION
A simple change to testing, most of which was enabled by #548.

Now that the key simulators have been templatised (#548), the last few conversion tests could be moved over to use `TEST_EACH_WORD_SIZE_W` as described in a comment in #559. As an aside, the remaining circuit, cmd and probability tests have also been moved over to be tested across all widths.