### PR TITLE
Update pybind11 to ~=2.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "pybind11==2.9.2"]
+requires = ["setuptools", "wheel", "pybind11~=2.11"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Tries to update `pybind11` to the latest version to see what happens.

Could close https://github.com/quantumlib/Stim/issues/623.