### PR TITLE
Refactor `stim::VectorSimulator` to take `GateType` enums instead of gate names

### DIFF
--- a/src/stim/simulators/tableau_simulator.inl
+++ b/src/stim/simulators/tableau_simulator.inl
@@ -1170,7 +1170,7 @@ std::vector<std::complex<float>> TableauSimulator<W>::to_state_vector(bool littl
     auto sim = to_vector_sim();
     if (!little_endian && inv_state.num_qubits > 0) {
         for (size_t q = 0; q < inv_state.num_qubits - q - 1; q++) {
-            sim.apply("SWAP", q, inv_state.num_qubits - q - 1);
+            sim.apply(GateType::SWAP, q, inv_state.num_qubits - q - 1);
         }
     }
     return sim.state;

--- a/src/stim/simulators/tableau_simulator.test.cc
+++ b/src/stim/simulators/tableau_simulator.test.cc
@@ -391,19 +391,19 @@ TEST_EACH_WORD_SIZE_W(TableauSimulator, to_vector_sim, {
     ASSERT_TRUE(sim_tab.to_vector_sim().approximate_equals(sim_vec, true));
 
     sim_tab.do_X(OpDat(0));
-    sim_vec.apply("X", 0);
+    sim_vec.apply(GateType::X, 0);
     ASSERT_TRUE(sim_tab.to_vector_sim().approximate_equals(sim_vec, true));
 
     sim_tab.do_H_XZ(OpDat(0));
-    sim_vec.apply("H_XZ", 0);
+    sim_vec.apply(GateType::H, 0);
     ASSERT_TRUE(sim_tab.to_vector_sim().approximate_equals(sim_vec, true));
 
     sim_tab.do_SQRT_Z(OpDat(0));
-    sim_vec.apply("SQRT_Z", 0);
+    sim_vec.apply(GateType::S, 0);
     ASSERT_TRUE(sim_tab.to_vector_sim().approximate_equals(sim_vec, true));
 
     sim_tab.do_ZCX(OpDat({0, 1}));
-    sim_vec.apply("ZCX", 0, 1);
+    sim_vec.apply(GateType::CX, 0, 1);
     ASSERT_TRUE(sim_tab.to_vector_sim().approximate_equals(sim_vec, true));
 
     sim_tab.inv_state = Tableau<W>::random(10, rng);
@@ -411,7 +411,7 @@ TEST_EACH_WORD_SIZE_W(TableauSimulator, to_vector_sim, {
     ASSERT_TRUE(sim_tab.to_vector_sim().approximate_equals(sim_vec, true));
 
     sim_tab.do_gate({GateType::XCX, {}, qubit_targets({4, 7})});
-    sim_vec.apply("XCX", 4, 7);
+    sim_vec.apply(GateType::XCX, 4, 7);
     ASSERT_TRUE(sim_tab.to_vector_sim().approximate_equals(sim_vec, true));
 })
 
@@ -432,8 +432,8 @@ TEST_EACH_WORD_SIZE_W(TableauSimulator, to_state_vector, {
 TEST_EACH_WORD_SIZE_W(TableauSimulator, to_state_vector_endian, {
     VectorSimulator sim_vec0(3);
     VectorSimulator sim_vec2(3);
-    sim_vec0.apply("H", 0);
-    sim_vec2.apply("H", 2);
+    sim_vec0.apply(GateType::H, 0);
+    sim_vec2.apply(GateType::H, 2);
 
     TableauSimulator<W> sim_tab(INDEPENDENT_TEST_RNG(), 3);
     sim_tab.do_H_XZ(OpDat(2));

--- a/src/stim/simulators/vector_simulator.cc
+++ b/src/stim/simulators/vector_simulator.cc
@@ -71,19 +71,19 @@ void VectorSimulator::apply(
     }
 }
 
-void VectorSimulator::apply(const std::string &gate, size_t qubit) {
+void VectorSimulator::apply(GateType gate, size_t qubit) {
     try {
-        apply(GATE_DATA.at(gate).unitary(), {qubit});
+        apply(GATE_DATA[gate].unitary(), {qubit});
     } catch (const std::out_of_range &) {
-        throw std::out_of_range("Single qubit gate isn't supported by VectorSimulator: " + gate);
+        throw std::out_of_range("Single qubit gate isn't supported by VectorSimulator: " + std::string(GATE_DATA[gate].name));
     }
 }
 
-void VectorSimulator::apply(const std::string &gate, size_t qubit1, size_t qubit2) {
+void VectorSimulator::apply(GateType gate, size_t qubit1, size_t qubit2) {
     try {
-        apply(GATE_DATA.at(gate).unitary(), {qubit1, qubit2});
+        apply(GATE_DATA[gate].unitary(), {qubit1, qubit2});
     } catch (const std::out_of_range &) {
-        throw std::out_of_range("Two qubit gate isn't supported by VectorSimulator: " + gate);
+        throw std::out_of_range("Two qubit gate isn't supported by VectorSimulator: " + std::string(GATE_DATA[gate].name));
     }
 }
 

--- a/src/stim/simulators/vector_simulator.cc
+++ b/src/stim/simulators/vector_simulator.cc
@@ -75,7 +75,8 @@ void VectorSimulator::apply(GateType gate, size_t qubit) {
     try {
         apply(GATE_DATA[gate].unitary(), {qubit});
     } catch (const std::out_of_range &) {
-        throw std::out_of_range("Single qubit gate isn't supported by VectorSimulator: " + std::string(GATE_DATA[gate].name));
+        throw std::out_of_range(
+            "Single qubit gate isn't supported by VectorSimulator: " + std::string(GATE_DATA[gate].name));
     }
 }
 
@@ -83,7 +84,8 @@ void VectorSimulator::apply(GateType gate, size_t qubit1, size_t qubit2) {
     try {
         apply(GATE_DATA[gate].unitary(), {qubit1, qubit2});
     } catch (const std::out_of_range &) {
-        throw std::out_of_range("Two qubit gate isn't supported by VectorSimulator: " + std::string(GATE_DATA[gate].name));
+        throw std::out_of_range(
+            "Two qubit gate isn't supported by VectorSimulator: " + std::string(GATE_DATA[gate].name));
     }
 }
 

--- a/src/stim/simulators/vector_simulator.h
+++ b/src/stim/simulators/vector_simulator.h
@@ -85,9 +85,9 @@ struct VectorSimulator {
     void apply(const std::vector<std::vector<std::complex<float>>> &matrix, const std::vector<size_t> &qubits);
 
     /// Helper method for applying named single qubit gates.
-    void apply(const std::string &gate, size_t qubit);
+    void apply(GateType gate, size_t qubit);
     /// Helper method for applying named two qubit gates.
-    void apply(const std::string &gate, size_t qubit1, size_t qubit2);
+    void apply(GateType gate, size_t qubit1, size_t qubit2);
 
     /// Helper method for applying the gates in a Pauli string.
     template <size_t W>
@@ -102,11 +102,11 @@ struct VectorSimulator {
             bool z = gate.zs[k];
             size_t q = qubit_offset + k;
             if (x && z) {
-                apply("Y", q);
+                apply(GateType::Y, q);
             } else if (x) {
-                apply("X", q);
+                apply(GateType::X, q);
             } else if (z) {
-                apply("Z", q);
+                apply(GateType::Z, q);
             }
         }
     }
@@ -132,9 +132,9 @@ struct VectorSimulator {
             for (size_t k = 0; k < observable.num_qubits; k++) {
                 if (observable.xs[k]) {
                     if (observable.zs[k]) {
-                        apply("H_YZ", k);
+                        apply(GateType::H_YZ, k);
                     } else {
-                        apply("H_XZ", k);
+                        apply(GateType::H, k);
                     }
                 }
             }

--- a/src/stim/simulators/vector_simulator.test.cc
+++ b/src/stim/simulators/vector_simulator.test.cc
@@ -31,8 +31,8 @@ static float complex_distance(std::complex<float> a, std::complex<float> b) {
 
 TEST(vector_sim, qubit_order) {
     VectorSimulator sim(2);
-    sim.apply("H_XZ", 0);
-    sim.apply("ZCX", 0, 1);
+    sim.apply(GateType::H, 0);
+    sim.apply(GateType::CX, 0, 1);
     ASSERT_NEAR_C(sim.state[0], sqrtf(0.5));
     ASSERT_NEAR_C(sim.state[1], 0);
     ASSERT_NEAR_C(sim.state[2], 0);
@@ -41,27 +41,27 @@ TEST(vector_sim, qubit_order) {
 
 TEST(vector_sim, h_squared) {
     VectorSimulator sim(1);
-    sim.apply("H_XZ", 0);
-    sim.apply("H_XZ", 0);
+    sim.apply(GateType::H, 0);
+    sim.apply(GateType::H, 0);
     ASSERT_NEAR_C(sim.state[0], 1);
     ASSERT_NEAR_C(sim.state[1], 0);
 }
 
 TEST(vector_sim, sqrt_x_squared) {
     VectorSimulator sim(1);
-    sim.apply("SQRT_X_DAG", 0);
-    sim.apply("SQRT_X_DAG", 0);
+    sim.apply(GateType::SQRT_X_DAG, 0);
+    sim.apply(GateType::SQRT_X_DAG, 0);
     ASSERT_NEAR_C(sim.state[0], 0);
     ASSERT_NEAR_C(sim.state[1], 1);
 }
 
 TEST(vector_sim, state_channel_duality_cnot) {
     VectorSimulator sim(4);
-    sim.apply("H_XZ", 0);
-    sim.apply("H_XZ", 1);
-    sim.apply("ZCX", 0, 2);
-    sim.apply("ZCX", 1, 3);
-    sim.apply("ZCX", 2, 3);
+    sim.apply(GateType::H, 0);
+    sim.apply(GateType::H, 1);
+    sim.apply(GateType::CX, 0, 2);
+    sim.apply(GateType::CX, 1, 3);
+    sim.apply(GateType::CX, 2, 3);
     auto u = GATE_DATA.at("ZCX").unitary();
     for (size_t row = 0; row < 4; row++) {
         for (size_t col = 0; col < 4; col++) {
@@ -72,9 +72,9 @@ TEST(vector_sim, state_channel_duality_cnot) {
 
 TEST(vector_sim, state_channel_duality_y) {
     VectorSimulator sim(2);
-    sim.apply("H_XZ", 0);
-    sim.apply("ZCX", 0, 1);
-    sim.apply("Y", 1);
+    sim.apply(GateType::H, 0);
+    sim.apply(GateType::CX, 0, 1);
+    sim.apply(GateType::Y, 1);
     auto u = GATE_DATA.at("Y").unitary();
     for (size_t row = 0; row < 2; row++) {
         for (size_t col = 0; col < 2; col++) {

--- a/src/stim/stabilizers/conversions.cc
+++ b/src/stim/stabilizers/conversions.cc
@@ -110,14 +110,16 @@ bool stim::try_disjoint_to_independent_xyz_errors_approx(
 
 double stim::depolarize1_probability_to_independent_per_channel_probability(double p) {
     if (p > 0.75) {
-        throw std::invalid_argument("depolarize1_probability_to_independent_per_channel_probability with p>0.75; p=" + std::to_string(p));
+        throw std::invalid_argument(
+            "depolarize1_probability_to_independent_per_channel_probability with p>0.75; p=" + std::to_string(p));
     }
     return 0.5 - 0.5 * sqrt(1 - (4 * p) / 3);
 }
 
 double stim::depolarize2_probability_to_independent_per_channel_probability(double p) {
     if (p > 0.9375) {
-        throw std::invalid_argument("depolarize2_probability_to_independent_per_channel_probability with p>15.0/16.0; p=" + std::to_string(p));
+        throw std::invalid_argument(
+            "depolarize2_probability_to_independent_per_channel_probability with p>15.0/16.0; p=" + std::to_string(p));
     }
     return 0.5 - 0.5 * pow(1 - (16 * p) / 15, 0.125);
 }

--- a/src/stim/stabilizers/tableau.test.cc
+++ b/src/stim/stabilizers/tableau.test.cc
@@ -72,8 +72,8 @@ bool tableau_agrees_with_unitary(
         VectorSimulator sim(n * 2);
         // Create EPR pairs to test all possible inputs via state channel duality.
         for (size_t q = 0; q < n; q++) {
-            sim.apply("H_XZ", q);
-            sim.apply("ZCX", q, q + n);
+            sim.apply(GateType::H, q);
+            sim.apply(GateType::CX, q, q + n);
         }
         // Apply input-side observable.
         sim.apply<W>(input_side_obs, n);


### PR DESCRIPTION
Not really that important... more a point of principle. Just less wasteful.