### PR TITLE
Fix stimcirq handling of 2-qubit cirq.AsymmetricDepolarizingChannel

### DIFF
--- a/glue/cirq/stimcirq/__init__.py
+++ b/glue/cirq/stimcirq/__init__.py
@@ -8,9 +8,9 @@ from ._stim_sampler import StimSampler
 from ._stim_to_cirq import (
     MeasureAndOrResetGate,
     stim_circuit_to_cirq_circuit,
-    TwoQubitAsymmetricDepolarizingChannel,
 )
 from ._sweep_pauli import SweepPauli
+from ._two_qubit_asymmetric_depolarize import TwoQubitAsymmetricDepolarizingChannel
 
 JSON_RESOLVERS_DICT = {
     "CumulativeObservableAnnotation": CumulativeObservableAnnotation,

--- a/glue/cirq/stimcirq/_cirq_to_stim.py
+++ b/glue/cirq/stimcirq/_cirq_to_stim.py
@@ -302,7 +302,32 @@ def _stim_append_dense_pauli_string_gate(
 def _stim_append_asymmetric_depolarizing_channel(
     c: stim.Circuit, g: cirq.AsymmetricDepolarizingChannel, t: List[int]
 ):
-    c.append_operation("PAULI_CHANNEL_1", t, [g.p_x, g.p_y, g.p_z])
+    if cirq.num_qubits(g) == 1:
+        c.append_operation("PAULI_CHANNEL_1", t, [g.p_x, g.p_y, g.p_z])
+    elif cirq.num_qubits(g) == 2:
+        c.append_operation(
+            "PAULI_CHANNEL_2",
+            t,
+            [
+                g.error_probabilities.get('IX', 0),
+                g.error_probabilities.get('IY', 0),
+                g.error_probabilities.get('IZ', 0),
+                g.error_probabilities.get('XI', 0),
+                g.error_probabilities.get('XX', 0),
+                g.error_probabilities.get('XY', 0),
+                g.error_probabilities.get('XZ', 0),
+                g.error_probabilities.get('YI', 0),
+                g.error_probabilities.get('YX', 0),
+                g.error_probabilities.get('YY', 0),
+                g.error_probabilities.get('YZ', 0),
+                g.error_probabilities.get('ZI', 0),
+                g.error_probabilities.get('ZX', 0),
+                g.error_probabilities.get('ZY', 0),
+                g.error_probabilities.get('ZZ', 0),
+            ]
+        )
+    else:
+        raise NotImplementedError(f'cirq-to-stim gate {g!r}')
 
 
 def _stim_append_depolarizing_channel(c: stim.Circuit, g: cirq.DepolarizingChannel, t: List[int]):

--- a/glue/cirq/stimcirq/_cirq_to_stim_test.py
+++ b/glue/cirq/stimcirq/_cirq_to_stim_test.py
@@ -1,3 +1,4 @@
+import itertools
 from typing import Dict, List, Sequence, Tuple, Union
 
 import cirq
@@ -146,13 +147,10 @@ ROUND_TRIP_NOISY_GATES = [
     cirq.AsymmetricDepolarizingChannel(p_x=0, p_y=0.1, p_z=0),
     cirq.AsymmetricDepolarizingChannel(p_x=0, p_y=0, p_z=0.1),
     *[
-        stimcirq.TwoQubitAsymmetricDepolarizingChannel(
-            cirq.one_hot(index=k, shape=15, value=0.1, dtype=np.float64)
-        )
-        for k in range(15)
+        cirq.asymmetric_depolarize(error_probabilities={a + b: 0.1})
+        for a, b in list(itertools.product('IXYZ', repeat=2))[1:]
     ],
-    stimcirq.TwoQubitAsymmetricDepolarizingChannel([k / 300 for k in range(1, 16)]),
-    stimcirq.TwoQubitAsymmetricDepolarizingChannel([0] * 15),
+    cirq.asymmetric_depolarize(error_probabilities={'IX': 0.125, 'ZY': 0.375}),
 ]
 
 

--- a/glue/cirq/stimcirq/_stim_to_cirq.py
+++ b/glue/cirq/stimcirq/_stim_to_cirq.py
@@ -103,7 +103,7 @@ class CircuitTranslationTracker:
         if len(args) != 15:
             raise ValueError(f"len(args={args!r}) != 15")
 
-        gate = cirq.asymmetric_depolarize(error_probabilities={
+        ps = {
             'IX': args[0],
             'IY': args[1],
             'IZ': args[2],
@@ -119,7 +119,11 @@ class CircuitTranslationTracker:
             'ZX': args[12],
             'ZY': args[13],
             'ZZ': args[14],
-        })
+        }
+        ps = {k: v for k, v in ps.items() if v}
+        if not ps:
+            ps['II'] = 1
+        gate = cirq.asymmetric_depolarize(error_probabilities=ps)
         self.process_gate_instruction(gate, instruction)
 
     def process_repeat_block(self, block: stim.CircuitRepeatBlock):

--- a/glue/cirq/stimcirq/_stim_to_cirq.py
+++ b/glue/cirq/stimcirq/_stim_to_cirq.py
@@ -21,7 +21,6 @@ from ._measure_and_or_reset_gate import MeasureAndOrResetGate
 from ._obs_annotation import CumulativeObservableAnnotation
 from ._shift_coords_annotation import ShiftCoordsAnnotation
 from ._sweep_pauli import SweepPauli
-from ._two_qubit_asymmetric_depolarize import TwoQubitAsymmetricDepolarizingChannel
 
 
 def _stim_targets_to_dense_pauli_string(
@@ -103,7 +102,25 @@ class CircuitTranslationTracker:
         args = instruction.gate_args_copy()
         if len(args) != 15:
             raise ValueError(f"len(args={args!r}) != 15")
-        self.process_gate_instruction(TwoQubitAsymmetricDepolarizingChannel(args), instruction)
+
+        gate = cirq.asymmetric_depolarize(error_probabilities={
+            'IX': args[0],
+            'IY': args[1],
+            'IZ': args[2],
+            'XI': args[3],
+            'XX': args[4],
+            'XY': args[5],
+            'XZ': args[6],
+            'YI': args[7],
+            'YX': args[8],
+            'YY': args[9],
+            'YZ': args[10],
+            'ZI': args[11],
+            'ZX': args[12],
+            'ZY': args[13],
+            'ZZ': args[14],
+        })
+        self.process_gate_instruction(gate, instruction)
 
     def process_repeat_block(self, block: stim.CircuitRepeatBlock):
         if self.flatten or block.repeat_count == 1:

--- a/glue/cirq/stimcirq/_two_qubit_asymmetric_depolarize.py
+++ b/glue/cirq/stimcirq/_two_qubit_asymmetric_depolarize.py
@@ -10,6 +10,9 @@ class TwoQubitAsymmetricDepolarizingChannel(cirq.Gate):
     distribution.
 
     The 15 probabilities are in IX, IY, ... ZY, ZZ order. II is skipped; it's the leftover.
+
+    This class is no longer used by stimcirq, but is kept around for backwards
+    compatibility of json-serialized circuits.
     """
 
     def __init__(self, probabilities: Sequence[float]):

--- a/glue/cirq/stimcirq/_two_qubit_asymmetric_depolarize_test.py
+++ b/glue/cirq/stimcirq/_two_qubit_asymmetric_depolarize_test.py
@@ -1,4 +1,5 @@
 import cirq
+import stim
 import stimcirq
 
 
@@ -51,3 +52,17 @@ def test_json_backwards_compat_exact():
     packed = '{\n  "cirq_type": "TwoQubitAsymmetricDepolarizingChannel",\n  "probabilities": [\n    0.0125,\n    0.1,\n    0,\n    0.23,\n    0,\n    0,\n    0.0375,\n    0,\n    0.01,\n    0,\n    0,\n    0,\n    0,\n    0.25,\n    0\n  ]\n}'
     assert cirq.read_json(json_text=packed, resolvers=[*cirq.DEFAULT_RESOLVERS, stimcirq.JSON_RESOLVER]) == raw
     assert cirq.to_json(raw) == packed
+
+
+def test_native_cirq_gate_converts():
+    c = cirq.Circuit(cirq.asymmetric_depolarize(
+        error_probabilities={
+            'IX': 0.125,
+            'ZY': 0.25
+        }).on(cirq.LineQubit(0), cirq.LineQubit(1)))
+    s = stim.Circuit("""
+        PAULI_CHANNEL_2(0.125, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.25, 0) 0 1
+        TICK
+    """)
+    assert stimcirq.cirq_circuit_to_stim_circuit(c) == s
+    assert stimcirq.stim_circuit_to_cirq_circuit(s) == c


### PR DESCRIPTION
- Deprecate usage of `stimcirq.TwoQubitAsymmetricDepolarizingChannel` in favor of cirq's native asymmetric channel
- Check number of qubits when converting from cirq's asymmetric noise channel

Fixes https://github.com/quantumlib/Stim/issues/625