### PR TITLE
Add `shorthand` argument to `stim.Circuit.has_flow`

### DIFF
--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -1889,9 +1889,10 @@ def get_final_qubit_coordinates(
 # (in class stim.Circuit)
 def has_flow(
     self,
+    shorthand: Optional[str] = None,
     *,
-    start: Optional[stim.PauliString] = None,
-    end: Optional[stim.PauliString] = None,
+    start: Union[None, str, stim.PauliString] = None,
+    end: Union[None, str, stim.PauliString] = None,
     measurements: Optional[Iterable[Union[int, stim.GateTarget]]] = None,
     unsigned: bool = False,
 ) -> bool:
@@ -1904,15 +1905,27 @@ def has_flow(
     the CNOT flows implemented by the circuit involve these measurements.
 
     A flow like P -> Q means that the circuit transforms P into Q.
-    A flow like IDENTITY -> P means that the circuit prepares P.
-    A flow like P -> IDENTITY means that the circuit measures P.
-    A flow like IDENTITY -> IDENTITY means that the circuit contains a detector.
+    A flow like 1 -> P means that the circuit prepares P.
+    A flow like P -> 1 means that the circuit measures P.
+    A flow like 1 -> 1 means that the circuit contains a detector.
 
     Args:
+        shorthand: Specifies the flow as a short string like "IX -> -YZ xor rec[1]".
+            The text must contain "->" to separate the input pauli string from the
+            output pauli string. Each pauli string should be a sequence of
+            characters from "_IXYZ" (or else just "1" to indicate the empty Pauli
+            string) optionally prefixed by "+" or "-". Measurements are included
+            by appending " xor rec[k]" for each measurement index k. Indexing uses
+            the python convention where non-negative indices index from the start
+            and negative indices index from the end.
         start: The input into the flow at the start of the circuit. Defaults to None
-            (the identity Pauli string).
+            (the identity Pauli string). When specified, this should be a
+            `stim.PauliString`, or a `str` (which will be parsed using
+            `stim.PauliString.__init__`).
         end: The output from the flow at the end of the circuit. Defaults to None
-            (the identity Pauli string).
+            (the identity Pauli string). When specified, this should be a
+            `stim.PauliString`, or a `str` (which will be parsed using
+            `stim.PauliString.__init__`).
         measurements: Defaults to None (empty). The indices of measurements to
             include in the flow. This should be a collection of integers and/or
             stim.GateTarget instances. Indexing uses the python convention where
@@ -1935,6 +1948,16 @@ def has_flow(
 
     Examples:
         >>> import stim
+
+        >>> m = stim.Circuit('M 0')
+        >>> m.has_flow('Z -> Z')
+        True
+        >>> m.has_flow('X -> X')
+        False
+        >>> m.has_flow('Z -> I')
+        False
+        >>> m.has_flow('Z -> I xor rec[-1]')
+        True
 
         >>> stim.Circuit('''
         ...     RY 0

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -1313,9 +1313,10 @@ class Circuit:
         """
     def has_flow(
         self,
+        shorthand: Optional[str] = None,
         *,
-        start: Optional[stim.PauliString] = None,
-        end: Optional[stim.PauliString] = None,
+        start: Union[None, str, stim.PauliString] = None,
+        end: Union[None, str, stim.PauliString] = None,
         measurements: Optional[Iterable[Union[int, stim.GateTarget]]] = None,
         unsigned: bool = False,
     ) -> bool:
@@ -1328,15 +1329,27 @@ class Circuit:
         the CNOT flows implemented by the circuit involve these measurements.
 
         A flow like P -> Q means that the circuit transforms P into Q.
-        A flow like IDENTITY -> P means that the circuit prepares P.
-        A flow like P -> IDENTITY means that the circuit measures P.
-        A flow like IDENTITY -> IDENTITY means that the circuit contains a detector.
+        A flow like 1 -> P means that the circuit prepares P.
+        A flow like P -> 1 means that the circuit measures P.
+        A flow like 1 -> 1 means that the circuit contains a detector.
 
         Args:
+            shorthand: Specifies the flow as a short string like "IX -> -YZ xor rec[1]".
+                The text must contain "->" to separate the input pauli string from the
+                output pauli string. Each pauli string should be a sequence of
+                characters from "_IXYZ" (or else just "1" to indicate the empty Pauli
+                string) optionally prefixed by "+" or "-". Measurements are included
+                by appending " xor rec[k]" for each measurement index k. Indexing uses
+                the python convention where non-negative indices index from the start
+                and negative indices index from the end.
             start: The input into the flow at the start of the circuit. Defaults to None
-                (the identity Pauli string).
+                (the identity Pauli string). When specified, this should be a
+                `stim.PauliString`, or a `str` (which will be parsed using
+                `stim.PauliString.__init__`).
             end: The output from the flow at the end of the circuit. Defaults to None
-                (the identity Pauli string).
+                (the identity Pauli string). When specified, this should be a
+                `stim.PauliString`, or a `str` (which will be parsed using
+                `stim.PauliString.__init__`).
             measurements: Defaults to None (empty). The indices of measurements to
                 include in the flow. This should be a collection of integers and/or
                 stim.GateTarget instances. Indexing uses the python convention where
@@ -1359,6 +1372,16 @@ class Circuit:
 
         Examples:
             >>> import stim
+
+            >>> m = stim.Circuit('M 0')
+            >>> m.has_flow('Z -> Z')
+            True
+            >>> m.has_flow('X -> X')
+            False
+            >>> m.has_flow('Z -> I')
+            False
+            >>> m.has_flow('Z -> I xor rec[-1]')
+            True
 
             >>> stim.Circuit('''
             ...     RY 0

--- a/glue/javascript/pauli_string.js.cc
+++ b/glue/javascript/pauli_string.js.cc
@@ -14,7 +14,7 @@ ExposedPauliString::ExposedPauliString(const emscripten::val &arg) : pauli_strin
     if (arg.isNumber()) {
         pauli_string = PauliString<stim::MAX_BITWORD_WIDTH>(js_val_to_uint32_t(arg));
     } else if (arg.isString()) {
-        pauli_string = PauliString<stim::MAX_BITWORD_WIDTH>::from_str(arg.as<std::string>().data());
+        pauli_string = PauliString<stim::MAX_BITWORD_WIDTH>::from_str(arg.as<std::string>());
     } else {
         throw std::invalid_argument("Expected an int or a string. Got " + t);
     }

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -1313,9 +1313,10 @@ class Circuit:
         """
     def has_flow(
         self,
+        shorthand: Optional[str] = None,
         *,
-        start: Optional[stim.PauliString] = None,
-        end: Optional[stim.PauliString] = None,
+        start: Union[None, str, stim.PauliString] = None,
+        end: Union[None, str, stim.PauliString] = None,
         measurements: Optional[Iterable[Union[int, stim.GateTarget]]] = None,
         unsigned: bool = False,
     ) -> bool:
@@ -1328,15 +1329,27 @@ class Circuit:
         the CNOT flows implemented by the circuit involve these measurements.
 
         A flow like P -> Q means that the circuit transforms P into Q.
-        A flow like IDENTITY -> P means that the circuit prepares P.
-        A flow like P -> IDENTITY means that the circuit measures P.
-        A flow like IDENTITY -> IDENTITY means that the circuit contains a detector.
+        A flow like 1 -> P means that the circuit prepares P.
+        A flow like P -> 1 means that the circuit measures P.
+        A flow like 1 -> 1 means that the circuit contains a detector.
 
         Args:
+            shorthand: Specifies the flow as a short string like "IX -> -YZ xor rec[1]".
+                The text must contain "->" to separate the input pauli string from the
+                output pauli string. Each pauli string should be a sequence of
+                characters from "_IXYZ" (or else just "1" to indicate the empty Pauli
+                string) optionally prefixed by "+" or "-". Measurements are included
+                by appending " xor rec[k]" for each measurement index k. Indexing uses
+                the python convention where non-negative indices index from the start
+                and negative indices index from the end.
             start: The input into the flow at the start of the circuit. Defaults to None
-                (the identity Pauli string).
+                (the identity Pauli string). When specified, this should be a
+                `stim.PauliString`, or a `str` (which will be parsed using
+                `stim.PauliString.__init__`).
             end: The output from the flow at the end of the circuit. Defaults to None
-                (the identity Pauli string).
+                (the identity Pauli string). When specified, this should be a
+                `stim.PauliString`, or a `str` (which will be parsed using
+                `stim.PauliString.__init__`).
             measurements: Defaults to None (empty). The indices of measurements to
                 include in the flow. This should be a collection of integers and/or
                 stim.GateTarget instances. Indexing uses the python convention where
@@ -1359,6 +1372,16 @@ class Circuit:
 
         Examples:
             >>> import stim
+
+            >>> m = stim.Circuit('M 0')
+            >>> m.has_flow('Z -> Z')
+            True
+            >>> m.has_flow('X -> X')
+            False
+            >>> m.has_flow('Z -> I')
+            False
+            >>> m.has_flow('Z -> I xor rec[-1]')
+            True
 
             >>> stim.Circuit('''
             ...     RY 0

--- a/src/stim/arg_parse.cc
+++ b/src/stim/arg_parse.cc
@@ -225,20 +225,20 @@ bool stim::find_bool_argument(const char *name, int argc, const char **argv) {
     throw std::invalid_argument(msg.str());
 }
 
-bool parse_int64(const char *data, int64_t *out) {
-    char c = *data;
-    if (c == 0) {
+bool stim::parse_int64(std::string_view data, int64_t *out) {
+    if (data.empty()) {
         return false;
     }
     bool negate = false;
-    if (c == '-') {
+    if (data.starts_with("-")) {
         negate = true;
-        data++;
-        c = *data;
+        data = data.substr(1);
+    } else if (data.starts_with("+")) {
+        data = data.substr(1);
     }
 
     uint64_t accumulator = 0;
-    while (c) {
+    for (char c : data) {
         if (!(c >= '0' && c <= '9')) {
             return false;
         }
@@ -248,8 +248,6 @@ bool parse_int64(const char *data, int64_t *out) {
             return false;  // Overflow.
         }
         accumulator = next;
-        data++;
-        c = *data;
     }
 
     if (negate && accumulator == (uint64_t)INT64_MAX + uint64_t{1}) {
@@ -423,7 +421,7 @@ uint64_t stim::parse_exact_uint64_t_from_string(const std::string &text) {
     if (end == c + text.size()) {
         // strtoull silently accepts spaces and negative signs and overflowing
         // values. The only guaranteed way I've found to ensure it actually
-        // worked is to recreate the string and check that it's the sam.e
+        // worked is to recreate the string and check that it's the same.
         std::stringstream ss;
         ss << v;
         if (ss.str() == text) {

--- a/src/stim/arg_parse.h
+++ b/src/stim/arg_parse.h
@@ -264,6 +264,7 @@ std::vector<std::string> split(char splitter, const std::string &text);
 
 double parse_exact_double_from_string(const std::string &text);
 uint64_t parse_exact_uint64_t_from_string(const std::string &text);
+bool parse_int64(std::string_view data, int64_t *out);
 
 }  // namespace stim
 

--- a/src/stim/arg_parse.test.cc
+++ b/src/stim/arg_parse.test.cc
@@ -346,3 +346,37 @@ TEST(arg_parse, parse_exact_uint64_t_from_string) {
     ASSERT_EQ(parse_exact_uint64_t_from_string("2"), 2);
     ASSERT_EQ(parse_exact_uint64_t_from_string("18446744073709551615"), UINT64_MAX);
 }
+
+TEST(arg_parse, parse_int64) {
+    int64_t x = 0;
+
+    ASSERT_TRUE(parse_int64("+0", &x));
+    ASSERT_EQ(x, 0);
+    ASSERT_TRUE(parse_int64("-0", &x));
+    ASSERT_EQ(x, 0);
+    ASSERT_TRUE(parse_int64("0", &x));
+    ASSERT_EQ(x, 0);
+    ASSERT_TRUE(parse_int64("1", &x));
+    ASSERT_EQ(x, 1);
+    ASSERT_TRUE(parse_int64("-1", &x));
+    ASSERT_EQ(x, -1);
+    ASSERT_FALSE(parse_int64("i", &x));
+    ASSERT_FALSE(parse_int64("1i", &x));
+    ASSERT_FALSE(parse_int64("i1", &x));
+    ASSERT_FALSE(parse_int64("1e2", &x));
+    ASSERT_FALSE(parse_int64("12i1", &x));
+    ASSERT_FALSE(parse_int64("12 ", &x));
+    ASSERT_FALSE(parse_int64(" 12", &x));
+
+    ASSERT_TRUE(parse_int64("0123", &x));
+    ASSERT_EQ(x, 123);
+    ASSERT_TRUE(parse_int64("-0123", &x));
+    ASSERT_EQ(x, -123);
+
+    ASSERT_FALSE(parse_int64("-9223372036854775809", &x));
+    ASSERT_TRUE(parse_int64("-9223372036854775808", &x));
+    ASSERT_EQ(x, INT64_MIN);
+    ASSERT_FALSE(parse_int64("9223372036854775808", &x));
+    ASSERT_TRUE(parse_int64("9223372036854775807", &x));
+    ASSERT_EQ(x, INT64_MAX);
+}

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -224,7 +224,7 @@ PyPauliString arg_to_pauli_string(const pybind11::object &arg) {
         return PyPauliString(PauliString<MAX_BITWORD_WIDTH>(0));
     } else if (pybind11::isinstance<PyPauliString>(arg)) {
         return pybind11::cast<PyPauliString>(arg);
-    } else if (pybind11::isinstance<std::string>(arg)) {
+    } else if (pybind11::isinstance<pybind11::str>(arg)) {
         return PyPauliString::from_text(pybind11::cast<std::string>(arg).c_str());
     } else {
         throw std::invalid_argument(

--- a/src/stim/circuit/circuit_pybind_test.py
+++ b/src/stim/circuit/circuit_pybind_test.py
@@ -1663,3 +1663,27 @@ def test_has_flow_lattice_surgery_without_feedback():
     assert not c.has_flow(start=stim.PauliString("X_"), end=stim.PauliString("-YX"))
     assert not c.has_flow(start=stim.PauliString("X_"), end=stim.PauliString("XX"), unsigned=True)
     assert c.has_flow(start=stim.PauliString("X_"), end=stim.PauliString("-YX"), unsigned=True, measurements=[1])
+
+
+def test_has_flow_shorthands():
+    c = stim.Circuit("""
+        MZ 99
+        MXX 1 99
+        MZZ 0 99
+        MX 99
+    """)
+
+    assert c.has_flow("X_ -> XX xor rec[1] xor rec[3]")
+    assert c.has_flow("Z_ -> Z_")
+    assert c.has_flow("_X -> _X")
+    assert c.has_flow("_Z -> ZZ", measurements=[0, 2])
+    assert c.has_flow("_Z -> ZZ xor rec[0]", measurements=[2])
+
+    assert not c.has_flow("Z_ -> -Z_")
+    assert not c.has_flow("-Z_ -> Z_")
+    assert not c.has_flow("Z_ -> X_")
+    assert c.has_flow("iX_ -> iXX xor rec[1] xor rec[3]")
+    assert not c.has_flow("-iX_ -> iXX xor rec[1] xor rec[3]")
+    assert c.has_flow("-iX_ -> -iXX xor rec[1] xor rec[3]")
+    with pytest.raises(ValueError):
+        c.has_flow("iX_ -> XX")

--- a/src/stim/circuit/circuit_pybind_test.py
+++ b/src/stim/circuit/circuit_pybind_test.py
@@ -1679,6 +1679,7 @@ def test_has_flow_shorthands():
     assert c.has_flow("_Z -> ZZ", measurements=[0, 2])
     assert c.has_flow("_Z -> ZZ xor rec[0]", measurements=[2])
 
+    assert c.has_flow(start="X_", end="XX", measurements=[1, 3])
     assert not c.has_flow("Z_ -> -Z_")
     assert not c.has_flow("-Z_ -> Z_")
     assert not c.has_flow("Z_ -> X_")

--- a/src/stim/circuit/stabilizer_flow.h
+++ b/src/stim/circuit/stabilizer_flow.h
@@ -31,7 +31,7 @@ struct StabilizerFlow {
     stim::PauliString<W> output;
     std::vector<stim::GateTarget> measurement_outputs;
 
-    static StabilizerFlow<W> from_str(const char *c);
+    static StabilizerFlow<W> from_str(const char *text, uint64_t num_measurements_for_non_neg_recs = 0);
     bool operator==(const StabilizerFlow<W> &other) const;
     bool operator!=(const StabilizerFlow<W> &other) const;
     std::string str() const;

--- a/src/stim/circuit/stabilizer_flow.test.cc
+++ b/src/stim/circuit/stabilizer_flow.test.cc
@@ -22,6 +22,101 @@
 
 using namespace stim;
 
+TEST_EACH_WORD_SIZE_W(stabilizer_flow, from_str, {
+    ASSERT_THROW({ StabilizerFlow<W>::from_str(""); }, std::invalid_argument);
+    ASSERT_THROW({ StabilizerFlow<W>::from_str("X"); }, std::invalid_argument);
+    ASSERT_THROW({ StabilizerFlow<W>::from_str("X>X"); }, std::invalid_argument);
+    ASSERT_THROW({ StabilizerFlow<W>::from_str("X-X"); }, std::invalid_argument);
+    ASSERT_THROW({ StabilizerFlow<W>::from_str("X > X"); }, std::invalid_argument);
+    ASSERT_THROW({ StabilizerFlow<W>::from_str("X - X"); }, std::invalid_argument);
+    ASSERT_THROW({ StabilizerFlow<W>::from_str("->X"); }, std::invalid_argument);
+    ASSERT_THROW({ StabilizerFlow<W>::from_str("X->"); }, std::invalid_argument);
+    ASSERT_THROW({ StabilizerFlow<W>::from_str("rec[0] -> X"); }, std::invalid_argument);
+    ASSERT_THROW({ StabilizerFlow<W>::from_str("X -> rec[ -1]"); }, std::invalid_argument);
+    ASSERT_THROW({ StabilizerFlow<W>::from_str("X -> X rec[-1]"); }, std::invalid_argument);
+    ASSERT_THROW({ StabilizerFlow<W>::from_str("X -> X xor"); }, std::invalid_argument);
+    ASSERT_THROW({ StabilizerFlow<W>::from_str("X -> rec[-1] xor X"); }, std::invalid_argument);
+    ASSERT_THROW({ StabilizerFlow<W>::from_str("X -> rec[55]"); }, std::invalid_argument);
+
+    ASSERT_EQ(
+        StabilizerFlow<W>::from_str("1 -> 1"),
+        (StabilizerFlow<W>{
+            .input = PauliString<W>::from_str(""),
+            .output = PauliString<W>::from_str(""),
+            .measurement_outputs = {},
+        }));
+    ASSERT_EQ(
+        StabilizerFlow<W>::from_str("i -> -i"),
+        (StabilizerFlow<W>{
+            .input = PauliString<W>::from_str(""),
+            .output = PauliString<W>::from_str("-"),
+            .measurement_outputs = {},
+        }));
+    ASSERT_EQ(
+        StabilizerFlow<W>::from_str("iX -> -iY"),
+        (StabilizerFlow<W>{
+            .input = PauliString<W>::from_str("X"),
+            .output = PauliString<W>::from_str("-Y"),
+            .measurement_outputs = {},
+        }));
+    ASSERT_EQ(
+        StabilizerFlow<W>::from_str("X->-Y"),
+        (StabilizerFlow<W>{
+            .input = PauliString<W>::from_str("X"),
+            .output = PauliString<W>::from_str("-Y"),
+            .measurement_outputs = {},
+        }));
+    ASSERT_EQ(
+        StabilizerFlow<W>::from_str("X -> -Y"),
+        (StabilizerFlow<W>{
+            .input = PauliString<W>::from_str("X"),
+            .output = PauliString<W>::from_str("-Y"),
+            .measurement_outputs = {},
+        }));
+    ASSERT_EQ(
+        StabilizerFlow<W>::from_str("-X -> Y"),
+        (StabilizerFlow<W>{
+            .input = PauliString<W>::from_str("-X"),
+            .output = PauliString<W>::from_str("Y"),
+            .measurement_outputs = {},
+        }));
+    ASSERT_EQ(
+        StabilizerFlow<W>::from_str("XYZ -> -Z_Z"),
+        (StabilizerFlow<W>{
+            .input = PauliString<W>::from_str("XYZ"),
+            .output = PauliString<W>::from_str("-Z_Z"),
+            .measurement_outputs = {},
+        }));
+    ASSERT_EQ(
+        StabilizerFlow<W>::from_str("XYZ -> Z_Y xor rec[-1]"),
+        (StabilizerFlow<W>{
+            .input = PauliString<W>::from_str("XYZ"),
+            .output = PauliString<W>::from_str("Z_Y"),
+            .measurement_outputs = {GateTarget::rec(-1)},
+        }));
+    ASSERT_EQ(
+        StabilizerFlow<W>::from_str("XYZ -> rec[-1]"),
+        (StabilizerFlow<W>{
+            .input = PauliString<W>::from_str("XYZ"),
+            .output = PauliString<W>::from_str(""),
+            .measurement_outputs = {GateTarget::rec(-1)},
+        }));
+    ASSERT_EQ(
+        StabilizerFlow<W>::from_str("XYZ -> Z_Y xor rec[-1] xor rec[-3]"),
+        (StabilizerFlow<W>{
+            .input = PauliString<W>::from_str("XYZ"),
+            .output = PauliString<W>::from_str("Z_Y"),
+            .measurement_outputs = {GateTarget::rec(-1), GateTarget::rec(-3)},
+        }));
+    ASSERT_EQ(
+        StabilizerFlow<W>::from_str("XYZ -> ZIY xor rec[55] xor rec[-3]", 100),
+        (StabilizerFlow<W>{
+            .input = PauliString<W>::from_str("XYZ"),
+            .output = PauliString<W>::from_str("Z_Y"),
+            .measurement_outputs = {GateTarget::rec(-45), GateTarget::rec(-3)},
+        }));
+});
+
 TEST_EACH_WORD_SIZE_W(stabilizer_flow, sample_if_circuit_has_stabilizer_flows, {
     auto rng = INDEPENDENT_TEST_RNG();
     auto results = sample_if_circuit_has_stabilizer_flows<W>(

--- a/src/stim/stabilizers/pauli_string.h
+++ b/src/stim/stabilizers/pauli_string.h
@@ -85,7 +85,7 @@ struct PauliString {
     /// Factory method for creating a PauliString whose Pauli entries are returned by a function.
     static PauliString<W> from_func(bool sign, size_t num_qubits, const std::function<char(size_t)> &func);
     /// Factory method for creating a PauliString by parsing a string (e.g. "-XIIYZ").
-    static PauliString<W> from_str(const char *text);
+    static PauliString<W> from_str(std::string_view text);
     /// Factory method for creating a PauliString with uniformly random sign and Pauli entries.
     static PauliString<W> random(size_t num_qubits, std::mt19937_64 &rng);
 

--- a/src/stim/stabilizers/pauli_string.inl
+++ b/src/stim/stabilizers/pauli_string.inl
@@ -37,7 +37,7 @@ PauliString<W>::PauliString(size_t num_qubits) : num_qubits(num_qubits), sign(fa
 
 template <size_t W>
 PauliString<W>::PauliString(const std::string &text) : num_qubits(0), sign(false), xs(0), zs(0) {
-    *this = std::move(PauliString<W>::from_str(text.c_str()));
+    *this = std::move(PauliString<W>::from_str(text));
 }
 
 template <size_t W>
@@ -104,12 +104,13 @@ PauliString<W> PauliString<W>::from_func(bool sign, size_t num_qubits, const std
 }
 
 template <size_t W>
-PauliString<W> PauliString<W>::from_str(const char *text) {
-    auto sign = text[0] == '-';
-    if (text[0] == '+' || text[0] == '-') {
-        text++;
+PauliString<W> PauliString<W>::from_str(std::string_view text) {
+    bool is_negated = text.starts_with('-');
+    bool is_prefixed = text.starts_with('+');
+    if (is_prefixed || is_negated) {
+        text = text.substr(1);
     }
-    return PauliString::from_func(sign, strlen(text), [&](size_t i) {
+    return PauliString::from_func(is_negated, text.size(), [&](size_t i) {
         return text[i];
     });
 }


### PR DESCRIPTION
- Refactor a few initial C++ methods to use `std::string_view` instead of `const char *` or `const std::string &`