### PR TITLE
Templatise the `DemSampler` and `SparseUnsignedRevFrameTracker`

### DIFF
--- a/file_lists/source_files_no_main
+++ b/file_lists/source_files_no_main
@@ -74,7 +74,6 @@ src/stim/search/hyper/edge.cc
 src/stim/search/hyper/graph.cc
 src/stim/search/hyper/node.cc
 src/stim/search/hyper/search_state.cc
-src/stim/simulators/dem_sampler.cc
 src/stim/simulators/error_analyzer.cc
 src/stim/simulators/error_matcher.cc
 src/stim/simulators/force_streaming.cc

--- a/src/stim/cmd/command_sample_dem.cc
+++ b/src/stim/cmd/command_sample_dem.cc
@@ -75,7 +75,7 @@ int stim::command_sample_dem(int argc, const char **argv) {
     auto dem = DetectorErrorModel::from_file(in.f);
     in.done();
 
-    DemSampler sampler(std::move(dem), optionally_seeded_rng(argc, argv), 1024);
+    DemSampler<MAX_BITWORD_WIDTH> sampler(std::move(dem), optionally_seeded_rng(argc, argv), 1024);
     sampler.sample_write(
         num_shots,
         out.f,

--- a/src/stim/dem/detector_error_model.pybind.cc
+++ b/src/stim/dem/detector_error_model.pybind.cc
@@ -996,8 +996,8 @@ void stim_pybind::pybind_detector_error_model_methods(
 
     c.def(
         "compile_sampler",
-        [](const DetectorErrorModel &self, const pybind11::object &seed) -> DemSampler {
-            return DemSampler(self, *make_py_seeded_rng(seed), 1024);
+        [](const DetectorErrorModel &self, const pybind11::object &seed) -> DemSampler<MAX_BITWORD_WIDTH> {
+            return DemSampler<MAX_BITWORD_WIDTH>(self, *make_py_seeded_rng(seed), 1024);
         },
         pybind11::kw_only(),
         pybind11::arg("seed") = pybind11::none(),

--- a/src/stim/simulators/dem_sampler.h
+++ b/src/stim/simulators/dem_sampler.h
@@ -26,6 +26,9 @@
 namespace stim {
 
 /// Performs high performance bulk sampling of a detector error model.
+///
+/// The template parameter, W, represents the SIMD width
+template <size_t W>
 struct DemSampler {
     DetectorErrorModel model;
     uint64_t num_detectors;
@@ -33,9 +36,9 @@ struct DemSampler {
     uint64_t num_errors;
     std::mt19937_64 rng;
     // TODO: allow these buffers to be streamed instead of entirely stored in memory.
-    simd_bit_table<MAX_BITWORD_WIDTH> det_buffer;
-    simd_bit_table<MAX_BITWORD_WIDTH> obs_buffer;
-    simd_bit_table<MAX_BITWORD_WIDTH> err_buffer;
+    simd_bit_table<W> det_buffer;
+    simd_bit_table<W> obs_buffer;
+    simd_bit_table<W> err_buffer;
     size_t num_stripes;
 
     /// Compiles a sampler for the given detector error model.
@@ -73,5 +76,7 @@ struct DemSampler {
 };
 
 }  // namespace stim
+
+#include "stim/simulators/dem_sampler.inl"
 
 #endif

--- a/src/stim/simulators/dem_sampler.perf.cc
+++ b/src/stim/simulators/dem_sampler.perf.cc
@@ -28,7 +28,7 @@ BENCHMARK(DemSampler_surface_code_rotated_memory_z_distance11_100rounds_1024stri
     auto circuit = generate_surface_code_circuit(params).circuit;
     auto dem = ErrorAnalyzer::circuit_to_detector_error_model(circuit, true, true, false, false, false, false);
     std::mt19937_64 rng(0);
-    DemSampler sampler(dem, std::mt19937_64(0), 1024);
+    DemSampler<MAX_BITWORD_WIDTH> sampler(dem, std::mt19937_64(0), 1024);
     size_t count = 0;
     benchmark_go([&]() {
         sampler.resample(false);

--- a/src/stim/simulators/dem_sampler.pybind.cc
+++ b/src/stim/simulators/dem_sampler.pybind.cc
@@ -38,12 +38,12 @@ RaiiFile optional_py_path_to_raii_file(const pybind11::object &obj, const char *
 }
 
 pybind11::object dem_sampler_py_sample(
-    DemSampler &self, size_t shots, bool bit_packed, bool return_errors, pybind11::object &recorded_errors_to_replay) {
+    DemSampler<MAX_BITWORD_WIDTH> &self, size_t shots, bool bit_packed, bool return_errors, pybind11::object &recorded_errors_to_replay) {
     self.set_min_stripes(shots);
 
     bool replay = !recorded_errors_to_replay.is_none();
     if (replay && min_bits_to_num_bits_padded<MAX_BITWORD_WIDTH>(shots) != self.num_stripes) {
-        DemSampler perfect_size(self.model, std::move(self.rng), shots);
+        DemSampler<MAX_BITWORD_WIDTH> perfect_size(self.model, std::move(self.rng), shots);
         auto result = dem_sampler_py_sample(perfect_size, shots, bit_packed, return_errors, recorded_errors_to_replay);
         self.rng = std::move(perfect_size.rng);
         return result;
@@ -74,8 +74,8 @@ pybind11::object dem_sampler_py_sample(
     return pybind11::make_tuple(det_out, obs_out, err_out);
 }
 
-pybind11::class_<DemSampler> stim_pybind::pybind_dem_sampler(pybind11::module &m) {
-    return pybind11::class_<DemSampler>(
+pybind11::class_<DemSampler<MAX_BITWORD_WIDTH>> stim_pybind::pybind_dem_sampler(pybind11::module &m) {
+    return pybind11::class_<DemSampler<MAX_BITWORD_WIDTH>>(
         m,
         "CompiledDemSampler",
         clean_doc_string(R"DOC(
@@ -110,7 +110,7 @@ pybind11::class_<DemSampler> stim_pybind::pybind_dem_sampler(pybind11::module &m
             .data());
 }
 
-void stim_pybind::pybind_dem_sampler_methods(pybind11::module &m, pybind11::class_<stim::DemSampler> &c) {
+void stim_pybind::pybind_dem_sampler_methods(pybind11::module &m, pybind11::class_<DemSampler<MAX_BITWORD_WIDTH>> &c) {
     c.def(
         "sample",
         &dem_sampler_py_sample,
@@ -267,7 +267,7 @@ void stim_pybind::pybind_dem_sampler_methods(pybind11::module &m, pybind11::clas
 
     c.def(
         "sample_write",
-        [](DemSampler &self,
+        [](DemSampler<MAX_BITWORD_WIDTH> &self,
            size_t shots,
            pybind11::object &det_out_file,
            const std::string &det_out_format,

--- a/src/stim/simulators/dem_sampler.pybind.h
+++ b/src/stim/simulators/dem_sampler.pybind.h
@@ -21,8 +21,8 @@
 
 namespace stim_pybind {
 
-pybind11::class_<stim::DemSampler> pybind_dem_sampler(pybind11::module &m);
-void pybind_dem_sampler_methods(pybind11::module &m, pybind11::class_<stim::DemSampler> &c);
+pybind11::class_<stim::DemSampler<stim::MAX_BITWORD_WIDTH>> pybind_dem_sampler(pybind11::module &m);
+void pybind_dem_sampler_methods(pybind11::module &m, pybind11::class_<stim::DemSampler<stim::MAX_BITWORD_WIDTH>> &c);
 
 }  // namespace stim_pybind
 

--- a/src/stim/simulators/dem_sampler.test.cc
+++ b/src/stim/simulators/dem_sampler.test.cc
@@ -16,13 +16,14 @@
 
 #include "gtest/gtest.h"
 
+#include "stim/mem/simd_word.test.h"
 #include "stim/test_util.test.h"
 
 using namespace stim;
 
-TEST(DemSampler, basic_sizing) {
+TEST_EACH_WORD_SIZE_W(DemSampler, basic_sizing, {
     std::mt19937_64 irrelevant_rng(0);
-    DemSampler sampler(DetectorErrorModel(R"DEM()DEM"), irrelevant_rng, 700);
+    DemSampler<W> sampler(DetectorErrorModel(R"DEM()DEM"), irrelevant_rng, 700);
     ASSERT_EQ(sampler.det_buffer.num_major_bits_padded(), 0);
     ASSERT_EQ(sampler.obs_buffer.num_major_bits_padded(), 0);
     ASSERT_GE(sampler.det_buffer.num_minor_bits_padded(), 700);
@@ -31,7 +32,7 @@ TEST(DemSampler, basic_sizing) {
     ASSERT_FALSE(sampler.obs_buffer.data.not_zero());
     ASSERT_FALSE(sampler.det_buffer.data.not_zero());
 
-    sampler = DemSampler(
+    sampler = DemSampler<W>(
         DetectorErrorModel(R"DEM(
             logical_observable L2000
             detector D1000
@@ -45,10 +46,10 @@ TEST(DemSampler, basic_sizing) {
     sampler.resample(false);
     ASSERT_FALSE(sampler.obs_buffer.data.not_zero());
     ASSERT_FALSE(sampler.det_buffer.data.not_zero());
-}
+})
 
-TEST(DemSampler, resample_basic_probabilities) {
-    DemSampler sampler(
+TEST_EACH_WORD_SIZE_W(DemSampler, resample_basic_probabilities, {
+    DemSampler<W> sampler(
         DetectorErrorModel(R"DEM(
             error(0) D0
             error(0.25) D1 L0
@@ -72,10 +73,10 @@ TEST(DemSampler, resample_basic_probabilities) {
         ASSERT_EQ(sampler.det_buffer[1], sampler.obs_buffer[0]);
         ASSERT_EQ(sampler.det_buffer[4], sampler.det_buffer[5]);
     }
-}
+})
 
-TEST(DemSampler, resample_combinations) {
-    DemSampler sampler(
+TEST_EACH_WORD_SIZE_W(DemSampler, resample_combinations, {
+    DemSampler<W> sampler(
         DetectorErrorModel(R"DEM(
             error(0.1) D0 D1
             error(0.2) D1 D2
@@ -92,9 +93,9 @@ TEST(DemSampler, resample_combinations) {
         ASSERT_GT(sampler.det_buffer[2].popcnt(), 380 - 100);
         ASSERT_LT(sampler.det_buffer[2].popcnt(), 380 + 100);
 
-        simd_bits<MAX_BITWORD_WIDTH> total = sampler.det_buffer[0];
+        simd_bits<W> total = sampler.det_buffer[0];
         total ^= sampler.det_buffer[1];
         total ^= sampler.det_buffer[2];
         ASSERT_FALSE(total.not_zero());
     }
-}
+})

--- a/src/stim/simulators/sparse_rev_frame_tracker.cc
+++ b/src/stim/simulators/sparse_rev_frame_tracker.cc
@@ -231,15 +231,6 @@ SparseUnsignedRevFrameTracker::SparseUnsignedRevFrameTracker(
       num_detectors_in_past(num_detectors_in_past) {
 }
 
-PauliString<MAX_BITWORD_WIDTH> SparseUnsignedRevFrameTracker::current_error_sensitivity_for(DemTarget target) const {
-    PauliString<MAX_BITWORD_WIDTH> result(xs.size());
-    for (size_t q = 0; q < xs.size(); q++) {
-        result.xs[q] = std::find(xs[q].begin(), xs[q].end(), target) != xs[q].end();
-        result.zs[q] = std::find(zs[q].begin(), zs[q].end(), target) != zs[q].end();
-    }
-    return result;
-}
-
 void SparseUnsignedRevFrameTracker::handle_xor_gauge(
     SpanRef<const DemTarget> sorted1, SpanRef<const DemTarget> sorted2) {
     if (sorted1 == sorted2) {
@@ -787,51 +778,6 @@ void SparseUnsignedRevFrameTracker::undo_ISWAP(const CircuitInstruction &dat) {
         zs[b] ^= xs[b];
         std::swap(xs[a], xs[b]);
         std::swap(zs[a], zs[b]);
-    }
-}
-
-void SparseUnsignedRevFrameTracker::undo_tableau(
-    const Tableau<MAX_BITWORD_WIDTH> &tableau, SpanRef<const uint32_t> targets) {
-    size_t n = tableau.num_qubits;
-    if (n != targets.size()) {
-        throw new std::invalid_argument("tableau.num_qubits != targets.size()");
-    }
-    std::set<uint32_t> target_set;
-    for (size_t k = 0; k < n; k++) {
-        if (!target_set.insert(targets[k]).second) {
-            throw new std::invalid_argument("duplicate target");
-        }
-    }
-
-    std::vector<SparseXorVec<DemTarget>> old_xs;
-    std::vector<SparseXorVec<DemTarget>> old_zs;
-    old_xs.reserve(n);
-    old_zs.reserve(n);
-    for (size_t k = 0; k < n; k++) {
-        old_xs.push_back(std::move(xs[targets[k]]));
-        old_zs.push_back(std::move(zs[targets[k]]));
-        xs[targets[k]].clear();
-        zs[targets[k]].clear();
-    }
-
-    for (size_t i = 0; i < n; i++) {
-        for (size_t j = 0; j < n; j++) {
-            uint64_t px = tableau.inverse_x_output_pauli_xyz(j, i);
-            if (px == 1 || px == 2) {
-                xs[targets[i]] ^= old_xs[j];
-            }
-            if (px == 2 || px == 3) {
-                zs[targets[i]] ^= old_xs[j];
-            }
-
-            uint64_t pz = tableau.inverse_z_output_pauli_xyz(j, i);
-            if (pz == 1 || pz == 2) {
-                xs[targets[i]] ^= old_zs[j];
-            }
-            if (pz == 2 || pz == 3) {
-                zs[targets[i]] ^= old_zs[j];
-            }
-        }
     }
 }
 

--- a/src/stim/simulators/sparse_rev_frame_tracker.h
+++ b/src/stim/simulators/sparse_rev_frame_tracker.h
@@ -42,7 +42,15 @@ struct SparseUnsignedRevFrameTracker {
     SparseUnsignedRevFrameTracker(
         uint64_t num_qubits, uint64_t num_measurements_in_past, uint64_t num_detectors_in_past);
 
-    PauliString<MAX_BITWORD_WIDTH> current_error_sensitivity_for(DemTarget target) const;
+    template <size_t W>
+    PauliString<W> current_error_sensitivity_for(DemTarget target) const {
+        PauliString<W> result(xs.size());
+        for (size_t q = 0; q < xs.size(); q++) {
+            result.xs[q] = std::find(xs[q].begin(), xs[q].end(), target) != xs[q].end();
+            result.zs[q] = std::find(zs[q].begin(), zs[q].end(), target) != zs[q].end();
+        }
+        return result;
+    }
 
     void undo_gate(const CircuitInstruction &data);
     void undo_gate(const CircuitInstruction &op, const Circuit &parent);
@@ -99,7 +107,51 @@ struct SparseUnsignedRevFrameTracker {
     void undo_ISWAP(const CircuitInstruction &inst);
     void undo_CXSWAP(const CircuitInstruction &inst);
     void undo_SWAPCX(const CircuitInstruction &inst);
-    void undo_tableau(const Tableau<MAX_BITWORD_WIDTH> &tableau, SpanRef<const uint32_t> targets);
+
+    template <size_t W>
+    void undo_tableau(const Tableau<W> &tableau, SpanRef<const uint32_t> targets) {
+        size_t n = tableau.num_qubits;
+        if (n != targets.size()) {
+            throw new std::invalid_argument("tableau.num_qubits != targets.size()");
+        }
+        std::set<uint32_t> target_set;
+        for (size_t k = 0; k < n; k++) {
+            if (!target_set.insert(targets[k]).second) {
+                throw new std::invalid_argument("duplicate target");
+            }
+        }
+
+        std::vector<SparseXorVec<DemTarget>> old_xs;
+        std::vector<SparseXorVec<DemTarget>> old_zs;
+        old_xs.reserve(n);
+        old_zs.reserve(n);
+        for (size_t k = 0; k < n; k++) {
+            old_xs.push_back(std::move(xs[targets[k]]));
+            old_zs.push_back(std::move(zs[targets[k]]));
+            xs[targets[k]].clear();
+            zs[targets[k]].clear();
+        }
+
+        for (size_t i = 0; i < n; i++) {
+            for (size_t j = 0; j < n; j++) {
+                uint64_t px = tableau.inverse_x_output_pauli_xyz(j, i);
+                if (px == 1 || px == 2) {
+                    xs[targets[i]] ^= old_xs[j];
+                }
+                if (px == 2 || px == 3) {
+                    zs[targets[i]] ^= old_xs[j];
+                }
+
+                uint64_t pz = tableau.inverse_z_output_pauli_xyz(j, i);
+                if (pz == 1 || pz == 2) {
+                    xs[targets[i]] ^= old_zs[j];
+                }
+                if (pz == 2 || pz == 3) {
+                    zs[targets[i]] ^= old_zs[j];
+                }
+            }
+        }
+    }
 
     bool is_shifted_copy(const SparseUnsignedRevFrameTracker &other) const;
     void shift(int64_t measurement_offset, int64_t detector_offset);

--- a/src/stim/simulators/sparse_rev_frame_tracker.test.cc
+++ b/src/stim/simulators/sparse_rev_frame_tracker.test.cc
@@ -17,12 +17,14 @@
 #include "gtest/gtest.h"
 
 #include "stim/circuit/circuit.test.h"
+#include "stim/mem/simd_word.test.h"
 #include "stim/test_util.test.h"
 
 using namespace stim;
 
+template <size_t W>
 SparseUnsignedRevFrameTracker _tracker_from_pauli_string(const char *text) {
-    auto p = PauliString<MAX_BITWORD_WIDTH>::from_str(text);
+    auto p = PauliString<W>::from_str(text);
     SparseUnsignedRevFrameTracker result(p.num_qubits, 0, 0);
     for (size_t q = 0; q < p.num_qubits; q++) {
         if (p.xs[q]) {
@@ -35,101 +37,101 @@ SparseUnsignedRevFrameTracker _tracker_from_pauli_string(const char *text) {
     return result;
 }
 
-TEST(SparseUnsignedRevFrameTracker, undo_tableau_h) {
+TEST_EACH_WORD_SIZE_W(SparseUnsignedRevFrameTracker, undo_tableau_h, {
     SparseUnsignedRevFrameTracker actual(0, 0, 0);
     std::vector<uint32_t> targets{0};
-    auto tableau = GATE_DATA.at("H").tableau<MAX_BITWORD_WIDTH>();
+    auto tableau = GATE_DATA.at("H").tableau<W>();
 
-    actual = _tracker_from_pauli_string("I");
-    actual.undo_tableau(tableau, targets);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("I"));
+    actual = _tracker_from_pauli_string<W>("I");
+    actual.undo_tableau<W>(tableau, targets);
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("I"));
 
-    actual = _tracker_from_pauli_string("X");
-    actual.undo_tableau(tableau, targets);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("Z"));
+    actual = _tracker_from_pauli_string<W>("X");
+    actual.undo_tableau<W>(tableau, targets);
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("Z"));
 
-    actual = _tracker_from_pauli_string("Y");
-    actual.undo_tableau(tableau, targets);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("Y"));
+    actual = _tracker_from_pauli_string<W>("Y");
+    actual.undo_tableau<W>(tableau, targets);
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("Y"));
 
-    actual = _tracker_from_pauli_string("Z");
-    actual.undo_tableau(tableau, targets);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("X"));
-}
+    actual = _tracker_from_pauli_string<W>("Z");
+    actual.undo_tableau<W>(tableau, targets);
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("X"));
+})
 
-TEST(SparseUnsignedRevFrameTracker, undo_tableau_s) {
+TEST_EACH_WORD_SIZE_W(SparseUnsignedRevFrameTracker, undo_tableau_s, {
     SparseUnsignedRevFrameTracker actual(0, 0, 0);
     std::vector<uint32_t> targets{0};
-    auto tableau = GATE_DATA.at("S").tableau<MAX_BITWORD_WIDTH>();
+    auto tableau = GATE_DATA.at("S").tableau<W>();
 
-    actual = _tracker_from_pauli_string("I");
-    actual.undo_tableau(tableau, targets);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("I"));
+    actual = _tracker_from_pauli_string<W>("I");
+    actual.undo_tableau<W>(tableau, targets);
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("I"));
 
-    actual = _tracker_from_pauli_string("X");
-    actual.undo_tableau(tableau, targets);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("Y"));
+    actual = _tracker_from_pauli_string<W>("X");
+    actual.undo_tableau<W>(tableau, targets);
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("Y"));
 
-    actual = _tracker_from_pauli_string("Y");
-    actual.undo_tableau(tableau, targets);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("X"));
+    actual = _tracker_from_pauli_string<W>("Y");
+    actual.undo_tableau<W>(tableau, targets);
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("X"));
 
-    actual = _tracker_from_pauli_string("Z");
-    actual.undo_tableau(tableau, targets);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("Z"));
-}
+    actual = _tracker_from_pauli_string<W>("Z");
+    actual.undo_tableau<W>(tableau, targets);
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("Z"));
+})
 
-TEST(SparseUnsignedRevFrameTracker, undo_tableau_c_xyz) {
+TEST_EACH_WORD_SIZE_W(SparseUnsignedRevFrameTracker, undo_tableau_c_xyz, {
     SparseUnsignedRevFrameTracker actual(0, 0, 0);
     std::vector<uint32_t> targets{0};
-    auto tableau = GATE_DATA.at("C_XYZ").tableau<MAX_BITWORD_WIDTH>();
+    auto tableau = GATE_DATA.at("C_XYZ").tableau<W>();
 
-    actual = _tracker_from_pauli_string("I");
-    actual.undo_tableau(tableau, targets);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("I"));
+    actual = _tracker_from_pauli_string<W>("I");
+    actual.undo_tableau<W>(tableau, targets);
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("I"));
 
-    actual = _tracker_from_pauli_string("X");
-    actual.undo_tableau(tableau, targets);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("Z"));
+    actual = _tracker_from_pauli_string<W>("X");
+    actual.undo_tableau<W>(tableau, targets);
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("Z"));
 
-    actual = _tracker_from_pauli_string("Y");
-    actual.undo_tableau(tableau, targets);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("X"));
+    actual = _tracker_from_pauli_string<W>("Y");
+    actual.undo_tableau<W>(tableau, targets);
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("X"));
 
-    actual = _tracker_from_pauli_string("Z");
-    actual.undo_tableau(tableau, targets);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("Y"));
-}
+    actual = _tracker_from_pauli_string<W>("Z");
+    actual.undo_tableau<W>(tableau, targets);
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("Y"));
+})
 
-TEST(SparseUnsignedRevFrameTracker, undo_tableau_cx) {
+TEST_EACH_WORD_SIZE_W(SparseUnsignedRevFrameTracker, undo_tableau_cx, {
     SparseUnsignedRevFrameTracker actual(0, 0, 0);
     std::vector<uint32_t> targets{0, 1};
-    auto tableau = GATE_DATA.at("CX").tableau<MAX_BITWORD_WIDTH>();
+    auto tableau = GATE_DATA.at("CX").tableau<W>();
 
-    actual = _tracker_from_pauli_string("II");
-    actual.undo_tableau(tableau, targets);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("II"));
+    actual = _tracker_from_pauli_string<W>("II");
+    actual.undo_tableau<W>(tableau, targets);
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("II"));
 
-    actual = _tracker_from_pauli_string("IZ");
-    actual.undo_tableau(tableau, targets);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("ZZ"));
+    actual = _tracker_from_pauli_string<W>("IZ");
+    actual.undo_tableau<W>(tableau, targets);
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("ZZ"));
 
-    actual = _tracker_from_pauli_string("ZI");
-    actual.undo_tableau(tableau, targets);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("ZI"));
+    actual = _tracker_from_pauli_string<W>("ZI");
+    actual.undo_tableau<W>(tableau, targets);
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("ZI"));
 
-    actual = _tracker_from_pauli_string("XI");
-    actual.undo_tableau(tableau, targets);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("XX"));
+    actual = _tracker_from_pauli_string<W>("XI");
+    actual.undo_tableau<W>(tableau, targets);
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("XX"));
 
-    actual = _tracker_from_pauli_string("IX");
-    actual.undo_tableau(tableau, targets);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("IX"));
+    actual = _tracker_from_pauli_string<W>("IX");
+    actual.undo_tableau<W>(tableau, targets);
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("IX"));
 
-    actual = _tracker_from_pauli_string("YY");
-    actual.undo_tableau(tableau, targets);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("XZ"));
-}
+    actual = _tracker_from_pauli_string<W>("YY");
+    actual.undo_tableau<W>(tableau, targets);
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("XZ"));
+})
 
 static std::vector<GateTarget> qubit_targets(const std::vector<uint32_t> &targets) {
     std::vector<GateTarget> result;
@@ -139,7 +141,8 @@ static std::vector<GateTarget> qubit_targets(const std::vector<uint32_t> &target
     return result;
 }
 
-TEST(SparseUnsignedRevFrameTracker, fuzz_all_unitary_gates_vs_tableau) {
+
+TEST_EACH_WORD_SIZE_W(SparseUnsignedRevFrameTracker, fuzz_all_unitary_gates_vs_tableau, {
     auto &rng = SHARED_TEST_RNG();
     for (const auto &gate : GATE_DATA.items) {
         if (gate.flags & GATE_IS_UNITARY) {
@@ -165,348 +168,349 @@ TEST(SparseUnsignedRevFrameTracker, fuzz_all_unitary_gates_vs_tableau) {
                 targets.push_back(n - k + 1);
             }
             tracker_gate.undo_gate({gate.id, {}, qubit_targets(targets)});
-            tracker_tableau.undo_tableau(gate.tableau<MAX_BITWORD_WIDTH>(), targets);
+            tracker_tableau.undo_tableau<W>(gate.tableau<W>(), targets);
             EXPECT_EQ(tracker_gate, tracker_tableau) << gate.name;
         }
     }
-}
+})
 
-TEST(SparseUnsignedRevFrameTracker, RX) {
+TEST_EACH_WORD_SIZE_W(SparseUnsignedRevFrameTracker, RX, {
     SparseUnsignedRevFrameTracker actual(0, 0, 0);
 
-    actual = _tracker_from_pauli_string("III");
+    actual = _tracker_from_pauli_string<W>("III");
     actual.undo_RX({GateType::RX, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("III"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("III"));
 
-    actual = _tracker_from_pauli_string("XXX");
+    actual = _tracker_from_pauli_string<W>("XXX");
     actual.undo_RX({GateType::RX, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("IXI"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("IXI"));
 
-    actual = _tracker_from_pauli_string("XIZ");
+    actual = _tracker_from_pauli_string<W>("XIZ");
     ASSERT_THROW({ actual.undo_RX({GateType::RX, {}, qubit_targets({0, 2})}); }, std::invalid_argument);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("XIZ"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("XIZ"));
 
-    actual = _tracker_from_pauli_string("YIX");
+    actual = _tracker_from_pauli_string<W>("YIX");
     ASSERT_THROW({ actual.undo_RX({GateType::RX, {}, qubit_targets({0, 2})}); }, std::invalid_argument);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("YIX"));
-}
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("YIX"));
+})
 
-TEST(SparseUnsignedRevFrameTracker, RY) {
+TEST_EACH_WORD_SIZE_W(SparseUnsignedRevFrameTracker, RY, {
     SparseUnsignedRevFrameTracker actual(0, 0, 0);
 
-    actual = _tracker_from_pauli_string("III");
+    actual = _tracker_from_pauli_string<W>("III");
     actual.undo_RY({GateType::RY, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("III"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("III"));
 
-    actual = _tracker_from_pauli_string("YYY");
+    actual = _tracker_from_pauli_string<W>("YYY");
     actual.undo_RY({GateType::RY, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("IYI"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("IYI"));
 
-    actual = _tracker_from_pauli_string("YIZ");
+    actual = _tracker_from_pauli_string<W>("YIZ");
     ASSERT_THROW({ actual.undo_RY({GateType::RY, {}, qubit_targets({0, 2})}); }, std::invalid_argument);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("YIZ"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("YIZ"));
 
-    actual = _tracker_from_pauli_string("XIY");
+    actual = _tracker_from_pauli_string<W>("XIY");
     ASSERT_THROW({ actual.undo_RY({GateType::RY, {}, qubit_targets({0, 2})}); }, std::invalid_argument);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("XIY"));
-}
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("XIY"));
+})
 
-TEST(SparseUnsignedRevFrameTracker, RZ) {
+TEST_EACH_WORD_SIZE_W(SparseUnsignedRevFrameTracker, RZ, {
     SparseUnsignedRevFrameTracker actual(0, 0, 0);
 
-    actual = _tracker_from_pauli_string("III");
+    actual = _tracker_from_pauli_string<W>("III");
     actual.undo_RZ({GateType::R, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("III"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("III"));
 
-    actual = _tracker_from_pauli_string("ZZZ");
+    actual = _tracker_from_pauli_string<W>("ZZZ");
     actual.undo_RZ({GateType::R, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("IZI"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("IZI"));
 
-    actual = _tracker_from_pauli_string("YIZ");
+    actual = _tracker_from_pauli_string<W>("YIZ");
     ASSERT_THROW({ actual.undo_RZ({GateType::R, {}, qubit_targets({0, 2})}); }, std::invalid_argument);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("YIZ"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("YIZ"));
 
-    actual = _tracker_from_pauli_string("ZIX");
+    actual = _tracker_from_pauli_string<W>("ZIX");
     ASSERT_THROW({ actual.undo_RZ({GateType::R, {}, qubit_targets({0, 2})}); }, std::invalid_argument);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("ZIX"));
-}
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("ZIX"));
+})
 
-TEST(SparseUnsignedRevFrameTracker, MX) {
+TEST_EACH_WORD_SIZE_W(SparseUnsignedRevFrameTracker, MX, {
     SparseUnsignedRevFrameTracker actual(0, 0, 0);
 
-    actual = _tracker_from_pauli_string("III");
+    actual = _tracker_from_pauli_string<W>("III");
     actual.num_measurements_in_past = 2;
     actual.undo_MX({GateType::MX, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("III"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("III"));
 
-    actual = _tracker_from_pauli_string("XXX");
+    actual = _tracker_from_pauli_string<W>("XXX");
     actual.num_measurements_in_past = 2;
     actual.undo_MX({GateType::MX, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("XXX"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("XXX"));
 
-    actual = _tracker_from_pauli_string("XIZ");
+    actual = _tracker_from_pauli_string<W>("XIZ");
     ASSERT_THROW({ actual.undo_MX({GateType::MX, {}, qubit_targets({0, 2})}); }, std::invalid_argument);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("XIZ"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("XIZ"));
 
-    actual = _tracker_from_pauli_string("YIX");
+    actual = _tracker_from_pauli_string<W>("YIX");
     ASSERT_THROW({ actual.undo_MX({GateType::MX, {}, qubit_targets({0, 2})}); }, std::invalid_argument);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("YIX"));
-}
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("YIX"));
+})
 
-TEST(SparseUnsignedRevFrameTracker, MY) {
+TEST_EACH_WORD_SIZE_W(SparseUnsignedRevFrameTracker, MY, {
     SparseUnsignedRevFrameTracker actual(0, 0, 0);
 
-    actual = _tracker_from_pauli_string("III");
+    actual = _tracker_from_pauli_string<W>("III");
     actual.num_measurements_in_past = 2;
     actual.undo_MY({GateType::MY, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("III"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("III"));
 
-    actual = _tracker_from_pauli_string("YYY");
+    actual = _tracker_from_pauli_string<W>("YYY");
     actual.num_measurements_in_past = 2;
     actual.undo_MY({GateType::MY, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("YYY"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("YYY"));
 
-    actual = _tracker_from_pauli_string("YIZ");
+    actual = _tracker_from_pauli_string<W>("YIZ");
     ASSERT_THROW({ actual.undo_MY({GateType::MY, {}, qubit_targets({0, 2})}); }, std::invalid_argument);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("YIZ"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("YIZ"));
 
-    actual = _tracker_from_pauli_string("XIY");
+    actual = _tracker_from_pauli_string<W>("XIY");
     ASSERT_THROW({ actual.undo_MY({GateType::MY, {}, qubit_targets({0, 2})}); }, std::invalid_argument);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("XIY"));
-}
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("XIY"));
+})
 
-TEST(SparseUnsignedRevFrameTracker, MZ) {
+TEST_EACH_WORD_SIZE_W(SparseUnsignedRevFrameTracker, MZ, {
     SparseUnsignedRevFrameTracker actual(0, 0, 0);
 
-    actual = _tracker_from_pauli_string("III");
+    actual = _tracker_from_pauli_string<W>("III");
     actual.num_measurements_in_past = 2;
     actual.undo_MZ({GateType::M, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("III"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("III"));
 
-    actual = _tracker_from_pauli_string("ZZZ");
+    actual = _tracker_from_pauli_string<W>("ZZZ");
     actual.num_measurements_in_past = 2;
     actual.undo_MZ({GateType::M, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("ZZZ"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("ZZZ"));
 
-    actual = _tracker_from_pauli_string("YIZ");
+    actual = _tracker_from_pauli_string<W>("YIZ");
     ASSERT_THROW({ actual.undo_MZ({GateType::M, {}, qubit_targets({0, 2})}); }, std::invalid_argument);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("YIZ"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("YIZ"));
 
-    actual = _tracker_from_pauli_string("ZIX");
+    actual = _tracker_from_pauli_string<W>("ZIX");
     ASSERT_THROW({ actual.undo_MZ({GateType::M, {}, qubit_targets({0, 2})}); }, std::invalid_argument);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("ZIX"));
-}
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("ZIX"));
+})
 
-TEST(SparseUnsignedRevFrameTracker, MRX) {
+TEST_EACH_WORD_SIZE_W(SparseUnsignedRevFrameTracker, MRX, {
     SparseUnsignedRevFrameTracker actual(0, 0, 0);
 
-    actual = _tracker_from_pauli_string("III");
+    actual = _tracker_from_pauli_string<W>("III");
     actual.num_measurements_in_past = 2;
     actual.undo_MRX({GateType::MRX, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("III"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("III"));
 
-    actual = _tracker_from_pauli_string("XXX");
+    actual = _tracker_from_pauli_string<W>("XXX");
     actual.num_measurements_in_past = 2;
     actual.undo_MRX({GateType::MRX, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("IXI"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("IXI"));
 
-    actual = _tracker_from_pauli_string("XIZ");
+    actual = _tracker_from_pauli_string<W>("XIZ");
     ASSERT_THROW({ actual.undo_MRX({GateType::MRX, {}, qubit_targets({0, 2})}); }, std::invalid_argument);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("XIZ"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("XIZ"));
 
-    actual = _tracker_from_pauli_string("YIX");
+    actual = _tracker_from_pauli_string<W>("YIX");
     ASSERT_THROW({ actual.undo_MRX({GateType::MRX, {}, qubit_targets({0, 2})}); }, std::invalid_argument);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("YIX"));
-}
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("YIX"));
+})
 
-TEST(SparseUnsignedRevFrameTracker, MRY) {
+TEST_EACH_WORD_SIZE_W(SparseUnsignedRevFrameTracker, MRY, {
     SparseUnsignedRevFrameTracker actual(0, 0, 0);
 
-    actual = _tracker_from_pauli_string("III");
+    actual = _tracker_from_pauli_string<W>("III");
     actual.num_measurements_in_past = 2;
     actual.undo_MRY({GateType::MRY, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("III"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("III"));
 
-    actual = _tracker_from_pauli_string("YYY");
+    actual = _tracker_from_pauli_string<W>("YYY");
     actual.num_measurements_in_past = 2;
     actual.undo_MRY({GateType::MRY, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("IYI"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("IYI"));
 
-    actual = _tracker_from_pauli_string("YIZ");
+    actual = _tracker_from_pauli_string<W>("YIZ");
     ASSERT_THROW({ actual.undo_MRY({GateType::MRY, {}, qubit_targets({0, 2})}); }, std::invalid_argument);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("YIZ"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("YIZ"));
 
-    actual = _tracker_from_pauli_string("XIY");
+    actual = _tracker_from_pauli_string<W>("XIY");
     ASSERT_THROW({ actual.undo_MRY({GateType::MRY, {}, qubit_targets({0, 2})}); }, std::invalid_argument);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("XIY"));
-}
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("XIY"));
+})
 
-TEST(SparseUnsignedRevFrameTracker, MRZ) {
+TEST_EACH_WORD_SIZE_W(SparseUnsignedRevFrameTracker, MRZ, {
     SparseUnsignedRevFrameTracker actual(0, 0, 0);
 
-    actual = _tracker_from_pauli_string("III");
+    actual = _tracker_from_pauli_string<W>("III");
     actual.num_measurements_in_past = 2;
     actual.undo_MRZ({GateType::MR, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("III"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("III"));
 
-    actual = _tracker_from_pauli_string("ZZZ");
+    actual = _tracker_from_pauli_string<W>("ZZZ");
     actual.num_measurements_in_past = 2;
     actual.undo_MRZ({GateType::MR, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("IZI"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("IZI"));
 
-    actual = _tracker_from_pauli_string("YIZ");
+    actual = _tracker_from_pauli_string<W>("YIZ");
     ASSERT_THROW({ actual.undo_MRZ({GateType::MR, {}, qubit_targets({0, 2})}); }, std::invalid_argument);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("YIZ"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("YIZ"));
 
-    actual = _tracker_from_pauli_string("ZIX");
+    actual = _tracker_from_pauli_string<W>("ZIX");
     ASSERT_THROW({ actual.undo_MRZ({GateType::MR, {}, qubit_targets({0, 2})}); }, std::invalid_argument);
-    ASSERT_EQ(actual, _tracker_from_pauli_string("ZIX"));
-}
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("ZIX"));
+})
 
-TEST(SparseUnsignedRevFrameTracker, feedback_from_measurement) {
+TEST_EACH_WORD_SIZE_W(SparseUnsignedRevFrameTracker, feedback_from_measurement, {
     SparseUnsignedRevFrameTracker actual(0, 0, 0);
 
-    actual = _tracker_from_pauli_string("III");
+    actual = _tracker_from_pauli_string<W>("III");
     actual.num_measurements_in_past = 2;
     actual.rec_bits[0].xor_item(DemTarget::observable_id(0));
     actual.undo_MX({GateType::MX, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("XII"));
-    actual = _tracker_from_pauli_string("XII");
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("XII"));
+    actual = _tracker_from_pauli_string<W>("XII");
     actual.num_measurements_in_past = 2;
     actual.rec_bits[0].xor_item(DemTarget::observable_id(0));
     actual.undo_MX({GateType::MX, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("III"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("III"));
 
-    actual = _tracker_from_pauli_string("III");
+    actual = _tracker_from_pauli_string<W>("III");
     actual.num_measurements_in_past = 2;
     actual.rec_bits[0].xor_item(DemTarget::observable_id(0));
     actual.undo_MY({GateType::MY, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("YII"));
-    actual = _tracker_from_pauli_string("YII");
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("YII"));
+    actual = _tracker_from_pauli_string<W>("YII");
     actual.num_measurements_in_past = 2;
     actual.rec_bits[0].xor_item(DemTarget::observable_id(0));
     actual.undo_MY({GateType::MY, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("III"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("III"));
 
-    actual = _tracker_from_pauli_string("III");
+    actual = _tracker_from_pauli_string<W>("III");
     actual.num_measurements_in_past = 2;
     actual.rec_bits[0].xor_item(DemTarget::observable_id(0));
     actual.undo_MZ({GateType::M, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("ZII"));
-    actual = _tracker_from_pauli_string("ZII");
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("ZII"));
+    actual = _tracker_from_pauli_string<W>("ZII");
     actual.num_measurements_in_past = 2;
     actual.rec_bits[0].xor_item(DemTarget::observable_id(0));
     actual.undo_MZ({GateType::M, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("III"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("III"));
 
-    actual = _tracker_from_pauli_string("III");
+    actual = _tracker_from_pauli_string<W>("III");
     actual.num_measurements_in_past = 2;
     actual.rec_bits[0].xor_item(DemTarget::observable_id(0));
     actual.undo_MRX({GateType::MRX, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("XII"));
-    actual = _tracker_from_pauli_string("XII");
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("XII"));
+    actual = _tracker_from_pauli_string<W>("XII");
     actual.num_measurements_in_past = 2;
     actual.rec_bits[0].xor_item(DemTarget::observable_id(0));
     actual.undo_MRX({GateType::MRX, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("XII"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("XII"));
 
-    actual = _tracker_from_pauli_string("III");
+    actual = _tracker_from_pauli_string<W>("III");
     actual.num_measurements_in_past = 2;
     actual.rec_bits[0].xor_item(DemTarget::observable_id(0));
     actual.undo_MRY({GateType::MRY, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("YII"));
-    actual = _tracker_from_pauli_string("YII");
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("YII"));
+    actual = _tracker_from_pauli_string<W>("YII");
     actual.num_measurements_in_past = 2;
     actual.rec_bits[0].xor_item(DemTarget::observable_id(0));
     actual.undo_MRY({GateType::MRY, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("YII"));
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("YII"));
 
-    actual = _tracker_from_pauli_string("III");
+    actual = _tracker_from_pauli_string<W>("III");
     actual.num_measurements_in_past = 2;
     actual.rec_bits[0].xor_item(DemTarget::observable_id(0));
     actual.undo_MRZ({GateType::MR, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("ZII"));
-    actual = _tracker_from_pauli_string("ZII");
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("ZII"));
+    actual = _tracker_from_pauli_string<W>("ZII");
     actual.num_measurements_in_past = 2;
     actual.rec_bits[0].xor_item(DemTarget::observable_id(0));
     actual.undo_MRZ({GateType::MR, {}, qubit_targets({0, 2})});
-    ASSERT_EQ(actual, _tracker_from_pauli_string("ZII"));
-}
+    ASSERT_EQ(actual, _tracker_from_pauli_string<W>("ZII"));
+})
 
-TEST(SparseUnsignedRevFrameTracker, feedback_into_measurement) {
+TEST_EACH_WORD_SIZE_W(SparseUnsignedRevFrameTracker, feedback_into_measurement, {
     SparseUnsignedRevFrameTracker actual(0, 0, 0);
     SparseUnsignedRevFrameTracker expected(0, 0, 0);
     std::vector<GateTarget> targets{GateTarget::rec(-5), GateTarget::qubit(0)};
 
-    actual = _tracker_from_pauli_string("XII");
+    actual = _tracker_from_pauli_string<W>("XII");
     actual.num_measurements_in_past = 12;
     actual.undo_ZCX({GateType::CX, {}, targets});
-    expected = _tracker_from_pauli_string("XII");
+    expected = _tracker_from_pauli_string<W>("XII");
     expected.num_measurements_in_past = 12;
     ASSERT_EQ(actual, expected);
 
-    actual = _tracker_from_pauli_string("YII");
+    actual = _tracker_from_pauli_string<W>("YII");
     actual.num_measurements_in_past = 12;
     actual.undo_ZCX({GateType::CX, {}, targets});
-    expected = _tracker_from_pauli_string("YII");
+    expected = _tracker_from_pauli_string<W>("YII");
     expected.num_measurements_in_past = 12;
     expected.rec_bits[7].xor_item(DemTarget::observable_id(0));
     ASSERT_EQ(actual, expected);
 
-    actual = _tracker_from_pauli_string("ZII");
+    actual = _tracker_from_pauli_string<W>("ZII");
     actual.num_measurements_in_past = 12;
     actual.undo_ZCX({GateType::CX, {}, targets});
-    expected = _tracker_from_pauli_string("ZII");
+    expected = _tracker_from_pauli_string<W>("ZII");
     expected.num_measurements_in_past = 12;
     expected.rec_bits[7].xor_item(DemTarget::observable_id(0));
     ASSERT_EQ(actual, expected);
 
-    actual = _tracker_from_pauli_string("XII");
+    actual = _tracker_from_pauli_string<W>("XII");
     actual.num_measurements_in_past = 12;
     actual.undo_ZCY({GateType::CY, {}, targets});
-    expected = _tracker_from_pauli_string("XII");
+    expected = _tracker_from_pauli_string<W>("XII");
     expected.num_measurements_in_past = 12;
     expected.rec_bits[7].xor_item(DemTarget::observable_id(0));
     ASSERT_EQ(actual, expected);
 
-    actual = _tracker_from_pauli_string("YII");
+    actual = _tracker_from_pauli_string<W>("YII");
     actual.num_measurements_in_past = 12;
     actual.undo_ZCY({GateType::CY, {}, targets});
-    expected = _tracker_from_pauli_string("YII");
+    expected = _tracker_from_pauli_string<W>("YII");
     expected.num_measurements_in_past = 12;
     ASSERT_EQ(actual, expected);
 
-    actual = _tracker_from_pauli_string("ZII");
+    actual = _tracker_from_pauli_string<W>("ZII");
     actual.num_measurements_in_past = 12;
     actual.undo_ZCY({GateType::CY, {}, targets});
-    expected = _tracker_from_pauli_string("ZII");
+    expected = _tracker_from_pauli_string<W>("ZII");
     expected.num_measurements_in_past = 12;
     expected.rec_bits[7].xor_item(DemTarget::observable_id(0));
     ASSERT_EQ(actual, expected);
 
-    actual = _tracker_from_pauli_string("XII");
+    actual = _tracker_from_pauli_string<W>("XII");
     actual.num_measurements_in_past = 12;
     actual.undo_ZCZ({GateType::CZ, {}, targets});
-    expected = _tracker_from_pauli_string("XII");
+    expected = _tracker_from_pauli_string<W>("XII");
     expected.num_measurements_in_past = 12;
     expected.rec_bits[7].xor_item(DemTarget::observable_id(0));
     ASSERT_EQ(actual, expected);
 
-    actual = _tracker_from_pauli_string("YII");
+    actual = _tracker_from_pauli_string<W>("YII");
     actual.num_measurements_in_past = 12;
     actual.undo_ZCZ({GateType::CZ, {}, targets});
-    expected = _tracker_from_pauli_string("YII");
+    expected = _tracker_from_pauli_string<W>("YII");
     expected.num_measurements_in_past = 12;
     expected.rec_bits[7].xor_item(DemTarget::observable_id(0));
     ASSERT_EQ(actual, expected);
 
-    actual = _tracker_from_pauli_string("ZII");
+    actual = _tracker_from_pauli_string<W>("ZII");
     actual.num_measurements_in_past = 12;
     actual.undo_ZCZ({GateType::CZ, {}, targets});
-    expected = _tracker_from_pauli_string("ZII");
+    expected = _tracker_from_pauli_string<W>("ZII");
     expected.num_measurements_in_past = 12;
     ASSERT_EQ(actual, expected);
-}
+})
+
 
 TEST(SparseUnsignedRevFrameTracker, undo_circuit_feedback) {
     SparseUnsignedRevFrameTracker actual(20, 100, 10);
@@ -585,98 +589,98 @@ TEST(SparseUnsignedRevFrameTracker, undo_circuit_loop_big_period) {
     ASSERT_EQ(actual.num_detectors_in_past, 4000000000000ULL - 1000000000001ULL - 500);
 }
 
-TEST(SparseUnsignedRevFrameTracker, mpad) {
+TEST_EACH_WORD_SIZE_W(SparseUnsignedRevFrameTracker, mpad, {
     SparseUnsignedRevFrameTracker actual(0, 0, 0);
     SparseUnsignedRevFrameTracker expected(0, 0, 0);
 
-    actual = _tracker_from_pauli_string("IIZ");
+    actual = _tracker_from_pauli_string<W>("IIZ");
     actual.num_measurements_in_past = 2;
     actual.rec_bits[1].xor_item(DemTarget::relative_detector_id(5));
     actual.undo_MPAD({GateType::MRY, {}, qubit_targets({0})});
 
-    expected = _tracker_from_pauli_string("IIZ");
+    expected = _tracker_from_pauli_string<W>("IIZ");
     expected.num_measurements_in_past = 1;
 
     ASSERT_EQ(actual, expected);
-}
+})
 
-TEST(SparseUnsignedRevFrameTracker, mxx) {
+TEST_EACH_WORD_SIZE_W(SparseUnsignedRevFrameTracker, mxx, {
     SparseUnsignedRevFrameTracker actual(0, 0, 0);
     SparseUnsignedRevFrameTracker expected(0, 0, 0);
 
-    actual = _tracker_from_pauli_string("III");
+    actual = _tracker_from_pauli_string<W>("III");
     actual.num_measurements_in_past = 2;
     actual.rec_bits[1].xor_item(DemTarget::observable_id(0));
     actual.undo_circuit(Circuit("MXX 0 1"));
-    expected = _tracker_from_pauli_string("XXI");
+    expected = _tracker_from_pauli_string<W>("XXI");
     expected.num_measurements_in_past = 1;
     ASSERT_EQ(actual, expected);
 
-    actual = _tracker_from_pauli_string("ZZI");
+    actual = _tracker_from_pauli_string<W>("ZZI");
     actual.num_measurements_in_past = 2;
     actual.rec_bits[1].xor_item(DemTarget::observable_id(0));
     actual.undo_circuit(Circuit("MXX !0 !1"));
-    expected = _tracker_from_pauli_string("YYI");
+    expected = _tracker_from_pauli_string<W>("YYI");
     expected.num_measurements_in_past = 1;
     ASSERT_EQ(actual, expected);
 
-    actual = _tracker_from_pauli_string("ZXI");
+    actual = _tracker_from_pauli_string<W>("ZXI");
     actual.num_measurements_in_past = 2;
     actual.rec_bits[1].xor_item(DemTarget::observable_id(0));
     ASSERT_THROW({ actual.undo_circuit(Circuit("MXX 0 1")); }, std::invalid_argument);
-}
+})
 
-TEST(SparseUnsignedRevFrameTracker, myy) {
+TEST_EACH_WORD_SIZE_W(SparseUnsignedRevFrameTracker, myy, {
     SparseUnsignedRevFrameTracker actual(0, 0, 0);
     SparseUnsignedRevFrameTracker expected(0, 0, 0);
 
-    actual = _tracker_from_pauli_string("III");
+    actual = _tracker_from_pauli_string<W>("III");
     actual.num_measurements_in_past = 2;
     actual.rec_bits[1].xor_item(DemTarget::observable_id(0));
     actual.undo_circuit(Circuit("MYY 0 1"));
-    expected = _tracker_from_pauli_string("YYI");
+    expected = _tracker_from_pauli_string<W>("YYI");
     expected.num_measurements_in_past = 1;
     ASSERT_EQ(actual, expected);
 
-    actual = _tracker_from_pauli_string("ZZI");
+    actual = _tracker_from_pauli_string<W>("ZZI");
     actual.num_measurements_in_past = 2;
     actual.rec_bits[1].xor_item(DemTarget::observable_id(0));
     actual.undo_circuit(Circuit("MYY !0 !1"));
-    expected = _tracker_from_pauli_string("XXI");
+    expected = _tracker_from_pauli_string<W>("XXI");
     expected.num_measurements_in_past = 1;
     ASSERT_EQ(actual, expected);
 
-    actual = _tracker_from_pauli_string("ZYI");
+    actual = _tracker_from_pauli_string<W>("ZYI");
     actual.num_measurements_in_past = 2;
     actual.rec_bits[1].xor_item(DemTarget::observable_id(0));
     ASSERT_THROW({ actual.undo_circuit(Circuit("MYY 0 1")); }, std::invalid_argument);
-}
+})
 
-TEST(SparseUnsignedRevFrameTracker, mzz) {
+TEST_EACH_WORD_SIZE_W(SparseUnsignedRevFrameTracker, mzz, {
     SparseUnsignedRevFrameTracker actual(0, 0, 0);
     SparseUnsignedRevFrameTracker expected(0, 0, 0);
 
-    actual = _tracker_from_pauli_string("III");
+    actual = _tracker_from_pauli_string<W>("III");
     actual.num_measurements_in_past = 2;
     actual.rec_bits[1].xor_item(DemTarget::observable_id(0));
     actual.undo_circuit(Circuit("MZZ 0 1"));
-    expected = _tracker_from_pauli_string("ZZI");
+    expected = _tracker_from_pauli_string<W>("ZZI");
     expected.num_measurements_in_past = 1;
     ASSERT_EQ(actual, expected);
 
-    actual = _tracker_from_pauli_string("XXI");
+    actual = _tracker_from_pauli_string<W>("XXI");
     actual.num_measurements_in_past = 2;
     actual.rec_bits[1].xor_item(DemTarget::observable_id(0));
     actual.undo_circuit(Circuit("MZZ !0 !1"));
-    expected = _tracker_from_pauli_string("YYI");
+    expected = _tracker_from_pauli_string<W>("YYI");
     expected.num_measurements_in_past = 1;
     ASSERT_EQ(actual, expected);
 
-    actual = _tracker_from_pauli_string("ZYI");
+    actual = _tracker_from_pauli_string<W>("ZYI");
     actual.num_measurements_in_past = 2;
     actual.rec_bits[1].xor_item(DemTarget::observable_id(0));
     ASSERT_THROW({ actual.undo_circuit(Circuit("MZZ 0 1")); }, std::invalid_argument);
-}
+})
 
 TEST(SparseUnsignedRevFrameTracker, runs_on_general_circuit) {
     auto circuit = generate_test_circuit_with_all_operations();


### PR DESCRIPTION
If merged, this PR proposes to build on #548 by extending templatisation of SIMD widths to two further simulators.

Firstly, the `DemSampler` has become a class template. Second, template functions have been added, where appropriate, to the `SparseUnsignedRevFrameTracker`. As before, the motivation for this was to remove the use of hardcoded SIMD widths. Templatisation also facilitates unit testing across all SIMD widths via `TEST_EACH_WORD_SIZE_W`.