### PR TITLE
Make `stim::DemSampler()` take its rng by forced rvalue

### DIFF
--- a/src/stim/simulators/dem_sampler.h
+++ b/src/stim/simulators/dem_sampler.h
@@ -42,7 +42,7 @@ struct DemSampler {
     size_t num_stripes;
 
     /// Compiles a sampler for the given detector error model.
-    DemSampler(DetectorErrorModel model, std::mt19937_64 rng, size_t min_stripes);
+    DemSampler(DetectorErrorModel model, std::mt19937_64 &&rng, size_t min_stripes);
 
     /// Clears the buffers and refills them with sampled shot data.
     void resample(bool replay_errors);

--- a/src/stim/simulators/dem_sampler.inl
+++ b/src/stim/simulators/dem_sampler.inl
@@ -25,7 +25,7 @@
 namespace stim {
 
 template <size_t W>
-DemSampler<W>::DemSampler(DetectorErrorModel init_model, std::mt19937_64 rng, size_t min_stripes)
+DemSampler<W>::DemSampler(DetectorErrorModel init_model, std::mt19937_64 &&rng, size_t min_stripes)
     : model(std::move(init_model)),
       num_detectors(model.count_detectors()),
       num_observables(model.count_observables()),

--- a/src/stim/simulators/dem_sampler.test.cc
+++ b/src/stim/simulators/dem_sampler.test.cc
@@ -22,8 +22,7 @@
 using namespace stim;
 
 TEST_EACH_WORD_SIZE_W(DemSampler, basic_sizing, {
-    std::mt19937_64 irrelevant_rng(0);
-    DemSampler<W> sampler(DetectorErrorModel(R"DEM()DEM"), irrelevant_rng, 700);
+    DemSampler<W> sampler(DetectorErrorModel(R"DEM()DEM"), std::mt19937_64(0), 700);
     ASSERT_EQ(sampler.det_buffer.num_major_bits_padded(), 0);
     ASSERT_EQ(sampler.obs_buffer.num_major_bits_padded(), 0);
     ASSERT_GE(sampler.det_buffer.num_minor_bits_padded(), 700);
@@ -37,7 +36,7 @@ TEST_EACH_WORD_SIZE_W(DemSampler, basic_sizing, {
             logical_observable L2000
             detector D1000
          )DEM"),
-        irrelevant_rng,
+        std::mt19937_64(0),
         200);
     ASSERT_GE(sampler.det_buffer.num_major_bits_padded(), 1000);
     ASSERT_GE(sampler.obs_buffer.num_major_bits_padded(), 2000);


### PR DESCRIPTION
- Safety against accidental duplication of rng states