### PR TITLE
Add `stim::DemInstruction` repeat block helper methods

### DIFF
--- a/file_lists/source_files_no_main
+++ b/file_lists/source_files_no_main
@@ -29,6 +29,7 @@ src/stim/cmd/command_m2d.cc
 src/stim/cmd/command_repl.cc
 src/stim/cmd/command_sample.cc
 src/stim/cmd/command_sample_dem.cc
+src/stim/dem/dem_instruction.cc
 src/stim/dem/detector_error_model.cc
 src/stim/diagram/ascii_diagram.cc
 src/stim/diagram/base64.cc

--- a/src/stim.h
+++ b/src/stim.h
@@ -22,6 +22,7 @@
 #include "stim/cmd/command_repl.h"
 #include "stim/cmd/command_sample.h"
 #include "stim/cmd/command_sample_dem.h"
+#include "stim/dem/dem_instruction.h"
 #include "stim/dem/detector_error_model.h"
 #include "stim/diagram/ascii_diagram.h"
 #include "stim/diagram/base64.h"

--- a/src/stim/dem/dem_instruction.cc
+++ b/src/stim/dem/dem_instruction.cc
@@ -1,0 +1,245 @@
+#include "stim/dem/dem_instruction.h"
+
+#include <cmath>
+
+#include "stim/simulators/error_analyzer.h"
+#include "stim/str_util.h"
+#include "stim/dem/detector_error_model.h"
+
+using namespace stim;
+
+constexpr uint64_t OBSERVABLE_BIT = uint64_t{1} << 63;
+constexpr uint64_t SEPARATOR_SYGIL = UINT64_MAX;
+
+DemTarget DemTarget::observable_id(uint64_t id) {
+    if (id > 0xFFFFFFFF) {
+        throw std::invalid_argument("id > 0xFFFFFFFF");
+    }
+    return {OBSERVABLE_BIT | id};
+}
+DemTarget DemTarget::relative_detector_id(uint64_t id) {
+    if (id >= (uint64_t{1} << 62)) {
+        throw std::invalid_argument("Relative detector id too large.");
+    }
+    return {id};
+}
+bool DemTarget::is_observable_id() const {
+    return data != SEPARATOR_SYGIL && (data & OBSERVABLE_BIT);
+}
+bool DemTarget::is_separator() const {
+    return data == SEPARATOR_SYGIL;
+}
+bool DemTarget::is_relative_detector_id() const {
+    return data != SEPARATOR_SYGIL && !(data & OBSERVABLE_BIT);
+}
+uint64_t DemTarget::raw_id() const {
+    return data & ~OBSERVABLE_BIT;
+}
+
+uint64_t DemTarget::val() const {
+    if (data == SEPARATOR_SYGIL) {
+        throw std::invalid_argument("Separator doesn't have an integer value.");
+    }
+    return raw_id();
+}
+
+bool DemTarget::operator==(const DemTarget &other) const {
+    return data == other.data;
+}
+bool DemTarget::operator!=(const DemTarget &other) const {
+    return !(*this == other);
+}
+bool DemTarget::operator<(const DemTarget &other) const {
+    return data < other.data;
+}
+std::ostream &stim::operator<<(std::ostream &out, const DemTarget &v) {
+    if (v.is_separator()) {
+        out << "^";
+        return out;
+    } else if (v.is_relative_detector_id()) {
+        out << "D" << v.raw_id();
+    } else {
+        out << "L" << v.raw_id();
+    }
+    return out;
+}
+
+std::string DemTarget::str() const {
+    std::stringstream s;
+    s << *this;
+    return s.str();
+}
+
+void DemTarget::shift_if_detector_id(int64_t offset) {
+    if (is_relative_detector_id()) {
+        data = (uint64_t)((int64_t)data + offset);
+    }
+}
+
+bool DemInstruction::operator<(const DemInstruction &other) const {
+    if (type != other.type) {
+        return type < other.type;
+    }
+    if (target_data != other.target_data) {
+        return target_data < other.target_data;
+    }
+    return arg_data < other.arg_data;
+}
+
+bool DemInstruction::operator==(const DemInstruction &other) const {
+    return approx_equals(other, 0);
+}
+bool DemInstruction::operator!=(const DemInstruction &other) const {
+    return !(*this == other);
+}
+bool DemInstruction::approx_equals(const DemInstruction &other, double atol) const {
+    if (target_data != other.target_data) {
+        return false;
+    }
+    if (type != other.type) {
+        return false;
+    }
+    if (arg_data.size() != other.arg_data.size()) {
+        return false;
+    }
+    for (size_t k = 0; k < arg_data.size(); k++) {
+        if (fabs(arg_data[k] - other.arg_data[k]) > atol) {
+            return false;
+        }
+    }
+    return true;
+}
+std::string DemInstruction::str() const {
+    std::stringstream s;
+    s << *this;
+    return s.str();
+}
+
+std::ostream &stim::operator<<(std::ostream &out, const DemInstructionType &type) {
+    switch (type) {
+        case DEM_ERROR:
+            out << "error";
+            break;
+        case DEM_DETECTOR:
+            out << "detector";
+            break;
+        case DEM_LOGICAL_OBSERVABLE:
+            out << "logical_observable";
+            break;
+        case DEM_SHIFT_DETECTORS:
+            out << "shift_detectors";
+            break;
+        case DEM_REPEAT_BLOCK:
+            out << "repeat";
+            break;
+        default:
+            out << "???unknown_instruction_type???";
+            break;
+    }
+    return out;
+}
+
+std::ostream &stim::operator<<(std::ostream &out, const DemInstruction &op) {
+    out << op.type;
+    if (!op.arg_data.empty()) {
+        out << "(" << comma_sep(op.arg_data) << ")";
+    }
+    if (op.type == DEM_SHIFT_DETECTORS || op.type == DEM_REPEAT_BLOCK) {
+        for (const auto &e : op.target_data) {
+            out << " " << e.data;
+        }
+    } else {
+        for (const auto &e : op.target_data) {
+            out << " " << e;
+        }
+    }
+    return out;
+}
+
+void DemInstruction::validate() const {
+    switch (type) {
+        case DEM_ERROR:
+            if (arg_data.size() != 1) {
+                throw std::invalid_argument(
+                    "'error' instruction takes 1 argument (a probability), but got " + std::to_string(arg_data.size()) +
+                    " arguments.");
+            }
+            if (arg_data[0] < 0 || arg_data[0] > 1) {
+                throw std::invalid_argument(
+                    "'error' instruction argument must be a probability (0 to 1) but got " +
+                    std::to_string(arg_data[0]));
+            }
+            if (!target_data.empty()) {
+                if (target_data.front() == DemTarget::separator() || target_data.back() == DemTarget::separator()) {
+                    throw std::invalid_argument(
+                        "First/last targets of 'error' instruction shouldn't be separators (^).");
+                }
+            }
+            for (size_t k = 1; k < target_data.size(); k++) {
+                if (target_data[k - 1] == DemTarget::separator() && target_data[k] == DemTarget::separator()) {
+                    throw std::invalid_argument("'error' instruction has adjacent separators (^ ^).");
+                }
+            }
+            break;
+        case DEM_SHIFT_DETECTORS:
+            if (target_data.size() != 1) {
+                throw std::invalid_argument(
+                    "'shift_detectors' instruction takes 1 target, but got " + std::to_string(target_data.size()) +
+                    " targets.");
+            }
+            break;
+        case DEM_DETECTOR:
+            if (target_data.size() != 1) {
+                throw std::invalid_argument(
+                    "'detector' instruction takes 1 target but got " + std::to_string(target_data.size()) +
+                    " arguments.");
+            }
+            if (!target_data[0].is_relative_detector_id()) {
+                throw std::invalid_argument(
+                    "'detector' instruction takes a relative detector target (D#) but got " + target_data[0].str() +
+                    " arguments.");
+            }
+            break;
+        case DEM_LOGICAL_OBSERVABLE:
+            if (arg_data.size() != 0) {
+                throw std::invalid_argument(
+                    "'logical_observable' instruction takes 0 arguments but got " + std::to_string(arg_data.size()) +
+                    " arguments.");
+            }
+            if (target_data.size() != 1) {
+                throw std::invalid_argument(
+                    "'logical_observable' instruction takes 1 target but got " + std::to_string(target_data.size()) +
+                    " arguments.");
+            }
+            if (!target_data[0].is_observable_id()) {
+                throw std::invalid_argument(
+                    "'logical_observable' instruction takes a logical observable target (L#) but got " +
+                    target_data[0].str() + " arguments.");
+            }
+            break;
+        case DEM_REPEAT_BLOCK:
+            // Handled elsewhere.
+            break;
+        default:
+            throw std::invalid_argument("Unknown instruction type.");
+    }
+}
+
+uint64_t DemInstruction::repeat_block_rep_count() const {
+    assert(target_data.size() > 0);
+    return target_data[0].data;
+}
+
+const DetectorErrorModel &DemInstruction::repeat_block_body(const DetectorErrorModel &host) const {
+    assert(target_data.size() == 2);
+    auto b = target_data[1].data;
+    assert(b < host.blocks.size());
+    return host.blocks[b];
+}
+
+DetectorErrorModel &DemInstruction::repeat_block_body(DetectorErrorModel &host) const {
+    assert(target_data.size() == 2);
+    auto b = target_data[1].data;
+    assert(b < host.blocks.size());
+    return host.blocks[b];
+}

--- a/src/stim/dem/dem_instruction.h
+++ b/src/stim/dem/dem_instruction.h
@@ -1,0 +1,67 @@
+#ifndef _STIM_DEM_DEM_INSTRUCTION_H
+#define _STIM_DEM_DEM_INSTRUCTION_H
+
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "stim/mem/span_ref.h"
+
+namespace stim {
+
+enum DemInstructionType : uint8_t {
+    DEM_ERROR,
+    DEM_SHIFT_DETECTORS,
+    DEM_DETECTOR,
+    DEM_LOGICAL_OBSERVABLE,
+    DEM_REPEAT_BLOCK,
+};
+
+struct DemTarget {
+    uint64_t data;
+
+    static DemTarget observable_id(uint64_t id);
+    static DemTarget relative_detector_id(uint64_t id);
+    static constexpr DemTarget separator() {
+        return {UINT64_MAX};
+    }
+    uint64_t raw_id() const;
+    uint64_t val() const;
+    bool is_observable_id() const;
+    bool is_separator() const;
+    bool is_relative_detector_id() const;
+    void shift_if_detector_id(int64_t offset);
+
+    bool operator==(const DemTarget &other) const;
+    bool operator!=(const DemTarget &other) const;
+    bool operator<(const DemTarget &other) const;
+    std::string str() const;
+};
+
+struct DetectorErrorModel;
+struct DemInstruction {
+    SpanRef<const double> arg_data;
+    SpanRef<const DemTarget> target_data;
+    DemInstructionType type;
+
+    bool operator<(const DemInstruction &other) const;
+    bool operator==(const DemInstruction &other) const;
+    bool operator!=(const DemInstruction &other) const;
+    bool approx_equals(const DemInstruction &other, double atol) const;
+    std::string str() const;
+
+    void validate() const;
+
+    uint64_t repeat_block_rep_count() const;
+    const DetectorErrorModel &repeat_block_body(const DetectorErrorModel &host) const;
+    DetectorErrorModel &repeat_block_body(DetectorErrorModel &host) const;
+};
+
+std::ostream &operator<<(std::ostream &out, const DemInstructionType &type);
+std::ostream &operator<<(std::ostream &out, const DemTarget &v);
+std::ostream &operator<<(std::ostream &out, const DemInstruction &v);
+
+}  // namespace stim
+
+#endif

--- a/src/stim/dem/detector_error_model.pybind.cc
+++ b/src/stim/dem/detector_error_model.pybind.cc
@@ -351,7 +351,7 @@ void stim_pybind::pybind_detector_error_model_methods(
             auto &op = self.instructions[index];
             if (op.type == DEM_REPEAT_BLOCK) {
                 return pybind11::cast(
-                    ExposedDemRepeatBlock{op.target_data[0].data, self.blocks[op.target_data[1].data]});
+                    ExposedDemRepeatBlock{op.repeat_block_rep_count(), op.repeat_block_body(self)});
             }
             ExposedDemInstruction result;
             result.targets.insert(result.targets.begin(), op.target_data.begin(), op.target_data.end());

--- a/src/stim/main_namespaced.test.cc
+++ b/src/stim/main_namespaced.test.cc
@@ -25,12 +25,14 @@ using namespace stim;
 
 std::string stim::run_captured_stim_main(std::vector<const char *> flags, const std::string &std_in_content) {
     // Setup input.
-    RaiiTempNamedFile raii_temp_file;
-    if (!std_in_content.empty()) {
-        raii_temp_file.write_contents(std_in_content);
-        flags.push_back("--in");
-        flags.push_back(raii_temp_file.path.data());
-    }
+    RaiiTempNamedFile raii_temp_file(std_in_content);
+    flags.push_back("--in");
+    flags.push_back(raii_temp_file.path.data());
+
+    return run_captured_stim_main(flags);
+}
+
+std::string stim::run_captured_stim_main(std::vector<const char *> flags) {
     flags.insert(flags.begin(), "[PROGRAM_LOCATION_IGNORE]");
 
     // Setup output.
@@ -75,21 +77,20 @@ bool stim::matches(std::string actual, std::string pattern) {
 }
 
 TEST(main, help_modes) {
-    ASSERT_TRUE(matches(run_captured_stim_main({"--help"}, ""), ".*Available stim commands.+"));
-    ASSERT_TRUE(matches(run_captured_stim_main({"help"}, ""), ".*Available stim commands.+"));
-    ASSERT_TRUE(matches(run_captured_stim_main({}, ""), ".+stderr.+No mode.+"));
-    ASSERT_TRUE(matches(run_captured_stim_main({"--sample", "--repl"}, ""), ".+stderr.+More than one mode.+"));
+    ASSERT_TRUE(matches(run_captured_stim_main({"--help"}), ".*Available stim commands.+"));
+    ASSERT_TRUE(matches(run_captured_stim_main({"help"}), ".*Available stim commands.+"));
+    ASSERT_TRUE(matches(run_captured_stim_main({}), ".+stderr.+No mode.+"));
+    ASSERT_TRUE(matches(run_captured_stim_main({"--sample", "--repl"}), ".+stderr.+More than one mode.+"));
     ASSERT_TRUE(
-        matches(run_captured_stim_main({"--sample", "--repl", "--detect"}, ""), ".+stderr.+More than one mode.+"));
-    ASSERT_TRUE(matches(run_captured_stim_main({"--help", "dhnsahddjoidsa"}, ""), ".*Unrecognized.*"));
-    ASSERT_TRUE(matches(run_captured_stim_main({"--help", "H"}, ""), ".+Hadamard.+"));
-    ASSERT_TRUE(matches(run_captured_stim_main({"--help", "--sample"}, ""), ".*Unrecognized.*"));
-    ASSERT_TRUE(matches(run_captured_stim_main({"--help", "sample"}, ""), ".*Samples measurements from a circuit.+"));
+        matches(run_captured_stim_main({"--sample", "--repl", "--detect"}), ".+stderr.+More than one mode.+"));
+    ASSERT_TRUE(matches(run_captured_stim_main({"--help", "dhnsahddjoidsa"}), ".*Unrecognized.*"));
+    ASSERT_TRUE(matches(run_captured_stim_main({"--help", "H"}), ".+Hadamard.+"));
+    ASSERT_TRUE(matches(run_captured_stim_main({"--help", "sample"}), ".*Samples measurements from a circuit.+"));
 }
 
 TEST(main, bad_flag) {
     ASSERT_EQ(
-        trim(run_captured_stim_main({"--gen", "--unknown"}, "")),
+        trim(run_captured_stim_main({"--gen", "--unknown"})),
         trim("[stderr=\033[31mUnrecognized command line argument --unknown for `stim gen`.\n"
              "Recognized command line arguments for `stim gen`:\n"
              "    --after_clifford_depolarization\n"

--- a/src/stim/main_namespaced.test.h
+++ b/src/stim/main_namespaced.test.h
@@ -20,6 +20,7 @@
 
 namespace stim {
 
+std::string run_captured_stim_main(std::vector<const char *> flags);
 std::string run_captured_stim_main(std::vector<const char *> flags, const std::string &std_in_content);
 std::string trim(std::string text);
 bool matches(std::string actual, std::string pattern);

--- a/src/stim/simulators/error_analyzer.cc
+++ b/src/stim/simulators/error_analyzer.cc
@@ -946,11 +946,11 @@ DetectorErrorModel unreversed(const DetectorErrorModel &rev, uint64_t &base_dete
                 }
                 break;
             case DEM_REPEAT_BLOCK: {
-                uint64_t repetitions = e.target_data[0].data;
+                uint64_t repetitions = e.repeat_block_rep_count();
                 if (repetitions) {
                     uint64_t old_base_detector_id = base_detector_id;
                     out.append_repeat_block(
-                        e.target_data[0].data, unreversed(rev.blocks[e.target_data[1].data], base_detector_id, seen));
+                        e.repeat_block_rep_count(), unreversed(e.repeat_block_body(rev), base_detector_id, seen));
                     uint64_t loop_shift = base_detector_id - old_base_detector_id;
                     base_detector_id += loop_shift * (repetitions - 1);
                 }


### PR DESCRIPTION
- Extract `dem_instruction.{h,cc}` files
- Fix test util `run_captured_stim_main` not having a way to specify `--in` for an empty file anymore