### PR TITLE
Loosen colinearity check used in diagrams when deciding to use curved paths

### DIFF
--- a/src/stim/diagram/detector_slice/detector_slice_set.h
+++ b/src/stim/diagram/detector_slice/detector_slice_set.h
@@ -82,7 +82,7 @@ struct FlattenedCoords {
     static FlattenedCoords from(const DetectorSliceSet &set, float desired_unit_distance);
 };
 Coord<2> pick_polygon_center(stim::SpanRef<const Coord<2>> coords);
-bool is_colinear(Coord<2> a, Coord<2> b, Coord<2> c);
+bool is_colinear(Coord<2> a, Coord<2> b, Coord<2> c, float atol);
 
 std::ostream &operator<<(std::ostream &out, const DetectorSliceSet &slice);
 

--- a/src/stim/diagram/detector_slice/detector_slice_set.test.cc
+++ b/src/stim/diagram/detector_slice/detector_slice_set.test.cc
@@ -277,14 +277,18 @@ TEST(detector_slice_set, pick_polygon_center) {
 }
 
 TEST(detector_slice_set_svg_diagram, is_colinear) {
-    ASSERT_TRUE(is_colinear({0, 0}, {0, 0}, {1, 2}));
-    ASSERT_TRUE(is_colinear({3, 6}, {1, 2}, {2, 4}));
-    ASSERT_FALSE(is_colinear({3, 7}, {1, 2}, {2, 4}));
-    ASSERT_FALSE(is_colinear({4, 6}, {1, 2}, {2, 4}));
-    ASSERT_FALSE(is_colinear({3, 6}, {1, 3}, {2, 4}));
-    ASSERT_FALSE(is_colinear({3, 6}, {2, 2}, {2, 4}));
-    ASSERT_FALSE(is_colinear({3, 6}, {1, 2}, {1, 4}));
-    ASSERT_FALSE(is_colinear({3, 6}, {1, 2}, {2, -4}));
+    ASSERT_TRUE(is_colinear({0, 0}, {0, 0}, {1, 2}, 1e-4f));
+    ASSERT_TRUE(is_colinear({3, 6}, {1, 2}, {2, 4}, 1e-4f));
+
+    ASSERT_FALSE(is_colinear({3, 7}, {1, 2}, {2, 4}, 1e-4f));
+    ASSERT_FALSE(is_colinear({4, 6}, {1, 2}, {2, 4}, 1e-4f));
+    ASSERT_FALSE(is_colinear({3, 6}, {1, 3}, {2, 4}, 1e-4f));
+    ASSERT_FALSE(is_colinear({3, 6}, {2, 2}, {2, 4}, 1e-4f));
+    ASSERT_FALSE(is_colinear({3, 6}, {1, 2}, {1, 4}, 1e-4f));
+    ASSERT_FALSE(is_colinear({3, 6}, {1, 2}, {2, -4}, 1e-4f));
+
+    ASSERT_FALSE(is_colinear({0, 1e-3f}, {0, 0}, {1, 2}, 1e-4f));
+    ASSERT_TRUE(is_colinear({0, 1e-3f}, {0, 0}, {1, 2}, 1e-2f));
 }
 
 TEST(detector_slice_set_svg_diagram, colinear_polygon) {


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Stim/issues/553