### PR TITLE
Speed up SparseXorVec.xor_item

### DIFF
--- a/src/stim/mem/sparse_xor_vec.h
+++ b/src/stim/mem/sparse_xor_vec.h
@@ -145,7 +145,24 @@ struct SparseXorVec {
     }
 
     void xor_item(const T &item) {
-        xor_sorted_items(&item);
+        // Just do a linear scan to find the insertion point, instead of a binary search.
+        // This is faster at small sizes, and complexity is linear anyways due to the shifting of later items.
+        auto it = sorted_items.begin();
+        while (true) {
+            if (it == sorted_items.end()) {
+                sorted_items.push_back(item);
+                break;
+            }
+            if (!(*it < item)) {
+                if (*it == item) {
+                    sorted_items.erase(it);
+                } else {
+                    sorted_items.insert(it, item);
+                }
+                break;
+            }
+            it++;
+        }
     }
 
     SparseXorVec &operator^=(const SparseXorVec<T> &other) {

--- a/src/stim/mem/sparse_xor_vec.perf.cc
+++ b/src/stim/mem/sparse_xor_vec.perf.cc
@@ -41,3 +41,16 @@ BENCHMARK(SparseXorTable_SmallRowXor_1000) {
         .show_rate("RowXors", n * 2)
         .show_rate("WordXors", n * 3);
 }
+
+BENCHMARK(SparseXorVec_XorItem) {
+    SparseXorVec<uint32_t> buf;
+    std::vector<uint32_t> data{2, 5, 9, 5, 3, 6, 10};
+
+    benchmark_go([&]() {
+        for (auto d : data) {
+            buf.xor_item(d);
+        }
+    })
+        .goal_nanos(30)
+        .show_rate("Item", data.size());
+}

--- a/src/stim/mem/sparse_xor_vec.test.cc
+++ b/src/stim/mem/sparse_xor_vec.test.cc
@@ -28,8 +28,8 @@ TEST(sparse_xor_table, inplace_xor) {
     SparseXorVec<uint32_t> v2;
     v1.xor_item(1);
     v1.xor_item(3);
-    v2.xor_item(2);
     v2.xor_item(3);
+    v2.xor_item(2);
     ASSERT_EQ(v1.sorted_items, (std::vector<uint32_t>{1, 3}));
     ASSERT_EQ(v2.sorted_items, (std::vector<uint32_t>{2, 3}));
     v1 ^= v2;


### PR DESCRIPTION
- This was going like 100x too slow due to delegating to the list case that used a buffer on the stack