### PR TITLE
Add `stim.pyi` to bazel dev build

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -102,10 +102,20 @@ cc_binary(
     deps = ["@pybind11"],
 )
 
+genrule(
+    name = "stim_wheel_files",
+    srcs = ["doc/stim.pyi"],
+    outs = ["stim.pyi"],
+    cmd = "cp $(location doc/stim.pyi) $@",
+)
+
 py_wheel(
     name = "stim_dev_wheel",
     distribution = "stim",
     requires = ["numpy"],
     version = "0.0.dev0",
-    deps = [":stim.so"],
+    deps = [
+        ":stim.so",
+        ":stim_wheel_files",
+    ],
 )


### PR DESCRIPTION
This makes autocomplete work when testing and debugging wheels during developments.