### PR TITLE
Add python 3.12 build along with various fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
-      - run: python -m pip install pybind11==2.9.2
+      - run: python -m pip install pybind11~=2.11.1 cibuildwheel~=2.16.2 setuptools wheel
       - run: python setup.py sdist
       - run: pip install dist/*.tar.gz
   upload_dev_release_to_pypi:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
           {os: ubuntu-latest, dist: cp39-manylinux_x86_64},
           {os: ubuntu-latest, dist: cp310-manylinux_x86_64},
           {os: ubuntu-latest, dist: cp311-manylinux_x86_64},
+          {os: ubuntu-latest, dist: cp312-manylinux_x86_64},
 
           {os: ubuntu-latest, dist: cp36-manylinux_i686},
           {os: ubuntu-latest, dist: cp37-manylinux_i686},
@@ -92,11 +93,13 @@ jobs:
           {os: macos-latest, dist: cp39-macosx_x86_64, macosarch: x86_64},
           {os: macos-latest, dist: cp310-macosx_x86_64, macosarch: x86_64},
           {os: macos-latest, dist: cp311-macosx_x86_64, macosarch: x86_64},
+          {os: macos-latest, dist: cp312-macosx_x86_64, macosarch: x86_64},
 
           {os: macos-latest, dist: cp38-macosx_arm64, macosarch: arm64},
           {os: macos-latest, dist: cp39-macosx_arm64, macosarch: arm64},
           {os: macos-latest, dist: cp310-macosx_arm64, macosarch: arm64},
           {os: macos-latest, dist: cp311-macosx_arm64, macosarch: arm64},
+          {os: macos-latest, dist: cp312-macosx_arm64, macosarch: arm64},
 
           # pypy OSX builds disabled because numpy isn't prebuilt and fails to build.
           #
@@ -119,6 +122,7 @@ jobs:
           {os: windows-2019, dist: cp39-win_amd64},
           {os: windows-2019, dist: cp310-win_amd64},
           {os: windows-2019, dist: cp311-win_amd64},
+          {os: windows-2019, dist: cp312-win_amd64},
 
           {os: windows-2019, dist: cp36-win32},
           {os: windows-2019, dist: cp37-win32},
@@ -152,7 +156,7 @@ jobs:
       - run: mkdir -p output/stim
       - run: mkdir -p output/stimcirq
       - run: mkdir -p output/sinter
-      - run: python -m pip install pybind11==2.9.2 cibuildwheel==2.11.1
+      - run: python -m pip install pybind11~=2.11.1 cibuildwheel~=2.16.2 setuptools wheel
       - run: python -m cibuildwheel --print-build-identifiers
       - run: python -m cibuildwheel --output-dir output/stim
       - run: python setup.py sdist

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,6 @@ if(NOT(MSVC))
 else()
     target_compile_options(stim_benchmark PRIVATE ${MACHINE_FLAG})
 endif()
-install(TARGETS stim_benchmark RUNTIME DESTINATION bin)
 
 find_package(GTest QUIET)
 if(${GTest_FOUND})

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,16 +11,16 @@ http_archive(
 http_archive(
     name = "pybind11",
     build_file = "@pybind11_bazel//:pybind11.BUILD",
-    sha256 = "832e2f309c57da9c1e6d4542dedd34b24e4192ecb4d62f6f4866a737454c9970",
-    strip_prefix = "pybind11-2.10.4",
-    urls = ["https://github.com/pybind/pybind11/archive/v2.10.4.tar.gz"],
+    sha256 = "d475978da0cdc2d43b73f30910786759d593a9d8ee05b1b6846d1eb16c6d2e0c",
+    strip_prefix = "pybind11-2.11.1",
+    urls = ["https://github.com/pybind/pybind11/archive/refs/tags/v2.11.1.tar.gz"],
 )
 
 http_archive(
     name = "pybind11_bazel",
-    sha256 = "b72c5b44135b90d1ffaba51e08240be0b91707ac60bea08bb4d84b47316211bb",
-    strip_prefix = "pybind11_bazel-b162c7c88a253e3f6b673df0c621aca27596ce6b",
-    urls = ["https://github.com/pybind/pybind11_bazel/archive/b162c7c88a253e3f6b673df0c621aca27596ce6b.zip"],
+    sha256 = "e8355ee56c2ff772334b4bfa22be17c709e5573f6d1d561c7176312156c27bd4",
+    strip_prefix = "pybind11_bazel-2.11.1",
+    urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v2.11.1/pybind11_bazel-2.11.1.tar.gz"],
 )
 
 http_archive(

--- a/glue/sample/src/sinter/_main_plot.py
+++ b/glue/sample/src/sinter/_main_plot.py
@@ -151,7 +151,7 @@ def parse_args(args: List[str]) -> Any:
                         )
     parser.add_argument('--plot_args_func',
                         type=str,
-                        default='''{'marker': 'ov*sp^<>8PhH+xXDd|'[index % 18]}''',
+                        default='''{'marker': 'ov*sp^<>8P+xXhHDd|'[index % 18]}''',
                         help='A python expression used to customize the look of curves.\n'
                              'Values available to the python expression:\n'
                              '    index: A unique integer identifying the curve.\n'
@@ -536,7 +536,7 @@ def _plot_helper(
 
     x_scale_name: Optional[str] = None
     for ax in [ax_err, ax_dis, ax_cus]:
-        x_scale_name = x_scale_name or _set_axis_scale_label_ticks(
+        v = _set_axis_scale_label_ticks(
             ax=ax,
             y_not_x=False,
             axis_label=xaxis,
@@ -548,6 +548,7 @@ def _plot_helper(
             plotted_stats=plotted_stats,
             v_func=x_func,
         )
+        x_scale_name = x_scale_name or v
 
     y_scale_name: Optional[str] = None
     if ax_err is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "pybind11==2.9.2"]
+requires = ["setuptools", "wheel", "pybind11~=2.11.1"]
 build-backend = "setuptools.build_meta"

--- a/src/stim/benchmark_main.perf.cc
+++ b/src/stim/benchmark_main.perf.cc
@@ -22,7 +22,8 @@
 using namespace stim;
 
 RegisteredBenchmark *running_benchmark = nullptr;
-std::vector<RegisteredBenchmark> all_registered_benchmarks{};
+std::vector<RegisteredBenchmark> *all_registered_benchmarks_data = nullptr;
+uint64_t registry_initialized = 0;
 
 /// Describe quantity as an SI-prefixed value with two significant figures.
 std::string si2(double val) {
@@ -83,14 +84,14 @@ void find_benchmarks(const std::string &filter, std::vector<RegisteredBenchmark>
 
     if (!filter.empty() && filter[filter.size() - 1] == '*') {
         std::string start = filter.substr(0, filter.size() - 1);
-        for (const auto &benchmark : all_registered_benchmarks) {
+        for (const auto &benchmark : *all_registered_benchmarks_data) {
             if (benchmark.name.substr(0, start.size()) == start) {
                 out.push_back(benchmark);
                 found = true;
             }
         }
     } else {
-        for (const auto &benchmark : all_registered_benchmarks) {
+        for (const auto &benchmark : *all_registered_benchmarks_data) {
             if (benchmark.name == filter) {
                 out.push_back(benchmark);
                 found = true;
@@ -100,7 +101,7 @@ void find_benchmarks(const std::string &filter, std::vector<RegisteredBenchmark>
 
     if (!found) {
         std::cerr << "No benchmark matching filter '" << filter << "'. Available benchmarks are:\n";
-        for (auto &benchmark : all_registered_benchmarks) {
+        for (auto &benchmark : *all_registered_benchmarks_data) {
             std::cerr << "    " << benchmark.name << "\n";
         }
         exit(EXIT_FAILURE);
@@ -116,7 +117,7 @@ int main(int argc, const char **argv) {
 
     std::vector<RegisteredBenchmark> chosen_benchmarks;
     if (only == nullptr) {
-        chosen_benchmarks = all_registered_benchmarks;
+        chosen_benchmarks = *all_registered_benchmarks_data;
     } else {
         std::string filter_text = only;
         std::vector<std::string> filters{};
@@ -179,6 +180,11 @@ int main(int argc, const char **argv) {
                 exit(EXIT_FAILURE);
             }
         }
+    }
+
+    if (all_registered_benchmarks_data != nullptr) {
+        delete all_registered_benchmarks_data;
+        all_registered_benchmarks_data = nullptr;
     }
     return 0;
 }

--- a/src/stim/benchmark_util.perf.h
+++ b/src/stim/benchmark_util.perf.h
@@ -61,13 +61,21 @@ struct RegisteredBenchmark {
     std::vector<BenchmarkResult> results;
 };
 extern RegisteredBenchmark *running_benchmark;
-extern std::vector<RegisteredBenchmark> all_registered_benchmarks;
+extern std::vector<RegisteredBenchmark> *all_registered_benchmarks_data;
+extern uint64_t registry_initialized;
+inline void add_benchmark(RegisteredBenchmark benchmark) {
+    if (all_registered_benchmarks_data == nullptr || registry_initialized != 4620243525989388168ULL) {
+        registry_initialized = 4620243525989388168ULL;
+        all_registered_benchmarks_data = new std::vector<RegisteredBenchmark>();
+    }
+    all_registered_benchmarks_data->push_back(benchmark);
+}
 
 #define BENCHMARK(name)                                                          \
     void BENCH_##name##_METHOD();                                                \
     struct BENCH_STARTUP_TYPE_##name {                                           \
         BENCH_STARTUP_TYPE_##name() {                                            \
-            all_registered_benchmarks.push_back({#name, BENCH_##name##_METHOD}); \
+            add_benchmark({#name, BENCH_##name##_METHOD});                       \
         }                                                                        \
     };                                                                           \
     static BENCH_STARTUP_TYPE_##name BENCH_STARTUP_INSTANCE_##name;              \


### PR DESCRIPTION
- Fix a static initialization order dependency in `stim_benchmark`
- Remove `stim_benchmark` from `make install`
- Rearrange marker ordering in sinter to defer the time until  visually ambiguous case  occurs (in both color and shape)
- Fix X axis only applying to first subplot in a sinter plot, instead of all
- Bump pybind version
- Add python 3.12 builds

Fixes https://github.com/quantumlib/Stim/issues/623