### PR TITLE
Squash more issues in prep for release

### DIFF
--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -2039,6 +2039,28 @@ class CircuitRepeatBlock:
             ''')
         """
     @property
+    def name(
+        self,
+    ) -> object:
+        """Returns the name "REPEAT".
+
+        This is a duck-typing convenience method. It exists so that code that doesn't
+        know whether it has a `stim.CircuitInstruction` or a `stim.CircuitRepeatBlock`
+        can check the object's name without having to do an `instanceof` check first.
+
+        Examples:
+            >>> import stim
+            >>> circuit = stim.Circuit('''
+            ...     H 0
+            ...     REPEAT 5 {
+            ...         CX 1 2
+            ...     }
+            ...     S 1
+            ... ''')
+            >>> [instruction.name for instruction in circuit]
+            ['H', 'REPEAT', 'S']
+        """
+    @property
     def repeat_count(
         self,
     ) -> int:
@@ -3153,6 +3175,29 @@ class DemRepeatBlock:
         self,
     ) -> int:
         """The number of times the repeat block's body is supposed to execute.
+        """
+    @property
+    def type(
+        self,
+    ) -> object:
+        """Returns the type name "repeat".
+
+        This is a duck-typing convenience method. It exists so that code that doesn't
+        know whether it has a `stim.DemInstruction` or a `stim.DemRepeatBlock`
+        can check the type field without having to do an `instanceof` check first.
+
+        Examples:
+            >>> import stim
+            >>> dem = stim.DetectorErrorModel('''
+            ...     error(0.1) D0 L0
+            ...     repeat 5 {
+            ...         error(0.1) D0 D1
+            ...         shift_detectors 1
+            ...     }
+            ...     logical_observable L0
+            ... ''')
+            >>> [instruction.type for instruction in dem]
+            ['error', 'repeat', 'logical_observable']
         """
 class DemTarget:
     """An instruction target from a detector error model (.dem) file.
@@ -8446,6 +8491,39 @@ class TableauSimulator:
             >>> s.peek_z(0)
             -1
         """
+    def postselect_observable(
+        self,
+        observable: stim.PauliString,
+        *,
+        desired_value: bool = False,
+    ) -> None:
+        """Projects into a desired observable, or raises an exception if it was impossible.
+
+        Postselecting an observable forces it to collapse to a specific eigenstate,
+        as if it was measured and that state was the result of the measurement.
+
+        Args:
+            observable: The observable to postselect, specified as a pauli string.
+                The pauli string's sign must be -1 or +1 (not -i or +i).
+            desired_value:
+                False (default): Postselect into the +1 eigenstate of the observable.
+                True: Postselect into the -1 eigenstate of the observable.
+
+        Raises:
+            ValueError:
+                The given observable had an imaginary sign.
+                OR
+                The postselection was impossible. The observable was in the opposite
+                eigenstate, so measuring it would never ever return the desired result.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.postselect_observable(stim.PauliString("+XX"))
+            >>> s.postselect_observable(stim.PauliString("+ZZ"))
+            >>> s.peek_observable_expectation(stim.PauliString("+YY"))
+            -1
+        """
     def postselect_x(
         self,
         targets: Union[int, Iterable[int]],
@@ -8469,6 +8547,21 @@ class TableauSimulator:
                 orthogonal to the desired state, so it was literally
                 impossible for a measurement of the qubit to return the
                 desired result.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.peek_x(0)
+            0
+            >>> s.postselect_x(0, desired_value=False)
+            >>> s.peek_x(0)
+            1
+            >>> s.h(0)
+            >>> s.peek_x(0)
+            0
+            >>> s.postselect_x(0, desired_value=True)
+            >>> s.peek_x(0)
+            -1
         """
     def postselect_y(
         self,
@@ -8493,6 +8586,21 @@ class TableauSimulator:
                 orthogonal to the desired state, so it was literally
                 impossible for a measurement of the qubit to return the
                 desired result.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.peek_y(0)
+            0
+            >>> s.postselect_y(0, desired_value=False)
+            >>> s.peek_y(0)
+            1
+            >>> s.reset_x(0)
+            >>> s.peek_y(0)
+            0
+            >>> s.postselect_y(0, desired_value=True)
+            >>> s.peek_y(0)
+            -1
         """
     def postselect_z(
         self,
@@ -8517,6 +8625,22 @@ class TableauSimulator:
                 orthogonal to the desired state, so it was literally
                 impossible for a measurement of the qubit to return the
                 desired result.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.h(0)
+            >>> s.peek_z(0)
+            0
+            >>> s.postselect_z(0, desired_value=False)
+            >>> s.peek_z(0)
+            1
+            >>> s.h(0)
+            >>> s.peek_z(0)
+            0
+            >>> s.postselect_z(0, desired_value=True)
+            >>> s.peek_z(0)
+            -1
         """
     def reset(
         self,

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -2039,6 +2039,28 @@ class CircuitRepeatBlock:
             ''')
         """
     @property
+    def name(
+        self,
+    ) -> object:
+        """Returns the name "REPEAT".
+
+        This is a duck-typing convenience method. It exists so that code that doesn't
+        know whether it has a `stim.CircuitInstruction` or a `stim.CircuitRepeatBlock`
+        can check the object's name without having to do an `instanceof` check first.
+
+        Examples:
+            >>> import stim
+            >>> circuit = stim.Circuit('''
+            ...     H 0
+            ...     REPEAT 5 {
+            ...         CX 1 2
+            ...     }
+            ...     S 1
+            ... ''')
+            >>> [instruction.name for instruction in circuit]
+            ['H', 'REPEAT', 'S']
+        """
+    @property
     def repeat_count(
         self,
     ) -> int:
@@ -3153,6 +3175,29 @@ class DemRepeatBlock:
         self,
     ) -> int:
         """The number of times the repeat block's body is supposed to execute.
+        """
+    @property
+    def type(
+        self,
+    ) -> object:
+        """Returns the type name "repeat".
+
+        This is a duck-typing convenience method. It exists so that code that doesn't
+        know whether it has a `stim.DemInstruction` or a `stim.DemRepeatBlock`
+        can check the type field without having to do an `instanceof` check first.
+
+        Examples:
+            >>> import stim
+            >>> dem = stim.DetectorErrorModel('''
+            ...     error(0.1) D0 L0
+            ...     repeat 5 {
+            ...         error(0.1) D0 D1
+            ...         shift_detectors 1
+            ...     }
+            ...     logical_observable L0
+            ... ''')
+            >>> [instruction.type for instruction in dem]
+            ['error', 'repeat', 'logical_observable']
         """
 class DemTarget:
     """An instruction target from a detector error model (.dem) file.
@@ -8446,6 +8491,39 @@ class TableauSimulator:
             >>> s.peek_z(0)
             -1
         """
+    def postselect_observable(
+        self,
+        observable: stim.PauliString,
+        *,
+        desired_value: bool = False,
+    ) -> None:
+        """Projects into a desired observable, or raises an exception if it was impossible.
+
+        Postselecting an observable forces it to collapse to a specific eigenstate,
+        as if it was measured and that state was the result of the measurement.
+
+        Args:
+            observable: The observable to postselect, specified as a pauli string.
+                The pauli string's sign must be -1 or +1 (not -i or +i).
+            desired_value:
+                False (default): Postselect into the +1 eigenstate of the observable.
+                True: Postselect into the -1 eigenstate of the observable.
+
+        Raises:
+            ValueError:
+                The given observable had an imaginary sign.
+                OR
+                The postselection was impossible. The observable was in the opposite
+                eigenstate, so measuring it would never ever return the desired result.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.postselect_observable(stim.PauliString("+XX"))
+            >>> s.postselect_observable(stim.PauliString("+ZZ"))
+            >>> s.peek_observable_expectation(stim.PauliString("+YY"))
+            -1
+        """
     def postselect_x(
         self,
         targets: Union[int, Iterable[int]],
@@ -8469,6 +8547,21 @@ class TableauSimulator:
                 orthogonal to the desired state, so it was literally
                 impossible for a measurement of the qubit to return the
                 desired result.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.peek_x(0)
+            0
+            >>> s.postselect_x(0, desired_value=False)
+            >>> s.peek_x(0)
+            1
+            >>> s.h(0)
+            >>> s.peek_x(0)
+            0
+            >>> s.postselect_x(0, desired_value=True)
+            >>> s.peek_x(0)
+            -1
         """
     def postselect_y(
         self,
@@ -8493,6 +8586,21 @@ class TableauSimulator:
                 orthogonal to the desired state, so it was literally
                 impossible for a measurement of the qubit to return the
                 desired result.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.peek_y(0)
+            0
+            >>> s.postselect_y(0, desired_value=False)
+            >>> s.peek_y(0)
+            1
+            >>> s.reset_x(0)
+            >>> s.peek_y(0)
+            0
+            >>> s.postselect_y(0, desired_value=True)
+            >>> s.peek_y(0)
+            -1
         """
     def postselect_z(
         self,
@@ -8517,6 +8625,22 @@ class TableauSimulator:
                 orthogonal to the desired state, so it was literally
                 impossible for a measurement of the qubit to return the
                 desired result.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.h(0)
+            >>> s.peek_z(0)
+            0
+            >>> s.postselect_z(0, desired_value=False)
+            >>> s.peek_z(0)
+            1
+            >>> s.h(0)
+            >>> s.peek_z(0)
+            0
+            >>> s.postselect_z(0, desired_value=True)
+            >>> s.peek_z(0)
+            -1
         """
     def reset(
         self,

--- a/src/stim/circuit/circuit_pybind_test.py
+++ b/src/stim/circuit/circuit_pybind_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import pathlib
+import re
 import tempfile
 from typing import cast
 
@@ -716,7 +717,7 @@ def test_shortest_graphlike_error_empty():
 def test_shortest_graphlike_error_msgs():
     with pytest.raises(
             ValueError,
-            match="Circuit defines no observables. Circuit defines no detectors. Circuit defines no errors that can flip detectors or observables."
+            match="NO OBSERVABLES"
     ):
         stim.Circuit().shortest_graphlike_error()
 
@@ -724,14 +725,16 @@ def test_shortest_graphlike_error_msgs():
         M 0
         OBSERVABLE_INCLUDE(0) rec[-1]
     """)
-    with pytest.raises(ValueError, match="Circuit defines no detectors. Circuit defines no errors that can flip detectors or observables."):
+    with pytest.raises(ValueError, match="NO DETECTORS"):
         c.shortest_graphlike_error()
 
     c = stim.Circuit("""
         X_ERROR(0.1) 0
         M 0
     """)
-    with pytest.raises(ValueError, match="Circuit defines no observables. Circuit defines no detectors. Circuit defines no errors that can flip detectors or observables."):
+    with pytest.raises(ValueError, match=r"NO OBSERVABLES(.|\n)*NO DETECTORS"):
+        c.shortest_graphlike_error()
+    with pytest.raises(ValueError, match=""):
         c.shortest_graphlike_error()
 
     c = stim.Circuit("""
@@ -739,7 +742,17 @@ def test_shortest_graphlike_error_msgs():
         DETECTOR rec[-1]
         OBSERVABLE_INCLUDE(0) rec[-1]
     """)
-    with pytest.raises(ValueError, match="Circuit defines no errors that can flip detectors or observables."):
+    with pytest.raises(ValueError, match="NO ERRORS"):
+        c.shortest_graphlike_error()
+
+    c = stim.Circuit("""
+        M(0.1) 0
+        DETECTOR rec[-1]
+        DETECTOR rec[-1]
+        DETECTOR rec[-1]
+        OBSERVABLE_INCLUDE(0) rec[-1]
+    """)
+    with pytest.raises(ValueError, match="NO GRAPHLIKE ERRORS"):
         c.shortest_graphlike_error()
 
     c = stim.Circuit("""
@@ -747,7 +760,7 @@ def test_shortest_graphlike_error_msgs():
         M 0
         DETECTOR rec[-1]
     """)
-    with pytest.raises(ValueError, match="Circuit defines no observables."):
+    with pytest.raises(ValueError, match="NO OBSERVABLES"):
         c.shortest_graphlike_error()
 
 
@@ -761,10 +774,7 @@ def test_search_for_undetectable_logical_errors_empty():
 
 
 def test_search_for_undetectable_logical_errors_msgs():
-    with pytest.raises(
-            ValueError,
-            match="Circuit defines no observables. Circuit defines no detectors. Circuit defines no errors that can flip detectors or observables."
-    ):
+    with pytest.raises(ValueError, match=r"NO OBSERVABLES(.|\n)*NO DETECTORS"):
         stim.Circuit().search_for_undetectable_logical_errors(
             dont_explore_edges_increasing_symptom_degree=True,
             dont_explore_edges_with_degree_above=4,
@@ -775,8 +785,7 @@ def test_search_for_undetectable_logical_errors_msgs():
         M 0
         OBSERVABLE_INCLUDE(0) rec[-1]
     """)
-    with pytest.raises(ValueError,
-                       match="Circuit defines no detectors. Circuit defines no errors that can flip detectors or observables."):
+    with pytest.raises(ValueError, match=r"NO DETECTORS(.|\n)*NO ERRORS"):
         c.search_for_undetectable_logical_errors(
             dont_explore_edges_increasing_symptom_degree=True,
             dont_explore_edges_with_degree_above=4,
@@ -787,8 +796,7 @@ def test_search_for_undetectable_logical_errors_msgs():
         X_ERROR(0.1) 0
         M 0
     """)
-    with pytest.raises(ValueError,
-                       match="Circuit defines no observables. Circuit defines no detectors. Circuit defines no errors that can flip detectors or observables."):
+    with pytest.raises(ValueError, match=r"NO OBSERVABLES(.|\n)*NO DETECTORS(.|\n)*NO ERRORS"):
         c.search_for_undetectable_logical_errors(
             dont_explore_edges_increasing_symptom_degree=True,
             dont_explore_edges_with_degree_above=4,
@@ -800,7 +808,7 @@ def test_search_for_undetectable_logical_errors_msgs():
         DETECTOR rec[-1]
         OBSERVABLE_INCLUDE(0) rec[-1]
     """)
-    with pytest.raises(ValueError, match="Circuit defines no errors that can flip detectors or observables."):
+    with pytest.raises(ValueError, match="NO ERRORS"):
         c.search_for_undetectable_logical_errors(
             dont_explore_edges_increasing_symptom_degree=True,
             dont_explore_edges_with_degree_above=4,
@@ -812,7 +820,7 @@ def test_search_for_undetectable_logical_errors_msgs():
         M 0
         DETECTOR rec[-1]
     """)
-    with pytest.raises(ValueError, match="Circuit defines no observables."):
+    with pytest.raises(ValueError, match="NO OBSERVABLES"):
         c.search_for_undetectable_logical_errors(
             dont_explore_edges_increasing_symptom_degree=True,
             dont_explore_edges_with_degree_above=4,

--- a/src/stim/circuit/circuit_repeat_block.pybind.cc
+++ b/src/stim/circuit/circuit_repeat_block.pybind.cc
@@ -105,6 +105,53 @@ void stim_pybind::pybind_circuit_repeat_block_methods(pybind11::module &m, pybin
         )DOC")
             .data());
 
+    c.def_property_readonly(
+        "name",
+        [](const CircuitRepeatBlock &self) -> pybind11::object {
+            return pybind11::cast("REPEAT");
+        },
+        clean_doc_string(R"DOC(
+            Returns the name "REPEAT".
+
+            This is a duck-typing convenience method. It exists so that code that doesn't
+            know whether it has a `stim.CircuitInstruction` or a `stim.CircuitRepeatBlock`
+            can check the object's name without having to do an `instanceof` check first.
+
+            Examples:
+                >>> import stim
+                >>> circuit = stim.Circuit('''
+                ...     H 0
+                ...     REPEAT 5 {
+                ...         CX 1 2
+                ...     }
+                ...     S 1
+                ... ''')
+                >>> [instruction.name for instruction in circuit]
+                ['H', 'REPEAT', 'S']
+        )DOC")
+            .data());
+
+    c.def_readonly(
+        "repeat_count",
+        &CircuitRepeatBlock::repeat_count,
+        clean_doc_string(R"DOC(
+            The repetition count of the repeat block.
+
+            Examples:
+                >>> import stim
+                >>> circuit = stim.Circuit('''
+                ...     H 0
+                ...     REPEAT 5 {
+                ...         CX 0 1
+                ...         CZ 1 2
+                ...     }
+                ... ''')
+                >>> repeat_block = circuit[1]
+                >>> repeat_block.repeat_count
+                5
+        )DOC")
+            .data());
+
     c.def(
         "body_copy",
         &CircuitRepeatBlock::body_copy,

--- a/src/stim/circuit/circuit_repeat_block_test.py
+++ b/src/stim/circuit/circuit_repeat_block_test.py
@@ -39,3 +39,13 @@ def test_init_and_equality():
 def test_repr(value):
     assert eval(repr(value), {'stim': stim}) == value
     assert repr(eval(repr(value), {'stim': stim})) == repr(value)
+
+
+def test_name():
+    assert [e.name for e in stim.Circuit('''
+        H 0
+        REPEAT 5 {
+            CX 1 2
+        }
+        S 1
+    ''')] == ['H', 'REPEAT', 'S']

--- a/src/stim/circuit/gate_data.test.cc
+++ b/src/stim/circuit/gate_data.test.cc
@@ -71,8 +71,7 @@ TEST(gate_data, hash_matches_storage_location) {
 }
 
 template <size_t W>
-std::pair<std::vector<PauliString<W>>, std::vector<PauliString<W>>>
-circuit_output_eq_val(const Circuit &circuit) {
+std::pair<std::vector<PauliString<W>>, std::vector<PauliString<W>>> circuit_output_eq_val(const Circuit &circuit) {
     if (circuit.count_measurements() > 1) {
         throw std::invalid_argument("count_measurements > 1");
     }

--- a/src/stim/cmd/command_diagram.pybind.cc
+++ b/src/stim/cmd/command_diagram.pybind.cc
@@ -44,17 +44,29 @@ pybind11::class_<DiagramHelper> stim_pybind::pybind_diagram(pybind11::module &m)
     return c;
 }
 
-std::string escape_html_for_srcdoc(const std::string& src) {
+std::string escape_html_for_srcdoc(const std::string &src) {
     // From https://stackoverflow.com/a/9907752
     std::stringstream dst;
     for (char ch : src) {
         switch (ch) {
-            case '&': dst << "&amp;"; break;
-            case '\'': dst << "&apos;"; break;
-            case '"': dst << "&quot;"; break;
-            case '<': dst << "&lt;"; break;
-            case '>': dst << "&gt;"; break;
-            default: dst << ch; break;
+            case '&':
+                dst << "&amp;";
+                break;
+            case '\'':
+                dst << "&apos;";
+                break;
+            case '"':
+                dst << "&quot;";
+                break;
+            case '<':
+                dst << "&lt;";
+                break;
+            case '>':
+                dst << "&gt;";
+                break;
+            default:
+                dst << ch;
+                break;
         }
     }
     return dst.str();
@@ -71,11 +83,10 @@ void stim_pybind::pybind_diagram_methods(pybind11::module &m, pybind11::class_<D
             // This commented out code would wrap the SVG in a little thing with a resizable tab.
             // That's convenient, but it breaks things like github showing the image.
             // std::stringstream out;
-            // out << R"HTML(<div style="border: 1px dashed gray; margin-bottom: 50px; height: 512px; resize: both; overflow: hidden">)HTML";
-            // out << R"HTML(<img style="max-width: 100%; max-height: 100%" src="data:image/svg+xml;base64,)HTML";
-            // write_data_as_base64_to(self.content.data(), self.content.size(), out);
-            // out << R"HTML("/></div>)HTML";
-            // output = out.str();
+            // out << R"HTML(<div style="border: 1px dashed gray; margin-bottom: 50px; height: 512px; resize: both;
+            // overflow: hidden">)HTML"; out << R"HTML(<img style="max-width: 100%; max-height: 100%"
+            // src="data:image/svg+xml;base64,)HTML"; write_data_as_base64_to(self.content.data(), self.content.size(),
+            // out); out << R"HTML("/></div>)HTML"; output = out.str();
         }
         if (self.type == DIAGRAM_TYPE_GLTF) {
             std::stringstream out;
@@ -85,8 +96,8 @@ void stim_pybind::pybind_diagram_methods(pybind11::module &m, pybind11::class_<D
         if (self.type == DIAGRAM_TYPE_HTML) {
             output = self.content;
         }
-	if (output == "None"){
-	    return pybind11::none();
+        if (output == "None") {
+            return pybind11::none();
         }
 
         // Wrap the output into an iframe.
@@ -94,7 +105,9 @@ void stim_pybind::pybind_diagram_methods(pybind11::module &m, pybind11::class_<D
         // cells from seeing each others' elements when finding elements by id.
         // Because, for some insane reason, Jupyter notebooks don't isolate the cells
         // from each other by default! Colab does the right thing at least...
-        std::string framed = R"HTML(<iframe style="width: 100%; height: 300px; overflow: hidden; resize: both; border: 1px dashed gray;" frameBorder="0" srcdoc=")HTML" + escape_html_for_srcdoc(output) + R"HTML("></iframe>)HTML";
+        std::string framed =
+            R"HTML(<iframe style="width: 100%; height: 300px; overflow: hidden; resize: both; border: 1px dashed gray;" frameBorder="0" srcdoc=")HTML" +
+            escape_html_for_srcdoc(output) + R"HTML("></iframe>)HTML";
         return pybind11::cast(framed);
     });
     c.def("_repr_svg_", [](const DiagramHelper &self) -> pybind11::object {

--- a/src/stim/cmd/command_gen.test.cc
+++ b/src/stim/cmd/command_gen.test.cc
@@ -45,8 +45,7 @@ TEST_EACH_WORD_SIZE_W(command_gen, no_noise_no_detections, {
                 }
                 CircuitGenParameters params(r, d, func.second.first);
                 auto circuit = func.second.second(params).circuit;
-                auto [det_samples, obs_samples] =
-                    sample_batch_detection_events<W>(circuit, 256, SHARED_TEST_RNG());
+                auto [det_samples, obs_samples] = sample_batch_detection_events<W>(circuit, 256, SHARED_TEST_RNG());
                 EXPECT_FALSE(det_samples.data.not_zero() || obs_samples.data.not_zero())
                     << "d=" << d << ", r=" << r << ", task=" << func.second.first << ", func=" << func.first;
             }

--- a/src/stim/dem/detector_error_model_pybind_test.py
+++ b/src/stim/dem/detector_error_model_pybind_test.py
@@ -275,24 +275,21 @@ def test_shortest_graphlike_error_rep_code():
 
 
 def test_shortest_graphlike_error_msgs():
-    with pytest.raises(
-            ValueError,
-            match="Circuit defines no observables. Circuit defines no detectors. Circuit defines no errors that can flip detectors or observables."
-    ):
+    with pytest.raises(ValueError, match=r"NO OBSERVABLES(.|\n)*NO DETECTORS(.|\n)*NO ERRORS"):
         stim.Circuit().detector_error_model(decompose_errors=True).shortest_graphlike_error()
 
     c = stim.Circuit("""
         M 0
         OBSERVABLE_INCLUDE(0) rec[-1]
     """)
-    with pytest.raises(ValueError, match="Circuit defines no detectors. Circuit defines no errors that can flip detectors or observables."):
+    with pytest.raises(ValueError, match=r"NO DETECTORS(.|\n)*NO ERRORS"):
         c.detector_error_model(decompose_errors=True).shortest_graphlike_error()
 
     c = stim.Circuit("""
         X_ERROR(0.1) 0
         M 0
     """)
-    with pytest.raises(ValueError, match="Circuit defines no observables. Circuit defines no detectors. Circuit defines no errors that can flip detectors or observables."):
+    with pytest.raises(ValueError, match=r"NO OBSERVABLES(.|\n)*NO DETECTORS(.|\n)*NO ERRORS"):
         c.detector_error_model(decompose_errors=True).shortest_graphlike_error()
 
     c = stim.Circuit("""
@@ -300,7 +297,7 @@ def test_shortest_graphlike_error_msgs():
         DETECTOR rec[-1]
         OBSERVABLE_INCLUDE(0) rec[-1]
     """)
-    with pytest.raises(ValueError, match="Circuit defines no errors that can flip detectors or observables."):
+    with pytest.raises(ValueError, match=r"NO ERRORS"):
         c.detector_error_model(decompose_errors=True).shortest_graphlike_error()
 
     c = stim.Circuit("""
@@ -308,7 +305,7 @@ def test_shortest_graphlike_error_msgs():
         M 0
         DETECTOR rec[-1]
     """)
-    with pytest.raises(ValueError, match="Circuit defines no observables."):
+    with pytest.raises(ValueError, match=r"NO OBSERVABLES"):
         c.detector_error_model(decompose_errors=True).shortest_graphlike_error()
 
 

--- a/src/stim/dem/detector_error_model_repeat_block.pybind.cc
+++ b/src/stim/dem/detector_error_model_repeat_block.pybind.cc
@@ -80,6 +80,32 @@ void stim_pybind::pybind_detector_error_model_repeat_block_methods(
             Returns a copy of the block's body, as a stim.DetectorErrorModel.
         )DOC")
             .data());
+    c.def_property_readonly(
+        "type",
+        [](const ExposedDemRepeatBlock &self) -> pybind11::object {
+            return pybind11::cast("repeat");
+        },
+        clean_doc_string(R"DOC(
+            Returns the type name "repeat".
+
+            This is a duck-typing convenience method. It exists so that code that doesn't
+            know whether it has a `stim.DemInstruction` or a `stim.DemRepeatBlock`
+            can check the type field without having to do an `instanceof` check first.
+
+            Examples:
+                >>> import stim
+                >>> dem = stim.DetectorErrorModel('''
+                ...     error(0.1) D0 L0
+                ...     repeat 5 {
+                ...         error(0.1) D0 D1
+                ...         shift_detectors 1
+                ...     }
+                ...     logical_observable L0
+                ... ''')
+                >>> [instruction.type for instruction in dem]
+                ['error', 'repeat', 'logical_observable']
+        )DOC")
+            .data());
     c.def(pybind11::self == pybind11::self, "Determines if two repeat blocks are identical.");
     c.def(pybind11::self != pybind11::self, "Determines if two repeat blocks are different.");
 

--- a/src/stim/dem/detector_error_model_repeat_block_pybind_test.py
+++ b/src/stim/dem/detector_error_model_repeat_block_pybind_test.py
@@ -35,3 +35,13 @@ def test_equality():
 def test_repr():
     v = stim.DemRepeatBlock(5, stim.DetectorErrorModel('error(0.125) D1 L2'))
     assert eval(repr(v), {"stim": stim}) == v
+
+
+def test_type():
+    assert [e.type for e in stim.DetectorErrorModel('''
+        detector D0
+        REPEAT 5 {
+            error(0.1) D0
+        }
+        logical_observable L0
+    ''')] == ['detector', 'repeat', 'logical_observable']

--- a/src/stim/diagram/detector_slice/detector_slice_set.cc
+++ b/src/stim/diagram/detector_slice/detector_slice_set.cc
@@ -55,7 +55,9 @@ bool DetectorSliceSetComputer::process_op_rev(const Circuit &parent, const Circu
         uint64_t max_skip = std::max(tick_cur, stop_iter) - stop_iter;
         uint64_t reps = op.repeat_block_rep_count();
         uint64_t ticks_per_iteration = loop_body.count_ticks();
-        uint64_t skipped_iterations = max_skip == 0 ? 0 : ticks_per_iteration == 0 ? reps : std::min(reps, max_skip / ticks_per_iteration);
+        uint64_t skipped_iterations = max_skip == 0              ? 0
+                                      : ticks_per_iteration == 0 ? reps
+                                                                 : std::min(reps, max_skip / ticks_per_iteration);
         if (skipped_iterations) {
             // We can allow the analyzer to fold parts of the loop we aren't yielding.
             tracker.undo_loop(loop_body, skipped_iterations);

--- a/src/stim/io/sparse_shot.cc
+++ b/src/stim/io/sparse_shot.cc
@@ -23,7 +23,8 @@ using namespace stim;
 
 SparseShot::SparseShot() : hits(), obs_mask(0) {
 }
-SparseShot::SparseShot(std::vector<uint64_t> hits, simd_bits<64> obs_mask) : hits(std::move(hits)), obs_mask(std::move(obs_mask)) {
+SparseShot::SparseShot(std::vector<uint64_t> hits, simd_bits<64> obs_mask)
+    : hits(std::move(hits)), obs_mask(std::move(obs_mask)) {
 }
 
 void SparseShot::clear() {

--- a/src/stim/io/sparse_shot.test.cc
+++ b/src/stim/io/sparse_shot.test.cc
@@ -41,5 +41,7 @@ TEST(sparse_shot, equality) {
 }
 
 TEST(sparse_shot, str) {
-    ASSERT_EQ((SparseShot{{1, 2, 3}, obs_mask(4)}.str()), "SparseShot{{1, 2, 3}, __1_____________________________________________________________}");
+    ASSERT_EQ(
+        (SparseShot{{1, 2, 3}, obs_mask(4)}.str()),
+        "SparseShot{{1, 2, 3}, __1_____________________________________________________________}");
 }

--- a/src/stim/mem/bitword.h
+++ b/src/stim/mem/bitword.h
@@ -15,7 +15,6 @@
  */
 
 #include <cstddef>
-#include <cstddef>
 
 #ifndef _STIM_MEM_BIT_WORD_H
 #define _STIM_MEM_BIT_WORD_H

--- a/src/stim/mem/bitword_128_sse.h
+++ b/src/stim/mem/bitword_128_sse.h
@@ -24,7 +24,7 @@
 #include <sstream>
 #include <stdexcept>
 
-#include "stim/mem/simd_word.h"
+#include "stim/mem/bitword.h"
 #include "stim/mem/simd_util.h"
 
 namespace stim {
@@ -89,7 +89,7 @@ struct bitword<128> {
         return (bool)(words[0] | words[1]);
     }
     inline operator int() const {  // NOLINT(hicpp-explicit-conversions)
-        return (int64_t)*this;
+        return (int64_t) * this;
     }
     inline operator uint64_t() const {  // NOLINT(hicpp-explicit-conversions)
         auto words = to_u64_array();

--- a/src/stim/mem/bitword_256_avx.h
+++ b/src/stim/mem/bitword_256_avx.h
@@ -21,8 +21,8 @@
 #include <array>
 #include <immintrin.h>
 #include <iostream>
-#include <stdexcept>
 #include <sstream>
+#include <stdexcept>
 
 #include "stim/mem/bitword.h"
 #include "stim/mem/simd_util.h"
@@ -88,7 +88,7 @@ struct bitword<256> {
         return (bool)(words[0] | words[1] | words[2] | words[3]);
     }
     inline operator int() const {  // NOLINT(hicpp-explicit-conversions)
-        return (int64_t)*this;
+        return (int64_t) * this;
     }
     inline operator uint64_t() const {  // NOLINT(hicpp-explicit-conversions)
         auto words = to_u64_array();

--- a/src/stim/mem/bitword_64.h
+++ b/src/stim/mem/bitword_64.h
@@ -68,7 +68,7 @@ struct bitword<64> {
         return (bool)(u64[0]);
     }
     inline operator int() const {  // NOLINT(hicpp-explicit-conversions)
-        return (int64_t)*this;
+        return (int64_t) * this;
     }
     inline operator uint64_t() const {  // NOLINT(hicpp-explicit-conversions)
         return u64[0];

--- a/src/stim/mem/simd_word.h
+++ b/src/stim/mem/simd_word.h
@@ -19,9 +19,9 @@
 #ifndef _STIM_MEM_SIMD_WORD_H
 #define _STIM_MEM_SIMD_WORD_H
 
-#include "stim/mem/bitword_64.h"
 #include "stim/mem/bitword_128_sse.h"
 #include "stim/mem/bitword_256_avx.h"
+#include "stim/mem/bitword_64.h"
 
 namespace stim {
 #if __AVX2__

--- a/src/stim/mem/simd_word.test.cc
+++ b/src/stim/mem/simd_word.test.cc
@@ -76,10 +76,12 @@ TEST_EACH_WORD_SIZE_W(simd_word, integer_conversions, {
     ASSERT_EQ((int64_t)(simd_word<W>{(int64_t)23}), 23);
     ASSERT_EQ((int64_t)(simd_word<W>{(int64_t)-23}), -23);
     if (W > 64) {
-        ASSERT_THROW({
-            uint64_t u = (uint64_t)(simd_word<W>{(int64_t)-23});
-            std::cerr << u;
-        }, std::invalid_argument);
+        ASSERT_THROW(
+            {
+                uint64_t u = (uint64_t)(simd_word<W>{(int64_t)-23});
+                std::cerr << u;
+            },
+            std::invalid_argument);
     }
 
     simd_word<W> w0{(uint64_t)0};

--- a/src/stim/search/graphlike/algo.cc
+++ b/src/stim/search/graphlike/algo.cc
@@ -96,17 +96,25 @@ DetectorErrorModel stim::shortest_graphlike_undetectable_logical_error(
     std::stringstream err_msg;
     err_msg << "Failed to find any graphlike logical errors.";
     if (graph.num_observables == 0) {
-        err_msg << " Circuit defines no observables.";
+        err_msg << "\n    WARNING: NO OBSERVABLES. The circuit or detector error model didn't define any observables, "
+                   "making it vacuously impossible to find a logical error.";
     }
     if (graph.nodes.size() == 0) {
-        err_msg << " Circuit defines no detectors.";
+        err_msg << "\n    WARNING: NO DETECTORS. The circuit or detector error model didn't define any detectors.";
     }
-    bool edges = 0;
-    for (const auto &n : graph.nodes) {
-        edges |= ( n.edges.size() > 0 );
-    }
-    if ( !edges ) {
-        err_msg << " Circuit defines no errors that can flip detectors or observables.";
+    if (model.count_errors() == 0) {
+        err_msg << "\n    WARNING: NO ERRORS. The circuit or detector error model didn't include any errors, making it "
+                   "vacuously impossible to find a logical error.";
+    } else {
+        bool edges = 0;
+        for (const auto &n : graph.nodes) {
+            edges |= n.edges.size() > 0;
+        }
+        if (!edges) {
+            err_msg << "\n    WARNING: NO GRAPHLIKE ERRORS. Although the circuit or detector error model does define "
+                       "some errors, none of them are graphlike (i.e. have at most two detection events), making it "
+                       "vacuously impossible to find a graphlike logical error.";
+        }
     }
     throw std::invalid_argument(err_msg.str());
 }

--- a/src/stim/search/graphlike/edge.h
+++ b/src/stim/search/graphlike/edge.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <iostream>
 #include <string>
+
 #include "stim/mem/simd_bits.h"
 
 namespace stim {

--- a/src/stim/search/graphlike/graph.cc
+++ b/src/stim/search/graphlike/graph.cc
@@ -105,17 +105,21 @@ Graph Graph::from_dem(const DetectorErrorModel &model, bool ignore_ungraphlike_e
     return result;
 }
 bool Graph::operator==(const Graph &other) const {
-    return nodes == other.nodes && num_observables == other.num_observables && distance_1_error_mask == other.distance_1_error_mask;
+    return nodes == other.nodes && num_observables == other.num_observables &&
+           distance_1_error_mask == other.distance_1_error_mask;
 }
 bool Graph::operator!=(const Graph &other) const {
     return !(*this == other);
 }
 
-Graph::Graph(size_t node_count, size_t num_observables) : nodes(node_count), num_observables(num_observables), distance_1_error_mask(num_observables) {
+Graph::Graph(size_t node_count, size_t num_observables)
+    : nodes(node_count), num_observables(num_observables), distance_1_error_mask(num_observables) {
 }
 
 Graph::Graph(std::vector<Node> nodes, size_t num_observables, simd_bits<64> distance_1_error_mask)
-    : nodes(std::move(nodes)), num_observables(num_observables), distance_1_error_mask(std::move(distance_1_error_mask)) {
+    : nodes(std::move(nodes)),
+      num_observables(num_observables),
+      distance_1_error_mask(std::move(distance_1_error_mask)) {
 }
 
 std::ostream &stim::impl_search_graphlike::operator<<(std::ostream &out, const Graph &v) {

--- a/src/stim/search/graphlike/search_state.cc
+++ b/src/stim/search/graphlike/search_state.cc
@@ -29,7 +29,8 @@ std::string SearchState::str() const {
     return result.str();
 }
 
-SearchState::SearchState(size_t num_observables) : det_active(NO_NODE_INDEX), det_held(NO_NODE_INDEX), obs_mask(num_observables) {
+SearchState::SearchState(size_t num_observables)
+    : det_active(NO_NODE_INDEX), det_held(NO_NODE_INDEX), obs_mask(num_observables) {
 }
 SearchState::SearchState(uint64_t det_active, uint64_t det_held, simd_bits<64> obs_mask)
     : det_active(det_active), det_held(det_held), obs_mask(std::move(obs_mask)) {

--- a/src/stim/search/graphlike/search_state.h
+++ b/src/stim/search/graphlike/search_state.h
@@ -25,9 +25,9 @@ namespace stim {
 namespace impl_search_graphlike {
 
 struct SearchState {
-    uint64_t det_active;  // The detection event being moved around in an attempt to remove it (or NO_NODE_INDEX).
-    uint64_t det_held;    // The detection event being left in the same place (or NO_NODE_INDEX).
-    simd_bits<64> obs_mask;    // The accumulated frame changes from moving the detection events around.
+    uint64_t det_active;     // The detection event being moved around in an attempt to remove it (or NO_NODE_INDEX).
+    uint64_t det_held;       // The detection event being left in the same place (or NO_NODE_INDEX).
+    simd_bits<64> obs_mask;  // The accumulated frame changes from moving the detection events around.
 
     SearchState() = delete;
     SearchState(size_t num_observables);

--- a/src/stim/search/graphlike/search_state.test.cc
+++ b/src/stim/search/graphlike/search_state.test.cc
@@ -89,7 +89,8 @@ TEST(search_graphlike, DemAdjGraphSearchState_append_transition_as_error_instruc
         error(1) D1 D3
     )MODEL"));
 
-    SearchState(1, 2, obs_mask(9)).append_transition_as_error_instruction_to(SearchState(1, NO_NODE_INDEX, obs_mask(9)), out);
+    SearchState(1, 2, obs_mask(9))
+        .append_transition_as_error_instruction_to(SearchState(1, NO_NODE_INDEX, obs_mask(9)), out);
     ASSERT_EQ(out, DetectorErrorModel(R"MODEL(
         error(1) L0 L3 L4
         error(1) D1 D3

--- a/src/stim/search/hyper/algo.cc
+++ b/src/stim/search/hyper/algo.cc
@@ -105,19 +105,17 @@ DetectorErrorModel stim::find_undetectable_logical_error(
     }
 
     std::stringstream err_msg;
-    err_msg << "Failed to find any graphlike logical errors.";
+    err_msg << "Failed to find any logical errors.";
     if (graph.num_observables == 0) {
-        err_msg << " Circuit defines no observables.";
+        err_msg << "\n    WARNING: NO OBSERVABLES. The circuit or detector error model didn't define any observables, "
+                   "making it vacuously impossible to find a logical error.";
     }
     if (graph.nodes.size() == 0) {
-        err_msg << " Circuit defines no detectors.";
+        err_msg << "\n    WARNING: NO DETECTORS. The circuit or detector error model didn't define any detectors.";
     }
-    bool edges = 0;
-    for (const auto &n : graph.nodes) {
-        edges |= ( n.edges.size() > 0 );
-    }
-    if ( !edges ) {
-        err_msg << " Circuit defines no errors that can flip detectors or observables.";
+    if (model.count_errors() == 0) {
+        err_msg << "\n    WARNING: NO ERRORS. The circuit or detector error model didn't include any errors, making it "
+                   "vacuously impossible to find a logical error.";
     }
     throw std::invalid_argument(err_msg.str());
 }

--- a/src/stim/search/hyper/edge.h
+++ b/src/stim/search/hyper/edge.h
@@ -21,8 +21,8 @@
 #include <iostream>
 #include <string>
 
-#include "stim/mem/sparse_xor_vec.h"
 #include "stim/mem/simd_bits.h"
+#include "stim/mem/sparse_xor_vec.h"
 
 namespace stim {
 

--- a/src/stim/search/hyper/graph.cc
+++ b/src/stim/search/hyper/graph.cc
@@ -57,17 +57,21 @@ Graph Graph::from_dem(const DetectorErrorModel &model, size_t dont_explore_edges
     return result;
 }
 bool Graph::operator==(const Graph &other) const {
-    return nodes == other.nodes && num_observables == other.num_observables && distance_1_error_mask == other.distance_1_error_mask;
+    return nodes == other.nodes && num_observables == other.num_observables &&
+           distance_1_error_mask == other.distance_1_error_mask;
 }
 bool Graph::operator!=(const Graph &other) const {
     return !(*this == other);
 }
 
-Graph::Graph(size_t node_count, size_t num_observables) : nodes(node_count), num_observables(num_observables), distance_1_error_mask(simd_bits<64>(num_observables)) {
+Graph::Graph(size_t node_count, size_t num_observables)
+    : nodes(node_count), num_observables(num_observables), distance_1_error_mask(simd_bits<64>(num_observables)) {
 }
 
 Graph::Graph(std::vector<Node> nodes, size_t num_observables, simd_bits<64> distance_1_error_mask)
-    : nodes(std::move(nodes)), num_observables(num_observables), distance_1_error_mask(std::move(distance_1_error_mask)) {
+    : nodes(std::move(nodes)),
+      num_observables(num_observables),
+      distance_1_error_mask(std::move(distance_1_error_mask)) {
 }
 
 std::ostream &stim::impl_search_hyper::operator<<(std::ostream &out, const Graph &v) {

--- a/src/stim/search/hyper/search_state.h
+++ b/src/stim/search/hyper/search_state.h
@@ -18,8 +18,8 @@
 #define _STIM_SEARCH_HYPER_SEARCH_STATE_H
 
 #include "stim/dem/detector_error_model.h"
-#include "stim/mem/sparse_xor_vec.h"
 #include "stim/mem/simd_bits.h"
+#include "stim/mem/sparse_xor_vec.h"
 
 namespace stim {
 

--- a/src/stim/search/hyper/search_state.test.cc
+++ b/src/stim/search/hyper/search_state.test.cc
@@ -30,18 +30,21 @@ static simd_bits<64> obs_mask(uint64_t v) {
 TEST(search_hyper_search_state, append_transition_as_error_instruction_to) {
     DetectorErrorModel out;
 
-    SearchState{{{1, 2}}, obs_mask(9)}.append_transition_as_error_instruction_to(SearchState{{{1, 2}}, obs_mask(16)}, out);
+    SearchState{{{1, 2}}, obs_mask(9)}.append_transition_as_error_instruction_to(
+        SearchState{{{1, 2}}, obs_mask(16)}, out);
     ASSERT_EQ(out, DetectorErrorModel(R"MODEL(
         error(1) L0 L3 L4
     )MODEL"));
 
-    SearchState{{{}}, obs_mask(9)}.append_transition_as_error_instruction_to(SearchState{{{1, 2, 4}}, obs_mask(16)}, out);
+    SearchState{{{}}, obs_mask(9)}.append_transition_as_error_instruction_to(
+        SearchState{{{1, 2, 4}}, obs_mask(16)}, out);
     ASSERT_EQ(out, DetectorErrorModel(R"MODEL(
         error(1) L0 L3 L4
         error(1) D1 D2 D4 L0 L3 L4
     )MODEL"));
 
-    SearchState{{{1, 2}}, obs_mask(9)}.append_transition_as_error_instruction_to(SearchState{{{2, 3}}, obs_mask(9)}, out);
+    SearchState{{{1, 2}}, obs_mask(9)}.append_transition_as_error_instruction_to(
+        SearchState{{{2, 3}}, obs_mask(9)}, out);
     ASSERT_EQ(out, DetectorErrorModel(R"MODEL(
         error(1) L0 L3 L4
         error(1) D1 D2 D4 L0 L3 L4

--- a/src/stim/simulators/dem_sampler.pybind.cc
+++ b/src/stim/simulators/dem_sampler.pybind.cc
@@ -38,7 +38,11 @@ RaiiFile optional_py_path_to_raii_file(const pybind11::object &obj, const char *
 }
 
 pybind11::object dem_sampler_py_sample(
-    DemSampler<MAX_BITWORD_WIDTH> &self, size_t shots, bool bit_packed, bool return_errors, pybind11::object &recorded_errors_to_replay) {
+    DemSampler<MAX_BITWORD_WIDTH> &self,
+    size_t shots,
+    bool bit_packed,
+    bool return_errors,
+    pybind11::object &recorded_errors_to_replay) {
     self.set_min_stripes(shots);
 
     bool replay = !recorded_errors_to_replay.is_none();

--- a/src/stim/simulators/sparse_rev_frame_tracker.test.cc
+++ b/src/stim/simulators/sparse_rev_frame_tracker.test.cc
@@ -141,7 +141,6 @@ static std::vector<GateTarget> qubit_targets(const std::vector<uint32_t> &target
     return result;
 }
 
-
 TEST_EACH_WORD_SIZE_W(SparseUnsignedRevFrameTracker, fuzz_all_unitary_gates_vs_tableau, {
     auto &rng = SHARED_TEST_RNG();
     for (const auto &gate : GATE_DATA.items) {
@@ -510,7 +509,6 @@ TEST_EACH_WORD_SIZE_W(SparseUnsignedRevFrameTracker, feedback_into_measurement, 
     expected.num_measurements_in_past = 12;
     ASSERT_EQ(actual, expected);
 })
-
 
 TEST(SparseUnsignedRevFrameTracker, undo_circuit_feedback) {
     SparseUnsignedRevFrameTracker actual(20, 100, 10);

--- a/src/stim/simulators/tableau_simulator.h
+++ b/src/stim/simulators/tableau_simulator.h
@@ -177,11 +177,11 @@ struct TableauSimulator {
     /// Returns the expectation value of measuring the qubit in the Z basis.
     int8_t peek_z(uint32_t target) const;
 
-    /// Forces a desired X basis measurement result, or raises an exception if it was impossible.
+    /// Projects the system into a desired qubit X observable, or raises an exception if it was impossible.
     void postselect_x(SpanRef<const GateTarget> targets, bool desired_result);
-    /// Forces a desired Y basis measurement result, or raises an exception if it was impossible.
+    /// Projects the system into a desired qubit Y observable, or raises an exception if it was impossible.
     void postselect_y(SpanRef<const GateTarget> targets, bool desired_result);
-    /// Forces a desired Z basis measurement result, or raises an exception if it was impossible.
+    /// Projects the system into a desired qubit Z observable, or raises an exception if it was impossible.
     void postselect_z(SpanRef<const GateTarget> targets, bool desired_result);
 
     /// Applies all of the Pauli operations in the given PauliString to the simulator's state.
@@ -258,7 +258,11 @@ struct TableauSimulator {
     ///     0: Observable will be random when measured.
     int8_t peek_observable_expectation(const PauliString<W> &observable) const;
 
+    /// Forces a desired measurement result, or raises an exception if it was impossible.
+    void postselect_observable(PauliStringRef<W> observable, bool desired_result);
+
    private:
+    uint32_t try_isolate_observable_to_qubit_z(PauliStringRef<W> observable, bool undo);
     void do_MXX_disjoint_controls_segment(const CircuitInstruction &inst);
     void do_MYY_disjoint_controls_segment(const CircuitInstruction &inst);
     void do_MZZ_disjoint_controls_segment(const CircuitInstruction &inst);

--- a/src/stim/simulators/tableau_simulator.pybind.cc
+++ b/src/stim/simulators/tableau_simulator.pybind.cc
@@ -1467,6 +1467,48 @@ void stim_pybind::pybind_tableau_simulator_methods(
             .data());
 
     c.def(
+        "postselect_observable",
+        [](TableauSimulator<MAX_BITWORD_WIDTH> &self, const PyPauliString &observable, bool desired_value) {
+            if (observable.imag) {
+                throw std::invalid_argument(
+                    "Observable isn't Hermitian; it has imaginary sign. Need observable.sign in [1, -1].");
+            }
+            self.postselect_observable(observable.value, desired_value);
+        },
+        pybind11::arg("observable"),
+        pybind11::kw_only(),
+        pybind11::arg("desired_value") = false,
+        clean_doc_string(R"DOC(
+            Projects into a desired observable, or raises an exception if it was impossible.
+
+            Postselecting an observable forces it to collapse to a specific eigenstate,
+            as if it was measured and that state was the result of the measurement.
+
+            Args:
+                observable: The observable to postselect, specified as a pauli string.
+                    The pauli string's sign must be -1 or +1 (not -i or +i).
+                desired_value:
+                    False (default): Postselect into the +1 eigenstate of the observable.
+                    True: Postselect into the -1 eigenstate of the observable.
+
+            Raises:
+                ValueError:
+                    The given observable had an imaginary sign.
+                    OR
+                    The postselection was impossible. The observable was in the opposite
+                    eigenstate, so measuring it would never ever return the desired result.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.postselect_observable(stim.PauliString("+XX"))
+                >>> s.postselect_observable(stim.PauliString("+ZZ"))
+                >>> s.peek_observable_expectation(stim.PauliString("+YY"))
+                -1
+        )DOC")
+            .data());
+
+    c.def(
         "measure",
         [](TableauSimulator<MAX_BITWORD_WIDTH> &self, uint32_t target) {
             self.ensure_large_enough_for_qubits(target + 1);
@@ -1540,6 +1582,21 @@ void stim_pybind::pybind_tableau_simulator_methods(
                     orthogonal to the desired state, so it was literally
                     impossible for a measurement of the qubit to return the
                     desired result.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.peek_x(0)
+                0
+                >>> s.postselect_x(0, desired_value=False)
+                >>> s.peek_x(0)
+                1
+                >>> s.h(0)
+                >>> s.peek_x(0)
+                0
+                >>> s.postselect_x(0, desired_value=True)
+                >>> s.peek_x(0)
+                -1
         )DOC")
             .data());
 
@@ -1571,6 +1628,21 @@ void stim_pybind::pybind_tableau_simulator_methods(
                     orthogonal to the desired state, so it was literally
                     impossible for a measurement of the qubit to return the
                     desired result.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.peek_y(0)
+                0
+                >>> s.postselect_y(0, desired_value=False)
+                >>> s.peek_y(0)
+                1
+                >>> s.reset_x(0)
+                >>> s.peek_y(0)
+                0
+                >>> s.postselect_y(0, desired_value=True)
+                >>> s.peek_y(0)
+                -1
         )DOC")
             .data());
 
@@ -1602,6 +1674,22 @@ void stim_pybind::pybind_tableau_simulator_methods(
                     orthogonal to the desired state, so it was literally
                     impossible for a measurement of the qubit to return the
                     desired result.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.h(0)
+                >>> s.peek_z(0)
+                0
+                >>> s.postselect_z(0, desired_value=False)
+                >>> s.peek_z(0)
+                1
+                >>> s.h(0)
+                >>> s.peek_z(0)
+                0
+                >>> s.postselect_z(0, desired_value=True)
+                >>> s.peek_z(0)
+                -1
         )DOC")
             .data());
 

--- a/src/stim/simulators/tableau_simulator.test.cc
+++ b/src/stim/simulators/tableau_simulator.test.cc
@@ -2335,3 +2335,39 @@ TEST_EACH_WORD_SIZE_W(TableauSimulator, heralded_erase, {
     ASSERT_EQ(sim.measurement_record.storage, (std::vector<bool>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}));
     ASSERT_NE(sim.inv_state, Tableau<W>(14));
 })
+
+TEST_EACH_WORD_SIZE_W(TableauSimulator, postselect_observable, {
+    TableauSimulator<W> sim(SHARED_TEST_RNG(), 0);
+    sim.postselect_observable(PauliString<W>("ZZ"), false);
+    sim.postselect_observable(PauliString<W>("XX"), false);
+
+    auto initial_state = sim.inv_state;
+    ASSERT_THROW({ sim.postselect_observable(PauliString<W>("YY"), false); }, std::invalid_argument);
+
+    sim.postselect_observable(PauliString<W>("ZZ"), false);
+    ASSERT_EQ(sim.inv_state, initial_state);
+
+    sim.postselect_observable(PauliString<W>("ZZ"), false);
+    ASSERT_EQ(sim.inv_state, initial_state);
+
+    ASSERT_THROW({ sim.postselect_observable(PauliString<W>("ZZ"), true); }, std::invalid_argument);
+    ASSERT_EQ(sim.inv_state, initial_state);
+
+    ASSERT_THROW({ sim.postselect_observable(PauliString<W>("ZZ"), true); }, std::invalid_argument);
+    ASSERT_EQ(sim.inv_state, initial_state);
+
+    sim.postselect_observable(PauliString<W>("ZZ"), false);
+    ASSERT_EQ(sim.inv_state, initial_state);
+
+    sim.postselect_observable(PauliString<W>("XX"), false);
+    ASSERT_EQ(sim.inv_state, initial_state);
+
+    sim.postselect_observable(PauliString<W>("-YY"), false);
+    ASSERT_EQ(sim.inv_state, initial_state);
+
+    sim.postselect_observable(PauliString<W>("YY"), true);
+    ASSERT_EQ(sim.inv_state, initial_state);
+
+    sim.postselect_observable(PauliString<W>("XZ"), true);
+    ASSERT_NE(sim.inv_state, initial_state);
+})

--- a/src/stim/simulators/tableau_simulator_pybind_test.py
+++ b/src/stim/simulators/tableau_simulator_pybind_test.py
@@ -706,3 +706,35 @@ def test_bad_inverse_padding_issue_is_fixed():
     sim.do(circuit)
     stabs = sim.canonical_stabilizers()
     assert stabs[-1] == stim.PauliString(466 * '_' + 'X')
+
+
+def test_postselect_observable():
+    sim = stim.TableauSimulator()
+    assert sim.peek_bloch(0) == stim.PauliString("+Z")
+
+    sim.postselect_observable(stim.PauliString("+X"))
+    assert sim.peek_bloch(0) == stim.PauliString("+X")
+
+    sim.postselect_observable(stim.PauliString("+Z"))
+    assert sim.peek_bloch(0) == stim.PauliString("+Z")
+
+    sim.postselect_observable(stim.PauliString("-X"))
+    assert sim.peek_bloch(0) == stim.PauliString("-X")
+
+    sim.postselect_observable(stim.PauliString("+Z"))
+    assert sim.peek_bloch(0) == stim.PauliString("+Z")
+
+    sim.postselect_observable(stim.PauliString("-X"), desired_value=True)
+    assert sim.peek_bloch(0) == stim.PauliString("+X")
+
+    with pytest.raises(ValueError, match="impossible"):
+        sim.postselect_observable(stim.PauliString("-X"))
+    assert sim.peek_bloch(0) == stim.PauliString("+X")
+
+    with pytest.raises(ValueError, match="imaginary sign"):
+        sim.postselect_observable(stim.PauliString("iZ"))
+    assert sim.peek_bloch(0) == stim.PauliString("+X")
+
+    sim.postselect_observable(stim.PauliString("+XX"))
+    sim.postselect_observable(stim.PauliString("+ZZ"))
+    assert sim.peek_observable_expectation(stim.PauliString("+YY")) == -1

--- a/src/stim/stabilizers/conversions.test.cc
+++ b/src/stim/stabilizers/conversions.test.cc
@@ -337,8 +337,7 @@ TEST_EACH_WORD_SIZE_W(conversions, circuit_to_tableau_ignoring_gates, {
     ASSERT_EQ(circuit_to_tableau<W>(annotations, false, false, false), Tableau<W>(1));
 
     ASSERT_EQ(
-        circuit_to_tableau<W>(
-            annotations + measure_reset + measure + reset + unitary + noise, true, true, true)
+        circuit_to_tableau<W>(annotations + measure_reset + measure + reset + unitary + noise, true, true, true)
             .num_qubits,
         2);
 })
@@ -418,8 +417,7 @@ TEST_EACH_WORD_SIZE_W(conversions, circuit_to_tableau, {
 })
 
 TEST_EACH_WORD_SIZE_W(conversions, circuit_to_output_state_vector, {
-    ASSERT_EQ(
-        circuit_to_output_state_vector<W>(Circuit(""), false), (std::vector<std::complex<float>>{{1}}));
+    ASSERT_EQ(circuit_to_output_state_vector<W>(Circuit(""), false), (std::vector<std::complex<float>>{{1}}));
     ASSERT_EQ(
         circuit_to_output_state_vector<W>(Circuit("H 0 1"), false),
         (std::vector<std::complex<float>>{{0.5}, {0.5}, {0.5}, {0.5}}));
@@ -475,8 +473,7 @@ TEST_EACH_WORD_SIZE_W(conversions, tableau_to_circuit, {
 TEST_EACH_WORD_SIZE_W(conversions, unitary_to_tableau_vs_gate_data, {
     for (const auto &gate : GATE_DATA.items) {
         if (gate.flags & GATE_IS_UNITARY) {
-            EXPECT_EQ(unitary_to_tableau<W>(gate.unitary(), true), gate.tableau<W>())
-                << gate.name;
+            EXPECT_EQ(unitary_to_tableau<W>(gate.unitary(), true), gate.tableau<W>()) << gate.name;
         }
     }
 })
@@ -508,31 +505,15 @@ TEST_EACH_WORD_SIZE_W(conversions, tableau_to_unitary_vs_gate_data, {
 })
 
 TEST_EACH_WORD_SIZE_W(conversions, unitary_vs_tableau_basic, {
-    ASSERT_EQ(
-        unitary_to_tableau<W>(GATE_DATA.at("XCZ").unitary(), false),
-        GATE_DATA.at("ZCX").tableau<W>());
-    ASSERT_EQ(
-        unitary_to_tableau<W>(GATE_DATA.at("XCZ").unitary(), true),
-        GATE_DATA.at("XCZ").tableau<W>());
-    ASSERT_EQ(
-        unitary_to_tableau<W>(GATE_DATA.at("ZCX").unitary(), false),
-        GATE_DATA.at("XCZ").tableau<W>());
-    ASSERT_EQ(
-        unitary_to_tableau<W>(GATE_DATA.at("ZCX").unitary(), true),
-        GATE_DATA.at("ZCX").tableau<W>());
+    ASSERT_EQ(unitary_to_tableau<W>(GATE_DATA.at("XCZ").unitary(), false), GATE_DATA.at("ZCX").tableau<W>());
+    ASSERT_EQ(unitary_to_tableau<W>(GATE_DATA.at("XCZ").unitary(), true), GATE_DATA.at("XCZ").tableau<W>());
+    ASSERT_EQ(unitary_to_tableau<W>(GATE_DATA.at("ZCX").unitary(), false), GATE_DATA.at("XCZ").tableau<W>());
+    ASSERT_EQ(unitary_to_tableau<W>(GATE_DATA.at("ZCX").unitary(), true), GATE_DATA.at("ZCX").tableau<W>());
 
-    ASSERT_EQ(
-        unitary_to_tableau<W>(GATE_DATA.at("XCY").unitary(), false),
-        GATE_DATA.at("YCX").tableau<W>());
-    ASSERT_EQ(
-        unitary_to_tableau<W>(GATE_DATA.at("XCY").unitary(), true),
-        GATE_DATA.at("XCY").tableau<W>());
-    ASSERT_EQ(
-        unitary_to_tableau<W>(GATE_DATA.at("YCX").unitary(), false),
-        GATE_DATA.at("XCY").tableau<W>());
-    ASSERT_EQ(
-        unitary_to_tableau<W>(GATE_DATA.at("YCX").unitary(), true),
-        GATE_DATA.at("YCX").tableau<W>());
+    ASSERT_EQ(unitary_to_tableau<W>(GATE_DATA.at("XCY").unitary(), false), GATE_DATA.at("YCX").tableau<W>());
+    ASSERT_EQ(unitary_to_tableau<W>(GATE_DATA.at("XCY").unitary(), true), GATE_DATA.at("XCY").tableau<W>());
+    ASSERT_EQ(unitary_to_tableau<W>(GATE_DATA.at("YCX").unitary(), false), GATE_DATA.at("XCY").tableau<W>());
+    ASSERT_EQ(unitary_to_tableau<W>(GATE_DATA.at("YCX").unitary(), true), GATE_DATA.at("YCX").tableau<W>());
 })
 
 TEST_EACH_WORD_SIZE_W(conversions, unitary_to_tableau_fuzz_vs_tableau_to_unitary, {

--- a/src/stim/stabilizers/pauli_string.h
+++ b/src/stim/stabilizers/pauli_string.h
@@ -80,6 +80,8 @@ struct PauliString {
 
     /// Identity constructor.
     explicit PauliString(size_t num_qubits);
+    /// Parse constructor.
+    explicit PauliString(const std::string &text);
     /// Factory method for creating a PauliString whose Pauli entries are returned by a function.
     static PauliString<W> from_func(bool sign, size_t num_qubits, const std::function<char(size_t)> &func);
     /// Factory method for creating a PauliString by parsing a string (e.g. "-XIIYZ").

--- a/src/stim/stabilizers/pauli_string.inl
+++ b/src/stim/stabilizers/pauli_string.inl
@@ -37,6 +37,11 @@ PauliString<W>::PauliString(size_t num_qubits) : num_qubits(num_qubits), sign(fa
 }
 
 template <size_t W>
+PauliString<W>::PauliString(const std::string &text) : num_qubits(0), sign(false), xs(0), zs(0) {
+    *this = std::move(PauliString<W>::from_str(text.c_str()));
+}
+
+template <size_t W>
 PauliString<W>::PauliString(const PauliStringRef<W> &other)
     : num_qubits(other.num_qubits), sign((bool)other.sign), xs(other.xs), zs(other.zs) {
 }

--- a/src/stim/stabilizers/tableau.h
+++ b/src/stim/stabilizers/tableau.h
@@ -176,7 +176,7 @@ struct Tableau {
     void prepend_X(size_t q);
     void prepend_Y(size_t q);
     void prepend_Z(size_t q);
-    void prepend_H_XZ(const size_t q);
+    void prepend_H_XZ(size_t q);
     void prepend_H_YZ(size_t q);
     void prepend_H_XY(size_t q);
     void prepend_C_XYZ(size_t q);


### PR DESCRIPTION
- Add `stim.CircuitRepeatBlock.name` for duck typing convenience
- Add `stim.DemRepeatBlock.type` for duck typing convenience
- Add `stim.TableauSimulator.postselect_observable`
- Improve logical error search messages
- autoformat

Fixes https://github.com/quantumlib/Stim/issues/606
Fixes https://github.com/quantumlib/Stim/issues/605
Fixes https://github.com/quantumlib/Stim/issues/278
