### PR TITLE
Use `enum class` instead of `enum`, and autoformat the code

### DIFF
--- a/src/stim/benchmark_util.perf.h
+++ b/src/stim/benchmark_util.perf.h
@@ -71,14 +71,14 @@ inline void add_benchmark(RegisteredBenchmark benchmark) {
     all_registered_benchmarks_data->push_back(benchmark);
 }
 
-#define BENCHMARK(name)                                                          \
-    void BENCH_##name##_METHOD();                                                \
-    struct BENCH_STARTUP_TYPE_##name {                                           \
-        BENCH_STARTUP_TYPE_##name() {                                            \
-            add_benchmark({#name, BENCH_##name##_METHOD});                       \
-        }                                                                        \
-    };                                                                           \
-    static BENCH_STARTUP_TYPE_##name BENCH_STARTUP_INSTANCE_##name;              \
+#define BENCHMARK(name)                                             \
+    void BENCH_##name##_METHOD();                                   \
+    struct BENCH_STARTUP_TYPE_##name {                              \
+        BENCH_STARTUP_TYPE_##name() {                               \
+            add_benchmark({#name, BENCH_##name##_METHOD});          \
+        }                                                           \
+    };                                                              \
+    static BENCH_STARTUP_TYPE_##name BENCH_STARTUP_INSTANCE_##name; \
     void BENCH_##name##_METHOD()
 
 // HACK: Templating the body function type makes inlining significantly more likely.

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -728,7 +728,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
                 for (auto t : op.args) {
                     args.append(t);
                 }
-                const auto &gate_data = GATE_DATA.items[op.gate_type];
+                const auto &gate_data = GATE_DATA[op.gate_type];
                 if (op.args.empty()) {
                     // Backwards compatibility.
                     result.append(pybind11::make_tuple(gate_data.name, targets, 0));

--- a/src/stim/circuit/circuit.test.cc
+++ b/src/stim/circuit/circuit.test.cc
@@ -1692,7 +1692,7 @@ Circuit stim::generate_test_circuit_with_all_operations() {
 
 TEST(circuit, generate_test_circuit_with_all_operations) {
     auto c = generate_test_circuit_with_all_operations();
-    std::set<GateType> seen{NOT_A_GATE};
+    std::set<GateType> seen{GateType::NOT_A_GATE};
     for (const auto &instruction : c.operations) {
         seen.insert(instruction.gate_type);
     }

--- a/src/stim/circuit/circuit_instruction.cc
+++ b/src/stim/circuit/circuit_instruction.cc
@@ -43,7 +43,7 @@ CircuitStats CircuitInstruction::compute_stats(const Circuit *host) const {
 }
 
 void CircuitInstruction::add_stats_to(CircuitStats &out, const Circuit *host) const {
-    if (gate_type == REPEAT) {
+    if (gate_type == GateType::REPEAT) {
         if (host == nullptr) {
             throw std::invalid_argument("gate_type == REPEAT && host == nullptr");
         }
@@ -110,7 +110,7 @@ CircuitInstruction::CircuitInstruction(
 }
 
 void CircuitInstruction::validate() const {
-    const Gate &gate = GATE_DATA.items[gate_type];
+    const Gate &gate = GATE_DATA[gate_type];
 
     if (gate.flags == GateFlags::NO_GATE_FLAG) {
         throw std::invalid_argument("Unrecognized gate_type. Associated flag is NO_GATE_FLAG.");
@@ -248,7 +248,7 @@ void CircuitInstruction::validate() const {
 }
 
 uint64_t CircuitInstruction::count_measurement_results() const {
-    auto flags = GATE_DATA.items[gate_type].flags;
+    auto flags = GATE_DATA[gate_type].flags;
     if (!(flags & GATE_PRODUCES_RESULTS)) {
         return 0;
     }
@@ -266,7 +266,7 @@ uint64_t CircuitInstruction::count_measurement_results() const {
 }
 
 bool CircuitInstruction::can_fuse(const CircuitInstruction &other) const {
-    auto flags = GATE_DATA.items[gate_type].flags;
+    auto flags = GATE_DATA[gate_type].flags;
     return gate_type == other.gate_type && args == other.args && !(flags & GATE_IS_NOT_FUSABLE);
 }
 

--- a/src/stim/circuit/circuit_instruction.pybind.cc
+++ b/src/stim/circuit/circuit_instruction.pybind.cc
@@ -74,7 +74,7 @@ PyCircuitInstruction::operator CircuitInstruction() const {
     return as_operation_ref();
 }
 std::string PyCircuitInstruction::name() const {
-    return GATE_DATA.items[gate_type].name;
+    return GATE_DATA[gate_type].name;
 }
 std::vector<uint32_t> PyCircuitInstruction::raw_targets() const {
     std::vector<uint32_t> result;

--- a/src/stim/circuit/gate_data.cc
+++ b/src/stim/circuit/gate_data.cc
@@ -16,8 +16,6 @@
 
 #include <complex>
 
-#include "stim/circuit/stabilizer_flow.h"
-
 using namespace stim;
 
 GateDataMap::GateDataMap() {
@@ -76,7 +74,7 @@ std::vector<std::vector<std::complex<float>>> Gate::unitary() const {
 const Gate &Gate::inverse() const {
     std::string inv_name = name;
     if ((flags & GATE_IS_UNITARY) || id == GateType::TICK) {
-        return GATE_DATA.items[static_cast<uint8_t>(best_candidate_inverse_id)];
+        return GATE_DATA[best_candidate_inverse_id];
     }
     throw std::out_of_range(inv_name + " has no inverse.");
 }
@@ -101,16 +99,16 @@ Gate::Gate(
 }
 
 void GateDataMap::add_gate(bool &failed, const Gate &gate) {
-    assert(gate.id < NUM_DEFINED_GATES);
+    assert((size_t)gate.id < NUM_DEFINED_GATES);
     const char *c = gate.name;
     auto h = gate_name_to_hash(c);
     auto &hash_loc = hashed_name_to_gate_type_table[h];
     if (hash_loc.expected_name_len != 0) {
-        std::cerr << "GATE COLLISION " << gate.name << " vs " << items[hash_loc.id].name << "\n";
+        std::cerr << "GATE COLLISION " << gate.name << " vs " << items[(size_t)hash_loc.id].name << "\n";
         failed = true;
         return;
     }
-    items[gate.id] = gate;
+    items[(size_t)gate.id] = gate;
     hash_loc.id = gate.id;
     hash_loc.expected_name = gate.name;
     hash_loc.expected_name_len = gate.name_len;
@@ -120,7 +118,7 @@ void GateDataMap::add_gate_alias(bool &failed, const char *alt_name, const char 
     auto h_alt = gate_name_to_hash(alt_name);
     auto &hash_loc = hashed_name_to_gate_type_table[h_alt];
     if (hash_loc.expected_name_len != 0) {
-        std::cerr << "GATE COLLISION " << alt_name << " vs " << items[hash_loc.id].name << "\n";
+        std::cerr << "GATE COLLISION " << alt_name << " vs " << items[(size_t)hash_loc.id].name << "\n";
         failed = true;
         return;
     }

--- a/src/stim/circuit/gate_data.pybind.cc
+++ b/src/stim/circuit/gate_data.pybind.cc
@@ -126,7 +126,7 @@ void stim_pybind::pybind_gate_data_methods(pybind11::module &m, pybind11::class_
 
             std::map<std::string, Gate> result;
             for (const auto &g : GATE_DATA.items) {
-                if (g.id != NOT_A_GATE) {
+                if (g.id != GateType::NOT_A_GATE) {
                     result.insert({g.name, g});
                 }
             }

--- a/src/stim/circuit/gate_data.test.cc
+++ b/src/stim/circuit/gate_data.test.cc
@@ -39,11 +39,12 @@ TEST(gate_data, lookup) {
 }
 
 TEST(gate_data, zero_flag_means_not_a_gate) {
-    ASSERT_EQ(GATE_DATA.items[0].id, 0);
-    ASSERT_EQ(GATE_DATA.items[0].flags, GateFlags::NO_GATE_FLAG);
+    ASSERT_EQ((GateType)0, GateType::NOT_A_GATE);
+    ASSERT_EQ(GATE_DATA[(GateType)0].id, (GateType)0);
+    ASSERT_EQ(GATE_DATA[(GateType)0].flags, GateFlags::NO_GATE_FLAG);
     for (size_t k = 0; k < GATE_DATA.items.size(); k++) {
-        const auto &g = GATE_DATA.items[k];
-        if (g.id != 0) {
+        const auto &g = GATE_DATA[(GateType)k];
+        if (g.id != GateType::NOT_A_GATE) {
             EXPECT_NE(g.flags, GateFlags::NO_GATE_FLAG) << g.name;
         }
     }
@@ -51,20 +52,21 @@ TEST(gate_data, zero_flag_means_not_a_gate) {
 
 TEST(gate_data, one_step_to_canonical_gate) {
     for (size_t k = 0; k < GATE_DATA.items.size(); k++) {
-        const auto &g = GATE_DATA.items[k];
-        if (g.id != 0) {
-            EXPECT_TRUE(g.id == k || GATE_DATA.items[g.id].id == g.id) << g.name;
+        const auto &g = GATE_DATA[(GateType)k];
+        if (g.id != GateType::NOT_A_GATE) {
+            EXPECT_TRUE(g.id == (GateType)k || GATE_DATA[g.id].id == g.id) << g.name;
         }
     }
 }
 
 TEST(gate_data, hash_matches_storage_location) {
-    ASSERT_EQ(GATE_DATA.items[0].id, 0);
-    ASSERT_EQ(GATE_DATA.items[0].flags, GateFlags::NO_GATE_FLAG);
+    ASSERT_EQ((GateType)0, GateType::NOT_A_GATE);
+    ASSERT_EQ(GATE_DATA[(GateType)0].id, (GateType)0);
+    ASSERT_EQ(GATE_DATA[(GateType)0].flags, GateFlags::NO_GATE_FLAG);
     for (size_t k = 0; k < GATE_DATA.items.size(); k++) {
-        const auto &g = GATE_DATA.items[k];
-        EXPECT_EQ(g.id, k) << g.name;
-        if (g.id != 0) {
+        const auto &g = GATE_DATA[(GateType)k];
+        EXPECT_EQ(g.id, (GateType)k) << g.name;
+        if (g.id != GateType::NOT_A_GATE) {
             EXPECT_EQ(GATE_DATA.hashed_name_to_gate_type_table[gate_name_to_hash(g.name)].id, g.id) << g.name;
         }
     }
@@ -132,7 +134,7 @@ TEST_EACH_WORD_SIZE_W(gate_data, unitary_inverses_are_correct, {
     for (const auto &g : GATE_DATA.items) {
         if (g.flags & GATE_IS_UNITARY) {
             auto g_t_inv = g.tableau<W>().inverse(false);
-            auto g_inv_t = GATE_DATA.items[static_cast<uint8_t>(g.best_candidate_inverse_id)].tableau<W>();
+            auto g_inv_t = GATE_DATA[g.best_candidate_inverse_id].tableau<W>();
             EXPECT_EQ(g_t_inv, g_inv_t) << g.name;
         }
     }

--- a/src/stim/circuit/gate_data_table.h
+++ b/src/stim/circuit/gate_data_table.h
@@ -34,10 +34,10 @@ struct GateVTable {
 #ifndef NDEBUG
         std::array<bool, NUM_DEFINED_GATES> seen{};
         for (const auto &[gate_id, value] : gate_data_pairs) {
-            seen[gate_id] = true;
+            seen[(size_t)gate_id] = true;
         }
         for (const auto &gate : GATE_DATA.items) {
-            if (!seen[gate.id]) {
+            if (!seen[(size_t)gate.id]) {
                 throw std::invalid_argument(
                     "Missing gate data! A value was not defined for '" + std::string(gate.name) + "'.");
             }

--- a/src/stim/circuit/gate_decomposition.test.cc
+++ b/src/stim/circuit/gate_decomposition.test.cc
@@ -96,9 +96,9 @@ TEST(gate_decomposition, decompose_pair_instruction_into_segments_with_single_us
         for (size_t k = 0; k < segment.targets.size(); k += 2) {
             evens.push_back(segment.targets[k]);
         }
-        out.safe_append(CircuitInstruction{stim::CX, {}, segment.targets});
-        out.safe_append(CircuitInstruction{stim::MX, segment.args, evens});
-        out.safe_append(CircuitInstruction{stim::CX, {}, segment.targets});
+        out.safe_append(CircuitInstruction{GateType::CX, {}, segment.targets});
+        out.safe_append(CircuitInstruction{GateType::MX, segment.args, evens});
+        out.safe_append(CircuitInstruction{GateType::CX, {}, segment.targets});
         out.append_from_text("TICK");
     };
     decompose_pair_instruction_into_segments_with_single_use_controls(

--- a/src/stim/cmd/command_convert.cc
+++ b/src/stim/cmd/command_convert.cc
@@ -164,7 +164,7 @@ int stim::command_convert(int argc, const char **argv) {
     // convert arbitrary bits.
     if (!details.include_measurements && !details.include_detectors && !details.include_observables) {
         // dets outputs explicit value types, which we don't know if we get here.
-        if (out_format.id == SAMPLE_FORMAT_DETS) {
+        if (out_format.id == SampleFormat::SAMPLE_FORMAT_DETS) {
             std::cerr
                 << "\033[31mNot enough information given to parse input file to write to dets. Please given a circuit "
                    "with --types, a DEM file, or explicit number of each desired type\n";

--- a/src/stim/cmd/command_detect.cc
+++ b/src/stim/cmd/command_detect.cc
@@ -42,7 +42,7 @@ int stim::command_detect(int argc, const char **argv) {
         find_argument("--shots", argc, argv)    ? (uint64_t)find_int64_argument("--shots", 1, 0, INT64_MAX, argc, argv)
         : find_argument("--detect", argc, argv) ? (uint64_t)find_int64_argument("--detect", 1, 0, INT64_MAX, argc, argv)
                                                 : 1;
-    if (out_format.id == SAMPLE_FORMAT_DETS && !append_observables) {
+    if (out_format.id == SampleFormat::SAMPLE_FORMAT_DETS && !append_observables) {
         prepend_observables = true;
     }
 

--- a/src/stim/cmd/command_diagram.cc
+++ b/src/stim/cmd/command_diagram.cc
@@ -31,7 +31,7 @@
 using namespace stim;
 using namespace stim_draw_internal;
 
-enum DiagramTypes {
+enum class DiagramTypes {
     NOT_A_DIAGRAM,
     INTERACTIVE_HTML,
     TIMELINE_TEXT,
@@ -102,37 +102,37 @@ std::vector<CoordFilter> _read_coord_filter(int argc, const char **argv) {
 
 DiagramTypes _read_diagram_type(int argc, const char **argv) {
     std::map<std::string, DiagramTypes> diagram_types{
-        {"timeline-text", TIMELINE_TEXT},
-        {"timeline-svg", TIMELINE_SVG},
-        {"timeline-3d", TIMELINE_3D},
-        {"timeline-3d-html", TIMELINE_3D_HTML},
-        {"timeslice-svg", TIME_SLICE_SVG},
-        {"detslice-with-ops-svg", TIME_SLICE_PLUS_DETECTOR_SLICE_SVG},
-        {"matchgraph-svg", MATCH_GRAPH_SVG},
-        {"matchgraph-3d", MATCH_GRAPH_3D},
-        {"matchgraph-3d-html", MATCH_GRAPH_3D_HTML},
-        {"interactive-html", INTERACTIVE_HTML},
-        {"detslice-text", DETECTOR_SLICE_TEXT},
-        {"detslice-svg", DETECTOR_SLICE_SVG},
+        {"timeline-text", DiagramTypes::TIMELINE_TEXT},
+        {"timeline-svg", DiagramTypes::TIMELINE_SVG},
+        {"timeline-3d", DiagramTypes::TIMELINE_3D},
+        {"timeline-3d-html", DiagramTypes::TIMELINE_3D_HTML},
+        {"timeslice-svg", DiagramTypes::TIME_SLICE_SVG},
+        {"detslice-with-ops-svg", DiagramTypes::TIME_SLICE_PLUS_DETECTOR_SLICE_SVG},
+        {"matchgraph-svg", DiagramTypes::MATCH_GRAPH_SVG},
+        {"matchgraph-3d", DiagramTypes::MATCH_GRAPH_3D},
+        {"matchgraph-3d-html", DiagramTypes::MATCH_GRAPH_3D_HTML},
+        {"interactive-html", DiagramTypes::INTERACTIVE_HTML},
+        {"detslice-text", DiagramTypes::DETECTOR_SLICE_TEXT},
+        {"detslice-svg", DiagramTypes::DETECTOR_SLICE_SVG},
     };
     std::map<std::string, DiagramTypes> quietly_allowed_diagram_types{
-        {"time-slice-svg", TIME_SLICE_SVG},
-        {"time+detector-slice-svg", TIME_SLICE_PLUS_DETECTOR_SLICE_SVG},
-        {"interactive", INTERACTIVE_HTML},
-        {"detector-slice-text", DETECTOR_SLICE_TEXT},
-        {"detector-slice-svg", DETECTOR_SLICE_SVG},
-        {"match-graph-svg", MATCH_GRAPH_SVG},
-        {"match-graph-3d", MATCH_GRAPH_3D},
-        {"match-graph-3d-html", MATCH_GRAPH_3D_HTML},
+        {"time-slice-svg", DiagramTypes::TIME_SLICE_SVG},
+        {"time+detector-slice-svg", DiagramTypes::TIME_SLICE_PLUS_DETECTOR_SLICE_SVG},
+        {"interactive", DiagramTypes::INTERACTIVE_HTML},
+        {"detector-slice-text", DiagramTypes::DETECTOR_SLICE_TEXT},
+        {"detector-slice-svg", DiagramTypes::DETECTOR_SLICE_SVG},
+        {"match-graph-svg", DiagramTypes::MATCH_GRAPH_SVG},
+        {"match-graph-3d", DiagramTypes::MATCH_GRAPH_3D},
+        {"match-graph-3d-html", DiagramTypes::MATCH_GRAPH_3D_HTML},
     };
-    DiagramTypes type = NOT_A_DIAGRAM;
+    DiagramTypes type = DiagramTypes::NOT_A_DIAGRAM;
     try {
         type = find_enum_argument("--type", nullptr, quietly_allowed_diagram_types, argc, argv);
     } catch (const std::invalid_argument &_) {
     }
-    if (type == NOT_A_DIAGRAM) {
+    if (type == DiagramTypes::NOT_A_DIAGRAM) {
         type = find_enum_argument("--type", nullptr, diagram_types, argc, argv);
-        assert(type != NOT_A_DIAGRAM);
+        assert(type != DiagramTypes::NOT_A_DIAGRAM);
     }
     return type;
 }
@@ -188,54 +188,54 @@ int stim::command_diagram(int argc, const char **argv) {
     uint64_t tick_num = UINT64_MAX;
     bool has_tick_arg = _read_tick(argc, argv, &tick, &tick_start, &tick_num);
 
-    if (type == TIMELINE_TEXT) {
+    if (type == DiagramTypes::TIMELINE_TEXT) {
         auto circuit = _read_circuit(in, argc, argv);
         out << DiagramTimelineAsciiDrawer::make_diagram(circuit);
-    } else if (type == TIMELINE_SVG) {
+    } else if (type == DiagramTypes::TIMELINE_SVG) {
         auto circuit = _read_circuit(in, argc, argv);
         auto coord_filter = _read_coord_filter(argc, argv);
         DiagramTimelineSvgDrawer::make_diagram_write_to(
-            circuit, out, tick_start, tick_num, SVG_MODE_TIMELINE, coord_filter);
-    } else if (type == TIME_SLICE_SVG) {
+            circuit, out, tick_start, tick_num, DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE, coord_filter);
+    } else if (type == DiagramTypes::TIME_SLICE_SVG) {
         auto circuit = _read_circuit(in, argc, argv);
         auto coord_filter = _read_coord_filter(argc, argv);
         DiagramTimelineSvgDrawer::make_diagram_write_to(
-            circuit, out, tick_start, tick_num, SVG_MODE_TIME_SLICE, coord_filter);
-    } else if (type == TIME_SLICE_PLUS_DETECTOR_SLICE_SVG) {
+            circuit, out, tick_start, tick_num, DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_SLICE, coord_filter);
+    } else if (type == DiagramTypes::TIME_SLICE_PLUS_DETECTOR_SLICE_SVG) {
         auto circuit = _read_circuit(in, argc, argv);
         auto coord_filter = _read_coord_filter(argc, argv);
         DiagramTimelineSvgDrawer::make_diagram_write_to(
-            circuit, out, tick_start, tick_num, SVG_MODE_TIME_DETECTOR_SLICE, coord_filter);
-    } else if (type == TIMELINE_3D) {
+            circuit, out, tick_start, tick_num, DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_DETECTOR_SLICE, coord_filter);
+    } else if (type == DiagramTypes::TIMELINE_3D) {
         auto circuit = _read_circuit(in, argc, argv);
         DiagramTimeline3DDrawer::circuit_to_basic_3d_diagram(circuit).to_gltf_scene().to_json().write(out);
-    } else if (type == TIMELINE_3D_HTML) {
+    } else if (type == DiagramTypes::TIMELINE_3D_HTML) {
         auto circuit = _read_circuit(in, argc, argv);
         std::stringstream tmp_out;
         DiagramTimeline3DDrawer::circuit_to_basic_3d_diagram(circuit).to_gltf_scene().to_json().write(tmp_out);
         write_html_viewer_for_gltf_data(tmp_out.str(), out);
-    } else if (type == INTERACTIVE_HTML) {
+    } else if (type == DiagramTypes::INTERACTIVE_HTML) {
         auto circuit = _read_circuit(in, argc, argv);
         write_crumble_html_with_preloaded_circuit(circuit, out);
-    } else if (type == MATCH_GRAPH_3D) {
+    } else if (type == DiagramTypes::MATCH_GRAPH_3D) {
         auto dem = _read_dem(in, argc, argv);
         dem_match_graph_to_basic_3d_diagram(dem).to_gltf_scene().to_json().write(out);
-    } else if (type == MATCH_GRAPH_3D_HTML) {
+    } else if (type == DiagramTypes::MATCH_GRAPH_3D_HTML) {
         auto dem = _read_dem(in, argc, argv);
         std::stringstream tmp_out;
         dem_match_graph_to_basic_3d_diagram(dem).to_gltf_scene().to_json().write(tmp_out);
         write_html_viewer_for_gltf_data(tmp_out.str(), out);
-    } else if (type == MATCH_GRAPH_SVG) {
+    } else if (type == DiagramTypes::MATCH_GRAPH_SVG) {
         auto dem = _read_dem(in, argc, argv);
         dem_match_graph_to_svg_diagram_write_to(dem, out);
-    } else if (type == DETECTOR_SLICE_TEXT) {
+    } else if (type == DiagramTypes::DETECTOR_SLICE_TEXT) {
         if (!has_tick_arg) {
             throw std::invalid_argument("Must specify --tick=# with --type=detector-slice-text");
         }
         auto coord_filter = _read_coord_filter(argc, argv);
         auto circuit = _read_circuit(in, argc, argv);
         out << DetectorSliceSet::from_circuit_ticks(circuit, (uint64_t)tick, 1, coord_filter);
-    } else if (type == DETECTOR_SLICE_SVG) {
+    } else if (type == DiagramTypes::DETECTOR_SLICE_SVG) {
         auto coord_filter = _read_coord_filter(argc, argv);
         auto circuit = _read_circuit(in, argc, argv);
         DetectorSliceSet::from_circuit_ticks(circuit, tick_start, tick_num, coord_filter).write_svg_diagram_to(out);

--- a/src/stim/cmd/command_diagram.cc
+++ b/src/stim/cmd/command_diagram.cc
@@ -205,7 +205,12 @@ int stim::command_diagram(int argc, const char **argv) {
         auto circuit = _read_circuit(in, argc, argv);
         auto coord_filter = _read_coord_filter(argc, argv);
         DiagramTimelineSvgDrawer::make_diagram_write_to(
-            circuit, out, tick_start, tick_num, DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_DETECTOR_SLICE, coord_filter);
+            circuit,
+            out,
+            tick_start,
+            tick_num,
+            DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_DETECTOR_SLICE,
+            coord_filter);
     } else if (type == DiagramTypes::TIMELINE_3D) {
         auto circuit = _read_circuit(in, argc, argv);
         DiagramTimeline3DDrawer::circuit_to_basic_3d_diagram(circuit).to_gltf_scene().to_json().write(out);

--- a/src/stim/cmd/command_diagram.pybind.h
+++ b/src/stim/cmd/command_diagram.pybind.h
@@ -22,7 +22,7 @@
 
 namespace stim_pybind {
 
-enum DiagramType {
+enum class DiagramType {
     DIAGRAM_TYPE_GLTF,
     DIAGRAM_TYPE_SVG,
     DIAGRAM_TYPE_TEXT,

--- a/src/stim/cmd/command_help.cc
+++ b/src/stim/cmd/command_help.cc
@@ -556,7 +556,7 @@ std::map<std::string, std::string> generate_gate_help_markdown() {
     std::map<std::string, std::string> result;
     for (const auto &e : GATE_DATA.hashed_name_to_gate_type_table) {
         if (e.expected_name_len > 0) {
-            result[e.expected_name] = generate_per_gate_help_markdown(GATE_DATA.items[e.id], 0, false);
+            result[e.expected_name] = generate_per_gate_help_markdown(GATE_DATA[e.id], 0, false);
         }
     }
 

--- a/src/stim/cmd/command_repl.cc
+++ b/src/stim/cmd/command_repl.cc
@@ -24,7 +24,7 @@ using namespace stim;
 int stim::command_repl(int argc, const char **argv) {
     check_for_unknown_arguments({}, {"--repl"}, "repl", argc, argv);
     auto rng = externally_seeded_rng();
-    TableauSimulator<MAX_BITWORD_WIDTH>::sample_stream(stdin, stdout, SAMPLE_FORMAT_01, true, rng);
+    TableauSimulator<MAX_BITWORD_WIDTH>::sample_stream(stdin, stdout, SampleFormat::SAMPLE_FORMAT_01, true, rng);
     return EXIT_SUCCESS;
 }
 

--- a/src/stim/dem/dem_instruction.cc
+++ b/src/stim/dem/dem_instruction.cc
@@ -117,19 +117,19 @@ std::string DemInstruction::str() const {
 
 std::ostream &stim::operator<<(std::ostream &out, const DemInstructionType &type) {
     switch (type) {
-        case DEM_ERROR:
+        case DemInstructionType::DEM_ERROR:
             out << "error";
             break;
-        case DEM_DETECTOR:
+        case DemInstructionType::DEM_DETECTOR:
             out << "detector";
             break;
-        case DEM_LOGICAL_OBSERVABLE:
+        case DemInstructionType::DEM_LOGICAL_OBSERVABLE:
             out << "logical_observable";
             break;
-        case DEM_SHIFT_DETECTORS:
+        case DemInstructionType::DEM_SHIFT_DETECTORS:
             out << "shift_detectors";
             break;
-        case DEM_REPEAT_BLOCK:
+        case DemInstructionType::DEM_REPEAT_BLOCK:
             out << "repeat";
             break;
         default:
@@ -144,7 +144,7 @@ std::ostream &stim::operator<<(std::ostream &out, const DemInstruction &op) {
     if (!op.arg_data.empty()) {
         out << "(" << comma_sep(op.arg_data) << ")";
     }
-    if (op.type == DEM_SHIFT_DETECTORS || op.type == DEM_REPEAT_BLOCK) {
+    if (op.type == DemInstructionType::DEM_SHIFT_DETECTORS || op.type == DemInstructionType::DEM_REPEAT_BLOCK) {
         for (const auto &e : op.target_data) {
             out << " " << e.data;
         }
@@ -158,7 +158,7 @@ std::ostream &stim::operator<<(std::ostream &out, const DemInstruction &op) {
 
 void DemInstruction::validate() const {
     switch (type) {
-        case DEM_ERROR:
+        case DemInstructionType::DEM_ERROR:
             if (arg_data.size() != 1) {
                 throw std::invalid_argument(
                     "'error' instruction takes 1 argument (a probability), but got " + std::to_string(arg_data.size()) +
@@ -181,14 +181,14 @@ void DemInstruction::validate() const {
                 }
             }
             break;
-        case DEM_SHIFT_DETECTORS:
+        case DemInstructionType::DEM_SHIFT_DETECTORS:
             if (target_data.size() != 1) {
                 throw std::invalid_argument(
                     "'shift_detectors' instruction takes 1 target, but got " + std::to_string(target_data.size()) +
                     " targets.");
             }
             break;
-        case DEM_DETECTOR:
+        case DemInstructionType::DEM_DETECTOR:
             if (target_data.size() != 1) {
                 throw std::invalid_argument(
                     "'detector' instruction takes 1 target but got " + std::to_string(target_data.size()) +
@@ -200,7 +200,7 @@ void DemInstruction::validate() const {
                     " arguments.");
             }
             break;
-        case DEM_LOGICAL_OBSERVABLE:
+        case DemInstructionType::DEM_LOGICAL_OBSERVABLE:
             if (arg_data.size() != 0) {
                 throw std::invalid_argument(
                     "'logical_observable' instruction takes 0 arguments but got " + std::to_string(arg_data.size()) +
@@ -217,7 +217,7 @@ void DemInstruction::validate() const {
                     target_data[0].str() + " arguments.");
             }
             break;
-        case DEM_REPEAT_BLOCK:
+        case DemInstructionType::DEM_REPEAT_BLOCK:
             // Handled elsewhere.
             break;
         default:

--- a/src/stim/dem/dem_instruction.cc
+++ b/src/stim/dem/dem_instruction.cc
@@ -2,9 +2,9 @@
 
 #include <cmath>
 
+#include "stim/dem/detector_error_model.h"
 #include "stim/simulators/error_analyzer.h"
 #include "stim/str_util.h"
-#include "stim/dem/detector_error_model.h"
 
 using namespace stim;
 

--- a/src/stim/dem/dem_instruction.h
+++ b/src/stim/dem/dem_instruction.h
@@ -10,7 +10,7 @@
 
 namespace stim {
 
-enum DemInstructionType : uint8_t {
+enum class DemInstructionType : uint8_t {
     DEM_ERROR,
     DEM_SHIFT_DETECTORS,
     DEM_DETECTOR,

--- a/src/stim/dem/detector_error_model.cc
+++ b/src/stim/dem/detector_error_model.cc
@@ -25,25 +25,25 @@
 using namespace stim;
 
 void DetectorErrorModel::append_error_instruction(double probability, SpanRef<const DemTarget> targets) {
-    append_dem_instruction(DemInstruction{&probability, targets, DEM_ERROR});
+    append_dem_instruction(DemInstruction{&probability, targets, DemInstructionType::DEM_ERROR});
 }
 
 void DetectorErrorModel::append_shift_detectors_instruction(
     SpanRef<const double> coord_shift, uint64_t detector_shift) {
     DemTarget shift{detector_shift};
-    append_dem_instruction(DemInstruction{coord_shift, &shift, DEM_SHIFT_DETECTORS});
+    append_dem_instruction(DemInstruction{coord_shift, &shift, DemInstructionType::DEM_SHIFT_DETECTORS});
 }
 
 void DetectorErrorModel::append_detector_instruction(SpanRef<const double> coords, DemTarget target) {
-    append_dem_instruction(DemInstruction{coords, &target, DEM_DETECTOR});
+    append_dem_instruction(DemInstruction{coords, &target, DemInstructionType::DEM_DETECTOR});
 }
 
 void DetectorErrorModel::append_logical_observable_instruction(DemTarget target) {
-    append_dem_instruction(DemInstruction{{}, &target, DEM_LOGICAL_OBSERVABLE});
+    append_dem_instruction(DemInstruction{{}, &target, DemInstructionType::DEM_LOGICAL_OBSERVABLE});
 }
 
 void DetectorErrorModel::append_dem_instruction(const DemInstruction &instruction) {
-    assert(instruction.type != DEM_REPEAT_BLOCK);
+    assert(instruction.type != DemInstructionType::DEM_REPEAT_BLOCK);
     instruction.validate();
     auto stored_targets = target_buf.take_copy(instruction.target_data);
     auto stored_args = arg_buf.take_copy(instruction.arg_data);
@@ -56,7 +56,7 @@ void DetectorErrorModel::append_repeat_block(uint64_t repeat_count, DetectorErro
     data[1].data = blocks.size();
     auto stored_targets = target_buf.take_copy({&data[0], &data[2]});
     blocks.push_back(std::move(body));
-    instructions.push_back({{}, stored_targets, DEM_REPEAT_BLOCK});
+    instructions.push_back({{}, stored_targets, DemInstructionType::DEM_REPEAT_BLOCK});
 }
 
 void DetectorErrorModel::append_repeat_block(uint64_t repeat_count, const DetectorErrorModel &body) {
@@ -65,7 +65,7 @@ void DetectorErrorModel::append_repeat_block(uint64_t repeat_count, const Detect
     data[1].data = blocks.size();
     auto stored_targets = target_buf.take_copy({&data[0], &data[2]});
     blocks.push_back(body);
-    instructions.push_back({{}, stored_targets, DEM_REPEAT_BLOCK});
+    instructions.push_back({{}, stored_targets, DemInstructionType::DEM_REPEAT_BLOCK});
 }
 
 bool DetectorErrorModel::operator==(const DetectorErrorModel &other) const {
@@ -107,7 +107,7 @@ void stim::print_detector_error_model(std::ostream &out, const DetectorErrorMode
         for (size_t k = 0; k < indent; k++) {
             out << " ";
         }
-        if (e.type == DEM_REPEAT_BLOCK) {
+        if (e.type == DemInstructionType::DEM_REPEAT_BLOCK) {
             out << "repeat " << e.repeat_block_rep_count() << " {\n";
             print_detector_error_model(out, e.repeat_block_body(v), indent + 4);
             out << "\n";
@@ -175,7 +175,7 @@ DetectorErrorModel &DetectorErrorModel::operator=(DetectorErrorModel &&other) no
     return *this;
 }
 
-enum DEM_READ_CONDITION {
+enum class DEM_READ_CONDITION {
     DEM_READ_AS_LITTLE_AS_POSSIBLE,
     DEM_READ_UNTIL_END_OF_BLOCK,
     DEM_READ_UNTIL_END_OF_FILE,
@@ -196,19 +196,19 @@ inline DemInstructionType read_instruction_name(int &c, SOURCE read_char) {
     }
     name_buf[n] = 0;
     if (!strcmp(name_buf, "error")) {
-        return DEM_ERROR;
+        return DemInstructionType::DEM_ERROR;
     }
     if (!strcmp(name_buf, "shift_detectors")) {
-        return DEM_SHIFT_DETECTORS;
+        return DemInstructionType::DEM_SHIFT_DETECTORS;
     }
     if (!strcmp(name_buf, "detector")) {
-        return DEM_DETECTOR;
+        return DemInstructionType::DEM_DETECTOR;
     }
     if (!strcmp(name_buf, "logical_observable")) {
-        return DEM_LOGICAL_OBSERVABLE;
+        return DemInstructionType::DEM_LOGICAL_OBSERVABLE;
     }
     if (!strcmp(name_buf, "repeat")) {
-        return DEM_REPEAT_BLOCK;
+        return DemInstructionType::DEM_REPEAT_BLOCK;
     }
     throw std::out_of_range("Unrecognized instruction name: " + std::string(name_buf));
 }
@@ -259,7 +259,7 @@ void dem_read_instruction(DetectorErrorModel &model, char lead_char, SOURCE read
     int c = (int)lead_char;
     auto type = read_instruction_name(c, read_char);
     try {
-        if (type == DEM_REPEAT_BLOCK) {
+        if (type == DemInstructionType::DEM_REPEAT_BLOCK) {
             if (!read_until_next_line_arg(c, read_char)) {
                 throw std::invalid_argument("Missing repeat count of repeat block.");
             }
@@ -272,7 +272,7 @@ void dem_read_instruction(DetectorErrorModel &model, char lead_char, SOURCE read
             }
         } else {
             read_parens_arguments(c, "detector error model instruction", read_char, model.arg_buf);
-            if (type == DEM_SHIFT_DETECTORS) {
+            if (type == DemInstructionType::DEM_SHIFT_DETECTORS) {
                 if (read_until_next_line_arg(c, read_char)) {
                     model.target_buf.append_tail(DemTarget{read_uint60_t(c, read_char)});
                 }
@@ -299,32 +299,32 @@ void model_read_operations(DetectorErrorModel &model, SOURCE read_char, DEM_READ
         int c = read_char();
         read_past_dead_space_between_commands(c, read_char);
         if (c == EOF) {
-            if (read_condition == DEM_READ_UNTIL_END_OF_BLOCK) {
+            if (read_condition == DEM_READ_CONDITION::DEM_READ_UNTIL_END_OF_BLOCK) {
                 throw std::out_of_range("Unterminated block. Got a '{' without an eventual '}'.");
             }
             return;
         }
         if (c == '}') {
-            if (read_condition != DEM_READ_UNTIL_END_OF_BLOCK) {
+            if (read_condition != DEM_READ_CONDITION::DEM_READ_UNTIL_END_OF_BLOCK) {
                 throw std::out_of_range("Uninitiated block. Got a '}' without a '{'.");
             }
             return;
         }
         dem_read_instruction(model, c, read_char);
 
-        if (ops.back().type == DEM_REPEAT_BLOCK) {
+        if (ops.back().type == DemInstructionType::DEM_REPEAT_BLOCK) {
             // Temporarily remove instruction until block is parsed.
             auto repeat_count = ops.back().repeat_block_rep_count();
             ops.pop_back();
 
             // Recursively read the block contents.
             DetectorErrorModel block;
-            model_read_operations(block, read_char, DEM_READ_UNTIL_END_OF_BLOCK);
+            model_read_operations(block, read_char, DEM_READ_CONDITION::DEM_READ_UNTIL_END_OF_BLOCK);
 
             // Restore repeat block instruction, including block reference.
             model.append_repeat_block(repeat_count, std::move(block));
         }
-    } while (read_condition != DEM_READ_AS_LITTLE_AS_POSSIBLE);
+    } while (read_condition != DEM_READ_CONDITION::DEM_READ_AS_LITTLE_AS_POSSIBLE);
 }
 
 void DetectorErrorModel::append_from_file(FILE *file, bool stop_asap) {
@@ -333,7 +333,7 @@ void DetectorErrorModel::append_from_file(FILE *file, bool stop_asap) {
         [&]() {
             return getc(file);
         },
-        stop_asap ? DEM_READ_AS_LITTLE_AS_POSSIBLE : DEM_READ_UNTIL_END_OF_FILE);
+        stop_asap ? DEM_READ_CONDITION::DEM_READ_AS_LITTLE_AS_POSSIBLE : DEM_READ_CONDITION::DEM_READ_UNTIL_END_OF_FILE);
 }
 
 void DetectorErrorModel::append_from_text(const char *text) {
@@ -343,7 +343,7 @@ void DetectorErrorModel::append_from_text(const char *text) {
         [&]() {
             return text[k] != 0 ? text[k++] : EOF;
         },
-        DEM_READ_UNTIL_END_OF_FILE);
+        DEM_READ_CONDITION::DEM_READ_UNTIL_END_OF_FILE);
 }
 
 DetectorErrorModel DetectorErrorModel::from_file(FILE *file) {
@@ -370,16 +370,16 @@ DetectorErrorModel DetectorErrorModel::rounded(uint8_t digits) const {
 
     DetectorErrorModel result;
     for (const auto &e : instructions) {
-        if (e.type == DEM_REPEAT_BLOCK) {
+        if (e.type == DemInstructionType::DEM_REPEAT_BLOCK) {
             auto reps = e.repeat_block_rep_count();
             auto &block = e.repeat_block_body(*this);
             result.append_repeat_block(reps, block.rounded(digits));
-        } else if (e.type == DEM_ERROR) {
+        } else if (e.type == DemInstructionType::DEM_ERROR) {
             std::vector<double> rounded_args;
             for (auto a : e.arg_data) {
                 rounded_args.push_back(round(a * scale) / scale);
             }
-            result.append_dem_instruction({rounded_args, e.target_data, DEM_ERROR});
+            result.append_dem_instruction({rounded_args, e.target_data, DemInstructionType::DEM_ERROR});
         } else {
             result.append_dem_instruction(e);
         }
@@ -390,9 +390,9 @@ DetectorErrorModel DetectorErrorModel::rounded(uint8_t digits) const {
 uint64_t DetectorErrorModel::total_detector_shift() const {
     uint64_t result = 0;
     for (const auto &e : instructions) {
-        if (e.type == DEM_SHIFT_DETECTORS) {
+        if (e.type == DemInstructionType::DEM_SHIFT_DETECTORS) {
             result += e.target_data[0].data;
-        } else if (e.type == DEM_REPEAT_BLOCK) {
+        } else if (e.type == DemInstructionType::DEM_REPEAT_BLOCK) {
             result += e.repeat_block_rep_count() * e.repeat_block_body(*this).total_detector_shift();
         }
     }
@@ -405,7 +405,7 @@ void flattened_helper(
     uint64_t &cur_detector_shift,
     DetectorErrorModel &out) {
     for (const auto &op : body.instructions) {
-        if (op.type == DEM_SHIFT_DETECTORS) {
+        if (op.type == DemInstructionType::DEM_SHIFT_DETECTORS) {
             while (cur_coordinate_shift.size() < op.arg_data.size()) {
                 cur_coordinate_shift.push_back(0);
             }
@@ -415,15 +415,15 @@ void flattened_helper(
             if (!op.target_data.empty()) {
                 cur_detector_shift += op.target_data[0].data;
             }
-        } else if (op.type == DEM_REPEAT_BLOCK) {
+        } else if (op.type == DemInstructionType::DEM_REPEAT_BLOCK) {
             const auto &loop_body = op.repeat_block_body(body);
             auto reps = op.repeat_block_rep_count();
             for (uint64_t k = 0; k < reps; k++) {
                 flattened_helper(loop_body, cur_coordinate_shift, cur_detector_shift, out);
             }
-        } else if (op.type == DEM_LOGICAL_OBSERVABLE) {
-            out.append_dem_instruction(DemInstruction{{}, op.target_data, DEM_LOGICAL_OBSERVABLE});
-        } else if (op.type == DEM_DETECTOR) {
+        } else if (op.type == DemInstructionType::DEM_LOGICAL_OBSERVABLE) {
+            out.append_dem_instruction(DemInstruction{{}, op.target_data, DemInstructionType::DEM_LOGICAL_OBSERVABLE});
+        } else if (op.type == DemInstructionType::DEM_DETECTOR) {
             while (cur_coordinate_shift.size() < op.arg_data.size()) {
                 cur_coordinate_shift.push_back(0);
             }
@@ -438,15 +438,15 @@ void flattened_helper(
                 shifted_detectors.push_back(t);
             }
 
-            out.append_dem_instruction(DemInstruction{shifted_coords, shifted_detectors, DEM_DETECTOR});
-        } else if (op.type == DEM_ERROR) {
+            out.append_dem_instruction(DemInstruction{shifted_coords, shifted_detectors, DemInstructionType::DEM_DETECTOR});
+        } else if (op.type == DemInstructionType::DEM_ERROR) {
             std::vector<DemTarget> shifted_detectors;
             for (DemTarget t : op.target_data) {
                 t.shift_if_detector_id(cur_detector_shift);
                 shifted_detectors.push_back(t);
             }
 
-            out.append_dem_instruction(DemInstruction{op.arg_data, shifted_detectors, DEM_ERROR});
+            out.append_dem_instruction(DemInstruction{op.arg_data, shifted_detectors, DemInstructionType::DEM_ERROR});
         } else {
             throw std::invalid_argument("Unrecognized instruction type: " + op.str());
         }
@@ -466,12 +466,12 @@ uint64_t DetectorErrorModel::count_detectors() const {
     uint64_t max_num = 0;
     for (const auto &e : instructions) {
         switch (e.type) {
-            case DEM_LOGICAL_OBSERVABLE:
+            case DemInstructionType::DEM_LOGICAL_OBSERVABLE:
                 break;
-            case DEM_SHIFT_DETECTORS:
+            case DemInstructionType::DEM_SHIFT_DETECTORS:
                 offset += e.target_data[0].data;
                 break;
-            case DEM_REPEAT_BLOCK: {
+            case DemInstructionType::DEM_REPEAT_BLOCK: {
                 auto &block = e.repeat_block_body(*this);
                 auto n = block.count_detectors();
                 auto reps = e.repeat_block_rep_count();
@@ -481,8 +481,8 @@ uint64_t DetectorErrorModel::count_detectors() const {
                     max_num = std::max(max_num, offset + n - 1 - block_shift);
                 }
             } break;
-            case DEM_DETECTOR:
-            case DEM_ERROR:
+            case DemInstructionType::DEM_DETECTOR:
+            case DemInstructionType::DEM_ERROR:
                 for (const auto &t : e.target_data) {
                     if (t.is_relative_detector_id()) {
                         max_num = std::max(max_num, offset + t.raw_id());
@@ -500,20 +500,20 @@ uint64_t DetectorErrorModel::count_errors() const {
     uint64_t total = 0;
     for (const auto &e : instructions) {
         switch (e.type) {
-            case DEM_LOGICAL_OBSERVABLE:
+            case DemInstructionType::DEM_LOGICAL_OBSERVABLE:
                 break;
-            case DEM_SHIFT_DETECTORS:
+            case DemInstructionType::DEM_SHIFT_DETECTORS:
                 break;
-            case DEM_REPEAT_BLOCK: {
+            case DemInstructionType::DEM_REPEAT_BLOCK: {
                 auto &block = e.repeat_block_body(*this);
                 auto n = block.count_errors();
                 auto reps = e.repeat_block_rep_count();
                 total += n * reps;
                 break;
             }
-            case DEM_DETECTOR:
+            case DemInstructionType::DEM_DETECTOR:
                 break;
-            case DEM_ERROR:
+            case DemInstructionType::DEM_ERROR:
                 total++;
                 break;
             default:
@@ -527,15 +527,15 @@ uint64_t DetectorErrorModel::count_observables() const {
     uint64_t max_num = 0;
     for (const auto &e : instructions) {
         switch (e.type) {
-            case DEM_SHIFT_DETECTORS:
-            case DEM_DETECTOR:
+            case DemInstructionType::DEM_SHIFT_DETECTORS:
+            case DemInstructionType::DEM_DETECTOR:
                 break;
-            case DEM_REPEAT_BLOCK: {
+            case DemInstructionType::DEM_REPEAT_BLOCK: {
                 auto &block = e.repeat_block_body(*this);
                 max_num = std::max(max_num, block.count_observables());
             } break;
-            case DEM_LOGICAL_OBSERVABLE:
-            case DEM_ERROR:
+            case DemInstructionType::DEM_LOGICAL_OBSERVABLE:
+            case DemInstructionType::DEM_ERROR:
                 for (const auto &t : e.target_data) {
                     if (t.is_observable_id()) {
                         max_num = std::max(max_num, t.raw_id() + 1);
@@ -555,7 +555,7 @@ DetectorErrorModel DetectorErrorModel::py_get_slice(int64_t start, int64_t step,
     DetectorErrorModel result;
     for (size_t k = 0; k < (size_t)slice_length; k++) {
         const auto &op = instructions[start + step * k];
-        if (op.type == DEM_REPEAT_BLOCK) {
+        if (op.type == DemInstructionType::DEM_REPEAT_BLOCK) {
             result.append_repeat_block(op.repeat_block_rep_count(), op.repeat_block_body(*this));
         } else {
             auto args = result.arg_buf.take_copy(op.arg_data);
@@ -598,7 +598,7 @@ DetectorErrorModel &DetectorErrorModel::operator+=(const DetectorErrorModel &oth
     }
 
     for (auto &e : other.instructions) {
-        if (e.type == DEM_REPEAT_BLOCK) {
+        if (e.type == DemInstructionType::DEM_REPEAT_BLOCK) {
             uint64_t repeat_count = e.repeat_block_rep_count();
             const DetectorErrorModel &block = e.repeat_block_body(other);
             append_repeat_block(repeat_count, block);
@@ -613,10 +613,10 @@ std::pair<uint64_t, std::vector<double>> DetectorErrorModel::final_detector_and_
     uint64_t detector_offset = 0;
     std::vector<double> coord_shift;
     for (const auto &op : instructions) {
-        if (op.type == DEM_SHIFT_DETECTORS) {
+        if (op.type == DemInstructionType::DEM_SHIFT_DETECTORS) {
             vec_pad_add_mul(coord_shift, op.arg_data);
             detector_offset += op.target_data[0].data;
-        } else if (op.type == DEM_REPEAT_BLOCK) {
+        } else if (op.type == DemInstructionType::DEM_REPEAT_BLOCK) {
             const auto &block = op.repeat_block_body(*this);
             uint64_t reps = op.repeat_block_rep_count();
             auto rec = block.final_detector_and_coord_shift();
@@ -675,7 +675,7 @@ bool get_detector_coordinates_helper(
     };
 
     for (const auto &op : dem.instructions) {
-        if (op.type == DEM_SHIFT_DETECTORS) {
+        if (op.type == DemInstructionType::DEM_SHIFT_DETECTORS) {
             vec_pad_add_mul(coord_shift, op.arg_data);
             detector_offset += op.target_data[0].data;
             while (*iter_desired_detector_index < detector_offset) {
@@ -686,14 +686,14 @@ bool get_detector_coordinates_helper(
                 }
             }
 
-        } else if (op.type == DEM_DETECTOR) {
+        } else if (op.type == DemInstructionType::DEM_DETECTOR) {
             for (const auto &t : op.target_data) {
                 if (fill_in_data(t.data + detector_offset, op.arg_data)) {
                     return true;
                 }
             }
 
-        } else if (op.type == DEM_REPEAT_BLOCK) {
+        } else if (op.type == DemInstructionType::DEM_REPEAT_BLOCK) {
             const auto &block = op.repeat_block_body(dem);
             uint64_t reps = op.repeat_block_rep_count();
 

--- a/src/stim/dem/detector_error_model.cc
+++ b/src/stim/dem/detector_error_model.cc
@@ -333,7 +333,8 @@ void DetectorErrorModel::append_from_file(FILE *file, bool stop_asap) {
         [&]() {
             return getc(file);
         },
-        stop_asap ? DEM_READ_CONDITION::DEM_READ_AS_LITTLE_AS_POSSIBLE : DEM_READ_CONDITION::DEM_READ_UNTIL_END_OF_FILE);
+        stop_asap ? DEM_READ_CONDITION::DEM_READ_AS_LITTLE_AS_POSSIBLE
+                  : DEM_READ_CONDITION::DEM_READ_UNTIL_END_OF_FILE);
 }
 
 void DetectorErrorModel::append_from_text(const char *text) {
@@ -438,7 +439,8 @@ void flattened_helper(
                 shifted_detectors.push_back(t);
             }
 
-            out.append_dem_instruction(DemInstruction{shifted_coords, shifted_detectors, DemInstructionType::DEM_DETECTOR});
+            out.append_dem_instruction(
+                DemInstruction{shifted_coords, shifted_detectors, DemInstructionType::DEM_DETECTOR});
         } else if (op.type == DemInstructionType::DEM_ERROR) {
             std::vector<DemTarget> shifted_detectors;
             for (DemTarget t : op.target_data) {

--- a/src/stim/dem/detector_error_model.h
+++ b/src/stim/dem/detector_error_model.h
@@ -23,8 +23,8 @@
 #include <vector>
 
 #include "stim/circuit/circuit.h"
-#include "stim/mem/monotonic_buffer.h"
 #include "stim/dem/dem_instruction.h"
+#include "stim/mem/monotonic_buffer.h"
 
 namespace stim {
 

--- a/src/stim/dem/detector_error_model.h
+++ b/src/stim/dem/detector_error_model.h
@@ -95,7 +95,7 @@ struct DetectorErrorModel {
         std::vector<DemTarget> translate_buf;
         for (const auto &op : instructions) {
             switch (op.type) {
-                case DEM_ERROR:
+                case DemInstructionType::DEM_ERROR:
                     translate_buf.clear();
                     translate_buf.insert(translate_buf.end(), op.target_data.begin(), op.target_data.end());
                     for (auto &t : translate_buf) {
@@ -103,7 +103,7 @@ struct DetectorErrorModel {
                     }
                     callback(DemInstruction{op.arg_data, translate_buf, op.type});
                     break;
-                case DEM_REPEAT_BLOCK: {
+                case DemInstructionType::DEM_REPEAT_BLOCK: {
                     const auto &block = op.repeat_block_body(*this);
                     auto reps = op.repeat_block_rep_count();
                     for (uint64_t k = 0; k < reps; k++) {
@@ -111,11 +111,11 @@ struct DetectorErrorModel {
                     }
                     break;
                 }
-                case DEM_SHIFT_DETECTORS:
+                case DemInstructionType::DEM_SHIFT_DETECTORS:
                     detector_shift += op.target_data[0].data;
                     break;
-                case DEM_DETECTOR:
-                case DEM_LOGICAL_OBSERVABLE:
+                case DemInstructionType::DEM_DETECTOR:
+                case DemInstructionType::DEM_LOGICAL_OBSERVABLE:
                     break;
                 default:
                     throw std::invalid_argument("Unrecognized DEM instruction type: " + op.str());

--- a/src/stim/dem/detector_error_model.pybind.cc
+++ b/src/stim/dem/detector_error_model.pybind.cc
@@ -350,8 +350,7 @@ void stim_pybind::pybind_detector_error_model_methods(
 
             auto &op = self.instructions[index];
             if (op.type == DEM_REPEAT_BLOCK) {
-                return pybind11::cast(
-                    ExposedDemRepeatBlock{op.repeat_block_rep_count(), op.repeat_block_body(self)});
+                return pybind11::cast(ExposedDemRepeatBlock{op.repeat_block_rep_count(), op.repeat_block_body(self)});
             }
             ExposedDemInstruction result;
             result.targets.insert(result.targets.begin(), op.target_data.begin(), op.target_data.end());

--- a/src/stim/dem/detector_error_model.pybind.cc
+++ b/src/stim/dem/detector_error_model.pybind.cc
@@ -349,7 +349,7 @@ void stim_pybind::pybind_detector_error_model_methods(
             }
 
             auto &op = self.instructions[index];
-            if (op.type == DEM_REPEAT_BLOCK) {
+            if (op.type == DemInstructionType::DEM_REPEAT_BLOCK) {
                 return pybind11::cast(ExposedDemRepeatBlock{op.repeat_block_rep_count(), op.repeat_block_body(self)});
             }
             ExposedDemInstruction result;

--- a/src/stim/dem/detector_error_model.test.cc
+++ b/src/stim/dem/detector_error_model.test.cc
@@ -54,7 +54,7 @@ TEST(detector_error_model, append_shift_detectors_instruction) {
     SpanRef<const double> arg_data_ref = arg_data;
     model.append_shift_detectors_instruction(arg_data_ref, 5);
     ASSERT_EQ(model.instructions.size(), 1);
-    ASSERT_EQ(model.instructions[0].type, DEM_SHIFT_DETECTORS);
+    ASSERT_EQ(model.instructions[0].type, DemInstructionType::DEM_SHIFT_DETECTORS);
     ASSERT_EQ(model.instructions[0].target_data.size(), 1);
     ASSERT_EQ(model.instructions[0].target_data[0].data, 5);
     ASSERT_EQ(model.instructions[0].arg_data, arg_data_ref);
@@ -70,7 +70,7 @@ TEST(detector_error_model, append_detector_instruction) {
     SpanRef<const double> arg_data_ref = arg_data;
     model.append_detector_instruction(arg_data_ref, DemTarget::relative_detector_id(5));
     ASSERT_EQ(model.instructions.size(), 1);
-    ASSERT_EQ(model.instructions[0].type, DEM_DETECTOR);
+    ASSERT_EQ(model.instructions[0].type, DemInstructionType::DEM_DETECTOR);
     ASSERT_EQ(model.instructions[0].target_data.size(), 1);
     ASSERT_EQ(model.instructions[0].target_data[0], DemTarget::relative_detector_id(5));
     ASSERT_EQ(model.instructions[0].arg_data, arg_data_ref);
@@ -88,7 +88,7 @@ TEST(detector_error_model, append_logical_observable_instruction) {
 
     model.append_logical_observable_instruction(DemTarget::observable_id(5));
     ASSERT_EQ(model.instructions.size(), 1);
-    ASSERT_EQ(model.instructions[0].type, DEM_LOGICAL_OBSERVABLE);
+    ASSERT_EQ(model.instructions[0].type, DemInstructionType::DEM_LOGICAL_OBSERVABLE);
     ASSERT_EQ(model.instructions[0].target_data.size(), 1);
     ASSERT_EQ(model.instructions[0].target_data[0], DemTarget::observable_id(5));
     ASSERT_EQ(model.instructions[0].arg_data.size(), 0);
@@ -108,7 +108,7 @@ TEST(detector_error_model, append_error_instruction) {
     model.append_error_instruction(0.25, symptoms);
     ASSERT_EQ(model.instructions.size(), 1);
     ASSERT_EQ(model.blocks.size(), 0);
-    ASSERT_EQ(model.instructions[0].type, DEM_ERROR);
+    ASSERT_EQ(model.instructions[0].type, DemInstructionType::DEM_ERROR);
     ASSERT_EQ(model.instructions[0].target_data, (SpanRef<DemTarget>)symptoms);
     ASSERT_EQ(model.instructions[0].arg_data.size(), 1);
     ASSERT_EQ(model.instructions[0].arg_data[0], 0.25);
@@ -122,7 +122,7 @@ TEST(detector_error_model, append_error_instruction) {
     model.append_error_instruction(0.125, symptoms);
     ASSERT_EQ(model.instructions.size(), 1);
     ASSERT_EQ(model.blocks.size(), 0);
-    ASSERT_EQ(model.instructions[0].type, DEM_ERROR);
+    ASSERT_EQ(model.instructions[0].type, DemInstructionType::DEM_ERROR);
     ASSERT_EQ(model.instructions[0].target_data, (SpanRef<DemTarget>)symptoms);
     ASSERT_EQ(model.instructions[0].arg_data.size(), 1);
     ASSERT_EQ(model.instructions[0].arg_data[0], 0.125);
@@ -158,13 +158,13 @@ TEST(detector_error_model, append_block) {
     model.append_repeat_block(20, block2);
     ASSERT_EQ(model.instructions.size(), 3);
     ASSERT_EQ(model.blocks.size(), 3);
-    ASSERT_EQ(model.instructions[0].type, DEM_REPEAT_BLOCK);
+    ASSERT_EQ(model.instructions[0].type, DemInstructionType::DEM_REPEAT_BLOCK);
     ASSERT_EQ(model.instructions[0].target_data[0].data, 5);
     ASSERT_EQ(model.instructions[0].target_data[1].data, 0);
-    ASSERT_EQ(model.instructions[1].type, DEM_REPEAT_BLOCK);
+    ASSERT_EQ(model.instructions[1].type, DemInstructionType::DEM_REPEAT_BLOCK);
     ASSERT_EQ(model.instructions[1].target_data[0].data, 6);
     ASSERT_EQ(model.instructions[1].target_data[1].data, 1);
-    ASSERT_EQ(model.instructions[2].type, DEM_REPEAT_BLOCK);
+    ASSERT_EQ(model.instructions[2].type, DemInstructionType::DEM_REPEAT_BLOCK);
     ASSERT_EQ(model.instructions[2].target_data[0].data, 20);
     ASSERT_EQ(model.instructions[2].target_data[1].data, 2);
     ASSERT_EQ(model.blocks[0], block2);
@@ -317,30 +317,30 @@ TEST(dem_instruction, general) {
     std::vector<double> p125{0.125};
     std::vector<double> p25{0.25};
     std::vector<double> p126{0.126};
-    DemInstruction i1{p125, d1, DEM_ERROR};
-    DemInstruction i1a{p125, d1, DEM_ERROR};
-    DemInstruction i2{p125, d2, DEM_ERROR};
+    DemInstruction i1{p125, d1, DemInstructionType::DEM_ERROR};
+    DemInstruction i1a{p125, d1, DemInstructionType::DEM_ERROR};
+    DemInstruction i2{p125, d2, DemInstructionType::DEM_ERROR};
     ASSERT_TRUE(i1 == i1a);
     ASSERT_TRUE(!(i1 != i1a));
     ASSERT_TRUE(!(i2 == i1a));
     ASSERT_TRUE(i2 != i1a);
 
-    ASSERT_EQ(i1, (DemInstruction{p125, d1, DEM_ERROR}));
-    ASSERT_NE(i1, (DemInstruction{p125, d2, DEM_ERROR}));
-    ASSERT_NE(i1, (DemInstruction{p25, d1, DEM_ERROR}));
-    ASSERT_NE(((DemInstruction{{}, {}, DEM_DETECTOR})), (DemInstruction{{}, {}, DEM_LOGICAL_OBSERVABLE}));
+    ASSERT_EQ(i1, (DemInstruction{p125, d1, DemInstructionType::DEM_ERROR}));
+    ASSERT_NE(i1, (DemInstruction{p125, d2, DemInstructionType::DEM_ERROR}));
+    ASSERT_NE(i1, (DemInstruction{p25, d1, DemInstructionType::DEM_ERROR}));
+    ASSERT_NE(((DemInstruction{{}, {}, DemInstructionType::DEM_DETECTOR})), (DemInstruction{{}, {}, DemInstructionType::DEM_LOGICAL_OBSERVABLE}));
 
-    ASSERT_TRUE(i1.approx_equals(DemInstruction{p125, d1, DEM_ERROR}, 0));
-    ASSERT_TRUE(!i1.approx_equals(DemInstruction{p126, d1, DEM_ERROR}, 0));
-    ASSERT_TRUE(i1.approx_equals(DemInstruction{p126, d1, DEM_ERROR}, 0.01));
-    ASSERT_TRUE(!i1.approx_equals(DemInstruction{p125, d2, DEM_ERROR}, 9999));
+    ASSERT_TRUE(i1.approx_equals(DemInstruction{p125, d1, DemInstructionType::DEM_ERROR}, 0));
+    ASSERT_TRUE(!i1.approx_equals(DemInstruction{p126, d1, DemInstructionType::DEM_ERROR}, 0));
+    ASSERT_TRUE(i1.approx_equals(DemInstruction{p126, d1, DemInstructionType::DEM_ERROR}, 0.01));
+    ASSERT_TRUE(!i1.approx_equals(DemInstruction{p125, d2, DemInstructionType::DEM_ERROR}, 9999));
 
     ASSERT_EQ(i1.str(), "error(0.125) L4 D3");
     ASSERT_EQ(i2.str(), "error(0.125) L4");
 
     d1.push_back(DemTarget::separator());
     d1.push_back(DemTarget::observable_id(11));
-    ASSERT_EQ((DemInstruction{p25, d1, DEM_ERROR}).str(), "error(0.25) L4 D3 ^ L11");
+    ASSERT_EQ((DemInstruction{p25, d1, DemInstructionType::DEM_ERROR}).str(), "error(0.25) L4 D3 ^ L11");
 }
 
 TEST(detector_error_model, total_detector_shift) {
@@ -625,7 +625,7 @@ TEST(detector_error_model, iter_flatten_error_instructions) {
 
     DetectorErrorModel dem;
     d.iter_flatten_error_instructions([&](const DemInstruction &e) {
-        EXPECT_EQ(e.type, DEM_ERROR);
+        EXPECT_EQ(e.type, DemInstructionType::DEM_ERROR);
         dem.append_error_instruction(e.arg_data[0], e.target_data);
     });
     ASSERT_EQ(dem, DetectorErrorModel(R"MODEL(

--- a/src/stim/dem/detector_error_model.test.cc
+++ b/src/stim/dem/detector_error_model.test.cc
@@ -328,7 +328,9 @@ TEST(dem_instruction, general) {
     ASSERT_EQ(i1, (DemInstruction{p125, d1, DemInstructionType::DEM_ERROR}));
     ASSERT_NE(i1, (DemInstruction{p125, d2, DemInstructionType::DEM_ERROR}));
     ASSERT_NE(i1, (DemInstruction{p25, d1, DemInstructionType::DEM_ERROR}));
-    ASSERT_NE(((DemInstruction{{}, {}, DemInstructionType::DEM_DETECTOR})), (DemInstruction{{}, {}, DemInstructionType::DEM_LOGICAL_OBSERVABLE}));
+    ASSERT_NE(
+        ((DemInstruction{{}, {}, DemInstructionType::DEM_DETECTOR})),
+        (DemInstruction{{}, {}, DemInstructionType::DEM_LOGICAL_OBSERVABLE}));
 
     ASSERT_TRUE(i1.approx_equals(DemInstruction{p125, d1, DemInstructionType::DEM_ERROR}, 0));
     ASSERT_TRUE(!i1.approx_equals(DemInstruction{p126, d1, DemInstructionType::DEM_ERROR}, 0));

--- a/src/stim/dem/detector_error_model_instruction.pybind.cc
+++ b/src/stim/dem/detector_error_model_instruction.pybind.cc
@@ -47,7 +47,7 @@ std::string ExposedDemInstruction::repr() const {
         } else {
             out << ", ";
         }
-        if (type == DEM_SHIFT_DETECTORS) {
+        if (type == DemInstructionType::DEM_SHIFT_DETECTORS) {
             out << e.data;
         } else if (e.is_relative_detector_id()) {
             out << "stim.target_relative_detector_id(" << e.raw_id() << ")";
@@ -69,7 +69,7 @@ bool ExposedDemInstruction::operator!=(const ExposedDemInstruction &other) const
 }
 std::vector<pybind11::object> ExposedDemInstruction::targets_copy() const {
     std::vector<pybind11::object> result;
-    if (type == DEM_SHIFT_DETECTORS) {
+    if (type == DemInstructionType::DEM_SHIFT_DETECTORS) {
         for (const auto &e : targets) {
             result.push_back(pybind11::cast(e.data));
         }
@@ -118,17 +118,17 @@ void stim_pybind::pybind_detector_error_model_instruction_methods(
                 DemInstructionType conv_type;
                 std::vector<DemTarget> conv_targets;
                 if (lower == "error") {
-                    conv_type = DEM_ERROR;
+                    conv_type = DemInstructionType::DEM_ERROR;
                 } else if (lower == "shift_detectors") {
-                    conv_type = DEM_SHIFT_DETECTORS;
+                    conv_type = DemInstructionType::DEM_SHIFT_DETECTORS;
                 } else if (lower == "detector") {
-                    conv_type = DEM_DETECTOR;
+                    conv_type = DemInstructionType::DEM_DETECTOR;
                 } else if (lower == "logical_observable") {
-                    conv_type = DEM_LOGICAL_OBSERVABLE;
+                    conv_type = DemInstructionType::DEM_LOGICAL_OBSERVABLE;
                 } else {
                     throw std::invalid_argument("Unrecognized instruction name '" + lower + "'.");
                 }
-                if (conv_type == DEM_SHIFT_DETECTORS) {
+                if (conv_type == DemInstructionType::DEM_SHIFT_DETECTORS) {
                     for (const auto &e : targets) {
                         try {
                             conv_targets.push_back(DemTarget{pybind11::cast<uint64_t>(e)});

--- a/src/stim/diagram/circuit_timeline_helper.cc
+++ b/src/stim/diagram/circuit_timeline_helper.cc
@@ -51,7 +51,7 @@ void CircuitTimelineHelper::do_operation_with_target_combiners(const CircuitInst
         while (end < op.targets.size() && op.targets[end].is_combiner()) {
             end += 2;
         }
-        if (GATE_DATA.items[op.gate_type].flags & GATE_PRODUCES_RESULTS) {
+        if (GATE_DATA[op.gate_type].flags & GATE_PRODUCES_RESULTS) {
             do_record_measure_result(op.targets[start].qubit_value());
         }
         do_atomic_operation(op.gate_type, op.args, {&op.targets[start], &op.targets[end]});
@@ -66,7 +66,7 @@ void CircuitTimelineHelper::do_multi_qubit_atomic_operation(const CircuitInstruc
 void CircuitTimelineHelper::do_two_qubit_gate(const CircuitInstruction &op) {
     for (size_t k = 0; k < op.targets.size(); k += 2) {
         const GateTarget *p = &op.targets[k];
-        if (GATE_DATA.items[op.gate_type].flags & GATE_PRODUCES_RESULTS) {
+        if (GATE_DATA[op.gate_type].flags & GATE_PRODUCES_RESULTS) {
             do_record_measure_result(p[0].qubit_value());
         }
         do_atomic_operation(op.gate_type, op.args, {p, p + 2});
@@ -75,7 +75,7 @@ void CircuitTimelineHelper::do_two_qubit_gate(const CircuitInstruction &op) {
 
 void CircuitTimelineHelper::do_single_qubit_gate(const CircuitInstruction &op) {
     for (const auto &t : op.targets) {
-        if (GATE_DATA.items[op.gate_type].flags & GATE_PRODUCES_RESULTS) {
+        if (GATE_DATA[op.gate_type].flags & GATE_PRODUCES_RESULTS) {
             do_record_measure_result(t.qubit_value());
         }
         do_atomic_operation(op.gate_type, op.args, {&t});
@@ -198,7 +198,7 @@ void CircuitTimelineHelper::do_next_operation(const Circuit &circuit, const Circ
     } else if (op.gate_type == GateType::TICK) {
         do_atomic_operation(op.gate_type, {}, {});
         num_ticks_seen += 1;
-    } else if (GATE_DATA.items[op.gate_type].flags & GATE_TARGETS_PAIRS) {
+    } else if (GATE_DATA[op.gate_type].flags & GATE_TARGETS_PAIRS) {
         do_two_qubit_gate(op);
     } else {
         do_single_qubit_gate(op);

--- a/src/stim/diagram/detector_slice/detector_slice_set.test.cc
+++ b/src/stim/diagram/detector_slice/detector_slice_set.test.cc
@@ -340,7 +340,7 @@ TEST(detector_slice_set_svg_diagram, observable) {
     obs_filter.exact_target = DemTarget::observable_id(0);
     std::stringstream ss;
     DiagramTimelineSvgDrawer::make_diagram_write_to(
-        circuit, ss, 0, circuit.count_ticks() + 1, SVG_MODE_TIME_DETECTOR_SLICE, {&obs_filter});
+        circuit, ss, 0, circuit.count_ticks() + 1, DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_DETECTOR_SLICE, {&obs_filter});
     expect_string_is_identical_to_saved_file(ss.str(), "observable_slices.svg");
 }
 

--- a/src/stim/diagram/detector_slice/detector_slice_set.test.cc
+++ b/src/stim/diagram/detector_slice/detector_slice_set.test.cc
@@ -340,7 +340,12 @@ TEST(detector_slice_set_svg_diagram, observable) {
     obs_filter.exact_target = DemTarget::observable_id(0);
     std::stringstream ss;
     DiagramTimelineSvgDrawer::make_diagram_write_to(
-        circuit, ss, 0, circuit.count_ticks() + 1, DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_DETECTOR_SLICE, {&obs_filter});
+        circuit,
+        ss,
+        0,
+        circuit.count_ticks() + 1,
+        DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_DETECTOR_SLICE,
+        {&obs_filter});
     expect_string_is_identical_to_saved_file(ss.str(), "observable_slices.svg");
 }
 

--- a/src/stim/diagram/diagram_util.cc
+++ b/src/stim/diagram/diagram_util.cc
@@ -28,7 +28,7 @@ std::pair<std::string, std::string> stim_draw_internal::two_qubit_gate_pieces(Ga
     } else if (gate_type == GateType::SWAPCX) {
         return {"XSWAP", "ZSWAP"};
     } else {
-        auto name = GATE_DATA.items[gate_type].name;
+        auto name = GATE_DATA[gate_type].name;
         return {name, name};
     }
 }

--- a/src/stim/diagram/graph/match_graph_3d_drawer.cc
+++ b/src/stim/diagram/graph/match_graph_3d_drawer.cc
@@ -129,7 +129,7 @@ Basic3dDiagram stim_draw_internal::dem_match_graph_to_basic_3d_diagram(const sti
     }
 
     dem.iter_flatten_error_instructions([&](const DemInstruction &op) {
-        if (op.type != stim::DEM_ERROR) {
+        if (op.type != DemInstructionType::DEM_ERROR) {
             return;
         }
         auto *p = op.target_data.ptr_start;

--- a/src/stim/diagram/timeline/timeline_3d_drawer.cc
+++ b/src/stim/diagram/timeline/timeline_3d_drawer.cc
@@ -140,7 +140,7 @@ void DiagramTimeline3DDrawer::do_single_qubit_gate_instance(const ResolvedTimeli
     const auto &target = op.targets[0];
 
     auto center = mq2xyz(cur_moment, target.qubit_value());
-    const auto &gate_data = GATE_DATA.items[op.gate_type];
+    const auto &gate_data = GATE_DATA[op.gate_type];
     diagram_out.elements.push_back({gate_data.name, center});
 }
 
@@ -171,7 +171,7 @@ void DiagramTimeline3DDrawer::do_multi_qubit_gate_with_pauli_targets(const Resol
             continue;
         }
         std::stringstream ss;
-        const auto &gate_data = GATE_DATA.items[op.gate_type];
+        const auto &gate_data = GATE_DATA[op.gate_type];
         ss << gate_data.name;
         if (t.is_x_target()) {
             ss << ":X";
@@ -309,7 +309,7 @@ void DiagramTimeline3DDrawer::do_resolved_operation(const ResolvedTimelineOperat
         do_else_correlated_error(op);
     } else if (op.gate_type == GateType::TICK) {
         do_tick();
-    } else if (GATE_DATA.items[op.gate_type].flags & GATE_TARGETS_PAIRS) {
+    } else if (GATE_DATA[op.gate_type].flags & GATE_TARGETS_PAIRS) {
         do_two_qubit_gate_instance(op);
     } else {
         do_single_qubit_gate_instance(op);

--- a/src/stim/diagram/timeline/timeline_ascii_drawer.cc
+++ b/src/stim/diagram/timeline/timeline_ascii_drawer.cc
@@ -43,7 +43,7 @@ void DiagramTimelineAsciiDrawer::do_two_qubit_gate_instance(const ResolvedTimeli
 
     const GateTarget &target1 = op.targets[0];
     const GateTarget &target2 = op.targets[1];
-    const auto &gate_data = GATE_DATA.items[op.gate_type];
+    const auto &gate_data = GATE_DATA[op.gate_type];
     auto ends = two_qubit_gate_pieces(op.gate_type);
     if (target1.is_measurement_record_target() || target1.is_sweep_bit_target()) {
         do_feedback(ends.second, target2, target1);
@@ -133,7 +133,7 @@ void DiagramTimelineAsciiDrawer::do_tick() {
 void DiagramTimelineAsciiDrawer::do_single_qubit_gate_instance(const ResolvedTimelineOperation &op) {
     reserve_drawing_room_for_targets(op.targets);
     const auto &target = op.targets[0];
-    const auto &gate_data = GATE_DATA.items[op.gate_type];
+    const auto &gate_data = GATE_DATA[op.gate_type];
 
     std::stringstream ss;
     ss << gate_data.name;
@@ -269,7 +269,7 @@ void DiagramTimelineAsciiDrawer::do_multi_qubit_gate_with_pauli_targets(const Re
             continue;
         }
         std::stringstream ss;
-        const auto &gate_data = GATE_DATA.items[op.gate_type];
+        const auto &gate_data = GATE_DATA[op.gate_type];
         ss << gate_data.name;
         if (t.is_x_target()) {
             ss << "[X]";
@@ -361,7 +361,7 @@ void DiagramTimelineAsciiDrawer::do_qubit_coords(const ResolvedTimelineOperation
     const auto &target = op.targets[0];
 
     std::stringstream ss;
-    const auto &gate_data = GATE_DATA.items[op.gate_type];
+    const auto &gate_data = GATE_DATA[op.gate_type];
     ss << gate_data.name;
     write_coords(ss, op.args);
     diagram.add_entry(AsciiDiagramEntry{
@@ -452,7 +452,7 @@ void DiagramTimelineAsciiDrawer::do_resolved_operation(const ResolvedTimelineOpe
         do_else_correlated_error(op);
     } else if (op.gate_type == GateType::TICK) {
         do_tick();
-    } else if (GATE_DATA.items[op.gate_type].flags & GATE_TARGETS_PAIRS) {
+    } else if (GATE_DATA[op.gate_type].flags & GATE_TARGETS_PAIRS) {
         do_two_qubit_gate_instance(op);
     } else {
         do_single_qubit_gate_instance(op);

--- a/src/stim/diagram/timeline/timeline_svg_drawer.cc
+++ b/src/stim/diagram/timeline/timeline_svg_drawer.cc
@@ -71,7 +71,14 @@ void DiagramTimelineSvgDrawer::do_feedback(
         c.xyz[0],
         c.xyz[1],
         SvgGateData{
-            (uint16_t)(mode == DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE ? 2 : 1), gate, "", exponent.str(), "lightgray", "black", 0, 10},
+            (uint16_t)(mode == DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE ? 2 : 1),
+            gate,
+            "",
+            exponent.str(),
+            "lightgray",
+            "black",
+            0,
+            10},
         {});
 }
 

--- a/src/stim/diagram/timeline/timeline_svg_drawer.cc
+++ b/src/stim/diagram/timeline/timeline_svg_drawer.cc
@@ -27,7 +27,7 @@ size_t DiagramTimelineSvgDrawer::m2x(size_t m) const {
 }
 
 Coord<2> DiagramTimelineSvgDrawer::qt2xy(uint64_t tick, uint64_t moment_delta, size_t q) const {
-    if (mode != SVG_MODE_TIMELINE) {
+    if (mode != DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE) {
         Coord<2> result = coord_sys.qubit_coords[q];
         result.xyz[0] += moment_delta * 14;
         result.xyz[1] += moment_delta * 16;
@@ -56,12 +56,12 @@ void DiagramTimelineSvgDrawer::do_feedback(
     std::stringstream exponent;
     if (feedback_target.is_sweep_bit_target()) {
         exponent << "sweep";
-        if (mode == SVG_MODE_TIMELINE) {
+        if (mode == DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE) {
             exponent << "[" << feedback_target.value() << "]";
         }
     } else if (feedback_target.is_measurement_record_target()) {
         exponent << "rec";
-        if (mode == SVG_MODE_TIMELINE) {
+        if (mode == DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE) {
             exponent << "[" << (feedback_target.value() + resolver.measure_offset) << "]";
         }
     }
@@ -71,7 +71,7 @@ void DiagramTimelineSvgDrawer::do_feedback(
         c.xyz[0],
         c.xyz[1],
         SvgGateData{
-            (uint16_t)(mode == SVG_MODE_TIMELINE ? 2 : 1), gate, "", exponent.str(), "lightgray", "black", 0, 10},
+            (uint16_t)(mode == DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE ? 2 : 1), gate, "", exponent.str(), "lightgray", "black", 0, 10},
         {});
 }
 
@@ -329,7 +329,7 @@ void DiagramTimelineSvgDrawer::start_next_moment() {
 }
 
 void DiagramTimelineSvgDrawer::do_tick() {
-    if (has_ticks && cur_moment > tick_start_moment && mode == SVG_MODE_TIMELINE) {
+    if (has_ticks && cur_moment > tick_start_moment && mode == DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE) {
         float x1 = (float)m2x(tick_start_moment);
         float x2 = (float)m2x(cur_moment + moment_width - 1);
         float y1 = PADDING;
@@ -361,7 +361,7 @@ void DiagramTimelineSvgDrawer::do_single_qubit_gate_instance(const ResolvedTimel
     const auto &target = op.targets[0];
 
     std::stringstream ss;
-    const auto &gate_data = GATE_DATA.items[op.gate_type];
+    const auto &gate_data = GATE_DATA[op.gate_type];
     ss << gate_data.name;
 
     auto c = q2xy(target.qubit_value());
@@ -451,7 +451,7 @@ std::pair<size_t, size_t> compute_minmax_q(SpanRef<const GateTarget> targets) {
 }
 
 void DiagramTimelineSvgDrawer::reserve_drawing_room_for_targets(SpanRef<const GateTarget> targets) {
-    if (mode != SVG_MODE_TIMELINE) {
+    if (mode != DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE) {
         for (const auto &t : targets) {
             if (t.has_qubit_value() && cur_moment_used_flags[t.qubit_value()]) {
                 start_next_moment();
@@ -513,7 +513,7 @@ void DiagramTimelineSvgDrawer::reserve_drawing_room_for_targets(SpanRef<const Ga
 }
 
 void DiagramTimelineSvgDrawer::draw_rec(float cx, float cy) {
-    if (mode != SVG_MODE_TIMELINE) {
+    if (mode != DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE) {
         return;
     }
     svg_out << "<text";
@@ -536,7 +536,7 @@ void DiagramTimelineSvgDrawer::do_multi_qubit_gate_with_pauli_targets(const Reso
             continue;
         }
         std::stringstream ss;
-        const auto &gate_data = GATE_DATA.items[op.gate_type];
+        const auto &gate_data = GATE_DATA[op.gate_type];
         ss << gate_data.name;
         if (t.is_x_target()) {
             ss << "[X]";
@@ -561,7 +561,7 @@ void DiagramTimelineSvgDrawer::do_start_repeat(const CircuitTimelineLoopData &lo
     if (cur_moment_is_used) {
         do_tick();
     }
-    if (mode != SVG_MODE_TIMELINE) {
+    if (mode != DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE) {
         return;
     }
 
@@ -600,7 +600,7 @@ void DiagramTimelineSvgDrawer::do_end_repeat(const CircuitTimelineLoopData &loop
     if (cur_moment_is_used) {
         do_tick();
     }
-    if (mode != SVG_MODE_TIMELINE) {
+    if (mode != DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE) {
         return;
     }
 
@@ -637,7 +637,7 @@ void DiagramTimelineSvgDrawer::do_else_correlated_error(const ResolvedTimelineOp
 }
 
 void DiagramTimelineSvgDrawer::do_qubit_coords(const ResolvedTimelineOperation &op) {
-    if (mode != SVG_MODE_TIMELINE) {
+    if (mode != DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE) {
         return;
     }
     reserve_drawing_room_for_targets(op.targets);
@@ -653,7 +653,7 @@ void DiagramTimelineSvgDrawer::do_qubit_coords(const ResolvedTimelineOperation &
 }
 
 void DiagramTimelineSvgDrawer::do_detector(const ResolvedTimelineOperation &op) {
-    if (mode != SVG_MODE_TIMELINE) {
+    if (mode != DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE) {
         return;
     }
     reserve_drawing_room_for_targets(op.targets);
@@ -701,7 +701,7 @@ void DiagramTimelineSvgDrawer::do_detector(const ResolvedTimelineOperation &op) 
 }
 
 void DiagramTimelineSvgDrawer::do_observable_include(const ResolvedTimelineOperation &op) {
-    if (mode != SVG_MODE_TIMELINE) {
+    if (mode != DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE) {
         return;
     }
     reserve_drawing_room_for_targets(op.targets);
@@ -754,7 +754,7 @@ void DiagramTimelineSvgDrawer::do_resolved_operation(const ResolvedTimelineOpera
         do_else_correlated_error(op);
     } else if (op.gate_type == GateType::TICK) {
         do_tick();
-    } else if (GATE_DATA.items[op.gate_type].flags & GATE_TARGETS_PAIRS) {
+    } else if (GATE_DATA[op.gate_type].flags & GATE_TARGETS_PAIRS) {
         do_two_qubit_gate_instance(op);
     } else {
         do_single_qubit_gate_instance(op);
@@ -782,7 +782,7 @@ void DiagramTimelineSvgDrawer::make_diagram_write_to(
     if (!circuit.operations.empty() && circuit.operations.back().gate_type == GateType::TICK) {
         tick_slice_num = std::min(tick_slice_num, circuit_num_ticks - tick_slice_start);
     }
-    if (mode != SVG_MODE_TIMELINE) {
+    if (mode != DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE) {
         // The +1 is because we're showing the detector slice at the end of each tick region.
         obj.detector_slice_set =
             DetectorSliceSet::from_circuit_ticks(circuit, tick_slice_start + 1, tick_slice_num, filter);
@@ -801,7 +801,7 @@ void DiagramTimelineSvgDrawer::make_diagram_write_to(
     obj.min_tick = tick_slice_start;
     obj.max_tick = tick_slice_start + tick_slice_num - 1;
     obj.mode = mode;
-    obj.resolver.unroll_loops = mode != SVG_MODE_TIMELINE;
+    obj.resolver.unroll_loops = mode != DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE;
     obj.resolver.resolved_op_callback = [&](const ResolvedTimelineOperation &op) {
         obj.do_resolved_operation(op);
     };
@@ -818,7 +818,7 @@ void DiagramTimelineSvgDrawer::make_diagram_write_to(
 
     auto w = obj.m2x(obj.cur_moment) - GATE_PITCH * 0.5f;
     svg_out << R"SVG(<svg viewBox="0 0 )SVG";
-    if (mode != SVG_MODE_TIMELINE) {
+    if (mode != DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE) {
         svg_out << obj.coord_sys.size.xyz[0] * ((obj.num_cols - 1) * SLICE_WINDOW_GAP + 1);
         svg_out << " ";
         svg_out << obj.coord_sys.size.xyz[1] * ((obj.num_rows - 1) * SLICE_WINDOW_GAP + 1);
@@ -832,7 +832,7 @@ void DiagramTimelineSvgDrawer::make_diagram_write_to(
     write_key_val(svg_out, "xmlns", "http://www.w3.org/2000/svg");
     svg_out << ">\n";
 
-    if (mode == SVG_MODE_TIME_DETECTOR_SLICE) {
+    if (mode == DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_DETECTOR_SLICE) {
         obj.detector_slice_set.write_svg_contents_to(
             svg_out,
             [&](uint32_t qubit) {
@@ -846,7 +846,7 @@ void DiagramTimelineSvgDrawer::make_diagram_write_to(
     }
 
     // Make sure qubit lines/points are drawn first, so they are in the background.
-    if (mode != SVG_MODE_TIMELINE) {
+    if (mode != DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE) {
         // Draw qubit points.
         auto tick = tick_slice_start;
         svg_out << "<g id=\"qubit_dots\">\n";
@@ -920,7 +920,7 @@ void DiagramTimelineSvgDrawer::make_diagram_write_to(
     svg_out << buffer.str();
 
     // Border around different slices.
-    if (mode != SVG_MODE_TIMELINE && tick_slice_num > 1) {
+    if (mode != DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE && tick_slice_num > 1) {
         auto k = 0;
         svg_out << "<g id=\"tick_borders\">\n";
         for (uint64_t col = 0; col < obj.num_cols; col++) {

--- a/src/stim/diagram/timeline/timeline_svg_drawer.h
+++ b/src/stim/diagram/timeline/timeline_svg_drawer.h
@@ -28,7 +28,7 @@
 
 namespace stim_draw_internal {
 
-enum DiagramTimelineSvgDrawerMode {
+enum class DiagramTimelineSvgDrawerMode {
     SVG_MODE_TIMELINE = 0,
     SVG_MODE_TIME_SLICE = 1,
     SVG_MODE_TIME_DETECTOR_SLICE = 2,

--- a/src/stim/diagram/timeline/timeline_svg_drawer.test.cc
+++ b/src/stim/diagram/timeline/timeline_svg_drawer.test.cc
@@ -30,7 +30,8 @@ using namespace stim_draw_internal;
 void expect_svg_diagram_is_identical_to_saved_file(const Circuit &circuit, const std::string &key) {
     std::stringstream ss;
     CoordFilter filter;
-    DiagramTimelineSvgDrawer::make_diagram_write_to(circuit, ss, 0, UINT64_MAX, DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE, {&filter});
+    DiagramTimelineSvgDrawer::make_diagram_write_to(
+        circuit, ss, 0, UINT64_MAX, DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE, {&filter});
     expect_string_is_identical_to_saved_file(ss.str(), key);
 }
 
@@ -206,7 +207,8 @@ TEST(circuit_diagram_timeline_svg, tick) {
 
     std::stringstream ss;
     CoordFilter filter;
-    DiagramTimelineSvgDrawer::make_diagram_write_to(circuit, ss, 0, UINT64_MAX, DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE, {&filter});
+    DiagramTimelineSvgDrawer::make_diagram_write_to(
+        circuit, ss, 0, UINT64_MAX, DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE, {&filter});
     expect_string_is_identical_to_saved_file(ss.str(), "tick.svg");
 }
 
@@ -262,7 +264,8 @@ TEST(circuit_diagram_time_detector_slice_svg, surface_code_partial) {
     CoordFilter filter;
     filter.coordinates.push_back(2);
     std::stringstream ss;
-    DiagramTimelineSvgDrawer::make_diagram_write_to(circuit, ss, 5, 11, DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_DETECTOR_SLICE, {&filter});
+    DiagramTimelineSvgDrawer::make_diagram_write_to(
+        circuit, ss, 5, 11, DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_DETECTOR_SLICE, {&filter});
     expect_string_is_identical_to_saved_file(ss.str(), "surface_code_time_detector_slice.svg");
 }
 
@@ -282,7 +285,8 @@ TEST(circuit_diagram_time_slice_svg, surface_code) {
     auto circuit = generate_surface_code_circuit(params).circuit;
     CoordFilter filter;
     std::stringstream ss;
-    DiagramTimelineSvgDrawer::make_diagram_write_to(circuit, ss, 5, 11, DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_SLICE, {&filter});
+    DiagramTimelineSvgDrawer::make_diagram_write_to(
+        circuit, ss, 5, 11, DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_SLICE, {&filter});
     expect_string_is_identical_to_saved_file(ss.str(), "surface_code_time_slice.svg");
 }
 
@@ -323,7 +327,12 @@ TEST(diagram_timeline_svg_drawer, make_diagram_write_to) {
     std::vector<CoordFilter> coord_filter{CoordFilter{}};
     std::stringstream ss;
     DiagramTimelineSvgDrawer::make_diagram_write_to(
-        circuit, ss, 0, circuit.count_ticks(), DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_DETECTOR_SLICE, coord_filter);
+        circuit,
+        ss,
+        0,
+        circuit.count_ticks(),
+        DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_DETECTOR_SLICE,
+        coord_filter);
     expect_string_is_identical_to_saved_file(ss.str(), "detslice-with-ops_surface_code.svg");
 }
 
@@ -331,7 +340,8 @@ TEST(diagram_timeline_svg_drawer, test_circuit_all_ops_time_slice) {
     auto circuit = generate_test_circuit_with_all_operations();
     CoordFilter filter;
     std::stringstream ss;
-    DiagramTimelineSvgDrawer::make_diagram_write_to(circuit, ss, 0, UINT64_MAX, DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_SLICE, {&filter});
+    DiagramTimelineSvgDrawer::make_diagram_write_to(
+        circuit, ss, 0, UINT64_MAX, DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_SLICE, {&filter});
     expect_string_is_identical_to_saved_file(ss.str(), "circuit_all_ops_timeslice.svg");
 }
 
@@ -339,7 +349,8 @@ TEST(diagram_timeline_svg_drawer, test_circuit_all_ops_time_line) {
     auto circuit = generate_test_circuit_with_all_operations();
     CoordFilter filter;
     std::stringstream ss;
-    DiagramTimelineSvgDrawer::make_diagram_write_to(circuit, ss, 0, UINT64_MAX, DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE, {&filter});
+    DiagramTimelineSvgDrawer::make_diagram_write_to(
+        circuit, ss, 0, UINT64_MAX, DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE, {&filter});
     expect_string_is_identical_to_saved_file(ss.str(), "circuit_all_ops_timeline.svg");
 }
 

--- a/src/stim/diagram/timeline/timeline_svg_drawer.test.cc
+++ b/src/stim/diagram/timeline/timeline_svg_drawer.test.cc
@@ -30,7 +30,7 @@ using namespace stim_draw_internal;
 void expect_svg_diagram_is_identical_to_saved_file(const Circuit &circuit, const std::string &key) {
     std::stringstream ss;
     CoordFilter filter;
-    DiagramTimelineSvgDrawer::make_diagram_write_to(circuit, ss, 0, UINT64_MAX, SVG_MODE_TIMELINE, {&filter});
+    DiagramTimelineSvgDrawer::make_diagram_write_to(circuit, ss, 0, UINT64_MAX, DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE, {&filter});
     expect_string_is_identical_to_saved_file(ss.str(), key);
 }
 
@@ -206,7 +206,7 @@ TEST(circuit_diagram_timeline_svg, tick) {
 
     std::stringstream ss;
     CoordFilter filter;
-    DiagramTimelineSvgDrawer::make_diagram_write_to(circuit, ss, 0, UINT64_MAX, SVG_MODE_TIMELINE, {&filter});
+    DiagramTimelineSvgDrawer::make_diagram_write_to(circuit, ss, 0, UINT64_MAX, DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE, {&filter});
     expect_string_is_identical_to_saved_file(ss.str(), "tick.svg");
 }
 
@@ -262,7 +262,7 @@ TEST(circuit_diagram_time_detector_slice_svg, surface_code_partial) {
     CoordFilter filter;
     filter.coordinates.push_back(2);
     std::stringstream ss;
-    DiagramTimelineSvgDrawer::make_diagram_write_to(circuit, ss, 5, 11, SVG_MODE_TIME_DETECTOR_SLICE, {&filter});
+    DiagramTimelineSvgDrawer::make_diagram_write_to(circuit, ss, 5, 11, DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_DETECTOR_SLICE, {&filter});
     expect_string_is_identical_to_saved_file(ss.str(), "surface_code_time_detector_slice.svg");
 }
 
@@ -273,7 +273,7 @@ TEST(circuit_diagram_time_detector_slice_svg, surface_code_full) {
     filter.coordinates.push_back(1);
     std::stringstream ss;
     DiagramTimelineSvgDrawer::make_diagram_write_to(
-        circuit, ss, 0, UINT64_MAX, SVG_MODE_TIME_DETECTOR_SLICE, {&filter});
+        circuit, ss, 0, UINT64_MAX, DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_DETECTOR_SLICE, {&filter});
     expect_string_is_identical_to_saved_file(ss.str(), "surface_code_full_time_detector_slice.svg");
 }
 
@@ -282,7 +282,7 @@ TEST(circuit_diagram_time_slice_svg, surface_code) {
     auto circuit = generate_surface_code_circuit(params).circuit;
     CoordFilter filter;
     std::stringstream ss;
-    DiagramTimelineSvgDrawer::make_diagram_write_to(circuit, ss, 5, 11, SVG_MODE_TIME_SLICE, {&filter});
+    DiagramTimelineSvgDrawer::make_diagram_write_to(circuit, ss, 5, 11, DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_SLICE, {&filter});
     expect_string_is_identical_to_saved_file(ss.str(), "surface_code_time_slice.svg");
 }
 
@@ -313,7 +313,7 @@ TEST(circuit_diagram_timeline_svg, chained_loops) {
     CoordFilter empty_filter;
     std::stringstream ss;
     DiagramTimelineSvgDrawer::make_diagram_write_to(
-        circuit, ss, 0, UINT64_MAX, SVG_MODE_TIME_DETECTOR_SLICE, {&empty_filter});
+        circuit, ss, 0, UINT64_MAX, DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_DETECTOR_SLICE, {&empty_filter});
     expect_string_is_identical_to_saved_file(ss.str(), "circuit_diagram_timeline_svg_chained_loops.svg");
 }
 
@@ -323,7 +323,7 @@ TEST(diagram_timeline_svg_drawer, make_diagram_write_to) {
     std::vector<CoordFilter> coord_filter{CoordFilter{}};
     std::stringstream ss;
     DiagramTimelineSvgDrawer::make_diagram_write_to(
-        circuit, ss, 0, circuit.count_ticks(), SVG_MODE_TIME_DETECTOR_SLICE, coord_filter);
+        circuit, ss, 0, circuit.count_ticks(), DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_DETECTOR_SLICE, coord_filter);
     expect_string_is_identical_to_saved_file(ss.str(), "detslice-with-ops_surface_code.svg");
 }
 
@@ -331,7 +331,7 @@ TEST(diagram_timeline_svg_drawer, test_circuit_all_ops_time_slice) {
     auto circuit = generate_test_circuit_with_all_operations();
     CoordFilter filter;
     std::stringstream ss;
-    DiagramTimelineSvgDrawer::make_diagram_write_to(circuit, ss, 0, UINT64_MAX, SVG_MODE_TIME_SLICE, {&filter});
+    DiagramTimelineSvgDrawer::make_diagram_write_to(circuit, ss, 0, UINT64_MAX, DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_SLICE, {&filter});
     expect_string_is_identical_to_saved_file(ss.str(), "circuit_all_ops_timeslice.svg");
 }
 
@@ -339,7 +339,7 @@ TEST(diagram_timeline_svg_drawer, test_circuit_all_ops_time_line) {
     auto circuit = generate_test_circuit_with_all_operations();
     CoordFilter filter;
     std::stringstream ss;
-    DiagramTimelineSvgDrawer::make_diagram_write_to(circuit, ss, 0, UINT64_MAX, SVG_MODE_TIMELINE, {&filter});
+    DiagramTimelineSvgDrawer::make_diagram_write_to(circuit, ss, 0, UINT64_MAX, DiagramTimelineSvgDrawerMode::SVG_MODE_TIMELINE, {&filter});
     expect_string_is_identical_to_saved_file(ss.str(), "circuit_all_ops_timeline.svg");
 }
 
@@ -348,6 +348,6 @@ TEST(diagram_timeline_svg_drawer, test_circuit_all_ops_detslice) {
     std::stringstream ss;
     auto circuit = generate_test_circuit_with_all_operations();
     DiagramTimelineSvgDrawer::make_diagram_write_to(
-        circuit, ss, 0, UINT64_MAX, SVG_MODE_TIME_DETECTOR_SLICE, {&empty_filter});
+        circuit, ss, 0, UINT64_MAX, DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_DETECTOR_SLICE, {&empty_filter});
     expect_string_is_identical_to_saved_file(ss.str(), "circuit_all_ops_detslice.svg");
 }

--- a/src/stim/io/measure_record.test.cc
+++ b/src/stim/io/measure_record.test.cc
@@ -36,7 +36,7 @@ TEST(MeasureRecord, basic_usage) {
     ASSERT_EQ(r.storage.size(), 102);
 
     FILE *tmp = tmpfile();
-    r.write_unwritten_results_to(*MeasureRecordWriter::make(tmp, SAMPLE_FORMAT_01));
+    r.write_unwritten_results_to(*MeasureRecordWriter::make(tmp, SampleFormat::SAMPLE_FORMAT_01));
     rewind(tmp);
     for (size_t k = 0; k < 102; k++) {
         ASSERT_EQ(getc(tmp), '0' + (~k & 1));

--- a/src/stim/io/measure_record_batch.test.cc
+++ b/src/stim/io/measure_record_batch.test.cc
@@ -47,7 +47,7 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordBatch, basic_usage, {
     ASSERT_EQ(r.unwritten, 102);
     ASSERT_EQ(r.stored, 102);
     FILE *tmp = tmpfile();
-    MeasureRecordBatchWriter w(tmp, 5, SAMPLE_FORMAT_01);
+    MeasureRecordBatchWriter w(tmp, 5, SampleFormat::SAMPLE_FORMAT_01);
     r.intermediate_write_unwritten_results_to(w, simd_bits<W>(0));
     ASSERT_EQ(r.unwritten, 102);
 

--- a/src/stim/io/measure_record_batch_writer.cc
+++ b/src/stim/io/measure_record_batch_writer.cc
@@ -25,13 +25,13 @@ MeasureRecordBatchWriter::MeasureRecordBatchWriter(FILE *out, size_t num_shots, 
     if (num_shots > 768) {
         throw std::out_of_range("num_shots > 768 (safety check to ensure staying away from linux file handle limit)");
     }
-    if (output_format == SAMPLE_FORMAT_PTB64 && num_shots % 64 != 0) {
+    if (output_format == SampleFormat::SAMPLE_FORMAT_PTB64 && num_shots % 64 != 0) {
         throw std::out_of_range("Number of shots must be a multiple of 64 to use output format ptb64.");
     }
     auto f = output_format;
     auto s = num_shots;
-    if (output_format == SAMPLE_FORMAT_PTB64) {
-        f = SAMPLE_FORMAT_B8;
+    if (output_format == SampleFormat::SAMPLE_FORMAT_PTB64) {
+        f = SampleFormat::SAMPLE_FORMAT_B8;
         s += 63;
         s /= 64;
     }

--- a/src/stim/io/measure_record_batch_writer.h
+++ b/src/stim/io/measure_record_batch_writer.h
@@ -44,7 +44,7 @@ struct MeasureRecordBatchWriter {
     ///     bits: The measurement results. The bit at offset k is the bit for the writer at offset k.
     template <size_t W>
     void batch_write_bit(simd_bits_range_ref<W> bits) {
-        if (output_format == SAMPLE_FORMAT_PTB64) {
+        if (output_format == SampleFormat::SAMPLE_FORMAT_PTB64) {
             uint8_t *p = bits.u8;
             for (auto &writer : writers) {
                 uint8_t *n = p + 8;
@@ -71,7 +71,7 @@ struct MeasureRecordBatchWriter {
     ///         results is required to be a multiple of 64 for performance reasons.
     template <size_t W>
     void batch_write_bytes(const simd_bit_table<W> &table, size_t num_major_u64) {
-        if (output_format == SAMPLE_FORMAT_PTB64) {
+        if (output_format == SampleFormat::SAMPLE_FORMAT_PTB64) {
             for (size_t k = 0; k < writers.size(); k++) {
                 for (size_t w = 0; w < num_major_u64; w++) {
                     uint8_t *p = table.data.u8 + (k * 8) + table.num_minor_u8_padded() * w;

--- a/src/stim/io/measure_record_batch_writer.test.cc
+++ b/src/stim/io/measure_record_batch_writer.test.cc
@@ -25,7 +25,7 @@ using namespace stim;
 
 TEST_EACH_WORD_SIZE_W(MeasureRecordBatchWriter, basic_usage, {
     FILE *tmp = tmpfile();
-    MeasureRecordBatchWriter w(tmp, 5, SAMPLE_FORMAT_01);
+    MeasureRecordBatchWriter w(tmp, 5, SampleFormat::SAMPLE_FORMAT_01);
     simd_bits<W> v(5);
     v[1] = true;
     w.batch_write_bit<W>(v);

--- a/src/stim/io/measure_record_reader.inl
+++ b/src/stim/io/measure_record_reader.inl
@@ -47,17 +47,17 @@ template <size_t W>
 std::unique_ptr<MeasureRecordReader<W>> MeasureRecordReader<W>::make(
     FILE *in, SampleFormat input_format, size_t num_measurements, size_t num_detectors, size_t num_observables) {
     switch (input_format) {
-        case SAMPLE_FORMAT_01:
+        case SampleFormat::SAMPLE_FORMAT_01:
             return std::make_unique<MeasureRecordReaderFormat01<W>>(in, num_measurements, num_detectors, num_observables);
-        case SAMPLE_FORMAT_B8:
+        case SampleFormat::SAMPLE_FORMAT_B8:
             return std::make_unique<MeasureRecordReaderFormatB8<W>>(in, num_measurements, num_detectors, num_observables);
-        case SAMPLE_FORMAT_DETS:
+        case SampleFormat::SAMPLE_FORMAT_DETS:
             return std::make_unique<MeasureRecordReaderFormatDets<W>>(in, num_measurements, num_detectors, num_observables);
-        case SAMPLE_FORMAT_HITS:
+        case SampleFormat::SAMPLE_FORMAT_HITS:
             return std::make_unique<MeasureRecordReaderFormatHits<W>>(in, num_measurements, num_detectors, num_observables);
-        case SAMPLE_FORMAT_PTB64:
+        case SampleFormat::SAMPLE_FORMAT_PTB64:
             return std::make_unique<MeasureRecordReaderFormatPTB64<W>>(in, num_measurements, num_detectors, num_observables);
-        case SAMPLE_FORMAT_R8:
+        case SampleFormat::SAMPLE_FORMAT_R8:
             return std::make_unique<MeasureRecordReaderFormatR8<W>>(in, num_measurements, num_detectors, num_observables);
         default:
             throw std::invalid_argument("Sample format not recognized by MeasurementRecordReader");

--- a/src/stim/io/measure_record_reader.perf.cc
+++ b/src/stim/io/measure_record_reader.perf.cc
@@ -77,54 +77,54 @@ void sparse_reader_benchmark(double goal_micros) {
 }
 
 BENCHMARK(read_01_dense_per10) {
-    dense_reader_benchmark<10000, 10, SAMPLE_FORMAT_01>(60);
+    dense_reader_benchmark<10000, 10, SampleFormat:: SAMPLE_FORMAT_01>(60);
 }
 BENCHMARK(read_01_sparse_per10) {
-    sparse_reader_benchmark<10000, 10, SAMPLE_FORMAT_01>(45);
+    sparse_reader_benchmark<10000, 10, SampleFormat:: SAMPLE_FORMAT_01>(45);
 }
 
 BENCHMARK(read_b8_dense_per10) {
-    dense_reader_benchmark<10000, 10, SAMPLE_FORMAT_B8>(0.65);
+    dense_reader_benchmark<10000, 10, SampleFormat:: SAMPLE_FORMAT_B8>(0.65);
 }
 BENCHMARK(read_b8_sparse_per10) {
-    sparse_reader_benchmark<10000, 10, SAMPLE_FORMAT_B8>(6);
+    sparse_reader_benchmark<10000, 10, SampleFormat:: SAMPLE_FORMAT_B8>(6);
 }
 
 BENCHMARK(read_hits_dense_per10) {
-    dense_reader_benchmark<10000, 10, SAMPLE_FORMAT_HITS>(16);
+    dense_reader_benchmark<10000, 10, SampleFormat:: SAMPLE_FORMAT_HITS>(16);
 }
 BENCHMARK(read_hits_dense_per100) {
-    dense_reader_benchmark<10000, 100, SAMPLE_FORMAT_HITS>(2.1);
+    dense_reader_benchmark<10000, 100, SampleFormat:: SAMPLE_FORMAT_HITS>(2.1);
 }
 BENCHMARK(read_hits_sparse_per10) {
-    sparse_reader_benchmark<10000, 10, SAMPLE_FORMAT_HITS>(15);
+    sparse_reader_benchmark<10000, 10, SampleFormat:: SAMPLE_FORMAT_HITS>(15);
 }
 BENCHMARK(read_hits_sparse_per100) {
-    sparse_reader_benchmark<10000, 100, SAMPLE_FORMAT_HITS>(2.2);
+    sparse_reader_benchmark<10000, 100, SampleFormat:: SAMPLE_FORMAT_HITS>(2.2);
 }
 
 BENCHMARK(read_dets_dense_per10) {
-    dense_reader_benchmark<10000, 10, SAMPLE_FORMAT_DETS>(23);
+    dense_reader_benchmark<10000, 10, SampleFormat:: SAMPLE_FORMAT_DETS>(23);
 }
 BENCHMARK(read_dets_dense_per100) {
-    dense_reader_benchmark<10000, 100, SAMPLE_FORMAT_DETS>(3.0);
+    dense_reader_benchmark<10000, 100, SampleFormat:: SAMPLE_FORMAT_DETS>(3.0);
 }
 BENCHMARK(read_dets_sparse_per10) {
-    sparse_reader_benchmark<10000, 10, SAMPLE_FORMAT_DETS>(23);
+    sparse_reader_benchmark<10000, 10, SampleFormat:: SAMPLE_FORMAT_DETS>(23);
 }
 BENCHMARK(read_dets_sparse_per100) {
-    sparse_reader_benchmark<10000, 100, SAMPLE_FORMAT_DETS>(3.0);
+    sparse_reader_benchmark<10000, 100, SampleFormat:: SAMPLE_FORMAT_DETS>(3.0);
 }
 
 BENCHMARK(read_r8_dense_per10) {
-    dense_reader_benchmark<10000, 10, SAMPLE_FORMAT_R8>(5);
+    dense_reader_benchmark<10000, 10, SampleFormat:: SAMPLE_FORMAT_R8>(5);
 }
 BENCHMARK(read_r8_dense_per100) {
-    dense_reader_benchmark<10000, 100, SAMPLE_FORMAT_R8>(1.3);
+    dense_reader_benchmark<10000, 100, SampleFormat:: SAMPLE_FORMAT_R8>(1.3);
 }
 BENCHMARK(read_r8_sparse_per10) {
-    sparse_reader_benchmark<10000, 10, SAMPLE_FORMAT_R8>(3.5);
+    sparse_reader_benchmark<10000, 10, SampleFormat:: SAMPLE_FORMAT_R8>(3.5);
 }
 BENCHMARK(read_r8_sparse_per100) {
-    sparse_reader_benchmark<10000, 100, SAMPLE_FORMAT_R8>(1.0);
+    sparse_reader_benchmark<10000, 100, SampleFormat:: SAMPLE_FORMAT_R8>(1.0);
 }

--- a/src/stim/io/measure_record_reader.test.cc
+++ b/src/stim/io/measure_record_reader.test.cc
@@ -88,25 +88,25 @@ void assert_contents_load_correctly(SampleFormat format, const std::string &cont
 }
 
 TEST_EACH_WORD_SIZE_W(MeasureRecordReader, Format01, {
-    assert_contents_load_correctly<W>(SAMPLE_FORMAT_01, "000111110000111111\n");
+    assert_contents_load_correctly<W>(SampleFormat::SAMPLE_FORMAT_01, "000111110000111111\n");
 })
 
 TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatB8, {
-    assert_contents_load_correctly<W>(SAMPLE_FORMAT_B8, "\xF8\xF0\x03");
+    assert_contents_load_correctly<W>(SampleFormat::SAMPLE_FORMAT_B8, "\xF8\xF0\x03");
 })
 
 TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatHits, {
-    assert_contents_load_correctly<W>(SAMPLE_FORMAT_HITS, "3,4,5,6,7,12,13,14,15,16,17\n");
+    assert_contents_load_correctly<W>(SampleFormat::SAMPLE_FORMAT_HITS, "3,4,5,6,7,12,13,14,15,16,17\n");
 })
 
 TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatR8, {
     char tmp_data[]{3, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0};
-    assert_contents_load_correctly<W>(SAMPLE_FORMAT_R8, std::string(std::begin(tmp_data), std::end(tmp_data)));
+    assert_contents_load_correctly<W>(SampleFormat::SAMPLE_FORMAT_R8, std::string(std::begin(tmp_data), std::end(tmp_data)));
 })
 
 TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatR8_LongGap, {
     FILE *tmp = tmpfile_with_contents("\xFF\xFF\x02\x20");
-    auto reader = MeasureRecordReader<W>::make(tmp, SAMPLE_FORMAT_R8, 8 * 64 + 32 + 1);
+    auto reader = MeasureRecordReader<W>::make(tmp, SampleFormat::SAMPLE_FORMAT_R8, 8 * 64 + 32 + 1);
     SparseShot sparse;
     ASSERT_TRUE(reader->start_and_read_entire_record(sparse));
     ASSERT_EQ(sparse.hits, (std::vector<uint64_t>{255 + 255 + 2}));
@@ -139,9 +139,9 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, Format01_WriteRead, {
     constexpr size_t num_bytes = sizeof(src) / sizeof(uint8_t);
     uint8_t dst[num_bytes];
     memset(dst, 0, num_bytes);
-    FILE *tmp = write_records({src, src + num_bytes}, SAMPLE_FORMAT_01);
+    FILE *tmp = write_records({src, src + num_bytes}, SampleFormat::SAMPLE_FORMAT_01);
     rewind(tmp);
-    ASSERT_EQ(num_bytes * 8, read_records_as_bytes<W>(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_01, 8 * num_bytes));
+    ASSERT_EQ(num_bytes * 8, read_records_as_bytes<W>(tmp, {dst, dst + num_bytes}, SampleFormat::SAMPLE_FORMAT_01, 8 * num_bytes));
     for (size_t i = 0; i < num_bytes; ++i) {
         ASSERT_EQ(src[i], dst[i]);
     }
@@ -152,9 +152,9 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatB8_WriteRead, {
     constexpr size_t num_bytes = sizeof(src) / sizeof(uint8_t);
     uint8_t dst[num_bytes];
     memset(dst, 0, num_bytes);
-    FILE *tmp = write_records({src, src + num_bytes}, SAMPLE_FORMAT_B8);
+    FILE *tmp = write_records({src, src + num_bytes}, SampleFormat::SAMPLE_FORMAT_B8);
     rewind(tmp);
-    ASSERT_EQ(num_bytes * 8, read_records_as_bytes<W>(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_B8, 8 * num_bytes));
+    ASSERT_EQ(num_bytes * 8, read_records_as_bytes<W>(tmp, {dst, dst + num_bytes}, SampleFormat::SAMPLE_FORMAT_B8, 8 * num_bytes));
     for (size_t i = 0; i < num_bytes; ++i) {
         ASSERT_EQ(src[i], dst[i]);
     }
@@ -164,9 +164,9 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatR8_WriteRead, {
     uint8_t src[]{0, 1, 2, 3, 4, 0xFF, 0xBF, 0xFE, 80, 0, 0, 1, 20};
     constexpr size_t num_bytes = sizeof(src) / sizeof(uint8_t);
     uint8_t dst[num_bytes]{};
-    FILE *tmp = write_records({src, src + num_bytes}, SAMPLE_FORMAT_R8);
+    FILE *tmp = write_records({src, src + num_bytes}, SampleFormat::SAMPLE_FORMAT_R8);
     rewind(tmp);
-    ASSERT_EQ(num_bytes * 8, read_records_as_bytes<W>(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_R8, 8 * num_bytes));
+    ASSERT_EQ(num_bytes * 8, read_records_as_bytes<W>(tmp, {dst, dst + num_bytes}, SampleFormat::SAMPLE_FORMAT_R8, 8 * num_bytes));
     for (size_t i = 0; i < num_bytes; ++i) {
         ASSERT_EQ(src[i], dst[i]);
     }
@@ -177,11 +177,11 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatHits_WriteRead, {
     constexpr size_t num_bytes = sizeof(src) / sizeof(uint8_t);
     uint8_t dst[num_bytes];
     memset(dst, 0, num_bytes);
-    FILE *tmp = write_records({src, src + num_bytes}, SAMPLE_FORMAT_HITS);
+    FILE *tmp = write_records({src, src + num_bytes}, SampleFormat::SAMPLE_FORMAT_HITS);
     rewind(tmp);
     ASSERT_EQ(
         num_bytes * 8 - 1,
-        read_records_as_bytes<W>(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_HITS, 8 * num_bytes - 1));
+        read_records_as_bytes<W>(tmp, {dst, dst + num_bytes}, SampleFormat::SAMPLE_FORMAT_HITS, 8 * num_bytes - 1));
     for (size_t i = 0; i < num_bytes; ++i) {
         ASSERT_EQ(src[i], dst[i]);
     }
@@ -192,11 +192,11 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatDets_WriteRead, {
     constexpr size_t num_bytes = sizeof(src) / sizeof(uint8_t);
     uint8_t dst[num_bytes];
     memset(dst, 0, num_bytes);
-    FILE *tmp = write_records({src, src + num_bytes}, SAMPLE_FORMAT_DETS);
+    FILE *tmp = write_records({src, src + num_bytes}, SampleFormat::SAMPLE_FORMAT_DETS);
     rewind(tmp);
     ASSERT_EQ(
         num_bytes * 8 - 1,
-        read_records_as_bytes<W>(tmp, {dst, dst + num_bytes}, SAMPLE_FORMAT_DETS, 8 * num_bytes - 1));
+        read_records_as_bytes<W>(tmp, {dst, dst + num_bytes}, SampleFormat::SAMPLE_FORMAT_DETS, 8 * num_bytes - 1));
     for (size_t i = 0; i < num_bytes; ++i) {
         ASSERT_EQ(src[i], dst[i]);
     }
@@ -210,7 +210,7 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, Format01_WriteRead_MultipleRecords, {
     constexpr size_t bits_per_record = 8 * num_bytes;
 
     FILE *tmp = tmpfile();
-    auto writer = MeasureRecordWriter::make(tmp, SAMPLE_FORMAT_01);
+    auto writer = MeasureRecordWriter::make(tmp, SampleFormat::SAMPLE_FORMAT_01);
     writer->write_bytes({record1, record1 + num_bytes});
     writer->write_end();
     writer->write_bytes({record2, record2 + num_bytes});
@@ -220,7 +220,7 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, Format01_WriteRead_MultipleRecords, {
 
     rewind(tmp);
 
-    auto reader = MeasureRecordReader<W>::make(tmp, SAMPLE_FORMAT_01, bits_per_record);
+    auto reader = MeasureRecordReader<W>::make(tmp, SampleFormat::SAMPLE_FORMAT_01, bits_per_record);
 
     simd_bits<W> buf(num_bytes * 8);
     ASSERT_TRUE(reader->start_and_read_entire_record(buf));
@@ -249,7 +249,7 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatHits_WriteRead_MultipleRecords,
     constexpr size_t bits_per_record = 8 * num_bytes - 1;
 
     FILE *tmp = tmpfile();
-    auto writer = MeasureRecordWriter::make(tmp, SAMPLE_FORMAT_HITS);
+    auto writer = MeasureRecordWriter::make(tmp, SampleFormat::SAMPLE_FORMAT_HITS);
     writer->write_bytes({record1, record1 + num_bytes});
     writer->write_end();
     writer->write_bytes({record2, record2 + num_bytes});
@@ -259,7 +259,7 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatHits_WriteRead_MultipleRecords,
 
     rewind(tmp);
 
-    auto reader = MeasureRecordReader<W>::make(tmp, SAMPLE_FORMAT_HITS, bits_per_record);
+    auto reader = MeasureRecordReader<W>::make(tmp, SampleFormat::SAMPLE_FORMAT_HITS, bits_per_record);
     simd_bits<W> buf(num_bytes * 8);
     ASSERT_TRUE(reader->start_and_read_entire_record(buf));
     for (size_t i = 0; i < num_bytes; ++i) {
@@ -287,7 +287,7 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatDets_WriteRead_MultipleRecords,
     constexpr size_t bits_per_record = 8 * num_bytes - 1;
 
     FILE *tmp = tmpfile();
-    auto writer = MeasureRecordWriter::make(tmp, SAMPLE_FORMAT_DETS);
+    auto writer = MeasureRecordWriter::make(tmp, SampleFormat::SAMPLE_FORMAT_DETS);
     writer->write_bytes({record1, record1 + num_bytes});
     writer->write_end();
     writer->write_bytes({record2, record2 + num_bytes});
@@ -297,7 +297,7 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatDets_WriteRead_MultipleRecords,
 
     rewind(tmp);
 
-    auto reader = MeasureRecordReader<W>::make(tmp, SAMPLE_FORMAT_DETS, bits_per_record);
+    auto reader = MeasureRecordReader<W>::make(tmp, SampleFormat::SAMPLE_FORMAT_DETS, bits_per_record);
     simd_bits<W> buf(num_bytes * 8);
     ASSERT_TRUE(reader->start_and_read_entire_record(buf));
     for (size_t i = 0; i < num_bytes; ++i) {
@@ -320,7 +320,7 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatDets_WriteRead_MultipleRecords,
 TEST_EACH_WORD_SIZE_W(MeasureRecordReader, Format01_MultipleRecords, {
     FILE *tmp = tmpfile_with_contents("111011001\n010000000\n101100011\n");
     ASSERT_NE(tmp, nullptr);
-    auto reader = MeasureRecordReader<W>::make(tmp, SAMPLE_FORMAT_01, 9);
+    auto reader = MeasureRecordReader<W>::make(tmp, SampleFormat::SAMPLE_FORMAT_01, 9);
     simd_bits<W> buf(9);
     ASSERT_TRUE(reader->start_and_read_entire_record(buf));
     ASSERT_TRUE(reader->start_and_read_entire_record(buf));
@@ -330,7 +330,7 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, Format01_MultipleRecords, {
 
 TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatDets_MultipleShortRecords, {
     FILE *tmp = tmpfile_with_contents("shot M0\nshot M1\nshot M0\nshot\n");
-    auto reader = MeasureRecordReader<W>::make(tmp, SAMPLE_FORMAT_DETS, 2);
+    auto reader = MeasureRecordReader<W>::make(tmp, SampleFormat::SAMPLE_FORMAT_DETS, 2);
 
     simd_bits<W> buf(2);
     ASSERT_TRUE(reader->start_and_read_entire_record(buf));
@@ -350,7 +350,7 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatDets_MultipleShortRecords, {
 
 TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatDets_HugeObservables, {
     FILE *tmp = tmpfile_with_contents("shot L1000\nshot D2 L999\n");
-    auto reader = MeasureRecordReader<W>::make(tmp, SAMPLE_FORMAT_DETS, 0, 10, 1500);
+    auto reader = MeasureRecordReader<W>::make(tmp, SampleFormat::SAMPLE_FORMAT_DETS, 0, 10, 1500);
 
     simd_bits<64> expected(1500);
     simd_bits<W> buf(2);
@@ -372,7 +372,7 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatDets_HugeObservables, {
 
 TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatDets_MultipleResultTypes_D0L0, {
     FILE *tmp = tmpfile_with_contents("shot D0 D3 D5 L1 L2\n");
-    auto reader = MeasureRecordReader<W>::make(tmp, SAMPLE_FORMAT_DETS, 0, 7, 4);
+    auto reader = MeasureRecordReader<W>::make(tmp, SampleFormat::SAMPLE_FORMAT_DETS, 0, 7, 4);
     simd_bits<W> buf(11);
     ASSERT_TRUE(reader->start_and_read_entire_record(buf));
     ASSERT_EQ(buf[0], 1);
@@ -388,7 +388,7 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatDets_MultipleResultTypes_D0L0, 
     ASSERT_EQ(buf[10], 0);
 
     rewind(tmp);
-    reader = MeasureRecordReader<W>::make(tmp, SAMPLE_FORMAT_DETS, 0, 7, 4);
+    reader = MeasureRecordReader<W>::make(tmp, SampleFormat::SAMPLE_FORMAT_DETS, 0, 7, 4);
     SparseShot sparse;
     reader->start_and_read_entire_record(sparse);
     ASSERT_EQ(sparse.hits, (std::vector<uint64_t>{0, 3, 5}));
@@ -398,28 +398,28 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatDets_MultipleResultTypes_D0L0, 
 TEST_EACH_WORD_SIZE_W(MeasureRecordReader, Format01_InvalidInput, {
     FILE *tmp = tmpfile_with_contents("012\n");
     ASSERT_NE(tmp, nullptr);
-    auto reader = MeasureRecordReader<W>::make(tmp, SAMPLE_FORMAT_01, 3);
+    auto reader = MeasureRecordReader<W>::make(tmp, SampleFormat::SAMPLE_FORMAT_01, 3);
     simd_bits<W> buf(3);
     ASSERT_THROW({ reader->start_and_read_entire_record(buf); }, std::invalid_argument);
 })
 
 TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatHits_InvalidInput, {
     FILE *tmp = tmpfile_with_contents("100,1\n");
-    auto reader = MeasureRecordReader<W>::make(tmp, SAMPLE_FORMAT_HITS, 3);
+    auto reader = MeasureRecordReader<W>::make(tmp, SampleFormat::SAMPLE_FORMAT_HITS, 3);
     simd_bits<W> buf(3);
     ASSERT_THROW({ reader->start_and_read_entire_record(buf); }, std::invalid_argument);
 })
 
 TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatHits_InvalidInput_sparse, {
     FILE *tmp = tmpfile_with_contents("100,1\n");
-    auto reader = MeasureRecordReader<W>::make(tmp, SAMPLE_FORMAT_HITS, 3);
+    auto reader = MeasureRecordReader<W>::make(tmp, SampleFormat::SAMPLE_FORMAT_HITS, 3);
     SparseShot sparse;
     ASSERT_THROW({ reader->start_and_read_entire_record(sparse); }, std::invalid_argument);
 })
 
 TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatHits_Repeated_Dense, {
     FILE *tmp = tmpfile_with_contents("1,1\n");
-    auto reader = MeasureRecordReader<W>::make(tmp, SAMPLE_FORMAT_HITS, 3);
+    auto reader = MeasureRecordReader<W>::make(tmp, SampleFormat::SAMPLE_FORMAT_HITS, 3);
     simd_bits<W> buf(3);
     ASSERT_TRUE(reader->start_and_read_entire_record(buf));
     ASSERT_EQ(buf[0], 0);
@@ -429,7 +429,7 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatHits_Repeated_Dense, {
 
 TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatHits_Repeated_Sparse, {
     FILE *tmp = tmpfile_with_contents("1,1\n");
-    auto reader = MeasureRecordReader<W>::make(tmp, SAMPLE_FORMAT_HITS, 3);
+    auto reader = MeasureRecordReader<W>::make(tmp, SampleFormat::SAMPLE_FORMAT_HITS, 3);
     SparseShot sparse;
     ASSERT_TRUE(reader->start_and_read_entire_record(sparse));
     ASSERT_EQ(sparse.hits, (std::vector<uint64_t>{1, 1}));
@@ -437,14 +437,14 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatHits_Repeated_Sparse, {
 
 TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatDets_InvalidInput_Sparse, {
     FILE *tmp = tmpfile_with_contents("D2\n");
-    auto r = MeasureRecordReader<W>::make(tmp, SAMPLE_FORMAT_DETS, 3);
+    auto r = MeasureRecordReader<W>::make(tmp, SampleFormat::SAMPLE_FORMAT_DETS, 3);
     SparseShot sparse;
     ASSERT_THROW({ r->start_and_read_entire_record(sparse); }, std::invalid_argument);
 })
 
 TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatDets_InvalidInput_Dense, {
     FILE *tmp = tmpfile_with_contents("D2\n");
-    auto r = MeasureRecordReader<W>::make(tmp, SAMPLE_FORMAT_DETS, 3);
+    auto r = MeasureRecordReader<W>::make(tmp, SampleFormat::SAMPLE_FORMAT_DETS, 3);
     simd_bits<W> buf(3);
     ASSERT_THROW({ r->start_and_read_entire_record(buf); }, std::invalid_argument);
 })
@@ -499,7 +499,7 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, read_records_into_RoundTrip, {
 
 TEST_EACH_WORD_SIZE_W(MeasureRecordReader, read_bits_into_bytes_entire_record_across_result_type, {
     FILE *f = tmpfile_with_contents("shot D1 L1");
-    auto reader = MeasureRecordReader<W>::make(f, SAMPLE_FORMAT_DETS, 0, 3, 3);
+    auto reader = MeasureRecordReader<W>::make(f, SampleFormat::SAMPLE_FORMAT_DETS, 0, 3, 3);
     simd_bit_table<W> read(6, 1);
     size_t n = reader->read_records_into(read, false);
     fclose(f);
@@ -518,7 +518,7 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, read_r8_detection_event_data, {
     putc(1, f);
     putc(4, f);
     rewind(f);
-    auto reader = MeasureRecordReader<W>::make(f, SAMPLE_FORMAT_R8, 0, 3, 3);
+    auto reader = MeasureRecordReader<W>::make(f, SampleFormat::SAMPLE_FORMAT_R8, 0, 3, 3);
     simd_bit_table<W> read(6, 2);
     size_t n = reader->read_records_into(read, false);
     fclose(f);
@@ -544,7 +544,7 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, read_b8_detection_event_data_full_run
     putc(2, f);
     putc(3, f);
     rewind(f);
-    auto reader = MeasureRecordReader<W>::make(f, SAMPLE_FORMAT_B8, 0, 27, 0);
+    auto reader = MeasureRecordReader<W>::make(f, SampleFormat::SAMPLE_FORMAT_B8, 0, 27, 0);
     simd_bit_table<W> read(27, 1);
     size_t n = reader->read_records_into(read, false);
     fclose(f);
@@ -675,7 +675,7 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, start_and_read_entire_record_ptb64_de
     rewind(f);
 
     simd_bits<W> loaded(71);
-    auto reader = MeasureRecordReader<W>::make(f, SAMPLE_FORMAT_PTB64, 71, 0, 0);
+    auto reader = MeasureRecordReader<W>::make(f, SampleFormat::SAMPLE_FORMAT_PTB64, 71, 0, 0);
     for (size_t shot = 0; shot < 64; shot++) {
         ASSERT_TRUE(reader->start_and_read_entire_record(loaded));
         for (size_t m = 0; m < 71; m++) {
@@ -696,7 +696,7 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, start_and_read_entire_record_ptb64_sp
     FILE *tmp = tmpfile();
     simd_bit_table<W> ground_truth(71, 64 * 5);
     {
-        MeasureRecordBatchWriter writer(tmp, 64 * 5, stim::SAMPLE_FORMAT_PTB64);
+        MeasureRecordBatchWriter writer(tmp, 64 * 5, SampleFormat::SAMPLE_FORMAT_PTB64);
         for (size_t k = 0; k < 71; k++) {
             ground_truth[k].randomize(64 * 5, rng);
             writer.batch_write_bit<W>(ground_truth[k]);
@@ -705,7 +705,7 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, start_and_read_entire_record_ptb64_sp
     }
     rewind(tmp);
 
-    auto reader = MeasureRecordReader<W>::make(tmp, SAMPLE_FORMAT_PTB64, 71, 0, 0);
+    auto reader = MeasureRecordReader<W>::make(tmp, SampleFormat::SAMPLE_FORMAT_PTB64, 71, 0, 0);
     for (size_t shot = 0; shot < 64 * 5; shot++) {
         SparseShot loaded;
         ASSERT_TRUE(reader->start_and_read_entire_record(loaded));
@@ -727,7 +727,7 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, read_file_data_into_shot_table_vs_wri
     for (const auto &format_data : format_name_to_enum_map()) {
         SampleFormat format = format_data.second.id;
         size_t num_shots = 500;
-        if (format == SAMPLE_FORMAT_PTB64) {
+        if (format == SampleFormat::SAMPLE_FORMAT_PTB64) {
             num_shots = 512 + 64;
         }
         size_t bits_per_shot = 1000;
@@ -763,7 +763,7 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, read_windows_newlines_01, {
     FILE *f = tmpfile();
     fprintf(f, "01\r\n01\r\n");
     rewind(f);
-    auto reader = MeasureRecordReader<W>::make(f, SAMPLE_FORMAT_01, 2, 0, 0);
+    auto reader = MeasureRecordReader<W>::make(f, SampleFormat::SAMPLE_FORMAT_01, 2, 0, 0);
     simd_bit_table<W> read(2, 2);
     size_t n = reader->read_records_into(read, false);
     ASSERT_EQ(n, 2);
@@ -778,7 +778,7 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, read_windows_newlines_hits, {
     FILE *f = tmpfile();
     fprintf(f, "3\r\n1\r\n");
     rewind(f);
-    auto reader = MeasureRecordReader<W>::make(f, SAMPLE_FORMAT_HITS, 4, 0, 0);
+    auto reader = MeasureRecordReader<W>::make(f, SampleFormat::SAMPLE_FORMAT_HITS, 4, 0, 0);
     simd_bit_table<W> read(4, 2);
     size_t n = reader->read_records_into(read, false);
     ASSERT_EQ(n, 2);
@@ -797,7 +797,7 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, read_windows_newlines_dets, {
     FILE *f = tmpfile();
     fprintf(f, "shot M3\r\n\r\n\n   shot M1\r\n\n");
     rewind(f);
-    auto reader = MeasureRecordReader<W>::make(f, SAMPLE_FORMAT_DETS, 4, 0, 0);
+    auto reader = MeasureRecordReader<W>::make(f, SampleFormat::SAMPLE_FORMAT_DETS, 4, 0, 0);
     simd_bit_table<W> read(4, 2);
     size_t n = reader->read_records_into(read, false);
     ASSERT_EQ(n, 2);

--- a/src/stim/io/measure_record_reader.test.cc
+++ b/src/stim/io/measure_record_reader.test.cc
@@ -101,7 +101,8 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatHits, {
 
 TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatR8, {
     char tmp_data[]{3, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0};
-    assert_contents_load_correctly<W>(SampleFormat::SAMPLE_FORMAT_R8, std::string(std::begin(tmp_data), std::end(tmp_data)));
+    assert_contents_load_correctly<W>(
+        SampleFormat::SAMPLE_FORMAT_R8, std::string(std::begin(tmp_data), std::end(tmp_data)));
 })
 
 TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatR8_LongGap, {
@@ -141,7 +142,9 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, Format01_WriteRead, {
     memset(dst, 0, num_bytes);
     FILE *tmp = write_records({src, src + num_bytes}, SampleFormat::SAMPLE_FORMAT_01);
     rewind(tmp);
-    ASSERT_EQ(num_bytes * 8, read_records_as_bytes<W>(tmp, {dst, dst + num_bytes}, SampleFormat::SAMPLE_FORMAT_01, 8 * num_bytes));
+    ASSERT_EQ(
+        num_bytes * 8,
+        read_records_as_bytes<W>(tmp, {dst, dst + num_bytes}, SampleFormat::SAMPLE_FORMAT_01, 8 * num_bytes));
     for (size_t i = 0; i < num_bytes; ++i) {
         ASSERT_EQ(src[i], dst[i]);
     }
@@ -154,7 +157,9 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatB8_WriteRead, {
     memset(dst, 0, num_bytes);
     FILE *tmp = write_records({src, src + num_bytes}, SampleFormat::SAMPLE_FORMAT_B8);
     rewind(tmp);
-    ASSERT_EQ(num_bytes * 8, read_records_as_bytes<W>(tmp, {dst, dst + num_bytes}, SampleFormat::SAMPLE_FORMAT_B8, 8 * num_bytes));
+    ASSERT_EQ(
+        num_bytes * 8,
+        read_records_as_bytes<W>(tmp, {dst, dst + num_bytes}, SampleFormat::SAMPLE_FORMAT_B8, 8 * num_bytes));
     for (size_t i = 0; i < num_bytes; ++i) {
         ASSERT_EQ(src[i], dst[i]);
     }
@@ -166,7 +171,9 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordReader, FormatR8_WriteRead, {
     uint8_t dst[num_bytes]{};
     FILE *tmp = write_records({src, src + num_bytes}, SampleFormat::SAMPLE_FORMAT_R8);
     rewind(tmp);
-    ASSERT_EQ(num_bytes * 8, read_records_as_bytes<W>(tmp, {dst, dst + num_bytes}, SampleFormat::SAMPLE_FORMAT_R8, 8 * num_bytes));
+    ASSERT_EQ(
+        num_bytes * 8,
+        read_records_as_bytes<W>(tmp, {dst, dst + num_bytes}, SampleFormat::SAMPLE_FORMAT_R8, 8 * num_bytes));
     for (size_t i = 0; i < num_bytes; ++i) {
         ASSERT_EQ(src[i], dst[i]);
     }

--- a/src/stim/io/measure_record_writer.cc
+++ b/src/stim/io/measure_record_writer.cc
@@ -22,17 +22,17 @@ using namespace stim;
 
 std::unique_ptr<MeasureRecordWriter> MeasureRecordWriter::make(FILE *out, SampleFormat output_format) {
     switch (output_format) {
-        case SAMPLE_FORMAT_01:
+        case SampleFormat::SAMPLE_FORMAT_01:
             return std::make_unique<MeasureRecordWriterFormat01>(out);
-        case SAMPLE_FORMAT_B8:
+        case SampleFormat::SAMPLE_FORMAT_B8:
             return std::make_unique<MeasureRecordWriterFormatB8>(out);
-        case SAMPLE_FORMAT_DETS:
+        case SampleFormat::SAMPLE_FORMAT_DETS:
             return std::make_unique<MeasureRecordWriterFormatDets>(out);
-        case SAMPLE_FORMAT_HITS:
+        case SampleFormat::SAMPLE_FORMAT_HITS:
             return std::make_unique<MeasureRecordWriterFormatHits>(out);
-        case SAMPLE_FORMAT_PTB64:
+        case SampleFormat::SAMPLE_FORMAT_PTB64:
             throw std::invalid_argument("SAMPLE_FORMAT_PTB64 incompatible with SingleMeasurementRecord");
-        case SAMPLE_FORMAT_R8:
+        case SampleFormat::SAMPLE_FORMAT_R8:
             return std::make_unique<MeasureRecordWriterFormatR8>(out);
         default:
             throw std::invalid_argument("Sample format not recognized by SingleMeasurementRecord");

--- a/src/stim/io/measure_record_writer.h
+++ b/src/stim/io/measure_record_writer.h
@@ -120,7 +120,7 @@ void write_table_data(
     char dets_prefix_1,
     char dets_prefix_2,
     size_t dets_prefix_transition) {
-    if (format == SAMPLE_FORMAT_PTB64) {
+    if (format == SampleFormat::SAMPLE_FORMAT_PTB64) {
         if (num_shots % 64 != 0) {
             throw std::invalid_argument("shots must be a multiple of 64 to use ptb64 format.");
         }

--- a/src/stim/io/measure_record_writer.test.cc
+++ b/src/stim/io/measure_record_writer.test.cc
@@ -25,7 +25,7 @@ using namespace stim;
 
 TEST(MeasureRecordWriter, Format01) {
     FILE *tmp = tmpfile();
-    auto writer = MeasureRecordWriter::make(tmp, SAMPLE_FORMAT_01);
+    auto writer = MeasureRecordWriter::make(tmp, SampleFormat::SAMPLE_FORMAT_01);
     uint8_t bytes[]{0xF8};
     writer->write_bytes({bytes});
     writer->write_bit(false);
@@ -37,7 +37,7 @@ TEST(MeasureRecordWriter, Format01) {
 
 TEST(MeasureRecordWriter, FormatB8) {
     FILE *tmp = tmpfile();
-    auto writer = MeasureRecordWriter::make(tmp, SAMPLE_FORMAT_B8);
+    auto writer = MeasureRecordWriter::make(tmp, SampleFormat::SAMPLE_FORMAT_B8);
     uint8_t bytes[]{0xF8};
     writer->write_bytes({bytes});
     writer->write_bit(false);
@@ -53,7 +53,7 @@ TEST(MeasureRecordWriter, FormatB8) {
 
 TEST(MeasureRecordWriter, FormatHits) {
     FILE *tmp = tmpfile();
-    auto writer = MeasureRecordWriter::make(tmp, SAMPLE_FORMAT_HITS);
+    auto writer = MeasureRecordWriter::make(tmp, SampleFormat::SAMPLE_FORMAT_HITS);
     uint8_t bytes[]{0xF8};
     writer->write_bytes({bytes});
     writer->write_bit(false);
@@ -65,7 +65,7 @@ TEST(MeasureRecordWriter, FormatHits) {
 
 TEST(MeasureRecordWriter, FormatDets) {
     FILE *tmp = tmpfile();
-    auto writer = MeasureRecordWriter::make(tmp, SAMPLE_FORMAT_DETS);
+    auto writer = MeasureRecordWriter::make(tmp, SampleFormat::SAMPLE_FORMAT_DETS);
     uint8_t bytes[]{0xF8};
     writer->begin_result_type('D');
     writer->write_bytes({bytes});
@@ -80,7 +80,7 @@ TEST(MeasureRecordWriter, FormatDets) {
 
 TEST(MeasureRecordWriter, FormatDets_EmptyRecords) {
     FILE *tmp = tmpfile();
-    auto writer = MeasureRecordWriter::make(tmp, SAMPLE_FORMAT_DETS);
+    auto writer = MeasureRecordWriter::make(tmp, SampleFormat::SAMPLE_FORMAT_DETS);
     writer->write_end();
     writer->write_end();
     writer->write_end();
@@ -89,7 +89,7 @@ TEST(MeasureRecordWriter, FormatDets_EmptyRecords) {
 
 TEST(MeasureRecordWriter, FormatDets_MultipleRecords) {
     FILE *tmp = tmpfile();
-    auto writer = MeasureRecordWriter::make(tmp, SAMPLE_FORMAT_DETS);
+    auto writer = MeasureRecordWriter::make(tmp, SampleFormat::SAMPLE_FORMAT_DETS);
 
     // First record
     writer->begin_result_type('D');
@@ -118,7 +118,7 @@ TEST(MeasureRecordWriter, FormatDets_MultipleRecords) {
 
 TEST(MeasureRecordWriter, FormatR8) {
     FILE *tmp = tmpfile();
-    auto writer = MeasureRecordWriter::make(tmp, SAMPLE_FORMAT_R8);
+    auto writer = MeasureRecordWriter::make(tmp, SampleFormat::SAMPLE_FORMAT_R8);
     uint8_t bytes[]{0xF8};
     writer->write_bytes({bytes});
     writer->write_bit(false);
@@ -143,7 +143,7 @@ TEST(MeasureRecordWriter, FormatR8) {
 
 TEST(MeasureRecordWriter, FormatR8_LongGap) {
     FILE *tmp = tmpfile();
-    auto writer = MeasureRecordWriter::make(tmp, SAMPLE_FORMAT_R8);
+    auto writer = MeasureRecordWriter::make(tmp, SampleFormat::SAMPLE_FORMAT_R8);
     uint8_t bytes[]{0, 0, 0, 0, 0, 0, 0, 0};
     writer->write_bytes({bytes, bytes + 8});
     writer->write_bytes({bytes, bytes + 8});
@@ -176,31 +176,31 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordWriter, write_table_data_small, {
     FILE *tmp;
 
     tmp = tmpfile();
-    write_table_data<W>(tmp, 5, 4, ref_sample, results, SAMPLE_FORMAT_01, 'M', 'M', 0);
+    write_table_data<W>(tmp, 5, 4, ref_sample, results, SampleFormat::SAMPLE_FORMAT_01, 'M', 'M', 0);
     ASSERT_EQ(rewind_read_close(tmp), "0100\n0100\n0100\n0100\n0100\n");
 
     tmp = tmpfile();
-    write_table_data<W>(tmp, 5, 4, ref_sample, results, SAMPLE_FORMAT_HITS, 'M', 'M', 0);
+    write_table_data<W>(tmp, 5, 4, ref_sample, results, SampleFormat::SAMPLE_FORMAT_HITS, 'M', 'M', 0);
     ASSERT_EQ(rewind_read_close(tmp), "1\n1\n1\n1\n1\n");
 
     tmp = tmpfile();
-    write_table_data<W>(tmp, 5, 4, ref_sample, results, SAMPLE_FORMAT_DETS, 'M', 'M', 0);
+    write_table_data<W>(tmp, 5, 4, ref_sample, results, SampleFormat::SAMPLE_FORMAT_DETS, 'M', 'M', 0);
     ASSERT_EQ(rewind_read_close(tmp), "shot M1\nshot M1\nshot M1\nshot M1\nshot M1\n");
 
     tmp = tmpfile();
-    write_table_data<W>(tmp, 5, 4, ref_sample, results, SAMPLE_FORMAT_DETS, 'D', 'L', 1);
+    write_table_data<W>(tmp, 5, 4, ref_sample, results, SampleFormat::SAMPLE_FORMAT_DETS, 'D', 'L', 1);
     ASSERT_EQ(rewind_read_close(tmp), "shot L0\nshot L0\nshot L0\nshot L0\nshot L0\n");
 
     tmp = tmpfile();
-    write_table_data<W>(tmp, 5, 4, ref_sample, results, SAMPLE_FORMAT_R8, 'M', 'M', 0);
+    write_table_data<W>(tmp, 5, 4, ref_sample, results, SampleFormat::SAMPLE_FORMAT_R8, 'M', 'M', 0);
     ASSERT_EQ(rewind_read_close(tmp), "\x01\x02\x01\x02\x01\x02\x01\x02\x01\x02");
 
     tmp = tmpfile();
-    write_table_data<W>(tmp, 5, 4, ref_sample, results, SAMPLE_FORMAT_B8, 'M', 'M', 0);
+    write_table_data<W>(tmp, 5, 4, ref_sample, results, SampleFormat::SAMPLE_FORMAT_B8, 'M', 'M', 0);
     ASSERT_EQ(rewind_read_close(tmp), "\x02\x02\x02\x02\x02");
 
     tmp = tmpfile();
-    write_table_data<W>(tmp, 64, 4, ref_sample, results, SAMPLE_FORMAT_PTB64, 'M', 'M', 0);
+    write_table_data<W>(tmp, 64, 4, ref_sample, results, SampleFormat::SAMPLE_FORMAT_PTB64, 'M', 'M', 0);
     ASSERT_EQ(
         rewind_read_close(tmp),
         std::string(
@@ -224,7 +224,7 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordWriter, write_table_data_large, {
     FILE *tmp;
 
     tmp = tmpfile();
-    write_table_data<W>(tmp, 2, 100, ref_sample, results, SAMPLE_FORMAT_01, 'M', 'M', 0);
+    write_table_data<W>(tmp, 2, 100, ref_sample, results, SampleFormat::SAMPLE_FORMAT_01, 'M', 'M', 0);
     ASSERT_EQ(
         rewind_read_close(tmp),
         "0011010100"
@@ -249,19 +249,19 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordWriter, write_table_data_large, {
         "0000000000\n");
 
     tmp = tmpfile();
-    write_table_data<W>(tmp, 2, 100, ref_sample, results, SAMPLE_FORMAT_HITS, 'M', 'M', 0);
+    write_table_data<W>(tmp, 2, 100, ref_sample, results, SampleFormat::SAMPLE_FORMAT_HITS, 'M', 'M', 0);
     ASSERT_EQ(rewind_read_close(tmp), "2,3,5,7,11\n2,3,5,11\n");
 
     tmp = tmpfile();
-    write_table_data<W>(tmp, 2, 100, ref_sample, results, SAMPLE_FORMAT_DETS, 'D', 'L', 5);
+    write_table_data<W>(tmp, 2, 100, ref_sample, results, SampleFormat::SAMPLE_FORMAT_DETS, 'D', 'L', 5);
     ASSERT_EQ(rewind_read_close(tmp), "shot D2 D3 L0 L2 L6\nshot D2 D3 L0 L6\n");
 
     tmp = tmpfile();
-    write_table_data<W>(tmp, 2, 100, ref_sample, results, SAMPLE_FORMAT_DETS, 'D', 'L', 90);
+    write_table_data<W>(tmp, 2, 100, ref_sample, results, SampleFormat::SAMPLE_FORMAT_DETS, 'D', 'L', 90);
     ASSERT_EQ(rewind_read_close(tmp), "shot D2 D3 D5 D7 D11\nshot D2 D3 D5 D11\n");
 
     tmp = tmpfile();
-    write_table_data<W>(tmp, 2, 100, ref_sample, results, SAMPLE_FORMAT_R8, 'M', 'M', 0);
+    write_table_data<W>(tmp, 2, 100, ref_sample, results, SampleFormat::SAMPLE_FORMAT_R8, 'M', 'M', 0);
     ASSERT_EQ(
         rewind_read_close(tmp),
         std::string(
@@ -270,7 +270,7 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordWriter, write_table_data_large, {
             11));
 
     tmp = tmpfile();
-    write_table_data<W>(tmp, 2, 100, ref_sample, results, SAMPLE_FORMAT_B8, 'M', 'M', 0);
+    write_table_data<W>(tmp, 2, 100, ref_sample, results, SampleFormat::SAMPLE_FORMAT_B8, 'M', 'M', 0);
     ASSERT_EQ(
         rewind_read_close(tmp),
         std::string(
@@ -279,7 +279,7 @@ TEST_EACH_WORD_SIZE_W(MeasureRecordWriter, write_table_data_large, {
             26));
 
     tmp = tmpfile();
-    write_table_data<W>(tmp, 64, 100, ref_sample, results, SAMPLE_FORMAT_PTB64, 'M', 'M', 0);
+    write_table_data<W>(tmp, 64, 100, ref_sample, results, SampleFormat::SAMPLE_FORMAT_PTB64, 'M', 'M', 0);
     auto actual = rewind_read_close(tmp);
     ASSERT_EQ(
         actual,

--- a/src/stim/io/stim_data_formats.cc
+++ b/src/stim/io/stim_data_formats.cc
@@ -8,7 +8,7 @@ const std::map<std::string, FileFormatData>& stim::format_name_to_enum_map() {
             "01",
             FileFormatData{
                 "01",
-                SAMPLE_FORMAT_01,
+                SampleFormat::SAMPLE_FORMAT_01,
                 R"HELP(
 The 01 format is a dense human readable format that stores shots as lines of '0' and '1' characters.
 
@@ -74,7 +74,7 @@ def parse_01(data: str) -> List[List[bool]]:
             "b8",
             FileFormatData{
                 "b8",
-                SAMPLE_FORMAT_B8,
+                SampleFormat::SAMPLE_FORMAT_B8,
                 R"HELP(
 The b8 format is a dense binary format that stores shots as bit-packed bytes.
 
@@ -136,7 +136,7 @@ def parse_b8(data: bytes, bits_per_shot: int) -> List[List[bool]]:
             "ptb64",
             FileFormatData{
                 "ptb64",
-                SAMPLE_FORMAT_PTB64,
+                SampleFormat::SAMPLE_FORMAT_PTB64,
                 R"HELP(
 The ptb64 format is a dense SIMD-focused binary format that stores shots as partially transposed bit-packed data.
 
@@ -214,7 +214,7 @@ def parse_ptb64(data: bytes, bits_per_shot: int) -> List[List[bool]]:
             "hits",
             FileFormatData{
                 "hits",
-                SAMPLE_FORMAT_HITS,
+                SampleFormat::SAMPLE_FORMAT_HITS,
                 R"HELP(
 The hits format is a dense human readable format that stores shots as a comma-separated list of integers.
 Each integer indicates the position of a bit that was True.
@@ -285,7 +285,7 @@ def parse_hits(data: str, bits_per_shot: int) -> List[List[bool]]:
             "r8",
             FileFormatData{
                 "r8",
-                SAMPLE_FORMAT_R8,
+                SampleFormat::SAMPLE_FORMAT_R8,
                 R"HELP(
 The r8 format is a sparse binary format that stores shots as a series of lengths of runs between 1s.
 
@@ -367,7 +367,7 @@ def parse_r8(data: bytes, bits_per_shot: int) -> List[List[bool]]:
             "dets",
             FileFormatData{
                 "dets",
-                SAMPLE_FORMAT_DETS,
+                SampleFormat::SAMPLE_FORMAT_DETS,
                 R"HELP(
 The dets format is a sparse human readable format that stores shots as lines starting with the word 'shot'
 and then containing space-separated prefixed values like 'D5' and 'L2'. Each value's prefix indicates whether

--- a/src/stim/io/stim_data_formats.h
+++ b/src/stim/io/stim_data_formats.h
@@ -6,7 +6,7 @@
 
 namespace stim {
 
-enum SampleFormat {
+enum class SampleFormat {
     SAMPLE_FORMAT_01,
     SAMPLE_FORMAT_B8,
     SAMPLE_FORMAT_PTB64,

--- a/src/stim/main_namespaced.perf.cc
+++ b/src/stim/main_namespaced.perf.cc
@@ -72,7 +72,7 @@ BENCHMARK(main_sample1_tableau_rep_d1000_r100) {
     benchmark_go([&]() {
         rewind(in);
         rewind(out);
-        TableauSimulator<MAX_BITWORD_WIDTH>::sample_stream(in, out, SAMPLE_FORMAT_B8, false, rng);
+        TableauSimulator<MAX_BITWORD_WIDTH>::sample_stream(in, out, SampleFormat::SAMPLE_FORMAT_B8, false, rng);
     })
         .goal_millis(22)
         .show_rate("Samples", circuit.count_measurements());
@@ -87,7 +87,7 @@ BENCHMARK(main_sample1_pauliframe_b8_rep_d1000_r100) {
     simd_bits<MAX_BITWORD_WIDTH> ref(0);
     benchmark_go([&]() {
         rewind(out);
-        sample_batch_measurements_writing_results_to_disk(circuit, ref, 1, out, SAMPLE_FORMAT_B8, rng);
+        sample_batch_measurements_writing_results_to_disk(circuit, ref, 1, out, SampleFormat:: SAMPLE_FORMAT_B8, rng);
     })
         .goal_millis(9)
         .show_rate("Samples", circuit.count_measurements());
@@ -104,7 +104,7 @@ BENCHMARK(main_sample1_detectors_b8_rep_d1000_r100) {
     benchmark_go([&]() {
         rewind(out);
         sample_batch_detection_events_writing_results_to_disk<MAX_BITWORD_WIDTH>(
-            circuit, 1, false, false, out, SAMPLE_FORMAT_B8, rng, obs_out, SAMPLE_FORMAT_B8);
+            circuit, 1, false, false, out, SampleFormat:: SAMPLE_FORMAT_B8, rng, obs_out, SampleFormat:: SAMPLE_FORMAT_B8);
     })
         .goal_millis(11)
         .show_rate("Samples", circuit.count_measurements());
@@ -119,7 +119,7 @@ BENCHMARK(main_sample256_pauliframe_b8_rep_d1000_r100) {
     simd_bits<MAX_BITWORD_WIDTH> ref(0);
     benchmark_go([&]() {
         rewind(out);
-        sample_batch_measurements_writing_results_to_disk(circuit, ref, 256, out, SAMPLE_FORMAT_B8, rng);
+        sample_batch_measurements_writing_results_to_disk(circuit, ref, 256, out, SampleFormat:: SAMPLE_FORMAT_B8, rng);
     })
         .goal_millis(13)
         .show_rate("Samples", circuit.count_measurements());
@@ -135,7 +135,7 @@ BENCHMARK(main_sample256_pauliframe_b8_rep_d1000_r1000_stream) {
     simd_bits<MAX_BITWORD_WIDTH> ref(0);
     benchmark_go([&]() {
         rewind(out);
-        sample_batch_measurements_writing_results_to_disk(circuit, ref, 256, out, SAMPLE_FORMAT_B8, rng);
+        sample_batch_measurements_writing_results_to_disk(circuit, ref, 256, out, SampleFormat:: SAMPLE_FORMAT_B8, rng);
     })
         .goal_millis(360)
         .show_rate("Samples", circuit.count_measurements());
@@ -152,7 +152,7 @@ BENCHMARK(main_sample256_detectors_b8_rep_d1000_r100) {
     benchmark_go([&]() {
         rewind(out);
         sample_batch_detection_events_writing_results_to_disk<MAX_BITWORD_WIDTH>(
-            circuit, 256, false, false, out, SAMPLE_FORMAT_B8, rng, obs_out, SAMPLE_FORMAT_B8);
+            circuit, 256, false, false, out, SampleFormat:: SAMPLE_FORMAT_B8, rng, obs_out, SampleFormat:: SAMPLE_FORMAT_B8);
     })
         .goal_millis(15)
         .show_rate("Samples", circuit.count_measurements());
@@ -170,7 +170,7 @@ BENCHMARK(main_sample256_detectors_b8_rep_d1000_r1000_stream) {
     benchmark_go([&]() {
         rewind(out);
         sample_batch_detection_events_writing_results_to_disk<MAX_BITWORD_WIDTH>(
-            circuit, 256, false, false, out, SAMPLE_FORMAT_B8, rng, obs_out, SAMPLE_FORMAT_B8);
+            circuit, 256, false, false, out, SampleFormat:: SAMPLE_FORMAT_B8, rng, obs_out, SampleFormat:: SAMPLE_FORMAT_B8);
     })
         .goal_millis(360)
         .show_rate("Samples", circuit.count_measurements());

--- a/src/stim/main_namespaced.test.cc
+++ b/src/stim/main_namespaced.test.cc
@@ -81,8 +81,7 @@ TEST(main, help_modes) {
     ASSERT_TRUE(matches(run_captured_stim_main({"help"}), ".*Available stim commands.+"));
     ASSERT_TRUE(matches(run_captured_stim_main({}), ".+stderr.+No mode.+"));
     ASSERT_TRUE(matches(run_captured_stim_main({"--sample", "--repl"}), ".+stderr.+More than one mode.+"));
-    ASSERT_TRUE(
-        matches(run_captured_stim_main({"--sample", "--repl", "--detect"}), ".+stderr.+More than one mode.+"));
+    ASSERT_TRUE(matches(run_captured_stim_main({"--sample", "--repl", "--detect"}), ".+stderr.+More than one mode.+"));
     ASSERT_TRUE(matches(run_captured_stim_main({"--help", "dhnsahddjoidsa"}), ".*Unrecognized.*"));
     ASSERT_TRUE(matches(run_captured_stim_main({"--help", "H"}), ".+Hadamard.+"));
     ASSERT_TRUE(matches(run_captured_stim_main({"--help", "sample"}), ".*Samples measurements from a circuit.+"));

--- a/src/stim/search/graphlike/search_state.cc
+++ b/src/stim/search/graphlike/search_state.cc
@@ -71,7 +71,8 @@ void SearchState::append_transition_as_error_instruction_to(const SearchState &o
 
     out.arg_buf.append_tail(1);
 
-    out.instructions.push_back(DemInstruction{out.arg_buf.commit_tail(), out.target_buf.commit_tail(), DemInstructionType::DEM_ERROR});
+    out.instructions.push_back(
+        DemInstruction{out.arg_buf.commit_tail(), out.target_buf.commit_tail(), DemInstructionType::DEM_ERROR});
 }
 
 bool SearchState::operator==(const SearchState &other) const {

--- a/src/stim/search/graphlike/search_state.cc
+++ b/src/stim/search/graphlike/search_state.cc
@@ -16,7 +16,6 @@
 
 #include <algorithm>
 #include <map>
-#include <queue>
 
 #include "stim/search/graphlike/node.h"
 
@@ -72,7 +71,7 @@ void SearchState::append_transition_as_error_instruction_to(const SearchState &o
 
     out.arg_buf.append_tail(1);
 
-    out.instructions.push_back(DemInstruction{out.arg_buf.commit_tail(), out.target_buf.commit_tail(), DEM_ERROR});
+    out.instructions.push_back(DemInstruction{out.arg_buf.commit_tail(), out.target_buf.commit_tail(), DemInstructionType::DEM_ERROR});
 }
 
 bool SearchState::operator==(const SearchState &other) const {

--- a/src/stim/search/hyper/search_state.cc
+++ b/src/stim/search/hyper/search_state.cc
@@ -45,7 +45,7 @@ void SearchState::append_transition_as_error_instruction_to(const SearchState &o
     // Default probability to 1.
     out.arg_buf.append_tail(1);
 
-    out.instructions.push_back(DemInstruction{out.arg_buf.commit_tail(), out.target_buf.commit_tail(), DEM_ERROR});
+    out.instructions.push_back(DemInstruction{out.arg_buf.commit_tail(), out.target_buf.commit_tail(), DemInstructionType::DEM_ERROR});
 }
 
 bool SearchState::operator==(const SearchState &other) const {

--- a/src/stim/search/hyper/search_state.cc
+++ b/src/stim/search/hyper/search_state.cc
@@ -45,7 +45,8 @@ void SearchState::append_transition_as_error_instruction_to(const SearchState &o
     // Default probability to 1.
     out.arg_buf.append_tail(1);
 
-    out.instructions.push_back(DemInstruction{out.arg_buf.commit_tail(), out.target_buf.commit_tail(), DemInstructionType::DEM_ERROR});
+    out.instructions.push_back(
+        DemInstruction{out.arg_buf.commit_tail(), out.target_buf.commit_tail(), DemInstructionType::DEM_ERROR});
 }
 
 bool SearchState::operator==(const SearchState &other) const {

--- a/src/stim/simulators/count_determined_measurements.inl
+++ b/src/stim/simulators/count_determined_measurements.inl
@@ -11,7 +11,7 @@ uint64_t count_determined_measurements(const Circuit &circuit) {
     PauliString<W> obs_buffer(n);
 
     circuit.for_each_operation([&](const CircuitInstruction &inst) {
-        if (!(GATE_DATA.items[inst.gate_type].flags & GATE_PRODUCES_RESULTS)) {
+        if (!(GATE_DATA[inst.gate_type].flags & GATE_PRODUCES_RESULTS)) {
             sim.do_gate(inst);
             return;
         }

--- a/src/stim/simulators/error_analyzer.cc
+++ b/src/stim/simulators/error_analyzer.cc
@@ -1124,10 +1124,12 @@ void ErrorAnalyzer::run_loop(const Circuit &loop, uint64_t iterations) {
             uint64_t lower_level_shifts = body.total_detector_shift();
             DemTarget remaining_shift = {detectors_per_period - lower_level_shifts};
             if (remaining_shift.data > 0) {
-                if (body.instructions.empty() || body.instructions.front().type != DemInstructionType::DEM_SHIFT_DETECTORS) {
+                if (body.instructions.empty() ||
+                    body.instructions.front().type != DemInstructionType::DEM_SHIFT_DETECTORS) {
                     auto shift_targets = body.target_buf.take_copy({&remaining_shift});
                     body.instructions.insert(
-                        body.instructions.begin(), DemInstruction{{}, shift_targets, DemInstructionType::DEM_SHIFT_DETECTORS});
+                        body.instructions.begin(),
+                        DemInstruction{{}, shift_targets, DemInstructionType::DEM_SHIFT_DETECTORS});
                 } else {
                     remaining_shift.data += body.instructions[0].target_data[0].data;
                     auto shift_targets = body.target_buf.take_copy({&remaining_shift});

--- a/src/stim/simulators/error_analyzer.cc
+++ b/src/stim/simulators/error_analyzer.cc
@@ -226,7 +226,7 @@ void ErrorAnalyzer::undo_gate(const CircuitInstruction &inst) {
             break;
         default:
             throw std::invalid_argument(
-                "Not implemented by ErrorAnalyzer::undo_gate: " + std::string(GATE_DATA.items[inst.gate_type].name));
+                "Not implemented by ErrorAnalyzer::undo_gate: " + std::string(GATE_DATA[inst.gate_type].name));
     }
 }
 
@@ -929,23 +929,23 @@ DetectorErrorModel unreversed(const DetectorErrorModel &rev, uint64_t &base_dete
     for (auto p = rev.instructions.crbegin(); p != rev.instructions.crend(); p++) {
         const auto &e = *p;
         switch (e.type) {
-            case DEM_SHIFT_DETECTORS:
+            case DemInstructionType::DEM_SHIFT_DETECTORS:
                 base_detector_id += e.target_data[0].data;
                 out.append_shift_detectors_instruction(e.arg_data, e.target_data[0].data);
                 break;
-            case DEM_ERROR:
+            case DemInstructionType::DEM_ERROR:
                 for (auto &t : e.target_data) {
                     seen.insert(t);
                 }
                 conv_append(e);
                 break;
-            case DEM_DETECTOR:
-            case DEM_LOGICAL_OBSERVABLE:
+            case DemInstructionType::DEM_DETECTOR:
+            case DemInstructionType::DEM_LOGICAL_OBSERVABLE:
                 if (!e.arg_data.empty() || seen.find(e.target_data[0]) == seen.end()) {
                     conv_append(e);
                 }
                 break;
-            case DEM_REPEAT_BLOCK: {
+            case DemInstructionType::DEM_REPEAT_BLOCK: {
                 uint64_t repetitions = e.repeat_block_rep_count();
                 if (repetitions) {
                     uint64_t old_base_detector_id = base_detector_id;
@@ -1124,10 +1124,10 @@ void ErrorAnalyzer::run_loop(const Circuit &loop, uint64_t iterations) {
             uint64_t lower_level_shifts = body.total_detector_shift();
             DemTarget remaining_shift = {detectors_per_period - lower_level_shifts};
             if (remaining_shift.data > 0) {
-                if (body.instructions.empty() || body.instructions.front().type != DEM_SHIFT_DETECTORS) {
+                if (body.instructions.empty() || body.instructions.front().type != DemInstructionType::DEM_SHIFT_DETECTORS) {
                     auto shift_targets = body.target_buf.take_copy({&remaining_shift});
                     body.instructions.insert(
-                        body.instructions.begin(), DemInstruction{{}, shift_targets, DEM_SHIFT_DETECTORS});
+                        body.instructions.begin(), DemInstruction{{}, shift_targets, DemInstructionType::DEM_SHIFT_DETECTORS});
                 } else {
                     remaining_shift.data += body.instructions[0].target_data[0].data;
                     auto shift_targets = body.target_buf.take_copy({&remaining_shift});

--- a/src/stim/simulators/error_matcher.cc
+++ b/src/stim/simulators/error_matcher.cc
@@ -14,7 +14,6 @@
 
 #include "stim/simulators/error_matcher.h"
 
-#include <algorithm>
 #include <queue>
 #include <sstream>
 
@@ -46,7 +45,7 @@ ErrorMatcher::ErrorMatcher(
     if (!allow_adding_new_dem_errors_to_output_map) {
         SparseXorVec<DemTarget> buf;
         init_filter->iter_flatten_error_instructions([&](const DemInstruction &instruction) {
-            assert(instruction.type == DEM_ERROR);
+            assert(instruction.type == DemInstructionType::DEM_ERROR);
             buf.clear();
             // Note: quadratic overhead, but typical size is 4 and 100 would be crazy big.
             for (const auto &target : instruction.target_data) {
@@ -211,7 +210,7 @@ void ErrorMatcher::err_m(const CircuitInstruction &op, uint32_t obs_mask) {
 
 void ErrorMatcher::rev_process_instruction(const CircuitInstruction &op) {
     cur_loc.instruction_targets.gate_type = op.gate_type;
-    auto flags = GATE_DATA.items[op.gate_type].flags;
+    auto flags = GATE_DATA[op.gate_type].flags;
     cur_loc.tick_offset = error_analyzer.num_ticks_in_past;
     cur_op = &op;
 
@@ -268,7 +267,7 @@ void ErrorMatcher::rev_process_instruction(const CircuitInstruction &op) {
     } else if (op.gate_type == GateType::M || op.gate_type == GateType::MR) {
         err_m(op, TARGET_PAULI_Z_BIT);
     } else {
-        throw std::invalid_argument("Not implemented: " + std::string(GATE_DATA.items[op.gate_type].name));
+        throw std::invalid_argument("Not implemented: " + std::string(GATE_DATA[op.gate_type].name));
     }
 }
 

--- a/src/stim/simulators/frame_simulator.h
+++ b/src/stim/simulators/frame_simulator.h
@@ -26,7 +26,7 @@
 
 namespace stim {
 
-enum FrameSimulatorMode {
+enum class FrameSimulatorMode {
     STORE_MEASUREMENTS_TO_MEMORY,  // all measurements stored, detections not stored
     STREAM_MEASUREMENTS_TO_DISK,   // measurements stored up to lookback, detections not stored
     STORE_DETECTIONS_TO_MEMORY,    // measurements stored up to lookback, all detections stored

--- a/src/stim/simulators/frame_simulator.inl
+++ b/src/stim/simulators/frame_simulator.inl
@@ -59,9 +59,9 @@ FrameSimulator<W>::FrameSimulator(
 
 template <size_t W>
 void FrameSimulator<W>::configure_for(CircuitStats new_circuit_stats, FrameSimulatorMode new_mode, size_t new_batch_size) {
-    bool storing_all_measurements = new_mode == STORE_MEASUREMENTS_TO_MEMORY || new_mode == STORE_EVERYTHING_TO_MEMORY;
-    bool storing_all_detections = new_mode == STORE_DETECTIONS_TO_MEMORY || new_mode == STORE_EVERYTHING_TO_MEMORY;
-    bool storing_any_detections = new_mode == STORE_DETECTIONS_TO_MEMORY || new_mode == STORE_EVERYTHING_TO_MEMORY || new_mode == STREAM_DETECTIONS_TO_DISK;
+    bool storing_all_measurements = new_mode == FrameSimulatorMode::STORE_MEASUREMENTS_TO_MEMORY || new_mode == FrameSimulatorMode::STORE_EVERYTHING_TO_MEMORY;
+    bool storing_all_detections = new_mode == FrameSimulatorMode::STORE_DETECTIONS_TO_MEMORY || new_mode == FrameSimulatorMode::STORE_EVERYTHING_TO_MEMORY;
+    bool storing_any_detections = new_mode == FrameSimulatorMode::STORE_DETECTIONS_TO_MEMORY || new_mode == FrameSimulatorMode::STORE_EVERYTHING_TO_MEMORY || new_mode == FrameSimulatorMode::STREAM_DETECTIONS_TO_DISK;
 
     batch_size = new_batch_size;
     num_qubits = new_circuit_stats.num_qubits;

--- a/src/stim/simulators/frame_simulator.test.cc
+++ b/src/stim/simulators/frame_simulator.test.cc
@@ -301,11 +301,11 @@ TEST_EACH_WORD_SIZE_W(FrameSimulator, sample_batch_measurements_writing_results_
     }
 
     FILE *tmp = tmpfile();
-    sample_batch_measurements_writing_results_to_disk(circuit, ref, 5, tmp, SAMPLE_FORMAT_01, rng);
+    sample_batch_measurements_writing_results_to_disk(circuit, ref, 5, tmp, SampleFormat::SAMPLE_FORMAT_01, rng);
     ASSERT_EQ(rewind_read_close(tmp), "0100\n0100\n0100\n0100\n0100\n");
 
     tmp = tmpfile();
-    sample_batch_measurements_writing_results_to_disk(circuit, ref, 5, tmp, SAMPLE_FORMAT_B8, rng);
+    sample_batch_measurements_writing_results_to_disk(circuit, ref, 5, tmp, SampleFormat::SAMPLE_FORMAT_B8, rng);
     rewind(tmp);
     for (size_t k = 0; k < 5; k++) {
         ASSERT_EQ(getc(tmp), 2);
@@ -313,7 +313,7 @@ TEST_EACH_WORD_SIZE_W(FrameSimulator, sample_batch_measurements_writing_results_
     ASSERT_EQ(getc(tmp), EOF);
 
     tmp = tmpfile();
-    sample_batch_measurements_writing_results_to_disk(circuit, ref, 64, tmp, SAMPLE_FORMAT_PTB64, rng);
+    sample_batch_measurements_writing_results_to_disk(circuit, ref, 64, tmp, SampleFormat::SAMPLE_FORMAT_PTB64, rng);
     rewind(tmp);
     for (size_t k = 0; k < 8; k++) {
         ASSERT_EQ(getc(tmp), 0);
@@ -346,7 +346,7 @@ TEST_EACH_WORD_SIZE_W(FrameSimulator, big_circuit_measurements, {
     }
 
     FILE *tmp = tmpfile();
-    sample_batch_measurements_writing_results_to_disk(circuit, ref, 750, tmp, SAMPLE_FORMAT_01, rng);
+    sample_batch_measurements_writing_results_to_disk(circuit, ref, 750, tmp, SampleFormat::SAMPLE_FORMAT_01, rng);
     rewind(tmp);
     for (size_t s = 0; s < 750; s++) {
         for (size_t k = 0; k < 1250; k++) {
@@ -357,7 +357,7 @@ TEST_EACH_WORD_SIZE_W(FrameSimulator, big_circuit_measurements, {
     ASSERT_EQ(getc(tmp), EOF);
 
     tmp = tmpfile();
-    sample_batch_measurements_writing_results_to_disk(circuit, ref, 750, tmp, SAMPLE_FORMAT_B8, rng);
+    sample_batch_measurements_writing_results_to_disk(circuit, ref, 750, tmp, SampleFormat::SAMPLE_FORMAT_B8, rng);
     rewind(tmp);
     for (size_t s = 0; s < 750; s++) {
         for (size_t k = 0; k < 1250; k += 8) {
@@ -380,17 +380,17 @@ TEST_EACH_WORD_SIZE_W(FrameSimulator, run_length_measurement_formats, {
     auto ref = TableauSimulator<W>::reference_sample_circuit(circuit);
 
     FILE *tmp = tmpfile();
-    sample_batch_measurements_writing_results_to_disk(circuit, ref, 3, tmp, SAMPLE_FORMAT_HITS, rng);
+    sample_batch_measurements_writing_results_to_disk(circuit, ref, 3, tmp, SampleFormat::SAMPLE_FORMAT_HITS, rng);
     ASSERT_EQ(rewind_read_close(tmp), "100,500,501,551,1200\n100,500,501,551,1200\n100,500,501,551,1200\n");
 
     tmp = tmpfile();
-    sample_batch_measurements_writing_results_to_disk(circuit, ref, 3, tmp, SAMPLE_FORMAT_DETS, rng);
+    sample_batch_measurements_writing_results_to_disk(circuit, ref, 3, tmp, SampleFormat::SAMPLE_FORMAT_DETS, rng);
     ASSERT_EQ(
         rewind_read_close(tmp),
         "shot M100 M500 M501 M551 M1200\nshot M100 M500 M501 M551 M1200\nshot M100 M500 M501 M551 M1200\n");
 
     tmp = tmpfile();
-    sample_batch_measurements_writing_results_to_disk(circuit, ref, 3, tmp, SAMPLE_FORMAT_R8, rng);
+    sample_batch_measurements_writing_results_to_disk(circuit, ref, 3, tmp, SampleFormat::SAMPLE_FORMAT_R8, rng);
     rewind(tmp);
     for (size_t k = 0; k < 3; k++) {
         ASSERT_EQ(getc(tmp), 100);
@@ -828,7 +828,7 @@ TEST_EACH_WORD_SIZE_W(FrameSimulator, record_gets_trimmed, {
     Circuit c = Circuit("M 0 1 2 3 4 5 6 7 8 9");
     FrameSimulator<W> sim(
         c.compute_stats(), FrameSimulatorMode::STREAM_MEASUREMENTS_TO_DISK, 768, INDEPENDENT_TEST_RNG());
-    MeasureRecordBatchWriter b(tmpfile(), 768, SAMPLE_FORMAT_B8);
+    MeasureRecordBatchWriter b(tmpfile(), 768, SampleFormat::SAMPLE_FORMAT_B8);
     for (size_t k = 0; k < 1000; k++) {
         sim.do_MZ(c.operations[0]);
         sim.m_record.intermediate_write_unwritten_results_to(b, simd_bits<W>(0));
@@ -849,7 +849,7 @@ TEST_EACH_WORD_SIZE_W(FrameSimulator, stream_huge_case, {
         simd_bits<W>(0),
         256,
         tmp,
-        SAMPLE_FORMAT_B8,
+        SampleFormat::SAMPLE_FORMAT_B8,
         rng);
     rewind(tmp);
     for (size_t k = 0; k < 256 * 100000 * 4 / 8; k++) {
@@ -868,7 +868,7 @@ TEST_EACH_WORD_SIZE_W(FrameSimulator, block_results_single_shot, {
         }
     )circuit");
     FILE *tmp = tmpfile();
-    sample_batch_measurements_writing_results_to_disk(circuit, simd_bits<W>(0), 3, tmp, SAMPLE_FORMAT_01, rng);
+    sample_batch_measurements_writing_results_to_disk(circuit, simd_bits<W>(0), 3, tmp, SampleFormat::SAMPLE_FORMAT_01, rng);
 
     auto result = rewind_read_close(tmp);
     for (size_t k = 0; k < 30000; k += 3) {
@@ -889,7 +889,7 @@ TEST_EACH_WORD_SIZE_W(FrameSimulator, block_results_triple_shot, {
         }
     )circuit");
     FILE *tmp = tmpfile();
-    sample_batch_measurements_writing_results_to_disk(circuit, simd_bits<W>(0), 3, tmp, SAMPLE_FORMAT_01, rng);
+    sample_batch_measurements_writing_results_to_disk(circuit, simd_bits<W>(0), 3, tmp, SampleFormat::SAMPLE_FORMAT_01, rng);
 
     auto result = rewind_read_close(tmp);
     for (size_t rep = 0; rep < 3; rep++) {
@@ -914,7 +914,7 @@ TEST_EACH_WORD_SIZE_W(FrameSimulator, stream_results, {
         }
     )circuit");
     FILE *tmp = tmpfile();
-    sample_batch_measurements_writing_results_to_disk(circuit, simd_bits<W>(0), 3, tmp, SAMPLE_FORMAT_01, rng);
+    sample_batch_measurements_writing_results_to_disk(circuit, simd_bits<W>(0), 3, tmp, SampleFormat::SAMPLE_FORMAT_01, rng);
 
     auto result = rewind_read_close(tmp);
     for (size_t k = 0; k < 30000; k += 3) {
@@ -933,7 +933,7 @@ TEST_EACH_WORD_SIZE_W(FrameSimulator, stream_many_shots, {
         M 0 1 2
     )circuit");
     FILE *tmp = tmpfile();
-    sample_batch_measurements_writing_results_to_disk(circuit, simd_bits<W>(0), 2049, tmp, SAMPLE_FORMAT_01, rng);
+    sample_batch_measurements_writing_results_to_disk(circuit, simd_bits<W>(0), 2049, tmp, SampleFormat::SAMPLE_FORMAT_01, rng);
 
     auto result = rewind_read_close(tmp);
     ASSERT_EQ(result.size(), 2049 * 4);
@@ -956,7 +956,7 @@ TEST_EACH_WORD_SIZE_W(FrameSimulator, stream_results_triple_shot, {
         }
     )circuit");
     FILE *tmp = tmpfile();
-    sample_batch_measurements_writing_results_to_disk(circuit, simd_bits<W>(0), 3, tmp, SAMPLE_FORMAT_01, rng);
+    sample_batch_measurements_writing_results_to_disk(circuit, simd_bits<W>(0), 3, tmp, SampleFormat::SAMPLE_FORMAT_01, rng);
 
     auto result = rewind_read_close(tmp);
     for (size_t rep = 0; rep < 3; rep++) {

--- a/src/stim/simulators/frame_simulator.test.cc
+++ b/src/stim/simulators/frame_simulator.test.cc
@@ -868,7 +868,8 @@ TEST_EACH_WORD_SIZE_W(FrameSimulator, block_results_single_shot, {
         }
     )circuit");
     FILE *tmp = tmpfile();
-    sample_batch_measurements_writing_results_to_disk(circuit, simd_bits<W>(0), 3, tmp, SampleFormat::SAMPLE_FORMAT_01, rng);
+    sample_batch_measurements_writing_results_to_disk(
+        circuit, simd_bits<W>(0), 3, tmp, SampleFormat::SAMPLE_FORMAT_01, rng);
 
     auto result = rewind_read_close(tmp);
     for (size_t k = 0; k < 30000; k += 3) {
@@ -889,7 +890,8 @@ TEST_EACH_WORD_SIZE_W(FrameSimulator, block_results_triple_shot, {
         }
     )circuit");
     FILE *tmp = tmpfile();
-    sample_batch_measurements_writing_results_to_disk(circuit, simd_bits<W>(0), 3, tmp, SampleFormat::SAMPLE_FORMAT_01, rng);
+    sample_batch_measurements_writing_results_to_disk(
+        circuit, simd_bits<W>(0), 3, tmp, SampleFormat::SAMPLE_FORMAT_01, rng);
 
     auto result = rewind_read_close(tmp);
     for (size_t rep = 0; rep < 3; rep++) {
@@ -914,7 +916,8 @@ TEST_EACH_WORD_SIZE_W(FrameSimulator, stream_results, {
         }
     )circuit");
     FILE *tmp = tmpfile();
-    sample_batch_measurements_writing_results_to_disk(circuit, simd_bits<W>(0), 3, tmp, SampleFormat::SAMPLE_FORMAT_01, rng);
+    sample_batch_measurements_writing_results_to_disk(
+        circuit, simd_bits<W>(0), 3, tmp, SampleFormat::SAMPLE_FORMAT_01, rng);
 
     auto result = rewind_read_close(tmp);
     for (size_t k = 0; k < 30000; k += 3) {
@@ -933,7 +936,8 @@ TEST_EACH_WORD_SIZE_W(FrameSimulator, stream_many_shots, {
         M 0 1 2
     )circuit");
     FILE *tmp = tmpfile();
-    sample_batch_measurements_writing_results_to_disk(circuit, simd_bits<W>(0), 2049, tmp, SampleFormat::SAMPLE_FORMAT_01, rng);
+    sample_batch_measurements_writing_results_to_disk(
+        circuit, simd_bits<W>(0), 2049, tmp, SampleFormat::SAMPLE_FORMAT_01, rng);
 
     auto result = rewind_read_close(tmp);
     ASSERT_EQ(result.size(), 2049 * 4);
@@ -956,7 +960,8 @@ TEST_EACH_WORD_SIZE_W(FrameSimulator, stream_results_triple_shot, {
         }
     )circuit");
     FILE *tmp = tmpfile();
-    sample_batch_measurements_writing_results_to_disk(circuit, simd_bits<W>(0), 3, tmp, SampleFormat::SAMPLE_FORMAT_01, rng);
+    sample_batch_measurements_writing_results_to_disk(
+        circuit, simd_bits<W>(0), 3, tmp, SampleFormat::SAMPLE_FORMAT_01, rng);
 
     auto result = rewind_read_close(tmp);
     for (size_t rep = 0; rep < 3; rep++) {

--- a/src/stim/simulators/frame_simulator_util.test.cc
+++ b/src/stim/simulators/frame_simulator_util.test.cc
@@ -59,22 +59,22 @@ TEST_EACH_WORD_SIZE_W(DetectionSimulator, sample_batch_detection_events_writing_
 
     FILE *tmp = tmpfile();
     sample_batch_detection_events_writing_results_to_disk<W>(
-        circuit, 2, false, false, tmp, SAMPLE_FORMAT_DETS, rng, nullptr, SAMPLE_FORMAT_01);
+        circuit, 2, false, false, tmp, SampleFormat::SAMPLE_FORMAT_DETS, rng, nullptr, SampleFormat::SAMPLE_FORMAT_01);
     ASSERT_EQ(rewind_read_close(tmp), "shot D1\nshot D1\n");
 
     tmp = tmpfile();
     sample_batch_detection_events_writing_results_to_disk<W>(
-        circuit, 2, true, false, tmp, SAMPLE_FORMAT_DETS, rng, nullptr, SAMPLE_FORMAT_01);
+        circuit, 2, true, false, tmp, SampleFormat::SAMPLE_FORMAT_DETS, rng, nullptr, SampleFormat::SAMPLE_FORMAT_01);
     ASSERT_EQ(rewind_read_close(tmp), "shot L4 D1\nshot L4 D1\n");
 
     tmp = tmpfile();
     sample_batch_detection_events_writing_results_to_disk<W>(
-        circuit, 2, false, true, tmp, SAMPLE_FORMAT_DETS, rng, nullptr, SAMPLE_FORMAT_01);
+        circuit, 2, false, true, tmp, SampleFormat::SAMPLE_FORMAT_DETS, rng, nullptr, SampleFormat::SAMPLE_FORMAT_01);
     ASSERT_EQ(rewind_read_close(tmp), "shot D1 L4\nshot D1 L4\n");
 
     tmp = tmpfile();
     sample_batch_detection_events_writing_results_to_disk<W>(
-        circuit, 2, false, true, tmp, SAMPLE_FORMAT_HITS, rng, nullptr, SAMPLE_FORMAT_01);
+        circuit, 2, false, true, tmp, SampleFormat::SAMPLE_FORMAT_HITS, rng, nullptr, SampleFormat::SAMPLE_FORMAT_01);
     ASSERT_EQ(rewind_read_close(tmp), "1,6\n1,6\n");
 })
 
@@ -90,7 +90,7 @@ TEST_EACH_WORD_SIZE_W(DetectionSimulator, stream_many_shots, {
     )circuit");
     FILE *tmp = tmpfile();
     sample_batch_detection_events_writing_results_to_disk<W>(
-        circuit, 2048, false, false, tmp, SAMPLE_FORMAT_01, rng, nullptr, SAMPLE_FORMAT_01);
+        circuit, 2048, false, false, tmp, SampleFormat::SAMPLE_FORMAT_01, rng, nullptr, SampleFormat::SAMPLE_FORMAT_01);
 
     auto result = rewind_read_close(tmp);
     for (size_t k = 0; k < 2048 * 4; k += 4) {
@@ -117,7 +117,7 @@ TEST_EACH_WORD_SIZE_W(DetectionSimulator, block_results_single_shot, {
     )circuit");
     FILE *tmp = tmpfile();
     sample_batch_detection_events_writing_results_to_disk<W>(
-        circuit, 1, false, true, tmp, SAMPLE_FORMAT_01, rng, nullptr, SAMPLE_FORMAT_01);
+        circuit, 1, false, true, tmp, SampleFormat::SAMPLE_FORMAT_01, rng, nullptr, SampleFormat::SAMPLE_FORMAT_01);
 
     auto result = rewind_read_close(tmp);
     for (size_t k = 0; k < 30000; k += 3) {
@@ -144,7 +144,7 @@ TEST_EACH_WORD_SIZE_W(DetectionSimulator, block_results_triple_shot, {
     )circuit");
     FILE *tmp = tmpfile();
     sample_batch_detection_events_writing_results_to_disk<W>(
-        circuit, 3, false, true, tmp, SAMPLE_FORMAT_01, rng, nullptr, SAMPLE_FORMAT_01);
+        circuit, 3, false, true, tmp, SampleFormat::SAMPLE_FORMAT_01, rng, nullptr, SampleFormat::SAMPLE_FORMAT_01);
 
     auto result = rewind_read_close(tmp);
     for (size_t rep = 0; rep < 3; rep++) {
@@ -177,7 +177,7 @@ TEST_EACH_WORD_SIZE_W(DetectionSimulator, stream_results, {
     RaiiTempNamedFile tmp;
     FILE *f = fopen(tmp.path.c_str(), "w");
     sample_batch_detection_events_writing_results_to_disk<W>(
-        circuit, 1, false, true, f, SAMPLE_FORMAT_01, rng, nullptr, SAMPLE_FORMAT_01);
+        circuit, 1, false, true, f, SampleFormat::SAMPLE_FORMAT_01, rng, nullptr, SampleFormat::SAMPLE_FORMAT_01);
     fclose(f);
 
     auto result = tmp.read_contents();
@@ -206,7 +206,7 @@ TEST_EACH_WORD_SIZE_W(DetectionSimulator, stream_results_triple_shot, {
     )circuit");
     FILE *tmp = tmpfile();
     sample_batch_detection_events_writing_results_to_disk<W>(
-        circuit, 3, false, true, tmp, SAMPLE_FORMAT_01, rng, nullptr, SAMPLE_FORMAT_01);
+        circuit, 3, false, true, tmp, SampleFormat::SAMPLE_FORMAT_01, rng, nullptr, SampleFormat::SAMPLE_FORMAT_01);
 
     auto result = rewind_read_close(tmp);
     for (size_t rep = 0; rep < 3; rep++) {
@@ -447,7 +447,7 @@ TEST_EACH_WORD_SIZE_W(DetectionSimulator, obs_data, {
     FILE *det_tmp = tmpfile();
     FILE *obs_tmp = tmpfile();
     sample_batch_detection_events_writing_results_to_disk<W>(
-        circuit, 1001, false, false, det_tmp, SAMPLE_FORMAT_B8, rng, obs_tmp, SAMPLE_FORMAT_B8);
+        circuit, 1001, false, false, det_tmp, SampleFormat::SAMPLE_FORMAT_B8, rng, obs_tmp, SampleFormat::SAMPLE_FORMAT_B8);
 
     auto det_saved = rewind_read_close(det_tmp);
     auto obs_saved = rewind_read_close(obs_tmp);

--- a/src/stim/simulators/frame_simulator_util.test.cc
+++ b/src/stim/simulators/frame_simulator_util.test.cc
@@ -447,7 +447,15 @@ TEST_EACH_WORD_SIZE_W(DetectionSimulator, obs_data, {
     FILE *det_tmp = tmpfile();
     FILE *obs_tmp = tmpfile();
     sample_batch_detection_events_writing_results_to_disk<W>(
-        circuit, 1001, false, false, det_tmp, SampleFormat::SAMPLE_FORMAT_B8, rng, obs_tmp, SampleFormat::SAMPLE_FORMAT_B8);
+        circuit,
+        1001,
+        false,
+        false,
+        det_tmp,
+        SampleFormat::SAMPLE_FORMAT_B8,
+        rng,
+        obs_tmp,
+        SampleFormat::SAMPLE_FORMAT_B8);
 
     auto det_saved = rewind_read_close(det_tmp);
     auto obs_saved = rewind_read_close(obs_tmp);

--- a/src/stim/simulators/matched_error.cc
+++ b/src/stim/simulators/matched_error.cc
@@ -56,7 +56,7 @@ void print_circuit_error_loc_indent(std::ostream &out, const CircuitErrorLocatio
         }
         out << indent << "        ";
         out << "at instruction #" << (frame.instruction_offset + 1);
-        const auto &gate_data = GATE_DATA.items[e.instruction_targets.gate_type];
+        const auto &gate_data = GATE_DATA[e.instruction_targets.gate_type];
         if (k < e.stack_frames.size() - 1) {
             out << " (a REPEAT " << frame.instruction_repetitions_arg << " block)";
         } else {
@@ -149,7 +149,7 @@ std::ostream &stim::operator<<(std::ostream &out, const ExplainedError &e) {
 }
 
 std::ostream &stim::operator<<(std::ostream &out, const CircuitTargetsInsideInstruction &e) {
-    const auto &gate_data = GATE_DATA.items[e.gate_type];
+    const auto &gate_data = GATE_DATA[e.gate_type];
     if (gate_data.flags == GateFlags::NO_GATE_FLAG) {
         out << "null";
     } else {
@@ -361,10 +361,10 @@ bool CircuitTargetsInsideInstruction::operator<(const CircuitTargetsInsideInstru
     if (args != other.args) {
         return vec_less_than(args, other.args);
     }
-    if ((gate_type == 0) || (other.gate_type == 0)) {
+    if (gate_type == GateType::NOT_A_GATE || other.gate_type == GateType::NOT_A_GATE) {
         return gate_type < other.gate_type;
     }
-    return strcmp(GATE_DATA.items[gate_type].name, GATE_DATA.items[other.gate_type].name) < 0;
+    return strcmp(GATE_DATA[gate_type].name, GATE_DATA[other.gate_type].name) < 0;
 }
 
 bool CircuitErrorLocation::is_simpler_than(const CircuitErrorLocation &other) const {

--- a/src/stim/simulators/matched_error.pybind.cc
+++ b/src/stim/simulators/matched_error.pybind.cc
@@ -46,7 +46,7 @@ std::string DemTargetWithCoords_repr(const DemTargetWithCoords &self) {
 pybind11::ssize_t CircuitTargetsInsideInstruction_hash(const CircuitTargetsInsideInstruction &self) {
     return pybind11::hash(pybind11::make_tuple(
         "CircuitTargetsInsideInstruction",
-        self.gate_type == 0 ? nullptr : GATE_DATA[self.gate_type].name,
+        self.gate_type == GateType::NOT_A_GATE ? nullptr : GATE_DATA[self.gate_type].name,
         self.target_range_start,
         self.target_range_end,
         tuple_tree(self.targets_in_range),
@@ -77,7 +77,7 @@ std::string FlippedMeasurement_repr(const FlippedMeasurement &self) {
 std::string CircuitTargetsInsideInstruction_repr(const CircuitTargetsInsideInstruction &self) {
     std::stringstream out;
     out << "stim.CircuitTargetsInsideInstruction";
-    out << "(gate='" << (self.gate_type == 0 ? "NULL" : GATE_DATA[self.gate_type].name) << "'";
+    out << "(gate='" << (self.gate_type == GateType::NOT_A_GATE ? "NULL" : GATE_DATA[self.gate_type].name) << "'";
     out << ", args=[" << comma_sep(self.args) << "]";
     out << ", target_range_start=" << self.target_range_start;
     out << ", target_range_end=" << self.target_range_end;
@@ -412,7 +412,7 @@ void stim_pybind::pybind_circuit_targets_inside_instruction_methods(
     c.def_property_readonly(
         "gate",
         [](const CircuitTargetsInsideInstruction &self) -> pybind11::object {
-            if (self.gate_type == 0) {
+            if (self.gate_type == GateType::NOT_A_GATE) {
                 return pybind11::none();
             }
             return pybind11::str(GATE_DATA[self.gate_type].name);

--- a/src/stim/simulators/matched_error.pybind.cc
+++ b/src/stim/simulators/matched_error.pybind.cc
@@ -46,7 +46,7 @@ std::string DemTargetWithCoords_repr(const DemTargetWithCoords &self) {
 pybind11::ssize_t CircuitTargetsInsideInstruction_hash(const CircuitTargetsInsideInstruction &self) {
     return pybind11::hash(pybind11::make_tuple(
         "CircuitTargetsInsideInstruction",
-        self.gate_type == 0 ? nullptr : GATE_DATA.items[self.gate_type].name,
+        self.gate_type == 0 ? nullptr : GATE_DATA[self.gate_type].name,
         self.target_range_start,
         self.target_range_end,
         tuple_tree(self.targets_in_range),
@@ -77,7 +77,7 @@ std::string FlippedMeasurement_repr(const FlippedMeasurement &self) {
 std::string CircuitTargetsInsideInstruction_repr(const CircuitTargetsInsideInstruction &self) {
     std::stringstream out;
     out << "stim.CircuitTargetsInsideInstruction";
-    out << "(gate='" << (self.gate_type == 0 ? "NULL" : GATE_DATA.items[self.gate_type].name) << "'";
+    out << "(gate='" << (self.gate_type == 0 ? "NULL" : GATE_DATA[self.gate_type].name) << "'";
     out << ", args=[" << comma_sep(self.args) << "]";
     out << ", target_range_start=" << self.target_range_start;
     out << ", target_range_end=" << self.target_range_end;
@@ -415,7 +415,7 @@ void stim_pybind::pybind_circuit_targets_inside_instruction_methods(
             if (self.gate_type == 0) {
                 return pybind11::none();
             }
-            return pybind11::str(GATE_DATA.items[self.gate_type].name);
+            return pybind11::str(GATE_DATA[self.gate_type].name);
         },
         clean_doc_string(R"DOC(
             Returns the name of the gate / instruction that was being executed.

--- a/src/stim/simulators/sparse_rev_frame_tracker.cc
+++ b/src/stim/simulators/sparse_rev_frame_tracker.cc
@@ -175,7 +175,7 @@ void SparseUnsignedRevFrameTracker::undo_gate(const CircuitInstruction &inst) {
         default:
             throw std::invalid_argument(
                 "Not implemented by SparseUnsignedRevFrameTracker::undo_gate: " +
-                std::string(GATE_DATA.items[inst.gate_type].name));
+                std::string(GATE_DATA[inst.gate_type].name));
     }
 }
 

--- a/src/stim/simulators/tableau_simulator.inl
+++ b/src/stim/simulators/tableau_simulator.inl
@@ -1727,7 +1727,7 @@ void TableauSimulator<W>::do_gate(const CircuitInstruction &inst) {
             break;
         default:
             throw std::invalid_argument(
-                "Not implemented by TableauSimulator::do_gate: " + std::string(GATE_DATA.items[inst.gate_type].name));
+                "Not implemented by TableauSimulator::do_gate: " + std::string(GATE_DATA[inst.gate_type].name));
     }
 }
 

--- a/src/stim/simulators/tableau_simulator.test.cc
+++ b/src/stim/simulators/tableau_simulator.test.cc
@@ -1418,7 +1418,7 @@ TEST_EACH_WORD_SIZE_W(TableauSimulator, sample_stream_mutates_rng_state, {
     rewind(in);
 
     std::mt19937_64 rng(2345);
-    TableauSimulator<W>::sample_stream(in, out, SAMPLE_FORMAT_B8, false, rng);
+    TableauSimulator<W>::sample_stream(in, out, SampleFormat::SAMPLE_FORMAT_B8, false, rng);
 
     ASSERT_NE(rng, std::mt19937_64(2345));
 })

--- a/src/stim/simulators/transform_without_feedback.cc
+++ b/src/stim/simulators/transform_without_feedback.cc
@@ -123,7 +123,7 @@ struct WithoutFeedbackHelper {
             const auto &op = circuit.operations[k];
             if (op.gate_type == GateType::REPEAT) {
                 undo_repeat_block(circuit, op);
-            } else if (GATE_DATA.items[op.gate_type].flags & GATE_CAN_TARGET_BITS) {
+            } else if (GATE_DATA[op.gate_type].flags & GATE_CAN_TARGET_BITS) {
                 undo_feedback_capable_operation(op);
             } else {
                 reversed_semi_flattened_output.operations.push_back(op);

--- a/src/stim/simulators/vector_simulator.cc
+++ b/src/stim/simulators/vector_simulator.cc
@@ -193,7 +193,7 @@ void VectorSimulator::do_unitary_circuit(const Circuit &circuit) {
     std::vector<size_t> targets1{1};
     std::vector<size_t> targets2{1, 2};
     circuit.for_each_operation([&](const CircuitInstruction &op) {
-        const auto &gate_data = GATE_DATA.items[op.gate_type];
+        const auto &gate_data = GATE_DATA[op.gate_type];
         if (!(gate_data.flags & GATE_IS_UNITARY)) {
             std::stringstream ss;
             ss << "Not a unitary gate: " << gate_data.name;

--- a/src/stim/stabilizers/conversions.h
+++ b/src/stim/stabilizers/conversions.h
@@ -43,7 +43,7 @@ std::vector<std::vector<std::complex<float>>> tableau_to_unitary(const Tableau<W
 inline Circuit unitary_circuit_inverse(const Circuit &unitary_circuit) {
     Circuit inverted;
     unitary_circuit.for_each_operation_reverse([&](const CircuitInstruction &op) {
-        const auto &gate_data = GATE_DATA.items[op.gate_type];
+        const auto &gate_data = GATE_DATA[op.gate_type];
         if (!(gate_data.flags & GATE_IS_UNITARY)) {
             throw std::invalid_argument("Not unitary: " + op.str());
         }

--- a/src/stim/stabilizers/conversions.inl
+++ b/src/stim/stabilizers/conversions.inl
@@ -150,7 +150,7 @@ Tableau<W> circuit_to_tableau(
     TableauSimulator<W> sim(std::mt19937_64(0), circuit.count_qubits());
 
     circuit.for_each_operation([&](const CircuitInstruction &op) {
-        const auto &flags = GATE_DATA.items[op.gate_type].flags;
+        const auto &flags = GATE_DATA[op.gate_type].flags;
         if (!ignore_measurement && (flags & GATE_PRODUCES_RESULTS)) {
             throw std::invalid_argument(
                 "The circuit has no well-defined tableau because it contains measurement operations.\n"
@@ -190,7 +190,7 @@ std::vector<std::complex<float>> circuit_to_output_state_vector(const Circuit &c
     TableauSimulator<W> sim(std::mt19937_64(0), circuit.count_qubits());
 
     circuit.for_each_operation([&](const CircuitInstruction &op) {
-        const auto &flags = GATE_DATA.items[op.gate_type].flags;
+        const auto &flags = GATE_DATA[op.gate_type].flags;
         if (flags & GATE_IS_UNITARY) {
             sim.do_gate(op);
         } else if (flags & (GATE_IS_NOISY | GATE_IS_RESET | GATE_PRODUCES_RESULTS)) {

--- a/src/stim/stabilizers/pauli_string.test.cc
+++ b/src/stim/stabilizers/pauli_string.test.cc
@@ -655,7 +655,7 @@ TEST_EACH_WORD_SIZE_W(pauli_string, weight, {
         p.xs[k] = k % 3 == 1;
         p.zs[k] = k % 5 == 1;
     }
-    ASSERT_EQ(p.ref().weight(), 333+199-66);
+    ASSERT_EQ(p.ref().weight(), 333 + 199 - 66);
     p.sign = true;
-    ASSERT_EQ(p.ref().weight(), 333+199-66);
+    ASSERT_EQ(p.ref().weight(), 333 + 199 - 66);
 })

--- a/src/stim/stabilizers/pauli_string_ref.inl
+++ b/src/stim/stabilizers/pauli_string_ref.inl
@@ -180,7 +180,7 @@ void PauliStringRef<W>::after_inplace(const Circuit &circuit) {
 
 template <size_t W>
 void PauliStringRef<W>::after_inplace(const CircuitInstruction &operation, bool inverse) {
-    const auto &gate_data = GATE_DATA.items[operation.gate_type];
+    const auto &gate_data = GATE_DATA[operation.gate_type];
     if (gate_data.flags & GATE_IS_UNITARY) {
         // TODO: use hand-optimized methods instead of the generic tableau method.
         std::vector<size_t> indices;


### PR DESCRIPTION
Enum class does less pollution of the namespace. This change involved some additional things like defining `&` operators since `enum class` isn't implicitly an int like `enum` is.