### PR TITLE
Add `stim.Circuit.{shortest,likeliest}_error_sat_problem`

### DIFF
--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -2447,7 +2447,7 @@ def shortest_error_problem_as_wcnf_file(
     self,
     *,
     weighted: bool = False,
-    num_distinct_weights: int = 1,
+    weight_scale_factor: int = 0,
 ) -> str:
     """Generates a maxSAT problem instance in WDIMACS format whose optimal value is
     the distance of the protocol, i.e. the minimum weight of any set of errors
@@ -2466,16 +2466,17 @@ def shortest_error_problem_as_wcnf_file(
         weighted: Defaults to False (unweighted), so that the problem is to find
         the minimum size set of errors that leads to an undetectable logical
         error.
-        num_distinct_weights: Defaults to 1. If weighted==False, must set
-        num_distinct_weights to 1. If weighted==True, num_distinct_weights can be
-        set to a value > 1. For a weighted problem, the errors will be quantized
-        into at most this many distinct weight values and the sum of the weights
+        weight_scale_factor: Defaults to 0. If weighted==False, must set
+        weight_scale_factor to 0. If weighted==True, weight_scale_factor must be
+        set to a value >= 1. For a weighted problem, the errors will be quantized
+        into integers using this scale factor and the sum of the weights
         will be minimized rather than the cardinality of the set of errors. For
-        a reasonably large quantization (num_distinct_weights > 100), the .wcnf
-        file solution should be the (approximately) most likely undetectable
-        logical error. Note, however, that maxSAT solvers often become slower
-        when many distinct weights are provided, so for computing the distance
-        it is better to use the default quantization num_distinct_weights = 1.
+        a reasonably large quantization (weight_scale_factor > 100 is often
+        sufficient), the .wcnf file solution should be the (approximately)
+        most likely undetectable logical error. Note, however, that maxSAT solvers
+        can become slower when many distinct weights are provided, so for computing
+        the distance it is better to simply use the defaults weighted=False and
+        weight_scale_factor = 0.
 
     Returns:
         A WCNF file in [WDIMACS format](http://www.maxhs.org/docs/wdimacs.html)
@@ -2483,12 +2484,12 @@ def shortest_error_problem_as_wcnf_file(
     Examples:
         >>> import stim
         >>> circuit = stim.Circuit("""
-        ...     X_ERROR(0.1) 0
-        ...     M 0
-        ...     OBSERVABLE_INCLUDE(0) rec[-1]
-        ...     X_ERROR(0.4) 0
-        ...     M 0
-        ...     DETECTOR rec[-1] rec[-2]
+        ...   X_ERROR(0.1) 0
+        ...   M 0
+        ...   OBSERVABLE_INCLUDE(0) rec[-1]
+        ...   X_ERROR(0.4) 0
+        ...   M 0
+        ...   DETECTOR rec[-1] rec[-2]
         ... """)
         >>> print(circuit.shortest_error_problem_as_wcnf_file())
         p wcnf 2 4 5
@@ -2497,16 +2498,15 @@ def shortest_error_problem_as_wcnf_file(
         5 -1 0
         5 2 0
 
-        >>> 
         >>> print(circuit.shortest_error_problem_as_wcnf_file(
         ...   weighted=True,
-        ...   num_distinct_weights=10
+        ...   weight_scale_factor=1000
         ... ))
-        p wcnf 2 4 41
-        2 -1 0
-        10 -2 0
-        41 -1 0
-        41 2 0
+        p wcnf 2 4 4001
+        185 -1 0
+        1000 -2 0
+        4001 -1 0
+        4001 2 0
     """
 ```
 

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -2145,13 +2145,13 @@ def likeliest_error_sat_problem(
     quantization: int = 100,
     format: str = 'WDIMACS',
 ) -> str:
-    """Makes a maxSAT problem of the circuit's distance, that other tools can solve.
+    """Makes a maxSAT problem of the circuit's most likely undetectable logical
+    error, that other tools can solve.
 
     The output is a string describing the maxSAT problem in WDIMACS format
     (see https://maxhs.org/docs/wdimacs.html). The optimal solution to the
-    problem is the fault distance of the circuit (the minimum number of error
-    mechanisms that combine to flip any logical observable while producing no
-    detection events).
+    problem is the highest likelihood set of error mechanisms that combine to
+    flip any logical observable while producing no detection events).
 
     There are many tools that can solve maxSAT problems in WDIMACS format.
     For example, you can download one of the entries in the 2023 maxSAT
@@ -2165,12 +2165,12 @@ def likeliest_error_sat_problem(
     Args:
         format: Defaults to "WDIMACS", corresponding to WDIMACS format which is
         described here: http://www.maxhs.org/docs/wdimacs.html
-        weight_bins: Defaults to 1 (unweighted errors). Error probabilities are
-            converted to log-odds and scaled/rounded to be positive integers at
-            most this large. Setting this argument to a larger number results in
-            the solution to the problem being the most likely logical error
-            weighted by probability of its parts, instead of just the one with
-            the fewest parts.
+        quantization: Defaults to 10. Error probabilities are converted to log-odds
+            and scaled/rounded to be positive integers at most this large. Setting
+            this argument to a larger number results in more accurate quantization
+            such that the returned error set should have a likelihood closer to the
+            true most likely solution. This comes at the cost of making some maxSAT
+            solvers slower.
 
     Returns:
         A string corresponding to the contents of a WCNF file in the requested
@@ -2541,12 +2541,6 @@ def shortest_error_sat_problem(
     Args:
         format: Defaults to "WDIMACS", corresponding to WDIMACS format which is
         described here: http://www.maxhs.org/docs/wdimacs.html
-        weight_bins: Defaults to 1 (unweighted errors). Error probabilities are
-            converted to log-odds and scaled/rounded to be positive integers at
-            most this large. Setting this argument to a larger number results in
-            the solution to the problem being the most likely logical error
-            weighted by probability of its parts, instead of just the one with
-            the fewest parts.
 
     Returns:
         A string corresponding to the contents of a WCNF file in the requested

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -2153,6 +2153,12 @@ def likeliest_error_sat_problem(
     problem is the highest likelihood set of error mechanisms that combine to
     flip any logical observable while producing no detection events).
 
+    If there are any errors with probability p > 0.5, they are inverted so
+    that the resulting weight ends up being positive. If there are errors
+    with weight close or equal to 0.5, they can end up with 0 weight meaning
+    that they can be included or not in the solution with no affect on the
+    likelihood.
+
     There are many tools that can solve maxSAT problems in WDIMACS format.
     One quick way to get started is to install pysat by running this BASH
     terminal command:
@@ -2535,7 +2541,9 @@ def shortest_error_sat_problem(
     (see https://maxhs.org/docs/wdimacs.html). The optimal solution to the
     problem is the fault distance of the circuit (the minimum number of error
     mechanisms that combine to flip any logical observable while producing no
-    detection events).
+    detection events). This method ignores the probabilities of the error
+    mechanisms since it only cares about minimizing the number of errors
+    triggered.
 
     There are many tools that can solve maxSAT problems in WDIMACS format.
     One quick way to get started is to install pysat by running this BASH

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -46,6 +46,7 @@ API references for stable versions are kept on the [stim github wiki](https://gi
     - [`stim.Circuit.num_ticks`](#stim.Circuit.num_ticks)
     - [`stim.Circuit.reference_sample`](#stim.Circuit.reference_sample)
     - [`stim.Circuit.search_for_undetectable_logical_errors`](#stim.Circuit.search_for_undetectable_logical_errors)
+    - [`stim.Circuit.shortest_error_problem_as_wcnf_file`](#stim.Circuit.shortest_error_problem_as_wcnf_file)
     - [`stim.Circuit.shortest_graphlike_error`](#stim.Circuit.shortest_graphlike_error)
     - [`stim.Circuit.to_file`](#stim.Circuit.to_file)
     - [`stim.Circuit.to_qasm`](#stim.Circuit.to_qasm)
@@ -2434,6 +2435,55 @@ def search_for_undetectable_logical_errors(
         ...     dont_explore_edges_increasing_symptom_degree=True,
         ... )))
         5
+    """
+```
+
+<a name="stim.Circuit.shortest_error_problem_as_wcnf_file"></a>
+```python
+# stim.Circuit.shortest_error_problem_as_wcnf_file
+
+# (in class stim.Circuit)
+def shortest_error_problem_as_wcnf_file(
+    self,
+    *,
+    weighted: bool = False,
+    num_distinct_weights: int = 1,
+) -> str:
+    """Generates a maxSAT problem instance in WDIMACS format whose optimal value is
+    the distance of the protocol, i.e. the minimum weight of any set of errors
+    that forms an undetectable logical error.
+
+    Args:
+        weighted: Defaults to False (unweighted), so that the problem is to find
+        the minimum size set of errors that leads to an undetectable logical
+        error.
+        num_distinct_weights: Defaults to 1. If weighted==False, must set
+        num_distinct_weights to 1. If weighted==True, num_distinct_weights can be
+        set to a value > 1. For a weighted problem, the errors will be quantized
+        into at most this many distinct weight values and the sum of the weights
+        will be minimized rather than the cardinality of the set of errors. For
+        a reasonably large quantization (num_distinct_weights > 100), the .wcnf
+        file solution should be the (approximately) most likely undetectable
+        logical error. Note, however, that maxSAT solvers often become slower
+        when many distinct weights are provided, so for computing the distance
+        it is better to use the default quantization num_distinct_weights = 1.
+
+    Returns:
+        A WCNF file in [WDIMACS format](http://www.maxhs.org/docs/wdimacs.html)
+
+    Examples:
+        >>> import stim
+        >>> circuit = stim.Circuit.generated(
+        ...     "surface_code:rotated_memory_x",
+        ...     rounds=5,
+        ...     distance=5,
+        ...     after_clifford_depolarization=0.001)
+        >>> print(circuit.shortest_undetectable_logical_error_wcnf(
+                        num_distinct_weights=1))
+        ....
+        >>> print(circuit.shortest_undetectable_logical_error_wcnf(
+                        num_distinct_weights=10))
+        ....
     """
 ```
 

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -2154,17 +2154,34 @@ def likeliest_error_sat_problem(
     flip any logical observable while producing no detection events).
 
     There are many tools that can solve maxSAT problems in WDIMACS format.
-    For example, you can download one of the entries in the 2023 maxSAT
-    competition (see https://maxsat-evaluations.github.io/2023), for example
-    CASHWMaxSAT-CorePlus.zip and run it on your problem by running these
-    BASH terminal commands:
+    One quick way to get started is to install pysat by running this BASH
+    terminal command:
+
+        pip install python-sat
+
+    Afterwards, you can run the included maxSAT solver "RC2" with this
+    Python code:
+
+        from pysat.examples.rc2 import RC2
+        from pysat.formula import WCNF
+
+        wcnf = WCNF(from_string="p wcnf 1 2 3\n3 -1 0\n3 1 0\n")
+
+        with RC2(wcnf) as rc2:
+        print(rc2.compute())  
+        print(rc2.cost)
+
+    Much faster solvers than RC2 are available on the 2023 maxSAT competition
+    website (see https://maxsat-evaluations.github.io/2023), for example
+    CASHWMaxSAT-CorePlus.zip. If you download this solver you can run it on your
+    problem by running these BASH terminal commands:
 
         unzip CASHWMaxSAT-CorePlus.zip
         ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m your_problem.wcnf
 
     Args:
         format: Defaults to "WDIMACS", corresponding to WDIMACS format which is
-        described here: http://www.maxhs.org/docs/wdimacs.html
+            described here: http://www.maxhs.org/docs/wdimacs.html
         quantization: Defaults to 10. Error probabilities are converted to log-odds
             and scaled/rounded to be positive integers at most this large. Setting
             this argument to a larger number results in more accurate quantization
@@ -2177,8 +2194,6 @@ def likeliest_error_sat_problem(
         format.
 
     Examples:
-
-    Examples:
         >>> import stim
         >>> circuit = stim.Circuit("""
         ...   X_ERROR(0.1) 0
@@ -2188,15 +2203,8 @@ def likeliest_error_sat_problem(
         ...   M 0
         ...   DETECTOR rec[-1] rec[-2]
         ... """)
-        >>> print(circuit.shortest_error_problem_as_wcnf_file(), end='')
-        p wcnf 2 4 5
-        1 -1 0
-        1 -2 0
-        5 -1 0
-        5 2 0
-        >>> print(circuit.shortest_error_problem_as_wcnf_file(
-        ...   weighted=True,
-        ...   weight_scale_factor=1000
+        >>> print(circuit.likeliest_error_problem_as_wcnf_file(
+        ...   quantization=1000
         ... ), end='')
         p wcnf 2 4 4001
         185 -1 0
@@ -2530,17 +2538,34 @@ def shortest_error_sat_problem(
     detection events).
 
     There are many tools that can solve maxSAT problems in WDIMACS format.
-    For example, you can download one of the entries in the 2023 maxSAT
-    competition (see https://maxsat-evaluations.github.io/2023), for example
-    CASHWMaxSAT-CorePlus.zip and run it on your problem by running these
-    BASH terminal commands:
+    One quick way to get started is to install pysat by running this BASH
+    terminal command:
+
+        pip install python-sat
+
+    Afterwards, you can run the included maxSAT solver "RC2" with this
+    Python code:
+
+        from pysat.examples.rc2 import RC2
+        from pysat.formula import WCNF
+
+        wcnf = WCNF(from_string="p wcnf 1 2 3\n3 -1 0\n3 1 0\n")
+
+        with RC2(wcnf) as rc2:
+        print(rc2.compute())  
+        print(rc2.cost)
+
+    Much faster solvers than RC2 are available on the 2023 maxSAT competition
+    website (see https://maxsat-evaluations.github.io/2023), for example
+    CASHWMaxSAT-CorePlus.zip. If you download this solver you can run it on your
+    problem by running these BASH terminal commands:
 
         unzip CASHWMaxSAT-CorePlus.zip
         ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m your_problem.wcnf
 
     Args:
         format: Defaults to "WDIMACS", corresponding to WDIMACS format which is
-        described here: http://www.maxhs.org/docs/wdimacs.html
+            described here: http://www.maxhs.org/docs/wdimacs.html
 
     Returns:
         A string corresponding to the contents of a WCNF file in the requested
@@ -2558,21 +2583,12 @@ def shortest_error_sat_problem(
         ...   M 0
         ...   DETECTOR rec[-1] rec[-2]
         ... """)
-        >>> print(circuit.shortest_error_problem_as_wcnf_file(), end='')
+        >>> print(circuit.shortest_error_sat_problem(), end='')
         p wcnf 2 4 5
         1 -1 0
         1 -2 0
         5 -1 0
         5 2 0
-        >>> print(circuit.shortest_error_problem_as_wcnf_file(
-        ...   weighted=True,
-        ...   weight_scale_factor=1000
-        ... ), end='')
-        p wcnf 2 4 4001
-        185 -1 0
-        1000 -2 0
-        4001 -1 0
-        4001 2 0
     """
 ```
 

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -38,6 +38,7 @@ API references for stable versions are kept on the [stim github wiki](https://gi
     - [`stim.Circuit.has_all_flows`](#stim.Circuit.has_all_flows)
     - [`stim.Circuit.has_flow`](#stim.Circuit.has_flow)
     - [`stim.Circuit.inverse`](#stim.Circuit.inverse)
+    - [`stim.Circuit.likeliest_error_sat_problem`](#stim.Circuit.likeliest_error_sat_problem)
     - [`stim.Circuit.num_detectors`](#stim.Circuit.num_detectors)
     - [`stim.Circuit.num_measurements`](#stim.Circuit.num_measurements)
     - [`stim.Circuit.num_observables`](#stim.Circuit.num_observables)
@@ -46,7 +47,7 @@ API references for stable versions are kept on the [stim github wiki](https://gi
     - [`stim.Circuit.num_ticks`](#stim.Circuit.num_ticks)
     - [`stim.Circuit.reference_sample`](#stim.Circuit.reference_sample)
     - [`stim.Circuit.search_for_undetectable_logical_errors`](#stim.Circuit.search_for_undetectable_logical_errors)
-    - [`stim.Circuit.shortest_error_problem_as_wcnf_file`](#stim.Circuit.shortest_error_problem_as_wcnf_file)
+    - [`stim.Circuit.shortest_error_sat_problem`](#stim.Circuit.shortest_error_sat_problem)
     - [`stim.Circuit.shortest_graphlike_error`](#stim.Circuit.shortest_graphlike_error)
     - [`stim.Circuit.to_file`](#stim.Circuit.to_file)
     - [`stim.Circuit.to_qasm`](#stim.Circuit.to_qasm)
@@ -2133,6 +2134,78 @@ def inverse(
     """
 ```
 
+<a name="stim.Circuit.likeliest_error_sat_problem"></a>
+```python
+# stim.Circuit.likeliest_error_sat_problem
+
+# (in class stim.Circuit)
+def likeliest_error_sat_problem(
+    self,
+    *,
+    quantization: int = 100,
+    format: str = 'WDIMACS',
+) -> str:
+    """Makes a maxSAT problem of the circuit's distance, that other tools can solve.
+
+    The output is a string describing the maxSAT problem in WDIMACS format
+    (see https://maxhs.org/docs/wdimacs.html). The optimal solution to the
+    problem is the fault distance of the circuit (the minimum number of error
+    mechanisms that combine to flip any logical observable while producing no
+    detection events).
+
+    There are many tools that can solve maxSAT problems in WDIMACS format.
+    For example, you can download one of the entries in the 2023 maxSAT
+    competition (see https://maxsat-evaluations.github.io/2023), for example
+    CASHWMaxSAT-CorePlus.zip and run it on your problem by running these
+    BASH terminal commands:
+
+        unzip CASHWMaxSAT-CorePlus.zip
+        ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m your_problem.wcnf
+
+    Args:
+        format: Defaults to "WDIMACS", corresponding to WDIMACS format which is
+        described here: http://www.maxhs.org/docs/wdimacs.html
+        weight_bins: Defaults to 1 (unweighted errors). Error probabilities are
+            converted to log-odds and scaled/rounded to be positive integers at
+            most this large. Setting this argument to a larger number results in
+            the solution to the problem being the most likely logical error
+            weighted by probability of its parts, instead of just the one with
+            the fewest parts.
+
+    Returns:
+        A string corresponding to the contents of a WCNF file in the requested
+        format.
+
+    Examples:
+
+    Examples:
+        >>> import stim
+        >>> circuit = stim.Circuit("""
+        ...   X_ERROR(0.1) 0
+        ...   M 0
+        ...   OBSERVABLE_INCLUDE(0) rec[-1]
+        ...   X_ERROR(0.4) 0
+        ...   M 0
+        ...   DETECTOR rec[-1] rec[-2]
+        ... """)
+        >>> print(circuit.shortest_error_problem_as_wcnf_file(), end='')
+        p wcnf 2 4 5
+        1 -1 0
+        1 -2 0
+        5 -1 0
+        5 2 0
+        >>> print(circuit.shortest_error_problem_as_wcnf_file(
+        ...   weighted=True,
+        ...   weight_scale_factor=1000
+        ... ), end='')
+        p wcnf 2 4 4001
+        185 -1 0
+        1000 -2 0
+        4001 -1 0
+        4001 2 0
+    """
+```
+
 <a name="stim.Circuit.num_detectors"></a>
 ```python
 # stim.Circuit.num_detectors
@@ -2438,48 +2511,48 @@ def search_for_undetectable_logical_errors(
     """
 ```
 
-<a name="stim.Circuit.shortest_error_problem_as_wcnf_file"></a>
+<a name="stim.Circuit.shortest_error_sat_problem"></a>
 ```python
-# stim.Circuit.shortest_error_problem_as_wcnf_file
+# stim.Circuit.shortest_error_sat_problem
 
 # (in class stim.Circuit)
-def shortest_error_problem_as_wcnf_file(
+def shortest_error_sat_problem(
     self,
     *,
-    weighted: bool = False,
-    weight_scale_factor: int = 0,
+    format: str = 'WDIMACS',
 ) -> str:
-    """Generates a maxSAT problem instance in WDIMACS format whose optimal value is
-    the distance of the protocol, i.e. the minimum weight of any set of errors
-    that forms an undetectable logical error.
-    FYI: here is how you could fetch a solver from the
-    [2023 maxSAT competition](https://maxsat-evaluations.github.io/2023/) and
-    run the solver on a file produced with this method:
-    ```
-    # first download nzip CASHWMaxSAT-CorePlus.zip from 
-    # https://maxsat-evaluations.github.io/2023
-    unzip CASHWMaxSAT-CorePlus.zip
-    time ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m problem.wcnf 
-    ```
+    """Makes a maxSAT problem of the circuit's distance, that other tools can solve.
+
+    The output is a string describing the maxSAT problem in WDIMACS format
+    (see https://maxhs.org/docs/wdimacs.html). The optimal solution to the
+    problem is the fault distance of the circuit (the minimum number of error
+    mechanisms that combine to flip any logical observable while producing no
+    detection events).
+
+    There are many tools that can solve maxSAT problems in WDIMACS format.
+    For example, you can download one of the entries in the 2023 maxSAT
+    competition (see https://maxsat-evaluations.github.io/2023), for example
+    CASHWMaxSAT-CorePlus.zip and run it on your problem by running these
+    BASH terminal commands:
+
+        unzip CASHWMaxSAT-CorePlus.zip
+        ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m your_problem.wcnf
 
     Args:
-        weighted: Defaults to False (unweighted), so that the problem is to find
-        the minimum size set of errors that leads to an undetectable logical
-        error.
-        weight_scale_factor: Defaults to 0. If weighted==False, must set
-        weight_scale_factor to 0. If weighted==True, weight_scale_factor must be
-        set to a value >= 1. For a weighted problem, the errors will be quantized
-        into integers using this scale factor and the sum of the weights
-        will be minimized rather than the cardinality of the set of errors. For
-        a reasonably large quantization (weight_scale_factor > 100 is often
-        sufficient), the .wcnf file solution should be the (approximately)
-        most likely undetectable logical error. Note, however, that maxSAT solvers
-        can become slower when many distinct weights are provided, so for computing
-        the distance it is better to simply use the defaults weighted=False and
-        weight_scale_factor = 0.
+        format: Defaults to "WDIMACS", corresponding to WDIMACS format which is
+        described here: http://www.maxhs.org/docs/wdimacs.html
+        weight_bins: Defaults to 1 (unweighted errors). Error probabilities are
+            converted to log-odds and scaled/rounded to be positive integers at
+            most this large. Setting this argument to a larger number results in
+            the solution to the problem being the most likely logical error
+            weighted by probability of its parts, instead of just the one with
+            the fewest parts.
 
     Returns:
-        A WCNF file in [WDIMACS format](http://www.maxhs.org/docs/wdimacs.html)
+        A string corresponding to the contents of a WCNF file in the requested
+        format.
+
+    Examples:
 
     Examples:
         >>> import stim

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -2412,14 +2412,14 @@ def likeliest_error_sat_problem(
 
     Examples:
         >>> import stim
-        >>> circuit = stim.Circuit("""
+        >>> circuit = stim.Circuit('''
         ...   X_ERROR(0.1) 0
         ...   M 0
         ...   OBSERVABLE_INCLUDE(0) rec[-1]
         ...   X_ERROR(0.4) 0
         ...   M 0
         ...   DETECTOR rec[-1] rec[-2]
-        ... """)
+        ... ''')
         >>> print(circuit.likeliest_error_sat_problem(
         ...   quantization=1000
         ... ), end='')
@@ -2793,14 +2793,14 @@ def shortest_error_sat_problem(
 
     Examples:
         >>> import stim
-        >>> circuit = stim.Circuit("""
+        >>> circuit = stim.Circuit('''
         ...   X_ERROR(0.1) 0
         ...   M 0
         ...   OBSERVABLE_INCLUDE(0) rec[-1]
         ...   X_ERROR(0.4) 0
         ...   M 0
         ...   DETECTOR rec[-1] rec[-2]
-        ... """)
+        ... ''')
         >>> print(circuit.shortest_error_sat_problem(), end='')
         p wcnf 2 4 5
         1 -1 0

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -2177,11 +2177,12 @@ def likeliest_error_sat_problem(
         print(rc2.compute())  
         print(rc2.cost)
 
-    Much faster solvers than RC2 are available on the 2023 maxSAT competition
-    website (see https://maxsat-evaluations.github.io/2023), for example
-    CASHWMaxSAT-CorePlus.zip. If you download this solver you can run it on your
-    problem by running these BASH terminal commands:
+    Much faster solvers are available online. For example, you can download
+    one of the entries in the 2023 maxSAT competition (see
+    https://maxsat-evaluations.github.io/2023) and run it on your problem by
+    running these BASH terminal commands:
 
+        wget https://maxsat-evaluations.github.io/2023/mse23-solver-src/exact/CASHWMaxSAT-CorePlus.zip
         unzip CASHWMaxSAT-CorePlus.zip
         ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m your_problem.wcnf
 
@@ -2563,11 +2564,12 @@ def shortest_error_sat_problem(
         print(rc2.compute())  
         print(rc2.cost)
 
-    Much faster solvers than RC2 are available on the 2023 maxSAT competition
-    website (see https://maxsat-evaluations.github.io/2023), for example
-    CASHWMaxSAT-CorePlus.zip. If you download this solver you can run it on your
-    problem by running these BASH terminal commands:
+    Much faster solvers are available online. For example, you can download
+    one of the entries in the 2023 maxSAT competition (see
+    https://maxsat-evaluations.github.io/2023) and run it on your problem by
+    running these BASH terminal commands:
 
+        wget https://maxsat-evaluations.github.io/2023/mse23-solver-src/exact/CASHWMaxSAT-CorePlus.zip
         unzip CASHWMaxSAT-CorePlus.zip
         ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m your_problem.wcnf
 

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -2792,8 +2792,6 @@ def shortest_error_sat_problem(
         requested format.
 
     Examples:
-
-    Examples:
         >>> import stim
         >>> circuit = stim.Circuit("""
         ...   X_ERROR(0.1) 0

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -2452,6 +2452,15 @@ def shortest_error_problem_as_wcnf_file(
     """Generates a maxSAT problem instance in WDIMACS format whose optimal value is
     the distance of the protocol, i.e. the minimum weight of any set of errors
     that forms an undetectable logical error.
+    FYI: here is how you could fetch a solver from the
+    [2023 maxSAT competition](https://maxsat-evaluations.github.io/2023/) and
+    run the solver on a file produced with this method:
+    ```
+    # first download nzip CASHWMaxSAT-CorePlus.zip from 
+    # https://maxsat-evaluations.github.io/2023
+    unzip CASHWMaxSAT-CorePlus.zip
+    time ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m problem.wcnf 
+    ```
 
     Args:
         weighted: Defaults to False (unweighted), so that the problem is to find
@@ -2473,17 +2482,31 @@ def shortest_error_problem_as_wcnf_file(
 
     Examples:
         >>> import stim
-        >>> circuit = stim.Circuit.generated(
-        ...     "surface_code:rotated_memory_x",
-        ...     rounds=5,
-        ...     distance=5,
-        ...     after_clifford_depolarization=0.001)
-        >>> print(circuit.shortest_undetectable_logical_error_wcnf(
-                        num_distinct_weights=1))
-        ....
-        >>> print(circuit.shortest_undetectable_logical_error_wcnf(
-                        num_distinct_weights=10))
-        ....
+        >>> circuit = stim.Circuit("""
+        ...     X_ERROR(0.1) 0
+        ...     M 0
+        ...     OBSERVABLE_INCLUDE(0) rec[-1]
+        ...     X_ERROR(0.4) 0
+        ...     M 0
+        ...     DETECTOR rec[-1] rec[-2]
+        ... """)
+        >>> print(circuit.shortest_error_problem_as_wcnf_file())
+        p wcnf 2 4 5
+        1 -1 0
+        1 -2 0
+        5 -1 0
+        5 2 0
+
+        >>> 
+        >>> print(circuit.shortest_error_problem_as_wcnf_file(
+        ...   weighted=True,
+        ...   num_distinct_weights=10
+        ... ))
+        p wcnf 2 4 41
+        2 -1 0
+        10 -2 0
+        41 -1 0
+        41 2 0
     """
 ```
 

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -2407,8 +2407,8 @@ def likeliest_error_sat_problem(
             solvers slower.
 
     Returns:
-        A string corresponding to the contents of a WCNF file in the requested
-        format.
+        A string corresponding to the contents of a maxSAT problem file in the
+        requested format.
 
     Examples:
         >>> import stim
@@ -2420,7 +2420,7 @@ def likeliest_error_sat_problem(
         ...   M 0
         ...   DETECTOR rec[-1] rec[-2]
         ... """)
-        >>> print(circuit.likeliest_error_problem_as_wcnf_file(
+        >>> print(circuit.likeliest_error_sat_problem(
         ...   quantization=1000
         ... ), end='')
         p wcnf 2 4 4001
@@ -2788,8 +2788,8 @@ def shortest_error_sat_problem(
             described here: http://www.maxhs.org/docs/wdimacs.html
 
     Returns:
-        A string corresponding to the contents of a WCNF file in the requested
-        format.
+        A string corresponding to the contents of a maxSAT problem file in the
+        requested format.
 
     Examples:
 

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -2491,17 +2491,16 @@ def shortest_error_problem_as_wcnf_file(
         ...   M 0
         ...   DETECTOR rec[-1] rec[-2]
         ... """)
-        >>> print(circuit.shortest_error_problem_as_wcnf_file())
+        >>> print(circuit.shortest_error_problem_as_wcnf_file(), end='')
         p wcnf 2 4 5
         1 -1 0
         1 -2 0
         5 -1 0
         5 2 0
-
         >>> print(circuit.shortest_error_problem_as_wcnf_file(
         ...   weighted=True,
         ...   weight_scale_factor=1000
-        ... ))
+        ... ), end='')
         p wcnf 2 4 4001
         185 -1 0
         1000 -2 0

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -1822,17 +1822,16 @@ class Circuit:
             ...   M 0
             ...   DETECTOR rec[-1] rec[-2]
             ... """)
-            >>> print(circuit.shortest_error_problem_as_wcnf_file())
+            >>> print(circuit.shortest_error_problem_as_wcnf_file(), end='')
             p wcnf 2 4 5
             1 -1 0
             1 -2 0
             5 -1 0
             5 2 0
-
             >>> print(circuit.shortest_error_problem_as_wcnf_file(
             ...   weighted=True,
             ...   weight_scale_factor=1000
-            ... ))
+            ... ), end='')
             p wcnf 2 4 4001
             185 -1 0
             1000 -2 0

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -2098,8 +2098,6 @@ class Circuit:
             requested format.
 
         Examples:
-
-        Examples:
             >>> import stim
             >>> circuit = stim.Circuit("""
             ...   X_ERROR(0.1) 0

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -1778,7 +1778,7 @@ class Circuit:
         self,
         *,
         weighted: bool = False,
-        num_distinct_weights: int = 1,
+        weight_scale_factor: int = 0,
     ) -> str:
         """Generates a maxSAT problem instance in WDIMACS format whose optimal value is
         the distance of the protocol, i.e. the minimum weight of any set of errors
@@ -1797,16 +1797,17 @@ class Circuit:
             weighted: Defaults to False (unweighted), so that the problem is to find
             the minimum size set of errors that leads to an undetectable logical
             error.
-            num_distinct_weights: Defaults to 1. If weighted==False, must set
-            num_distinct_weights to 1. If weighted==True, num_distinct_weights can be
-            set to a value > 1. For a weighted problem, the errors will be quantized
-            into at most this many distinct weight values and the sum of the weights
+            weight_scale_factor: Defaults to 0. If weighted==False, must set
+            weight_scale_factor to 0. If weighted==True, weight_scale_factor must be
+            set to a value >= 1. For a weighted problem, the errors will be quantized
+            into integers using this scale factor and the sum of the weights
             will be minimized rather than the cardinality of the set of errors. For
-            a reasonably large quantization (num_distinct_weights > 100), the .wcnf
-            file solution should be the (approximately) most likely undetectable
-            logical error. Note, however, that maxSAT solvers often become slower
-            when many distinct weights are provided, so for computing the distance
-            it is better to use the default quantization num_distinct_weights = 1.
+            a reasonably large quantization (weight_scale_factor > 100 is often
+            sufficient), the .wcnf file solution should be the (approximately)
+            most likely undetectable logical error. Note, however, that maxSAT solvers
+            can become slower when many distinct weights are provided, so for computing
+            the distance it is better to simply use the defaults weighted=False and
+            weight_scale_factor = 0.
 
         Returns:
             A WCNF file in [WDIMACS format](http://www.maxhs.org/docs/wdimacs.html)
@@ -1814,12 +1815,12 @@ class Circuit:
         Examples:
             >>> import stim
             >>> circuit = stim.Circuit("""
-            ...     X_ERROR(0.1) 0
-            ...     M 0
-            ...     OBSERVABLE_INCLUDE(0) rec[-1]
-            ...     X_ERROR(0.4) 0
-            ...     M 0
-            ...     DETECTOR rec[-1] rec[-2]
+            ...   X_ERROR(0.1) 0
+            ...   M 0
+            ...   OBSERVABLE_INCLUDE(0) rec[-1]
+            ...   X_ERROR(0.4) 0
+            ...   M 0
+            ...   DETECTOR rec[-1] rec[-2]
             ... """)
             >>> print(circuit.shortest_error_problem_as_wcnf_file())
             p wcnf 2 4 5
@@ -1828,16 +1829,15 @@ class Circuit:
             5 -1 0
             5 2 0
 
-            >>>
             >>> print(circuit.shortest_error_problem_as_wcnf_file(
             ...   weighted=True,
-            ...   num_distinct_weights=10
+            ...   weight_scale_factor=1000
             ... ))
-            p wcnf 2 4 41
-            2 -1 0
-            10 -2 0
-            41 -1 0
-            41 2 0
+            p wcnf 2 4 4001
+            185 -1 0
+            1000 -2 0
+            4001 -1 0
+            4001 2 0
         """
     def shortest_graphlike_error(
         self,

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -1776,8 +1776,8 @@ class Circuit:
                 solvers slower.
 
         Returns:
-            A string corresponding to the contents of a WCNF file in the requested
-            format.
+            A string corresponding to the contents of a maxSAT problem file in the
+            requested format.
 
         Examples:
             >>> import stim
@@ -1789,7 +1789,7 @@ class Circuit:
             ...   M 0
             ...   DETECTOR rec[-1] rec[-2]
             ... """)
-            >>> print(circuit.likeliest_error_problem_as_wcnf_file(
+            >>> print(circuit.likeliest_error_sat_problem(
             ...   quantization=1000
             ... ), end='')
             p wcnf 2 4 4001
@@ -2094,8 +2094,8 @@ class Circuit:
                 described here: http://www.maxhs.org/docs/wdimacs.html
 
         Returns:
-            A string corresponding to the contents of a WCNF file in the requested
-            format.
+            A string corresponding to the contents of a maxSAT problem file in the
+            requested format.
 
         Examples:
 

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -1781,14 +1781,14 @@ class Circuit:
 
         Examples:
             >>> import stim
-            >>> circuit = stim.Circuit("""
+            >>> circuit = stim.Circuit('''
             ...   X_ERROR(0.1) 0
             ...   M 0
             ...   OBSERVABLE_INCLUDE(0) rec[-1]
             ...   X_ERROR(0.4) 0
             ...   M 0
             ...   DETECTOR rec[-1] rec[-2]
-            ... """)
+            ... ''')
             >>> print(circuit.likeliest_error_sat_problem(
             ...   quantization=1000
             ... ), end='')
@@ -2099,14 +2099,14 @@ class Circuit:
 
         Examples:
             >>> import stim
-            >>> circuit = stim.Circuit("""
+            >>> circuit = stim.Circuit('''
             ...   X_ERROR(0.1) 0
             ...   M 0
             ...   OBSERVABLE_INCLUDE(0) rec[-1]
             ...   X_ERROR(0.4) 0
             ...   M 0
             ...   DETECTOR rec[-1] rec[-2]
-            ... """)
+            ... ''')
             >>> print(circuit.shortest_error_sat_problem(), end='')
             p wcnf 2 4 5
             1 -1 0

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -1525,6 +1525,71 @@ class Circuit:
                 H 1 0
             ''')
         """
+    def likeliest_error_sat_problem(
+        self,
+        *,
+        quantization: int = 100,
+        format: str = 'WDIMACS',
+    ) -> str:
+        """Makes a maxSAT problem of the circuit's distance, that other tools can solve.
+
+        The output is a string describing the maxSAT problem in WDIMACS format
+        (see https://maxhs.org/docs/wdimacs.html). The optimal solution to the
+        problem is the fault distance of the circuit (the minimum number of error
+        mechanisms that combine to flip any logical observable while producing no
+        detection events).
+
+        There are many tools that can solve maxSAT problems in WDIMACS format.
+        For example, you can download one of the entries in the 2023 maxSAT
+        competition (see https://maxsat-evaluations.github.io/2023), for example
+        CASHWMaxSAT-CorePlus.zip and run it on your problem by running these
+        BASH terminal commands:
+
+            unzip CASHWMaxSAT-CorePlus.zip
+            ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m your_problem.wcnf
+
+        Args:
+            format: Defaults to "WDIMACS", corresponding to WDIMACS format which is
+            described here: http://www.maxhs.org/docs/wdimacs.html
+            weight_bins: Defaults to 1 (unweighted errors). Error probabilities are
+                converted to log-odds and scaled/rounded to be positive integers at
+                most this large. Setting this argument to a larger number results in
+                the solution to the problem being the most likely logical error
+                weighted by probability of its parts, instead of just the one with
+                the fewest parts.
+
+        Returns:
+            A string corresponding to the contents of a WCNF file in the requested
+            format.
+
+        Examples:
+
+        Examples:
+            >>> import stim
+            >>> circuit = stim.Circuit("""
+            ...   X_ERROR(0.1) 0
+            ...   M 0
+            ...   OBSERVABLE_INCLUDE(0) rec[-1]
+            ...   X_ERROR(0.4) 0
+            ...   M 0
+            ...   DETECTOR rec[-1] rec[-2]
+            ... """)
+            >>> print(circuit.shortest_error_problem_as_wcnf_file(), end='')
+            p wcnf 2 4 5
+            1 -1 0
+            1 -2 0
+            5 -1 0
+            5 2 0
+            >>> print(circuit.shortest_error_problem_as_wcnf_file(
+            ...   weighted=True,
+            ...   weight_scale_factor=1000
+            ... ), end='')
+            p wcnf 2 4 4001
+            185 -1 0
+            1000 -2 0
+            4001 -1 0
+            4001 2 0
+        """
     @property
     def num_detectors(
         self,
@@ -1774,43 +1839,43 @@ class Circuit:
             ... )))
             5
         """
-    def shortest_error_problem_as_wcnf_file(
+    def shortest_error_sat_problem(
         self,
         *,
-        weighted: bool = False,
-        weight_scale_factor: int = 0,
+        format: str = 'WDIMACS',
     ) -> str:
-        """Generates a maxSAT problem instance in WDIMACS format whose optimal value is
-        the distance of the protocol, i.e. the minimum weight of any set of errors
-        that forms an undetectable logical error.
-        FYI: here is how you could fetch a solver from the
-        [2023 maxSAT competition](https://maxsat-evaluations.github.io/2023/) and
-        run the solver on a file produced with this method:
-        ```
-        # first download nzip CASHWMaxSAT-CorePlus.zip from
-        # https://maxsat-evaluations.github.io/2023
-        unzip CASHWMaxSAT-CorePlus.zip
-        time ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m problem.wcnf
-        ```
+        """Makes a maxSAT problem of the circuit's distance, that other tools can solve.
+
+        The output is a string describing the maxSAT problem in WDIMACS format
+        (see https://maxhs.org/docs/wdimacs.html). The optimal solution to the
+        problem is the fault distance of the circuit (the minimum number of error
+        mechanisms that combine to flip any logical observable while producing no
+        detection events).
+
+        There are many tools that can solve maxSAT problems in WDIMACS format.
+        For example, you can download one of the entries in the 2023 maxSAT
+        competition (see https://maxsat-evaluations.github.io/2023), for example
+        CASHWMaxSAT-CorePlus.zip and run it on your problem by running these
+        BASH terminal commands:
+
+            unzip CASHWMaxSAT-CorePlus.zip
+            ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m your_problem.wcnf
 
         Args:
-            weighted: Defaults to False (unweighted), so that the problem is to find
-            the minimum size set of errors that leads to an undetectable logical
-            error.
-            weight_scale_factor: Defaults to 0. If weighted==False, must set
-            weight_scale_factor to 0. If weighted==True, weight_scale_factor must be
-            set to a value >= 1. For a weighted problem, the errors will be quantized
-            into integers using this scale factor and the sum of the weights
-            will be minimized rather than the cardinality of the set of errors. For
-            a reasonably large quantization (weight_scale_factor > 100 is often
-            sufficient), the .wcnf file solution should be the (approximately)
-            most likely undetectable logical error. Note, however, that maxSAT solvers
-            can become slower when many distinct weights are provided, so for computing
-            the distance it is better to simply use the defaults weighted=False and
-            weight_scale_factor = 0.
+            format: Defaults to "WDIMACS", corresponding to WDIMACS format which is
+            described here: http://www.maxhs.org/docs/wdimacs.html
+            weight_bins: Defaults to 1 (unweighted errors). Error probabilities are
+                converted to log-odds and scaled/rounded to be positive integers at
+                most this large. Setting this argument to a larger number results in
+                the solution to the problem being the most likely logical error
+                weighted by probability of its parts, instead of just the one with
+                the fewest parts.
 
         Returns:
-            A WCNF file in [WDIMACS format](http://www.maxhs.org/docs/wdimacs.html)
+            A string corresponding to the contents of a WCNF file in the requested
+            format.
+
+        Examples:
 
         Examples:
             >>> import stim

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -1540,17 +1540,34 @@ class Circuit:
         flip any logical observable while producing no detection events).
 
         There are many tools that can solve maxSAT problems in WDIMACS format.
-        For example, you can download one of the entries in the 2023 maxSAT
-        competition (see https://maxsat-evaluations.github.io/2023), for example
-        CASHWMaxSAT-CorePlus.zip and run it on your problem by running these
-        BASH terminal commands:
+        One quick way to get started is to install pysat by running this BASH
+        terminal command:
+
+            pip install python-sat
+
+        Afterwards, you can run the included maxSAT solver "RC2" with this
+        Python code:
+
+            from pysat.examples.rc2 import RC2
+            from pysat.formula import WCNF
+
+            wcnf = WCNF(from_string="p wcnf 1 2 3\n3 -1 0\n3 1 0\n")
+
+            with RC2(wcnf) as rc2:
+            print(rc2.compute())
+            print(rc2.cost)
+
+        Much faster solvers than RC2 are available on the 2023 maxSAT competition
+        website (see https://maxsat-evaluations.github.io/2023), for example
+        CASHWMaxSAT-CorePlus.zip. If you download this solver you can run it on your
+        problem by running these BASH terminal commands:
 
             unzip CASHWMaxSAT-CorePlus.zip
             ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m your_problem.wcnf
 
         Args:
             format: Defaults to "WDIMACS", corresponding to WDIMACS format which is
-            described here: http://www.maxhs.org/docs/wdimacs.html
+                described here: http://www.maxhs.org/docs/wdimacs.html
             quantization: Defaults to 10. Error probabilities are converted to log-odds
                 and scaled/rounded to be positive integers at most this large. Setting
                 this argument to a larger number results in more accurate quantization
@@ -1563,8 +1580,6 @@ class Circuit:
             format.
 
         Examples:
-
-        Examples:
             >>> import stim
             >>> circuit = stim.Circuit("""
             ...   X_ERROR(0.1) 0
@@ -1574,15 +1589,8 @@ class Circuit:
             ...   M 0
             ...   DETECTOR rec[-1] rec[-2]
             ... """)
-            >>> print(circuit.shortest_error_problem_as_wcnf_file(), end='')
-            p wcnf 2 4 5
-            1 -1 0
-            1 -2 0
-            5 -1 0
-            5 2 0
-            >>> print(circuit.shortest_error_problem_as_wcnf_file(
-            ...   weighted=True,
-            ...   weight_scale_factor=1000
+            >>> print(circuit.likeliest_error_problem_as_wcnf_file(
+            ...   quantization=1000
             ... ), end='')
             p wcnf 2 4 4001
             185 -1 0
@@ -1853,17 +1861,34 @@ class Circuit:
         detection events).
 
         There are many tools that can solve maxSAT problems in WDIMACS format.
-        For example, you can download one of the entries in the 2023 maxSAT
-        competition (see https://maxsat-evaluations.github.io/2023), for example
-        CASHWMaxSAT-CorePlus.zip and run it on your problem by running these
-        BASH terminal commands:
+        One quick way to get started is to install pysat by running this BASH
+        terminal command:
+
+            pip install python-sat
+
+        Afterwards, you can run the included maxSAT solver "RC2" with this
+        Python code:
+
+            from pysat.examples.rc2 import RC2
+            from pysat.formula import WCNF
+
+            wcnf = WCNF(from_string="p wcnf 1 2 3\n3 -1 0\n3 1 0\n")
+
+            with RC2(wcnf) as rc2:
+            print(rc2.compute())
+            print(rc2.cost)
+
+        Much faster solvers than RC2 are available on the 2023 maxSAT competition
+        website (see https://maxsat-evaluations.github.io/2023), for example
+        CASHWMaxSAT-CorePlus.zip. If you download this solver you can run it on your
+        problem by running these BASH terminal commands:
 
             unzip CASHWMaxSAT-CorePlus.zip
             ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m your_problem.wcnf
 
         Args:
             format: Defaults to "WDIMACS", corresponding to WDIMACS format which is
-            described here: http://www.maxhs.org/docs/wdimacs.html
+                described here: http://www.maxhs.org/docs/wdimacs.html
 
         Returns:
             A string corresponding to the contents of a WCNF file in the requested
@@ -1881,21 +1906,12 @@ class Circuit:
             ...   M 0
             ...   DETECTOR rec[-1] rec[-2]
             ... """)
-            >>> print(circuit.shortest_error_problem_as_wcnf_file(), end='')
+            >>> print(circuit.shortest_error_sat_problem(), end='')
             p wcnf 2 4 5
             1 -1 0
             1 -2 0
             5 -1 0
             5 2 0
-            >>> print(circuit.shortest_error_problem_as_wcnf_file(
-            ...   weighted=True,
-            ...   weight_scale_factor=1000
-            ... ), end='')
-            p wcnf 2 4 4001
-            185 -1 0
-            1000 -2 0
-            4001 -1 0
-            4001 2 0
         """
     def shortest_graphlike_error(
         self,

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -1539,6 +1539,12 @@ class Circuit:
         problem is the highest likelihood set of error mechanisms that combine to
         flip any logical observable while producing no detection events).
 
+        If there are any errors with probability p > 0.5, they are inverted so
+        that the resulting weight ends up being positive. If there are errors
+        with weight close or equal to 0.5, they can end up with 0 weight meaning
+        that they can be included or not in the solution with no affect on the
+        likelihood.
+
         There are many tools that can solve maxSAT problems in WDIMACS format.
         One quick way to get started is to install pysat by running this BASH
         terminal command:
@@ -1858,7 +1864,9 @@ class Circuit:
         (see https://maxhs.org/docs/wdimacs.html). The optimal solution to the
         problem is the fault distance of the circuit (the minimum number of error
         mechanisms that combine to flip any logical observable while producing no
-        detection events).
+        detection events). This method ignores the probabilities of the error
+        mechanisms since it only cares about minimizing the number of errors
+        triggered.
 
         There are many tools that can solve maxSAT problems in WDIMACS format.
         One quick way to get started is to install pysat by running this BASH

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -1563,11 +1563,12 @@ class Circuit:
             print(rc2.compute())
             print(rc2.cost)
 
-        Much faster solvers than RC2 are available on the 2023 maxSAT competition
-        website (see https://maxsat-evaluations.github.io/2023), for example
-        CASHWMaxSAT-CorePlus.zip. If you download this solver you can run it on your
-        problem by running these BASH terminal commands:
+        Much faster solvers are available online. For example, you can download
+        one of the entries in the 2023 maxSAT competition (see
+        https://maxsat-evaluations.github.io/2023) and run it on your problem by
+        running these BASH terminal commands:
 
+            wget https://maxsat-evaluations.github.io/2023/mse23-solver-src/exact/CASHWMaxSAT-CorePlus.zip
             unzip CASHWMaxSAT-CorePlus.zip
             ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m your_problem.wcnf
 
@@ -1886,11 +1887,12 @@ class Circuit:
             print(rc2.compute())
             print(rc2.cost)
 
-        Much faster solvers than RC2 are available on the 2023 maxSAT competition
-        website (see https://maxsat-evaluations.github.io/2023), for example
-        CASHWMaxSAT-CorePlus.zip. If you download this solver you can run it on your
-        problem by running these BASH terminal commands:
+        Much faster solvers are available online. For example, you can download
+        one of the entries in the 2023 maxSAT competition (see
+        https://maxsat-evaluations.github.io/2023) and run it on your problem by
+        running these BASH terminal commands:
 
+            wget https://maxsat-evaluations.github.io/2023/mse23-solver-src/exact/CASHWMaxSAT-CorePlus.zip
             unzip CASHWMaxSAT-CorePlus.zip
             ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m your_problem.wcnf
 

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -1531,13 +1531,13 @@ class Circuit:
         quantization: int = 100,
         format: str = 'WDIMACS',
     ) -> str:
-        """Makes a maxSAT problem of the circuit's distance, that other tools can solve.
+        """Makes a maxSAT problem of the circuit's most likely undetectable logical
+        error, that other tools can solve.
 
         The output is a string describing the maxSAT problem in WDIMACS format
         (see https://maxhs.org/docs/wdimacs.html). The optimal solution to the
-        problem is the fault distance of the circuit (the minimum number of error
-        mechanisms that combine to flip any logical observable while producing no
-        detection events).
+        problem is the highest likelihood set of error mechanisms that combine to
+        flip any logical observable while producing no detection events).
 
         There are many tools that can solve maxSAT problems in WDIMACS format.
         For example, you can download one of the entries in the 2023 maxSAT
@@ -1551,12 +1551,12 @@ class Circuit:
         Args:
             format: Defaults to "WDIMACS", corresponding to WDIMACS format which is
             described here: http://www.maxhs.org/docs/wdimacs.html
-            weight_bins: Defaults to 1 (unweighted errors). Error probabilities are
-                converted to log-odds and scaled/rounded to be positive integers at
-                most this large. Setting this argument to a larger number results in
-                the solution to the problem being the most likely logical error
-                weighted by probability of its parts, instead of just the one with
-                the fewest parts.
+            quantization: Defaults to 10. Error probabilities are converted to log-odds
+                and scaled/rounded to be positive integers at most this large. Setting
+                this argument to a larger number results in more accurate quantization
+                such that the returned error set should have a likelihood closer to the
+                true most likely solution. This comes at the cost of making some maxSAT
+                solvers slower.
 
         Returns:
             A string corresponding to the contents of a WCNF file in the requested
@@ -1864,12 +1864,6 @@ class Circuit:
         Args:
             format: Defaults to "WDIMACS", corresponding to WDIMACS format which is
             described here: http://www.maxhs.org/docs/wdimacs.html
-            weight_bins: Defaults to 1 (unweighted errors). Error probabilities are
-                converted to log-odds and scaled/rounded to be positive integers at
-                most this large. Setting this argument to a larger number results in
-                the solution to the problem being the most likely logical error
-                weighted by probability of its parts, instead of just the one with
-                the fewest parts.
 
         Returns:
             A string corresponding to the contents of a WCNF file in the requested

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -1783,6 +1783,15 @@ class Circuit:
         """Generates a maxSAT problem instance in WDIMACS format whose optimal value is
         the distance of the protocol, i.e. the minimum weight of any set of errors
         that forms an undetectable logical error.
+        FYI: here is how you could fetch a solver from the
+        [2023 maxSAT competition](https://maxsat-evaluations.github.io/2023/) and
+        run the solver on a file produced with this method:
+        ```
+        # first download nzip CASHWMaxSAT-CorePlus.zip from
+        # https://maxsat-evaluations.github.io/2023
+        unzip CASHWMaxSAT-CorePlus.zip
+        time ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m problem.wcnf
+        ```
 
         Args:
             weighted: Defaults to False (unweighted), so that the problem is to find
@@ -1804,17 +1813,31 @@ class Circuit:
 
         Examples:
             >>> import stim
-            >>> circuit = stim.Circuit.generated(
-            ...     "surface_code:rotated_memory_x",
-            ...     rounds=5,
-            ...     distance=5,
-            ...     after_clifford_depolarization=0.001)
-            >>> print(circuit.shortest_undetectable_logical_error_wcnf(
-                            num_distinct_weights=1))
-            ....
-            >>> print(circuit.shortest_undetectable_logical_error_wcnf(
-                            num_distinct_weights=10))
-            ....
+            >>> circuit = stim.Circuit("""
+            ...     X_ERROR(0.1) 0
+            ...     M 0
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ...     X_ERROR(0.4) 0
+            ...     M 0
+            ...     DETECTOR rec[-1] rec[-2]
+            ... """)
+            >>> print(circuit.shortest_error_problem_as_wcnf_file())
+            p wcnf 2 4 5
+            1 -1 0
+            1 -2 0
+            5 -1 0
+            5 2 0
+
+            >>>
+            >>> print(circuit.shortest_error_problem_as_wcnf_file(
+            ...   weighted=True,
+            ...   num_distinct_weights=10
+            ... ))
+            p wcnf 2 4 41
+            2 -1 0
+            10 -2 0
+            41 -1 0
+            41 2 0
         """
     def shortest_graphlike_error(
         self,

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -1774,6 +1774,48 @@ class Circuit:
             ... )))
             5
         """
+    def shortest_error_problem_as_wcnf_file(
+        self,
+        *,
+        weighted: bool = False,
+        num_distinct_weights: int = 1,
+    ) -> str:
+        """Generates a maxSAT problem instance in WDIMACS format whose optimal value is
+        the distance of the protocol, i.e. the minimum weight of any set of errors
+        that forms an undetectable logical error.
+
+        Args:
+            weighted: Defaults to False (unweighted), so that the problem is to find
+            the minimum size set of errors that leads to an undetectable logical
+            error.
+            num_distinct_weights: Defaults to 1. If weighted==False, must set
+            num_distinct_weights to 1. If weighted==True, num_distinct_weights can be
+            set to a value > 1. For a weighted problem, the errors will be quantized
+            into at most this many distinct weight values and the sum of the weights
+            will be minimized rather than the cardinality of the set of errors. For
+            a reasonably large quantization (num_distinct_weights > 100), the .wcnf
+            file solution should be the (approximately) most likely undetectable
+            logical error. Note, however, that maxSAT solvers often become slower
+            when many distinct weights are provided, so for computing the distance
+            it is better to use the default quantization num_distinct_weights = 1.
+
+        Returns:
+            A WCNF file in [WDIMACS format](http://www.maxhs.org/docs/wdimacs.html)
+
+        Examples:
+            >>> import stim
+            >>> circuit = stim.Circuit.generated(
+            ...     "surface_code:rotated_memory_x",
+            ...     rounds=5,
+            ...     distance=5,
+            ...     after_clifford_depolarization=0.001)
+            >>> print(circuit.shortest_undetectable_logical_error_wcnf(
+                            num_distinct_weights=1))
+            ....
+            >>> print(circuit.shortest_undetectable_logical_error_wcnf(
+                            num_distinct_weights=10))
+            ....
+        """
     def shortest_graphlike_error(
         self,
         *,

--- a/file_lists/source_files_no_main
+++ b/file_lists/source_files_no_main
@@ -77,6 +77,7 @@ src/stim/search/hyper/edge.cc
 src/stim/search/hyper/graph.cc
 src/stim/search/hyper/node.cc
 src/stim/search/hyper/search_state.cc
+src/stim/search/sat/wcnf.cc
 src/stim/simulators/error_analyzer.cc
 src/stim/simulators/error_matcher.cc
 src/stim/simulators/force_streaming.cc

--- a/file_lists/test_files
+++ b/file_lists/test_files
@@ -56,6 +56,7 @@ src/stim/search/hyper/edge.test.cc
 src/stim/search/hyper/graph.test.cc
 src/stim/search/hyper/node.test.cc
 src/stim/search/hyper/search_state.test.cc
+src/stim/search/sat/wcnf.test.cc
 src/stim/simulators/count_determined_measurements.test.cc
 src/stim/simulators/dem_sampler.test.cc
 src/stim/simulators/error_analyzer.test.cc

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -1822,17 +1822,16 @@ class Circuit:
             ...   M 0
             ...   DETECTOR rec[-1] rec[-2]
             ... """)
-            >>> print(circuit.shortest_error_problem_as_wcnf_file())
+            >>> print(circuit.shortest_error_problem_as_wcnf_file(), end='')
             p wcnf 2 4 5
             1 -1 0
             1 -2 0
             5 -1 0
             5 2 0
-
             >>> print(circuit.shortest_error_problem_as_wcnf_file(
             ...   weighted=True,
             ...   weight_scale_factor=1000
-            ... ))
+            ... ), end='')
             p wcnf 2 4 4001
             185 -1 0
             1000 -2 0

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -2098,8 +2098,6 @@ class Circuit:
             requested format.
 
         Examples:
-
-        Examples:
             >>> import stim
             >>> circuit = stim.Circuit("""
             ...   X_ERROR(0.1) 0

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -1778,7 +1778,7 @@ class Circuit:
         self,
         *,
         weighted: bool = False,
-        num_distinct_weights: int = 1,
+        weight_scale_factor: int = 0,
     ) -> str:
         """Generates a maxSAT problem instance in WDIMACS format whose optimal value is
         the distance of the protocol, i.e. the minimum weight of any set of errors
@@ -1797,16 +1797,17 @@ class Circuit:
             weighted: Defaults to False (unweighted), so that the problem is to find
             the minimum size set of errors that leads to an undetectable logical
             error.
-            num_distinct_weights: Defaults to 1. If weighted==False, must set
-            num_distinct_weights to 1. If weighted==True, num_distinct_weights can be
-            set to a value > 1. For a weighted problem, the errors will be quantized
-            into at most this many distinct weight values and the sum of the weights
+            weight_scale_factor: Defaults to 0. If weighted==False, must set
+            weight_scale_factor to 0. If weighted==True, weight_scale_factor must be
+            set to a value >= 1. For a weighted problem, the errors will be quantized
+            into integers using this scale factor and the sum of the weights
             will be minimized rather than the cardinality of the set of errors. For
-            a reasonably large quantization (num_distinct_weights > 100), the .wcnf
-            file solution should be the (approximately) most likely undetectable
-            logical error. Note, however, that maxSAT solvers often become slower
-            when many distinct weights are provided, so for computing the distance
-            it is better to use the default quantization num_distinct_weights = 1.
+            a reasonably large quantization (weight_scale_factor > 100 is often
+            sufficient), the .wcnf file solution should be the (approximately)
+            most likely undetectable logical error. Note, however, that maxSAT solvers
+            can become slower when many distinct weights are provided, so for computing
+            the distance it is better to simply use the defaults weighted=False and
+            weight_scale_factor = 0.
 
         Returns:
             A WCNF file in [WDIMACS format](http://www.maxhs.org/docs/wdimacs.html)
@@ -1814,12 +1815,12 @@ class Circuit:
         Examples:
             >>> import stim
             >>> circuit = stim.Circuit("""
-            ...     X_ERROR(0.1) 0
-            ...     M 0
-            ...     OBSERVABLE_INCLUDE(0) rec[-1]
-            ...     X_ERROR(0.4) 0
-            ...     M 0
-            ...     DETECTOR rec[-1] rec[-2]
+            ...   X_ERROR(0.1) 0
+            ...   M 0
+            ...   OBSERVABLE_INCLUDE(0) rec[-1]
+            ...   X_ERROR(0.4) 0
+            ...   M 0
+            ...   DETECTOR rec[-1] rec[-2]
             ... """)
             >>> print(circuit.shortest_error_problem_as_wcnf_file())
             p wcnf 2 4 5
@@ -1828,16 +1829,15 @@ class Circuit:
             5 -1 0
             5 2 0
 
-            >>>
             >>> print(circuit.shortest_error_problem_as_wcnf_file(
             ...   weighted=True,
-            ...   num_distinct_weights=10
+            ...   weight_scale_factor=1000
             ... ))
-            p wcnf 2 4 41
-            2 -1 0
-            10 -2 0
-            41 -1 0
-            41 2 0
+            p wcnf 2 4 4001
+            185 -1 0
+            1000 -2 0
+            4001 -1 0
+            4001 2 0
         """
     def shortest_graphlike_error(
         self,

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -1776,8 +1776,8 @@ class Circuit:
                 solvers slower.
 
         Returns:
-            A string corresponding to the contents of a WCNF file in the requested
-            format.
+            A string corresponding to the contents of a maxSAT problem file in the
+            requested format.
 
         Examples:
             >>> import stim
@@ -1789,7 +1789,7 @@ class Circuit:
             ...   M 0
             ...   DETECTOR rec[-1] rec[-2]
             ... """)
-            >>> print(circuit.likeliest_error_problem_as_wcnf_file(
+            >>> print(circuit.likeliest_error_sat_problem(
             ...   quantization=1000
             ... ), end='')
             p wcnf 2 4 4001
@@ -2094,8 +2094,8 @@ class Circuit:
                 described here: http://www.maxhs.org/docs/wdimacs.html
 
         Returns:
-            A string corresponding to the contents of a WCNF file in the requested
-            format.
+            A string corresponding to the contents of a maxSAT problem file in the
+            requested format.
 
         Examples:
 

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -1781,14 +1781,14 @@ class Circuit:
 
         Examples:
             >>> import stim
-            >>> circuit = stim.Circuit("""
+            >>> circuit = stim.Circuit('''
             ...   X_ERROR(0.1) 0
             ...   M 0
             ...   OBSERVABLE_INCLUDE(0) rec[-1]
             ...   X_ERROR(0.4) 0
             ...   M 0
             ...   DETECTOR rec[-1] rec[-2]
-            ... """)
+            ... ''')
             >>> print(circuit.likeliest_error_sat_problem(
             ...   quantization=1000
             ... ), end='')
@@ -2099,14 +2099,14 @@ class Circuit:
 
         Examples:
             >>> import stim
-            >>> circuit = stim.Circuit("""
+            >>> circuit = stim.Circuit('''
             ...   X_ERROR(0.1) 0
             ...   M 0
             ...   OBSERVABLE_INCLUDE(0) rec[-1]
             ...   X_ERROR(0.4) 0
             ...   M 0
             ...   DETECTOR rec[-1] rec[-2]
-            ... """)
+            ... ''')
             >>> print(circuit.shortest_error_sat_problem(), end='')
             p wcnf 2 4 5
             1 -1 0

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -1525,6 +1525,71 @@ class Circuit:
                 H 1 0
             ''')
         """
+    def likeliest_error_sat_problem(
+        self,
+        *,
+        quantization: int = 100,
+        format: str = 'WDIMACS',
+    ) -> str:
+        """Makes a maxSAT problem of the circuit's distance, that other tools can solve.
+
+        The output is a string describing the maxSAT problem in WDIMACS format
+        (see https://maxhs.org/docs/wdimacs.html). The optimal solution to the
+        problem is the fault distance of the circuit (the minimum number of error
+        mechanisms that combine to flip any logical observable while producing no
+        detection events).
+
+        There are many tools that can solve maxSAT problems in WDIMACS format.
+        For example, you can download one of the entries in the 2023 maxSAT
+        competition (see https://maxsat-evaluations.github.io/2023), for example
+        CASHWMaxSAT-CorePlus.zip and run it on your problem by running these
+        BASH terminal commands:
+
+            unzip CASHWMaxSAT-CorePlus.zip
+            ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m your_problem.wcnf
+
+        Args:
+            format: Defaults to "WDIMACS", corresponding to WDIMACS format which is
+            described here: http://www.maxhs.org/docs/wdimacs.html
+            weight_bins: Defaults to 1 (unweighted errors). Error probabilities are
+                converted to log-odds and scaled/rounded to be positive integers at
+                most this large. Setting this argument to a larger number results in
+                the solution to the problem being the most likely logical error
+                weighted by probability of its parts, instead of just the one with
+                the fewest parts.
+
+        Returns:
+            A string corresponding to the contents of a WCNF file in the requested
+            format.
+
+        Examples:
+
+        Examples:
+            >>> import stim
+            >>> circuit = stim.Circuit("""
+            ...   X_ERROR(0.1) 0
+            ...   M 0
+            ...   OBSERVABLE_INCLUDE(0) rec[-1]
+            ...   X_ERROR(0.4) 0
+            ...   M 0
+            ...   DETECTOR rec[-1] rec[-2]
+            ... """)
+            >>> print(circuit.shortest_error_problem_as_wcnf_file(), end='')
+            p wcnf 2 4 5
+            1 -1 0
+            1 -2 0
+            5 -1 0
+            5 2 0
+            >>> print(circuit.shortest_error_problem_as_wcnf_file(
+            ...   weighted=True,
+            ...   weight_scale_factor=1000
+            ... ), end='')
+            p wcnf 2 4 4001
+            185 -1 0
+            1000 -2 0
+            4001 -1 0
+            4001 2 0
+        """
     @property
     def num_detectors(
         self,
@@ -1774,43 +1839,43 @@ class Circuit:
             ... )))
             5
         """
-    def shortest_error_problem_as_wcnf_file(
+    def shortest_error_sat_problem(
         self,
         *,
-        weighted: bool = False,
-        weight_scale_factor: int = 0,
+        format: str = 'WDIMACS',
     ) -> str:
-        """Generates a maxSAT problem instance in WDIMACS format whose optimal value is
-        the distance of the protocol, i.e. the minimum weight of any set of errors
-        that forms an undetectable logical error.
-        FYI: here is how you could fetch a solver from the
-        [2023 maxSAT competition](https://maxsat-evaluations.github.io/2023/) and
-        run the solver on a file produced with this method:
-        ```
-        # first download nzip CASHWMaxSAT-CorePlus.zip from
-        # https://maxsat-evaluations.github.io/2023
-        unzip CASHWMaxSAT-CorePlus.zip
-        time ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m problem.wcnf
-        ```
+        """Makes a maxSAT problem of the circuit's distance, that other tools can solve.
+
+        The output is a string describing the maxSAT problem in WDIMACS format
+        (see https://maxhs.org/docs/wdimacs.html). The optimal solution to the
+        problem is the fault distance of the circuit (the minimum number of error
+        mechanisms that combine to flip any logical observable while producing no
+        detection events).
+
+        There are many tools that can solve maxSAT problems in WDIMACS format.
+        For example, you can download one of the entries in the 2023 maxSAT
+        competition (see https://maxsat-evaluations.github.io/2023), for example
+        CASHWMaxSAT-CorePlus.zip and run it on your problem by running these
+        BASH terminal commands:
+
+            unzip CASHWMaxSAT-CorePlus.zip
+            ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m your_problem.wcnf
 
         Args:
-            weighted: Defaults to False (unweighted), so that the problem is to find
-            the minimum size set of errors that leads to an undetectable logical
-            error.
-            weight_scale_factor: Defaults to 0. If weighted==False, must set
-            weight_scale_factor to 0. If weighted==True, weight_scale_factor must be
-            set to a value >= 1. For a weighted problem, the errors will be quantized
-            into integers using this scale factor and the sum of the weights
-            will be minimized rather than the cardinality of the set of errors. For
-            a reasonably large quantization (weight_scale_factor > 100 is often
-            sufficient), the .wcnf file solution should be the (approximately)
-            most likely undetectable logical error. Note, however, that maxSAT solvers
-            can become slower when many distinct weights are provided, so for computing
-            the distance it is better to simply use the defaults weighted=False and
-            weight_scale_factor = 0.
+            format: Defaults to "WDIMACS", corresponding to WDIMACS format which is
+            described here: http://www.maxhs.org/docs/wdimacs.html
+            weight_bins: Defaults to 1 (unweighted errors). Error probabilities are
+                converted to log-odds and scaled/rounded to be positive integers at
+                most this large. Setting this argument to a larger number results in
+                the solution to the problem being the most likely logical error
+                weighted by probability of its parts, instead of just the one with
+                the fewest parts.
 
         Returns:
-            A WCNF file in [WDIMACS format](http://www.maxhs.org/docs/wdimacs.html)
+            A string corresponding to the contents of a WCNF file in the requested
+            format.
+
+        Examples:
 
         Examples:
             >>> import stim

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -1540,17 +1540,34 @@ class Circuit:
         flip any logical observable while producing no detection events).
 
         There are many tools that can solve maxSAT problems in WDIMACS format.
-        For example, you can download one of the entries in the 2023 maxSAT
-        competition (see https://maxsat-evaluations.github.io/2023), for example
-        CASHWMaxSAT-CorePlus.zip and run it on your problem by running these
-        BASH terminal commands:
+        One quick way to get started is to install pysat by running this BASH
+        terminal command:
+
+            pip install python-sat
+
+        Afterwards, you can run the included maxSAT solver "RC2" with this
+        Python code:
+
+            from pysat.examples.rc2 import RC2
+            from pysat.formula import WCNF
+
+            wcnf = WCNF(from_string="p wcnf 1 2 3\n3 -1 0\n3 1 0\n")
+
+            with RC2(wcnf) as rc2:
+            print(rc2.compute())
+            print(rc2.cost)
+
+        Much faster solvers than RC2 are available on the 2023 maxSAT competition
+        website (see https://maxsat-evaluations.github.io/2023), for example
+        CASHWMaxSAT-CorePlus.zip. If you download this solver you can run it on your
+        problem by running these BASH terminal commands:
 
             unzip CASHWMaxSAT-CorePlus.zip
             ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m your_problem.wcnf
 
         Args:
             format: Defaults to "WDIMACS", corresponding to WDIMACS format which is
-            described here: http://www.maxhs.org/docs/wdimacs.html
+                described here: http://www.maxhs.org/docs/wdimacs.html
             quantization: Defaults to 10. Error probabilities are converted to log-odds
                 and scaled/rounded to be positive integers at most this large. Setting
                 this argument to a larger number results in more accurate quantization
@@ -1563,8 +1580,6 @@ class Circuit:
             format.
 
         Examples:
-
-        Examples:
             >>> import stim
             >>> circuit = stim.Circuit("""
             ...   X_ERROR(0.1) 0
@@ -1574,15 +1589,8 @@ class Circuit:
             ...   M 0
             ...   DETECTOR rec[-1] rec[-2]
             ... """)
-            >>> print(circuit.shortest_error_problem_as_wcnf_file(), end='')
-            p wcnf 2 4 5
-            1 -1 0
-            1 -2 0
-            5 -1 0
-            5 2 0
-            >>> print(circuit.shortest_error_problem_as_wcnf_file(
-            ...   weighted=True,
-            ...   weight_scale_factor=1000
+            >>> print(circuit.likeliest_error_problem_as_wcnf_file(
+            ...   quantization=1000
             ... ), end='')
             p wcnf 2 4 4001
             185 -1 0
@@ -1853,17 +1861,34 @@ class Circuit:
         detection events).
 
         There are many tools that can solve maxSAT problems in WDIMACS format.
-        For example, you can download one of the entries in the 2023 maxSAT
-        competition (see https://maxsat-evaluations.github.io/2023), for example
-        CASHWMaxSAT-CorePlus.zip and run it on your problem by running these
-        BASH terminal commands:
+        One quick way to get started is to install pysat by running this BASH
+        terminal command:
+
+            pip install python-sat
+
+        Afterwards, you can run the included maxSAT solver "RC2" with this
+        Python code:
+
+            from pysat.examples.rc2 import RC2
+            from pysat.formula import WCNF
+
+            wcnf = WCNF(from_string="p wcnf 1 2 3\n3 -1 0\n3 1 0\n")
+
+            with RC2(wcnf) as rc2:
+            print(rc2.compute())
+            print(rc2.cost)
+
+        Much faster solvers than RC2 are available on the 2023 maxSAT competition
+        website (see https://maxsat-evaluations.github.io/2023), for example
+        CASHWMaxSAT-CorePlus.zip. If you download this solver you can run it on your
+        problem by running these BASH terminal commands:
 
             unzip CASHWMaxSAT-CorePlus.zip
             ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m your_problem.wcnf
 
         Args:
             format: Defaults to "WDIMACS", corresponding to WDIMACS format which is
-            described here: http://www.maxhs.org/docs/wdimacs.html
+                described here: http://www.maxhs.org/docs/wdimacs.html
 
         Returns:
             A string corresponding to the contents of a WCNF file in the requested
@@ -1881,21 +1906,12 @@ class Circuit:
             ...   M 0
             ...   DETECTOR rec[-1] rec[-2]
             ... """)
-            >>> print(circuit.shortest_error_problem_as_wcnf_file(), end='')
+            >>> print(circuit.shortest_error_sat_problem(), end='')
             p wcnf 2 4 5
             1 -1 0
             1 -2 0
             5 -1 0
             5 2 0
-            >>> print(circuit.shortest_error_problem_as_wcnf_file(
-            ...   weighted=True,
-            ...   weight_scale_factor=1000
-            ... ), end='')
-            p wcnf 2 4 4001
-            185 -1 0
-            1000 -2 0
-            4001 -1 0
-            4001 2 0
         """
     def shortest_graphlike_error(
         self,

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -1539,6 +1539,12 @@ class Circuit:
         problem is the highest likelihood set of error mechanisms that combine to
         flip any logical observable while producing no detection events).
 
+        If there are any errors with probability p > 0.5, they are inverted so
+        that the resulting weight ends up being positive. If there are errors
+        with weight close or equal to 0.5, they can end up with 0 weight meaning
+        that they can be included or not in the solution with no affect on the
+        likelihood.
+
         There are many tools that can solve maxSAT problems in WDIMACS format.
         One quick way to get started is to install pysat by running this BASH
         terminal command:
@@ -1858,7 +1864,9 @@ class Circuit:
         (see https://maxhs.org/docs/wdimacs.html). The optimal solution to the
         problem is the fault distance of the circuit (the minimum number of error
         mechanisms that combine to flip any logical observable while producing no
-        detection events).
+        detection events). This method ignores the probabilities of the error
+        mechanisms since it only cares about minimizing the number of errors
+        triggered.
 
         There are many tools that can solve maxSAT problems in WDIMACS format.
         One quick way to get started is to install pysat by running this BASH

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -1563,11 +1563,12 @@ class Circuit:
             print(rc2.compute())
             print(rc2.cost)
 
-        Much faster solvers than RC2 are available on the 2023 maxSAT competition
-        website (see https://maxsat-evaluations.github.io/2023), for example
-        CASHWMaxSAT-CorePlus.zip. If you download this solver you can run it on your
-        problem by running these BASH terminal commands:
+        Much faster solvers are available online. For example, you can download
+        one of the entries in the 2023 maxSAT competition (see
+        https://maxsat-evaluations.github.io/2023) and run it on your problem by
+        running these BASH terminal commands:
 
+            wget https://maxsat-evaluations.github.io/2023/mse23-solver-src/exact/CASHWMaxSAT-CorePlus.zip
             unzip CASHWMaxSAT-CorePlus.zip
             ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m your_problem.wcnf
 
@@ -1886,11 +1887,12 @@ class Circuit:
             print(rc2.compute())
             print(rc2.cost)
 
-        Much faster solvers than RC2 are available on the 2023 maxSAT competition
-        website (see https://maxsat-evaluations.github.io/2023), for example
-        CASHWMaxSAT-CorePlus.zip. If you download this solver you can run it on your
-        problem by running these BASH terminal commands:
+        Much faster solvers are available online. For example, you can download
+        one of the entries in the 2023 maxSAT competition (see
+        https://maxsat-evaluations.github.io/2023) and run it on your problem by
+        running these BASH terminal commands:
 
+            wget https://maxsat-evaluations.github.io/2023/mse23-solver-src/exact/CASHWMaxSAT-CorePlus.zip
             unzip CASHWMaxSAT-CorePlus.zip
             ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m your_problem.wcnf
 

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -1531,13 +1531,13 @@ class Circuit:
         quantization: int = 100,
         format: str = 'WDIMACS',
     ) -> str:
-        """Makes a maxSAT problem of the circuit's distance, that other tools can solve.
+        """Makes a maxSAT problem of the circuit's most likely undetectable logical
+        error, that other tools can solve.
 
         The output is a string describing the maxSAT problem in WDIMACS format
         (see https://maxhs.org/docs/wdimacs.html). The optimal solution to the
-        problem is the fault distance of the circuit (the minimum number of error
-        mechanisms that combine to flip any logical observable while producing no
-        detection events).
+        problem is the highest likelihood set of error mechanisms that combine to
+        flip any logical observable while producing no detection events).
 
         There are many tools that can solve maxSAT problems in WDIMACS format.
         For example, you can download one of the entries in the 2023 maxSAT
@@ -1551,12 +1551,12 @@ class Circuit:
         Args:
             format: Defaults to "WDIMACS", corresponding to WDIMACS format which is
             described here: http://www.maxhs.org/docs/wdimacs.html
-            weight_bins: Defaults to 1 (unweighted errors). Error probabilities are
-                converted to log-odds and scaled/rounded to be positive integers at
-                most this large. Setting this argument to a larger number results in
-                the solution to the problem being the most likely logical error
-                weighted by probability of its parts, instead of just the one with
-                the fewest parts.
+            quantization: Defaults to 10. Error probabilities are converted to log-odds
+                and scaled/rounded to be positive integers at most this large. Setting
+                this argument to a larger number results in more accurate quantization
+                such that the returned error set should have a likelihood closer to the
+                true most likely solution. This comes at the cost of making some maxSAT
+                solvers slower.
 
         Returns:
             A string corresponding to the contents of a WCNF file in the requested
@@ -1864,12 +1864,6 @@ class Circuit:
         Args:
             format: Defaults to "WDIMACS", corresponding to WDIMACS format which is
             described here: http://www.maxhs.org/docs/wdimacs.html
-            weight_bins: Defaults to 1 (unweighted errors). Error probabilities are
-                converted to log-odds and scaled/rounded to be positive integers at
-                most this large. Setting this argument to a larger number results in
-                the solution to the problem being the most likely logical error
-                weighted by probability of its parts, instead of just the one with
-                the fewest parts.
 
         Returns:
             A string corresponding to the contents of a WCNF file in the requested

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -1783,6 +1783,15 @@ class Circuit:
         """Generates a maxSAT problem instance in WDIMACS format whose optimal value is
         the distance of the protocol, i.e. the minimum weight of any set of errors
         that forms an undetectable logical error.
+        FYI: here is how you could fetch a solver from the
+        [2023 maxSAT competition](https://maxsat-evaluations.github.io/2023/) and
+        run the solver on a file produced with this method:
+        ```
+        # first download nzip CASHWMaxSAT-CorePlus.zip from
+        # https://maxsat-evaluations.github.io/2023
+        unzip CASHWMaxSAT-CorePlus.zip
+        time ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m problem.wcnf
+        ```
 
         Args:
             weighted: Defaults to False (unweighted), so that the problem is to find
@@ -1804,17 +1813,31 @@ class Circuit:
 
         Examples:
             >>> import stim
-            >>> circuit = stim.Circuit.generated(
-            ...     "surface_code:rotated_memory_x",
-            ...     rounds=5,
-            ...     distance=5,
-            ...     after_clifford_depolarization=0.001)
-            >>> print(circuit.shortest_undetectable_logical_error_wcnf(
-                            num_distinct_weights=1))
-            ....
-            >>> print(circuit.shortest_undetectable_logical_error_wcnf(
-                            num_distinct_weights=10))
-            ....
+            >>> circuit = stim.Circuit("""
+            ...     X_ERROR(0.1) 0
+            ...     M 0
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ...     X_ERROR(0.4) 0
+            ...     M 0
+            ...     DETECTOR rec[-1] rec[-2]
+            ... """)
+            >>> print(circuit.shortest_error_problem_as_wcnf_file())
+            p wcnf 2 4 5
+            1 -1 0
+            1 -2 0
+            5 -1 0
+            5 2 0
+
+            >>>
+            >>> print(circuit.shortest_error_problem_as_wcnf_file(
+            ...   weighted=True,
+            ...   num_distinct_weights=10
+            ... ))
+            p wcnf 2 4 41
+            2 -1 0
+            10 -2 0
+            41 -1 0
+            41 2 0
         """
     def shortest_graphlike_error(
         self,

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -1774,6 +1774,48 @@ class Circuit:
             ... )))
             5
         """
+    def shortest_error_problem_as_wcnf_file(
+        self,
+        *,
+        weighted: bool = False,
+        num_distinct_weights: int = 1,
+    ) -> str:
+        """Generates a maxSAT problem instance in WDIMACS format whose optimal value is
+        the distance of the protocol, i.e. the minimum weight of any set of errors
+        that forms an undetectable logical error.
+
+        Args:
+            weighted: Defaults to False (unweighted), so that the problem is to find
+            the minimum size set of errors that leads to an undetectable logical
+            error.
+            num_distinct_weights: Defaults to 1. If weighted==False, must set
+            num_distinct_weights to 1. If weighted==True, num_distinct_weights can be
+            set to a value > 1. For a weighted problem, the errors will be quantized
+            into at most this many distinct weight values and the sum of the weights
+            will be minimized rather than the cardinality of the set of errors. For
+            a reasonably large quantization (num_distinct_weights > 100), the .wcnf
+            file solution should be the (approximately) most likely undetectable
+            logical error. Note, however, that maxSAT solvers often become slower
+            when many distinct weights are provided, so for computing the distance
+            it is better to use the default quantization num_distinct_weights = 1.
+
+        Returns:
+            A WCNF file in [WDIMACS format](http://www.maxhs.org/docs/wdimacs.html)
+
+        Examples:
+            >>> import stim
+            >>> circuit = stim.Circuit.generated(
+            ...     "surface_code:rotated_memory_x",
+            ...     rounds=5,
+            ...     distance=5,
+            ...     after_clifford_depolarization=0.001)
+            >>> print(circuit.shortest_undetectable_logical_error_wcnf(
+                            num_distinct_weights=1))
+            ....
+            >>> print(circuit.shortest_undetectable_logical_error_wcnf(
+                            num_distinct_weights=10))
+            ....
+        """
     def shortest_graphlike_error(
         self,
         *,

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -2021,17 +2021,16 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
                 ...   M 0
                 ...   DETECTOR rec[-1] rec[-2]
                 ... """)
-                >>> print(circuit.shortest_error_problem_as_wcnf_file())
+                >>> print(circuit.shortest_error_problem_as_wcnf_file(), end='')
                 p wcnf 2 4 5
                 1 -1 0
                 1 -2 0
                 5 -1 0
                 5 2 0
-
                 >>> print(circuit.shortest_error_problem_as_wcnf_file(
                 ...   weighted=True,
                 ...   weight_scale_factor=1000
-                ... ))
+                ... ), end='')
                 p wcnf 2 4 4001
                 185 -1 0
                 1000 -2 0

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -1989,7 +1989,9 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
             (see https://maxhs.org/docs/wdimacs.html). The optimal solution to the
             problem is the fault distance of the circuit (the minimum number of error
             mechanisms that combine to flip any logical observable while producing no
-            detection events).
+            detection events). This method ignores the probabilities of the error
+            mechanisms since it only cares about minimizing the number of errors
+            triggered.
 
             There are many tools that can solve maxSAT problems in WDIMACS format.
             One quick way to get started is to install pysat by running this BASH
@@ -2060,6 +2062,12 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
             (see https://maxhs.org/docs/wdimacs.html). The optimal solution to the
             problem is the highest likelihood set of error mechanisms that combine to
             flip any logical observable while producing no detection events).
+
+            If there are any errors with probability p > 0.5, they are inverted so
+            that the resulting weight ends up being positive. If there are errors
+            with weight close or equal to 0.5, they can end up with 0 weight meaning
+            that they can be included or not in the solution with no affect on the
+            likelihood.
 
             There are many tools that can solve maxSAT problems in WDIMACS format.
             One quick way to get started is to install pysat by running this BASH

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -2112,8 +2112,6 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
                 requested format.
 
             Examples:
-
-            Examples:
                 >>> import stim
                 >>> circuit = stim.Circuit("""
                 ...   X_ERROR(0.1) 0

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -2108,8 +2108,8 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
                     described here: http://www.maxhs.org/docs/wdimacs.html
 
             Returns:
-                A string corresponding to the contents of a WCNF file in the requested
-                format.
+                A string corresponding to the contents of a maxSAT problem file in the
+                requested format.
 
             Examples:
 
@@ -2191,8 +2191,8 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
                     solvers slower.
 
             Returns:
-                A string corresponding to the contents of a WCNF file in the requested
-                format.
+                A string corresponding to the contents of a maxSAT problem file in the
+                requested format.
 
             Examples:
                 >>> import stim
@@ -2204,7 +2204,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
                 ...   M 0
                 ...   DETECTOR rec[-1] rec[-2]
                 ... """)
-                >>> print(circuit.likeliest_error_problem_as_wcnf_file(
+                >>> print(circuit.likeliest_error_sat_problem(
                 ...   quantization=1000
                 ... ), end='')
                 p wcnf 2 4 4001

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -2113,14 +2113,14 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
 
             Examples:
                 >>> import stim
-                >>> circuit = stim.Circuit("""
+                >>> circuit = stim.Circuit('''
                 ...   X_ERROR(0.1) 0
                 ...   M 0
                 ...   OBSERVABLE_INCLUDE(0) rec[-1]
                 ...   X_ERROR(0.4) 0
                 ...   M 0
                 ...   DETECTOR rec[-1] rec[-2]
-                ... """)
+                ... ''')
                 >>> print(circuit.shortest_error_sat_problem(), end='')
                 p wcnf 2 4 5
                 1 -1 0
@@ -2194,14 +2194,14 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
 
             Examples:
                 >>> import stim
-                >>> circuit = stim.Circuit("""
+                >>> circuit = stim.Circuit('''
                 ...   X_ERROR(0.1) 0
                 ...   M 0
                 ...   OBSERVABLE_INCLUDE(0) rec[-1]
                 ...   X_ERROR(0.4) 0
                 ...   M 0
                 ...   DETECTOR rec[-1] rec[-2]
-                ... """)
+                ... ''')
                 >>> print(circuit.likeliest_error_sat_problem(
                 ...   quantization=1000
                 ... ), end='')

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -2011,11 +2011,12 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
                 print(rc2.compute())  
                 print(rc2.cost)
 
-            Much faster solvers than RC2 are available on the 2023 maxSAT competition
-            website (see https://maxsat-evaluations.github.io/2023), for example
-            CASHWMaxSAT-CorePlus.zip. If you download this solver you can run it on your
-            problem by running these BASH terminal commands:
+            Much faster solvers are available online. For example, you can download
+            one of the entries in the 2023 maxSAT competition (see
+            https://maxsat-evaluations.github.io/2023) and run it on your problem by
+            running these BASH terminal commands:
 
+                wget https://maxsat-evaluations.github.io/2023/mse23-solver-src/exact/CASHWMaxSAT-CorePlus.zip
                 unzip CASHWMaxSAT-CorePlus.zip
                 ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m your_problem.wcnf
 
@@ -2087,11 +2088,12 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
                 print(rc2.compute())  
                 print(rc2.cost)
 
-            Much faster solvers than RC2 are available on the 2023 maxSAT competition
-            website (see https://maxsat-evaluations.github.io/2023), for example
-            CASHWMaxSAT-CorePlus.zip. If you download this solver you can run it on your
-            problem by running these BASH terminal commands:
+            Much faster solvers are available online. For example, you can download
+            one of the entries in the 2023 maxSAT competition (see
+            https://maxsat-evaluations.github.io/2023) and run it on your problem by
+            running these BASH terminal commands:
 
+                wget https://maxsat-evaluations.github.io/2023/mse23-solver-src/exact/CASHWMaxSAT-CorePlus.zip
                 unzip CASHWMaxSAT-CorePlus.zip
                 ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m your_problem.wcnf
 

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -80,9 +80,14 @@ std::vector<ExplainedError> py_find_undetectable_logical_error(
     return ErrorMatcher::explain_errors_from_circuit(self, &filter, reduce_to_representative);
 }
 
-std::string py_shortest_error_problem_as_wcnf_file(const Circuit& self, bool weighted, size_t weight_scale_factor) {
+std::string py_shortest_error_sat_problem(const Circuit &self, std::string format) {
     DetectorErrorModel dem = ErrorAnalyzer::circuit_to_detector_error_model(self, false, true, false, 1, false, false);
-    return stim::shortest_error_problem_as_wcnf_file(dem, weighted, weight_scale_factor);
+    return stim::shortest_error_sat_problem(dem, format);
+}
+
+std::string py_likeliest_error_sat_problem(const Circuit &self, int quantization, std::string format) {
+    DetectorErrorModel dem = ErrorAnalyzer::circuit_to_detector_error_model(self, false, true, false, 1, false, false);
+    return stim::likeliest_error_sat_problem(dem, quantization, format);
 }
 
 void circuit_append(
@@ -1973,43 +1978,43 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
             .data());
 
     c.def(
-        "shortest_error_problem_as_wcnf_file",
-        &py_shortest_error_problem_as_wcnf_file,
+        "shortest_error_sat_problem",
+        &py_shortest_error_sat_problem,
         pybind11::kw_only(),
-        pybind11::arg("weighted") = false,
-        pybind11::arg("weight_scale_factor") = 0,
+        pybind11::arg("format") = "WDIMACS",
         clean_doc_string(R"DOC(
-            Generates a maxSAT problem instance in WDIMACS format whose optimal value is
-            the distance of the protocol, i.e. the minimum weight of any set of errors
-            that forms an undetectable logical error.
-            FYI: here is how you could fetch a solver from the
-            [2023 maxSAT competition](https://maxsat-evaluations.github.io/2023/) and
-            run the solver on a file produced with this method:
-            ```
-            # first download nzip CASHWMaxSAT-CorePlus.zip from 
-            # https://maxsat-evaluations.github.io/2023
-            unzip CASHWMaxSAT-CorePlus.zip
-            time ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m problem.wcnf 
-            ```
+            Makes a maxSAT problem of the circuit's distance, that other tools can solve.
+
+            The output is a string describing the maxSAT problem in WDIMACS format
+            (see https://maxhs.org/docs/wdimacs.html). The optimal solution to the
+            problem is the fault distance of the circuit (the minimum number of error
+            mechanisms that combine to flip any logical observable while producing no
+            detection events).
+
+            There are many tools that can solve maxSAT problems in WDIMACS format.
+            For example, you can download one of the entries in the 2023 maxSAT
+            competition (see https://maxsat-evaluations.github.io/2023), for example
+            CASHWMaxSAT-CorePlus.zip and run it on your problem by running these
+            BASH terminal commands:
+
+                unzip CASHWMaxSAT-CorePlus.zip
+                ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m your_problem.wcnf
 
             Args:
-                weighted: Defaults to False (unweighted), so that the problem is to find
-                the minimum size set of errors that leads to an undetectable logical
-                error.
-                weight_scale_factor: Defaults to 0. If weighted==False, must set
-                weight_scale_factor to 0. If weighted==True, weight_scale_factor must be
-                set to a value >= 1. For a weighted problem, the errors will be quantized
-                into integers using this scale factor and the sum of the weights
-                will be minimized rather than the cardinality of the set of errors. For
-                a reasonably large quantization (weight_scale_factor > 100 is often
-                sufficient), the .wcnf file solution should be the (approximately)
-                most likely undetectable logical error. Note, however, that maxSAT solvers
-                can become slower when many distinct weights are provided, so for computing
-                the distance it is better to simply use the defaults weighted=False and
-                weight_scale_factor = 0.
+                format: Defaults to "WDIMACS", corresponding to WDIMACS format which is
+                described here: http://www.maxhs.org/docs/wdimacs.html
+                weight_bins: Defaults to 1 (unweighted errors). Error probabilities are
+                    converted to log-odds and scaled/rounded to be positive integers at
+                    most this large. Setting this argument to a larger number results in
+                    the solution to the problem being the most likely logical error
+                    weighted by probability of its parts, instead of just the one with
+                    the fewest parts.
 
             Returns:
-                A WCNF file in [WDIMACS format](http://www.maxhs.org/docs/wdimacs.html)
+                A string corresponding to the contents of a WCNF file in the requested
+                format.
+
+            Examples:
 
             Examples:
                 >>> import stim
@@ -2038,6 +2043,141 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
                 4001 2 0
         )DOC")
             .data());
+
+    c.def(
+        "likeliest_error_sat_problem",
+        &py_likeliest_error_sat_problem,
+        pybind11::kw_only(),
+        pybind11::arg("quantization") = 100,
+        pybind11::arg("format") = "WDIMACS",
+        clean_doc_string(R"DOC(
+            Makes a maxSAT problem of the circuit's distance, that other tools can solve.
+
+            The output is a string describing the maxSAT problem in WDIMACS format
+            (see https://maxhs.org/docs/wdimacs.html). The optimal solution to the
+            problem is the fault distance of the circuit (the minimum number of error
+            mechanisms that combine to flip any logical observable while producing no
+            detection events).
+
+            There are many tools that can solve maxSAT problems in WDIMACS format.
+            For example, you can download one of the entries in the 2023 maxSAT
+            competition (see https://maxsat-evaluations.github.io/2023), for example
+            CASHWMaxSAT-CorePlus.zip and run it on your problem by running these
+            BASH terminal commands:
+
+                unzip CASHWMaxSAT-CorePlus.zip
+                ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m your_problem.wcnf
+
+            Args:
+                format: Defaults to "WDIMACS", corresponding to WDIMACS format which is
+                described here: http://www.maxhs.org/docs/wdimacs.html
+                weight_bins: Defaults to 1 (unweighted errors). Error probabilities are
+                    converted to log-odds and scaled/rounded to be positive integers at
+                    most this large. Setting this argument to a larger number results in
+                    the solution to the problem being the most likely logical error
+                    weighted by probability of its parts, instead of just the one with
+                    the fewest parts.
+
+            Returns:
+                A string corresponding to the contents of a WCNF file in the requested
+                format.
+
+            Examples:
+
+            Examples:
+                >>> import stim
+                >>> circuit = stim.Circuit("""
+                ...   X_ERROR(0.1) 0
+                ...   M 0
+                ...   OBSERVABLE_INCLUDE(0) rec[-1]
+                ...   X_ERROR(0.4) 0
+                ...   M 0
+                ...   DETECTOR rec[-1] rec[-2]
+                ... """)
+                >>> print(circuit.shortest_error_problem_as_wcnf_file(), end='')
+                p wcnf 2 4 5
+                1 -1 0
+                1 -2 0
+                5 -1 0
+                5 2 0
+                >>> print(circuit.shortest_error_problem_as_wcnf_file(
+                ...   weighted=True,
+                ...   weight_scale_factor=1000
+                ... ), end='')
+                p wcnf 2 4 4001
+                185 -1 0
+                1000 -2 0
+                4001 -1 0
+                4001 2 0
+        )DOC")
+            .data());
+
+    // c.def(
+    //     "shortest_error_problem_as_wcnf_file",
+    //     &py_shortest_error_problem_as_wcnf_file,
+    //     pybind11::kw_only(),
+    //     pybind11::arg("weighted") = false,
+    //     pybind11::arg("weight_scale_factor") = 0,
+    //     clean_doc_string(R"DOC(
+    //         Makes a maxSAT problem of the circuit's distance, that other tools can solve.
+
+    //         The output is a string describing the maxSAT problem in WDIMACS format
+    //         (see https://maxhs.org/docs/wdimacs.html). The optimal solution to the
+    //         problem is the fault distance of the circuit (the minimum number of error
+    //         mechanisms that combine to flip any logical observable while producing no
+    //         detection events).
+
+    //         There are many tools that can solve maxSAT problems in WDIMACS format.
+    //         For example, you can download one of the entries in the 2023 maxSAT
+    //         competition (see https://maxsat-evaluations.github.io/2023), for example
+    //         CASHWMaxSAT-CorePlus.zip and run it on your problem by running these
+    //         BASH terminal commands:
+
+    //             unzip CASHWMaxSAT-CorePlus.zip
+    //             ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m your_problem.wcnf
+
+    //         Args:
+    //             format: Defaults to "WDIMACS", corresponding to WDIMACS format which is
+    //             described here: http://www.maxhs.org/docs/wdimacs.html
+    //             weight_bins: Defaults to 1 (unweighted errors). Error probabilities are
+    //                 converted to log-odds and scaled/rounded to be positive integers at
+    //                 most this large. Setting this argument to a larger number results in
+    //                 the solution to the problem being the most likely logical error
+    //                 weighted by probability of its parts, instead of just the one with
+    //                 the fewest parts.
+
+    //         Returns:
+    //             A string corresponding to the contents of a WCNF file in the requested
+    //             format.
+
+    //         Examples:
+    //             >>> import stim
+    //             >>> circuit = stim.Circuit("""
+    //             ...   X_ERROR(0.1) 0
+    //             ...   M 0
+    //             ...   OBSERVABLE_INCLUDE(0) rec[-1]
+    //             ...   X_ERROR(0.4) 0
+    //             ...   M 0
+    //             ...   DETECTOR rec[-1] rec[-2]
+    //             ... """)
+    //             >>> print(circuit.shortest_error_problem_as_wcnf_file(), end='')
+    //             p wcnf 2 4 5
+    //             1 -1 0
+    //             1 -2 0
+    //             5 -1 0
+    //             5 2 0
+    //             >>> print(circuit.shortest_error_problem_as_wcnf_file(
+    //             ...   weighted=True,
+    //             ...   weight_scale_factor=1000
+    //             ... ), end='')
+    //             p wcnf 2 4 4001
+    //             185 -1 0
+    //             1000 -2 0
+    //             4001 -1 0
+    //             4001 2 0
+    //     )DOC")
+    //         .data());
+
     c.def(
         "explain_detector_error_model_errors",
         [](const Circuit &self,

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -1992,17 +1992,34 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
             detection events).
 
             There are many tools that can solve maxSAT problems in WDIMACS format.
-            For example, you can download one of the entries in the 2023 maxSAT
-            competition (see https://maxsat-evaluations.github.io/2023), for example
-            CASHWMaxSAT-CorePlus.zip and run it on your problem by running these
-            BASH terminal commands:
+            One quick way to get started is to install pysat by running this BASH
+            terminal command:
+
+                pip install python-sat
+
+            Afterwards, you can run the included maxSAT solver "RC2" with this
+            Python code:
+
+                from pysat.examples.rc2 import RC2
+                from pysat.formula import WCNF
+
+                wcnf = WCNF(from_string="p wcnf 1 2 3\n3 -1 0\n3 1 0\n")
+
+                with RC2(wcnf) as rc2:
+                print(rc2.compute())  
+                print(rc2.cost)
+
+            Much faster solvers than RC2 are available on the 2023 maxSAT competition
+            website (see https://maxsat-evaluations.github.io/2023), for example
+            CASHWMaxSAT-CorePlus.zip. If you download this solver you can run it on your
+            problem by running these BASH terminal commands:
 
                 unzip CASHWMaxSAT-CorePlus.zip
                 ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m your_problem.wcnf
 
             Args:
                 format: Defaults to "WDIMACS", corresponding to WDIMACS format which is
-                described here: http://www.maxhs.org/docs/wdimacs.html
+                    described here: http://www.maxhs.org/docs/wdimacs.html
 
             Returns:
                 A string corresponding to the contents of a WCNF file in the requested
@@ -2020,21 +2037,12 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
                 ...   M 0
                 ...   DETECTOR rec[-1] rec[-2]
                 ... """)
-                >>> print(circuit.shortest_error_problem_as_wcnf_file(), end='')
+                >>> print(circuit.shortest_error_sat_problem(), end='')
                 p wcnf 2 4 5
                 1 -1 0
                 1 -2 0
                 5 -1 0
                 5 2 0
-                >>> print(circuit.shortest_error_problem_as_wcnf_file(
-                ...   weighted=True,
-                ...   weight_scale_factor=1000
-                ... ), end='')
-                p wcnf 2 4 4001
-                185 -1 0
-                1000 -2 0
-                4001 -1 0
-                4001 2 0
         )DOC")
             .data());
 
@@ -2054,17 +2062,34 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
             flip any logical observable while producing no detection events).
 
             There are many tools that can solve maxSAT problems in WDIMACS format.
-            For example, you can download one of the entries in the 2023 maxSAT
-            competition (see https://maxsat-evaluations.github.io/2023), for example
-            CASHWMaxSAT-CorePlus.zip and run it on your problem by running these
-            BASH terminal commands:
+            One quick way to get started is to install pysat by running this BASH
+            terminal command:
+
+                pip install python-sat
+
+            Afterwards, you can run the included maxSAT solver "RC2" with this
+            Python code:
+
+                from pysat.examples.rc2 import RC2
+                from pysat.formula import WCNF
+
+                wcnf = WCNF(from_string="p wcnf 1 2 3\n3 -1 0\n3 1 0\n")
+
+                with RC2(wcnf) as rc2:
+                print(rc2.compute())  
+                print(rc2.cost)
+
+            Much faster solvers than RC2 are available on the 2023 maxSAT competition
+            website (see https://maxsat-evaluations.github.io/2023), for example
+            CASHWMaxSAT-CorePlus.zip. If you download this solver you can run it on your
+            problem by running these BASH terminal commands:
 
                 unzip CASHWMaxSAT-CorePlus.zip
                 ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m your_problem.wcnf
 
             Args:
                 format: Defaults to "WDIMACS", corresponding to WDIMACS format which is
-                described here: http://www.maxhs.org/docs/wdimacs.html
+                    described here: http://www.maxhs.org/docs/wdimacs.html
                 quantization: Defaults to 10. Error probabilities are converted to log-odds
                     and scaled/rounded to be positive integers at most this large. Setting
                     this argument to a larger number results in more accurate quantization
@@ -2077,8 +2102,6 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
                 format.
 
             Examples:
-
-            Examples:
                 >>> import stim
                 >>> circuit = stim.Circuit("""
                 ...   X_ERROR(0.1) 0
@@ -2088,15 +2111,8 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
                 ...   M 0
                 ...   DETECTOR rec[-1] rec[-2]
                 ... """)
-                >>> print(circuit.shortest_error_problem_as_wcnf_file(), end='')
-                p wcnf 2 4 5
-                1 -1 0
-                1 -2 0
-                5 -1 0
-                5 2 0
-                >>> print(circuit.shortest_error_problem_as_wcnf_file(
-                ...   weighted=True,
-                ...   weight_scale_factor=1000
+                >>> print(circuit.likeliest_error_problem_as_wcnf_file(
+                ...   quantization=1000
                 ... ), end='')
                 p wcnf 2 4 4001
                 185 -1 0

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -2003,12 +2003,6 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
             Args:
                 format: Defaults to "WDIMACS", corresponding to WDIMACS format which is
                 described here: http://www.maxhs.org/docs/wdimacs.html
-                weight_bins: Defaults to 1 (unweighted errors). Error probabilities are
-                    converted to log-odds and scaled/rounded to be positive integers at
-                    most this large. Setting this argument to a larger number results in
-                    the solution to the problem being the most likely logical error
-                    weighted by probability of its parts, instead of just the one with
-                    the fewest parts.
 
             Returns:
                 A string corresponding to the contents of a WCNF file in the requested
@@ -2051,13 +2045,13 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
         pybind11::arg("quantization") = 100,
         pybind11::arg("format") = "WDIMACS",
         clean_doc_string(R"DOC(
-            Makes a maxSAT problem of the circuit's distance, that other tools can solve.
+            Makes a maxSAT problem of the circuit's most likely undetectable logical
+            error, that other tools can solve.
 
             The output is a string describing the maxSAT problem in WDIMACS format
             (see https://maxhs.org/docs/wdimacs.html). The optimal solution to the
-            problem is the fault distance of the circuit (the minimum number of error
-            mechanisms that combine to flip any logical observable while producing no
-            detection events).
+            problem is the highest likelihood set of error mechanisms that combine to
+            flip any logical observable while producing no detection events).
 
             There are many tools that can solve maxSAT problems in WDIMACS format.
             For example, you can download one of the entries in the 2023 maxSAT
@@ -2071,12 +2065,12 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
             Args:
                 format: Defaults to "WDIMACS", corresponding to WDIMACS format which is
                 described here: http://www.maxhs.org/docs/wdimacs.html
-                weight_bins: Defaults to 1 (unweighted errors). Error probabilities are
-                    converted to log-odds and scaled/rounded to be positive integers at
-                    most this large. Setting this argument to a larger number results in
-                    the solution to the problem being the most likely logical error
-                    weighted by probability of its parts, instead of just the one with
-                    the fewest parts.
+                quantization: Defaults to 10. Error probabilities are converted to log-odds
+                    and scaled/rounded to be positive integers at most this large. Setting
+                    this argument to a larger number results in more accurate quantization
+                    such that the returned error set should have a likelihood closer to the
+                    true most likely solution. This comes at the cost of making some maxSAT
+                    solvers slower.
 
             Returns:
                 A string corresponding to the contents of a WCNF file in the requested
@@ -2111,72 +2105,6 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
                 4001 2 0
         )DOC")
             .data());
-
-    // c.def(
-    //     "shortest_error_problem_as_wcnf_file",
-    //     &py_shortest_error_problem_as_wcnf_file,
-    //     pybind11::kw_only(),
-    //     pybind11::arg("weighted") = false,
-    //     pybind11::arg("weight_scale_factor") = 0,
-    //     clean_doc_string(R"DOC(
-    //         Makes a maxSAT problem of the circuit's distance, that other tools can solve.
-
-    //         The output is a string describing the maxSAT problem in WDIMACS format
-    //         (see https://maxhs.org/docs/wdimacs.html). The optimal solution to the
-    //         problem is the fault distance of the circuit (the minimum number of error
-    //         mechanisms that combine to flip any logical observable while producing no
-    //         detection events).
-
-    //         There are many tools that can solve maxSAT problems in WDIMACS format.
-    //         For example, you can download one of the entries in the 2023 maxSAT
-    //         competition (see https://maxsat-evaluations.github.io/2023), for example
-    //         CASHWMaxSAT-CorePlus.zip and run it on your problem by running these
-    //         BASH terminal commands:
-
-    //             unzip CASHWMaxSAT-CorePlus.zip
-    //             ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m your_problem.wcnf
-
-    //         Args:
-    //             format: Defaults to "WDIMACS", corresponding to WDIMACS format which is
-    //             described here: http://www.maxhs.org/docs/wdimacs.html
-    //             weight_bins: Defaults to 1 (unweighted errors). Error probabilities are
-    //                 converted to log-odds and scaled/rounded to be positive integers at
-    //                 most this large. Setting this argument to a larger number results in
-    //                 the solution to the problem being the most likely logical error
-    //                 weighted by probability of its parts, instead of just the one with
-    //                 the fewest parts.
-
-    //         Returns:
-    //             A string corresponding to the contents of a WCNF file in the requested
-    //             format.
-
-    //         Examples:
-    //             >>> import stim
-    //             >>> circuit = stim.Circuit("""
-    //             ...   X_ERROR(0.1) 0
-    //             ...   M 0
-    //             ...   OBSERVABLE_INCLUDE(0) rec[-1]
-    //             ...   X_ERROR(0.4) 0
-    //             ...   M 0
-    //             ...   DETECTOR rec[-1] rec[-2]
-    //             ... """)
-    //             >>> print(circuit.shortest_error_problem_as_wcnf_file(), end='')
-    //             p wcnf 2 4 5
-    //             1 -1 0
-    //             1 -2 0
-    //             5 -1 0
-    //             5 2 0
-    //             >>> print(circuit.shortest_error_problem_as_wcnf_file(
-    //             ...   weighted=True,
-    //             ...   weight_scale_factor=1000
-    //             ... ), end='')
-    //             p wcnf 2 4 4001
-    //             185 -1 0
-    //             1000 -2 0
-    //             4001 -1 0
-    //             4001 2 0
-    //     )DOC")
-    //         .data());
 
     c.def(
         "explain_detector_error_model_errors",

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -1986,7 +1986,8 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
             [2023 maxSAT competition](https://maxsat-evaluations.github.io/2023/) and
             run the solver on a file produced with this method:
             ```
-            wget https://maxsat-evaluations.github.io/2023/mse23-solver-src/exact/CASHWMaxSAT-CorePlus.zip
+            # first download nzip CASHWMaxSAT-CorePlus.zip from 
+            # https://maxsat-evaluations.github.io/2023
             unzip CASHWMaxSAT-CorePlus.zip
             time ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m problem.wcnf 
             ```

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -80,9 +80,9 @@ std::vector<ExplainedError> py_find_undetectable_logical_error(
     return ErrorMatcher::explain_errors_from_circuit(self, &filter, reduce_to_representative);
 }
 
-std::string py_shortest_error_problem_as_wcnf_file(const Circuit& self, bool weighted, size_t num_distinct_weights) {
+std::string py_shortest_error_problem_as_wcnf_file(const Circuit& self, bool weighted, size_t weight_scale_factor) {
     DetectorErrorModel dem = ErrorAnalyzer::circuit_to_detector_error_model(self, false, true, false, 1, false, false);
-    return stim::shortest_error_problem_as_wcnf_file(dem, weighted, num_distinct_weights);
+    return stim::shortest_error_problem_as_wcnf_file(dem, weighted, weight_scale_factor);
 }
 
 void circuit_append(
@@ -1977,7 +1977,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
         &py_shortest_error_problem_as_wcnf_file,
         pybind11::kw_only(),
         pybind11::arg("weighted") = false,
-        pybind11::arg("num_distinct_weights") = 1,
+        pybind11::arg("weight_scale_factor") = 0,
         clean_doc_string(R"DOC(
             Generates a maxSAT problem instance in WDIMACS format whose optimal value is
             the distance of the protocol, i.e. the minimum weight of any set of errors
@@ -1996,16 +1996,17 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
                 weighted: Defaults to False (unweighted), so that the problem is to find
                 the minimum size set of errors that leads to an undetectable logical
                 error.
-                num_distinct_weights: Defaults to 1. If weighted==False, must set
-                num_distinct_weights to 1. If weighted==True, num_distinct_weights can be
-                set to a value > 1. For a weighted problem, the errors will be quantized
-                into at most this many distinct weight values and the sum of the weights
+                weight_scale_factor: Defaults to 0. If weighted==False, must set
+                weight_scale_factor to 0. If weighted==True, weight_scale_factor must be
+                set to a value >= 1. For a weighted problem, the errors will be quantized
+                into integers using this scale factor and the sum of the weights
                 will be minimized rather than the cardinality of the set of errors. For
-                a reasonably large quantization (num_distinct_weights > 100), the .wcnf
-                file solution should be the (approximately) most likely undetectable
-                logical error. Note, however, that maxSAT solvers often become slower
-                when many distinct weights are provided, so for computing the distance
-                it is better to use the default quantization num_distinct_weights = 1.
+                a reasonably large quantization (weight_scale_factor > 100 is often
+                sufficient), the .wcnf file solution should be the (approximately)
+                most likely undetectable logical error. Note, however, that maxSAT solvers
+                can become slower when many distinct weights are provided, so for computing
+                the distance it is better to simply use the defaults weighted=False and
+                weight_scale_factor = 0.
 
             Returns:
                 A WCNF file in [WDIMACS format](http://www.maxhs.org/docs/wdimacs.html)
@@ -2013,12 +2014,12 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
             Examples:
                 >>> import stim
                 >>> circuit = stim.Circuit("""
-                ...     X_ERROR(0.1) 0
-                ...     M 0
-                ...     OBSERVABLE_INCLUDE(0) rec[-1]
-                ...     X_ERROR(0.4) 0
-                ...     M 0
-                ...     DETECTOR rec[-1] rec[-2]
+                ...   X_ERROR(0.1) 0
+                ...   M 0
+                ...   OBSERVABLE_INCLUDE(0) rec[-1]
+                ...   X_ERROR(0.4) 0
+                ...   M 0
+                ...   DETECTOR rec[-1] rec[-2]
                 ... """)
                 >>> print(circuit.shortest_error_problem_as_wcnf_file())
                 p wcnf 2 4 5
@@ -2027,16 +2028,15 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
                 5 -1 0
                 5 2 0
 
-                >>> 
                 >>> print(circuit.shortest_error_problem_as_wcnf_file(
                 ...   weighted=True,
-                ...   num_distinct_weights=10
+                ...   weight_scale_factor=1000
                 ... ))
-                p wcnf 2 4 41
-                2 -1 0
-                10 -2 0
-                41 -1 0
-                41 2 0
+                p wcnf 2 4 4001
+                185 -1 0
+                1000 -2 0
+                4001 -1 0
+                4001 2 0
         )DOC")
             .data());
     c.def(

--- a/src/stim/circuit/circuit_pybind_test.py
+++ b/src/stim/circuit/circuit_pybind_test.py
@@ -827,6 +827,19 @@ def test_search_for_undetectable_logical_errors_msgs():
             dont_explore_detection_event_sets_with_size_above=4,
         )
 
+def test_shortest_undetectable_logical_error_wcnf():
+    c = stim.Circuit("""
+        X_ERROR(0.1) 0
+        M 0
+        OBSERVABLE_INCLUDE(0) rec[-1]
+        X_ERROR(0.4) 0
+        M 0
+        DETECTOR rec[-1] rec[-2]
+    """)
+    wcnf_str = c.shortest_undetectable_logical_error_wcnf()
+    assert wcnf_str == 'p wcnf 2 3 4\n1 -1 0\n1 -2 0\n4 2 0\n'
+    wcnf_str = c.shortest_undetectable_logical_error_wcnf(num_distinct_weights=2)
+    assert wcnf_str == 'p wcnf 2 3 7\n1 -1 0\n2 -2 0\n7 2 0\n'
 
 def test_shortest_graphlike_error_ignore():
     c = stim.Circuit("""

--- a/src/stim/circuit/circuit_pybind_test.py
+++ b/src/stim/circuit/circuit_pybind_test.py
@@ -837,11 +837,19 @@ def test_shortest_error_problem_as_wcnf_file():
         DETECTOR rec[-1] rec[-2]
     """)
     wcnf_str = c.shortest_error_problem_as_wcnf_file()
-    print(wcnf_str)
     assert wcnf_str == 'p wcnf 2 4 5\n1 -1 0\n1 -2 0\n5 -1 0\n5 2 0\n'
-    wcnf_str = c.shortest_error_problem_as_wcnf_file(num_distinct_weights=2)
-    print(wcnf_str)
+    wcnf_str = c.shortest_error_problem_as_wcnf_file(weighted=True, num_distinct_weights=2)
     assert wcnf_str == 'p wcnf 2 4 9\n1 -1 0\n2 -2 0\n9 -1 0\n9 2 0\n'
+    c = stim.Circuit("""
+        X_ERROR(0.1) 0
+        M 0
+        OBSERVABLE_INCLUDE(0) rec[-1]
+        X_ERROR(0.7) 0
+        M 0
+        DETECTOR rec[-1] rec[-2]
+    """)
+    wcnf_str = c.shortest_error_problem_as_wcnf_file(weighted=True)
+    assert wcnf_str == 'p wcnf 2 4 5\n1 1 0\n1 -2 0\n5 -1 0\n5 2 0\n'
 
 def test_shortest_graphlike_error_ignore():
     c = stim.Circuit("""

--- a/src/stim/circuit/circuit_pybind_test.py
+++ b/src/stim/circuit/circuit_pybind_test.py
@@ -838,8 +838,8 @@ def test_shortest_error_problem_as_wcnf_file():
     """)
     wcnf_str = c.shortest_error_problem_as_wcnf_file()
     assert wcnf_str == 'p wcnf 2 4 5\n1 -1 0\n1 -2 0\n5 -1 0\n5 2 0\n'
-    wcnf_str = c.shortest_error_problem_as_wcnf_file(weighted=True, num_distinct_weights=2)
-    assert wcnf_str == 'p wcnf 2 4 9\n1 -1 0\n2 -2 0\n9 -1 0\n9 2 0\n'
+    wcnf_str = c.shortest_error_problem_as_wcnf_file(weighted=True, weight_scale_factor=100)
+    assert wcnf_str == 'p wcnf 2 4 401\n18 -1 0\n100 -2 0\n401 -1 0\n401 2 0\n'
     c = stim.Circuit("""
         X_ERROR(0.1) 0
         M 0
@@ -848,8 +848,8 @@ def test_shortest_error_problem_as_wcnf_file():
         M 0
         DETECTOR rec[-1] rec[-2]
     """)
-    wcnf_str = c.shortest_error_problem_as_wcnf_file(weighted=True)
-    assert wcnf_str == 'p wcnf 2 4 5\n1 1 0\n1 -2 0\n5 -1 0\n5 2 0\n'
+    with pytest.raises(ValueError, match='for weighted problems, weight_scale_factor must be >= 1'):
+      wcnf_str = c.shortest_error_problem_as_wcnf_file(weighted=True)
 
 def test_shortest_graphlike_error_ignore():
     c = stim.Circuit("""

--- a/src/stim/circuit/circuit_pybind_test.py
+++ b/src/stim/circuit/circuit_pybind_test.py
@@ -827,7 +827,8 @@ def test_search_for_undetectable_logical_errors_msgs():
             dont_explore_detection_event_sets_with_size_above=4,
         )
 
-def test_shortest_error_problem_as_wcnf_file():
+
+def test_shortest_error_sat_problem_unrecognized_format():
     c = stim.Circuit("""
         X_ERROR(0.1) 0
         M 0
@@ -836,20 +837,36 @@ def test_shortest_error_problem_as_wcnf_file():
         M 0
         DETECTOR rec[-1] rec[-2]
     """)
-    wcnf_str = c.shortest_error_problem_as_wcnf_file()
-    assert wcnf_str == 'p wcnf 2 4 5\n1 -1 0\n1 -2 0\n5 -1 0\n5 2 0\n'
-    wcnf_str = c.shortest_error_problem_as_wcnf_file(weighted=True, weight_scale_factor=100)
-    assert wcnf_str == 'p wcnf 2 4 401\n18 -1 0\n100 -2 0\n401 -1 0\n401 2 0\n'
+    with pytest.raises(ValueError, match='Unsupported format'):
+      sat_str = c.shortest_error_sat_problem(format='unsupported format name')
+
+
+def test_shortest_error_sat_problem():
     c = stim.Circuit("""
         X_ERROR(0.1) 0
         M 0
         OBSERVABLE_INCLUDE(0) rec[-1]
-        X_ERROR(0.7) 0
+        X_ERROR(0.4) 0
         M 0
         DETECTOR rec[-1] rec[-2]
     """)
-    with pytest.raises(ValueError, match='for weighted problems, weight_scale_factor must be >= 1'):
-      wcnf_str = c.shortest_error_problem_as_wcnf_file(weighted=True)
+    sat_str = c.shortest_error_sat_problem()
+    assert sat_str == 'p wcnf 2 4 5\n1 -1 0\n1 -2 0\n5 -1 0\n5 2 0\n'
+
+
+def test_likeliest_error_sat_problem():
+    c = stim.Circuit("""
+        X_ERROR(0.1) 0
+        M 0
+        OBSERVABLE_INCLUDE(0) rec[-1]
+        X_ERROR(0.4) 0
+        M 0
+        DETECTOR rec[-1] rec[-2]
+    """)
+    sat_str = c.likeliest_error_sat_problem(quantization=100)
+    print(sat_str)
+    assert sat_str == 'p wcnf 2 4 401\n18 -1 0\n100 -2 0\n401 -1 0\n401 2 0\n'
+
 
 def test_shortest_graphlike_error_ignore():
     c = stim.Circuit("""

--- a/src/stim/circuit/circuit_pybind_test.py
+++ b/src/stim/circuit/circuit_pybind_test.py
@@ -827,7 +827,7 @@ def test_search_for_undetectable_logical_errors_msgs():
             dont_explore_detection_event_sets_with_size_above=4,
         )
 
-def test_shortest_undetectable_logical_error_wcnf():
+def test_shortest_error_problem_as_wcnf_file():
     c = stim.Circuit("""
         X_ERROR(0.1) 0
         M 0
@@ -836,9 +836,11 @@ def test_shortest_undetectable_logical_error_wcnf():
         M 0
         DETECTOR rec[-1] rec[-2]
     """)
-    wcnf_str = c.shortest_undetectable_logical_error_wcnf()
+    wcnf_str = c.shortest_error_problem_as_wcnf_file()
+    print(wcnf_str)
     assert wcnf_str == 'p wcnf 2 4 5\n1 -1 0\n1 -2 0\n5 -1 0\n5 2 0\n'
-    wcnf_str = c.shortest_undetectable_logical_error_wcnf(num_distinct_weights=2)
+    wcnf_str = c.shortest_error_problem_as_wcnf_file(num_distinct_weights=2)
+    print(wcnf_str)
     assert wcnf_str == 'p wcnf 2 4 9\n1 -1 0\n2 -2 0\n9 -1 0\n9 2 0\n'
 
 def test_shortest_graphlike_error_ignore():

--- a/src/stim/circuit/circuit_pybind_test.py
+++ b/src/stim/circuit/circuit_pybind_test.py
@@ -837,9 +837,9 @@ def test_shortest_undetectable_logical_error_wcnf():
         DETECTOR rec[-1] rec[-2]
     """)
     wcnf_str = c.shortest_undetectable_logical_error_wcnf()
-    assert wcnf_str == 'p wcnf 2 3 4\n1 -1 0\n1 -2 0\n4 2 0\n'
+    assert wcnf_str == 'p wcnf 2 4 5\n1 -1 0\n1 -2 0\n5 -1 0\n5 2 0\n'
     wcnf_str = c.shortest_undetectable_logical_error_wcnf(num_distinct_weights=2)
-    assert wcnf_str == 'p wcnf 2 3 7\n1 -1 0\n2 -2 0\n7 2 0\n'
+    assert wcnf_str == 'p wcnf 2 4 9\n1 -1 0\n2 -2 0\n9 -1 0\n9 2 0\n'
 
 def test_shortest_graphlike_error_ignore():
     c = stim.Circuit("""

--- a/src/stim/cmd/command_help.cc
+++ b/src/stim/cmd/command_help.cc
@@ -69,8 +69,13 @@ std::string stim::clean_doc_string(const char *c, bool allow_too_long) {
             }
             line_length++;
         }
+        const char *start_of_line = result.c_str() + result.size() - line_length - 1;
+        if (strstr(start_of_line, "\"\"\"") != nullptr) {
+            std::stringstream ss;
+            ss << "Docstring line contains \"\"\" (please use ''' instead):\n" << start_of_line << "\n";
+            throw std::invalid_argument(ss.str());
+        }
         if (!allow_too_long && line_length > 80) {
-            const char *start_of_line = result.c_str() + result.size() - line_length - 1;
             if (memcmp(start_of_line, "@signature", strlen("@signature")) != 0 &&
                 memcmp(start_of_line, "@overload", strlen("@overload")) != 0 &&
                 strstr(start_of_line, "https://") == nullptr) {

--- a/src/stim/cmd/command_help.cc
+++ b/src/stim/cmd/command_help.cc
@@ -73,7 +73,7 @@ std::string stim::clean_doc_string(const char *c, bool allow_too_long) {
             const char *start_of_line = result.c_str() + result.size() - line_length - 1;
             if (memcmp(start_of_line, "@signature", strlen("@signature")) != 0 &&
                 memcmp(start_of_line, "@overload", strlen("@overload")) != 0 &&
-                memcmp(start_of_line, "https://", strlen("https://")) != 0) {
+                strstr(start_of_line, "https://") == nullptr) {
                 std::stringstream ss;
                 ss << "Docstring line has length " << line_length << " > 80:\n"
                    << start_of_line << std::string(80, '^') << "\n";

--- a/src/stim/search/sat/wcnf.cc
+++ b/src/stim/search/sat/wcnf.cc
@@ -180,7 +180,7 @@ std::string sat_problem_as_wcnf_string(const DetectorErrorModel& model, bool wei
     size_t num_observables = model.count_observables();
     size_t num_detectors = model.count_detectors();
     size_t num_errors = model.count_errors();
-    if (num_observables == 0 or num_detectors == 0 or num_errors == 0) {
+    if (num_observables == 0 or num_errors == 0) {
         return UNSAT_WCNF_STR;
     }
 

--- a/src/stim/search/sat/wcnf.cc
+++ b/src/stim/search/sat/wcnf.cc
@@ -196,7 +196,7 @@ std::string sat_problem_as_wcnf_string(const DetectorErrorModel& model, bool wei
 
     size_t error_index = 0;
     model.iter_flatten_error_instructions([&](const DemInstruction& e) {
-        if (e.arg_data[0] != 0) {
+        if (!weighted or e.arg_data[0] != 0) {
             BoolRef err_x = errors_activated[error_index];
             // Add parity contribution to the detectors and observables
             for (const auto& t : e.target_data) {
@@ -232,7 +232,7 @@ std::string sat_problem_as_wcnf_string(const DetectorErrorModel& model, bool wei
                 // For unweighted search the error should be soft clause should be that
                 // the error is inactive.
                 clause.add_var(~err_x);
-                clause.weight = -std::log(p / (1 - p));
+                clause.weight = 1.0;
                 instance.add_clause(clause);
             }
         }

--- a/src/stim/search/sat/wcnf.cc
+++ b/src/stim/search/sat/wcnf.cc
@@ -208,6 +208,15 @@ std::string stim::shortest_undetectable_logical_error_wcnf(const DetectorErrorMo
       }
       ++error_index;
   });
+  assert(error_index == num_errors);
+
+  // Add a hard clause for each detector to be inactive
+  for (size_t d=0; d<num_detectors; ++d) {
+      Clause clause;
+      if (detectors_activated[d].variable == BOOL_LITERAL_FALSE) continue;
+      clause.add_var(~detectors_activated[d]);
+      instance.add_clause(clause);
+  }
 
   // Add a hard clause for any observable to be flipped
   Clause clause;

--- a/src/stim/search/sat/wcnf.cc
+++ b/src/stim/search/sat/wcnf.cc
@@ -1,0 +1,220 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include "stim/search/sat/wcnf.h"
+
+
+using namespace stim;
+
+typedef double Weight;
+constexpr Weight HARD_CLAUSE_WEIGHT = -1.0;
+
+constexpr size_t BOOL_LITERAL_FALSE = SIZE_MAX - 1;
+constexpr size_t BOOL_LITERAL_TRUE = SIZE_MAX;
+struct BoolRef {
+  size_t variable = BOOL_LITERAL_FALSE;
+  bool negated = false;
+  BoolRef operator~() const {
+    return {variable, !negated};
+  }
+  static BoolRef False() {
+    return {BOOL_LITERAL_FALSE, false};
+  }
+  static BoolRef True() {
+    return {BOOL_LITERAL_TRUE, false};
+  }
+};
+
+struct Clause {
+  std::vector<BoolRef> vars;
+  Weight weight = HARD_CLAUSE_WEIGHT;
+  void add_var(BoolRef x) {
+    vars.push_back(x);
+  }
+};
+
+struct MaxSATInstance {
+  size_t num_variables = 0;
+  Weight max_weight = 0;
+  std::vector<Clause> clauses;
+  BoolRef new_bool() {
+    return {num_variables++};
+  }
+  void add_clause(Clause& clause) {
+    if (clause.weight != HARD_CLAUSE_WEIGHT) {
+      if (clause.weight <= 0) {
+        throw std::invalid_argument("Clauses must have positive weight or HARD_CLAUSE_WEIGHT.");
+      }
+      max_weight = std::max(max_weight, clause.weight);
+    }
+    clauses.push_back(clause);
+  }
+  BoolRef Xor(BoolRef& x, BoolRef& y) {
+    if (x.variable == BOOL_LITERAL_FALSE) {
+      return y;
+    }
+    if (x.variable == BOOL_LITERAL_TRUE) {
+      return ~y;
+    }
+    if (y.variable == BOOL_LITERAL_FALSE) {
+      return x;
+    }
+    if (y.variable == BOOL_LITERAL_TRUE) {
+      return ~x;
+    }
+    BoolRef z = new_bool();
+    // Forbid strings (x, y, z) such that z != XOR(x, y)
+    {
+      Clause clause;
+      // hard clause (x, y, z) != (0, 0, 1)
+      clause.add_var(x);
+      clause.add_var(y);
+      clause.add_var(~z);
+      add_clause(clause);
+    }
+    {
+      Clause clause;
+      // hard clause (x, y, z) != (0, 1, 0)
+      clause.add_var(x);
+      clause.add_var(~y);
+      clause.add_var(z);
+      add_clause(clause);
+    }
+    {
+      Clause clause;
+      // hard clause (x, y, z) != (1, 0, 0)
+      clause.add_var(~x);
+      clause.add_var(y);
+      clause.add_var(z);
+      add_clause(clause);
+    }
+    {
+      Clause clause;
+      // hard clause (x, y, z) != (1, 1, 1)
+      clause.add_var(~x);
+      clause.add_var(~y);
+      clause.add_var(~z);
+      add_clause(clause);
+    }
+    return z;
+  }
+
+  size_t quantized_weight(size_t num_distinct_weights, size_t top, Weight weight) {
+    if (weight == HARD_CLAUSE_WEIGHT) {
+      return top;
+    }
+    return std::max(1ul, (size_t)std::round(weight / max_weight * (double)num_distinct_weights));
+  }
+
+  std::string to_wdimacs(size_t num_distinct_weights=1) {
+    if (num_distinct_weights < 1) {
+      throw std::invalid_argument("There must be at least 1 distinct weight value");
+    }
+    // 'top' is a special weight used to indicate a hard clause.
+    // Should be at least the sum of the weights of all soft clauses plus 1.
+    size_t top = 1 + num_distinct_weights * clauses.size();
+
+    // WDIMACS header format: p wcnf nbvar nbclauses top
+    // see http://www.maxhs.org/docs/wdimacs.html
+    std::stringstream ss;
+    ss << "p wcnf "<< num_variables << " "<<clauses.size() << " " << top << "\n";
+
+    // Add clauses, 1 on each line.
+    for (const auto& clause : clauses) {
+      // WDIMACS clause format: weight var1 var2 ...
+      // To show negation of a variable, the index should be negated.
+      ss << quantized_weight(num_distinct_weights, top, clause.weight);
+      for (size_t i=0; i<clause.vars.size(); ++i) {
+        BoolRef var = clause.vars[i];
+        // Variables are 1-indexed
+        if (var.negated) {
+          ss << " -" << (var.variable + 1);
+        } else {
+          ss << " " << (var.variable + 1);
+        }
+      }
+      // Each clause ends with 0
+      ss << " 0\n";
+    }
+    return ss.str();
+  }
+};
+
+std::string stim::shortest_undetectable_logical_error_wcnf(const DetectorErrorModel &model, size_t num_distinct_weights) {
+  MaxSATInstance inst;
+
+  size_t num_observables = model.count_observables();
+  size_t num_detectors = model.count_detectors();
+  size_t num_errors = model.count_errors();
+  if (num_observables == 0 or num_detectors == 0 or num_errors == 0) {
+    std::stringstream err_msg;
+    err_msg << "Failed to find any logical errors.";
+    if (num_observables == 0) {
+        err_msg << "\n    WARNING: NO OBSERVABLES. The circuit or detector error model didn't define any observables, "
+                   "making it vacuously impossible to find a logical error.";
+    }
+    if (num_detectors == 0) {
+        err_msg << "\n    WARNING: NO DETECTORS. The circuit or detector error model didn't define any detectors.";
+    }
+    if (num_errors == 0) {
+        err_msg << "\n    WARNING: NO ERRORS. The circuit or detector error model didn't include any errors, making it "
+                   "vacuously impossible to find a logical error.";
+    }
+    throw std::invalid_argument(err_msg.str());
+  }
+  if (num_distinct_weights == 0) {
+    throw std::invalid_argument("num_distinct_weights must be >= 1");
+  }
+
+  MaxSATInstance instance;
+  // Create a boolean variable for each error, which indicates whether it is activated.
+  std::vector<BoolRef> errors_activated;
+  for (size_t i=0; i<num_errors; ++i) {
+    errors_activated.push_back(instance.new_bool());
+  }
+
+  std::vector<BoolRef> detectors_activated(num_detectors, BoolRef::False());
+  std::vector<BoolRef> observables_flipped(num_observables, BoolRef::False());
+
+  size_t error_index = 0;
+  model.iter_flatten_error_instructions([&](const DemInstruction &e) {
+      if (e.arg_data[0] != 0) {
+        BoolRef err_x = errors_activated[error_index];
+        // Add parity contribution to the detectors and observables
+        for (const auto &t : e.target_data) {
+            if (t.is_relative_detector_id()) {
+              detectors_activated[t.val()] = instance.Xor(detectors_activated[t.val()], err_x);
+            } else if (t.is_observable_id()) {
+              observables_flipped[t.val()] = instance.Xor(observables_flipped[t.val()], err_x);
+            }
+        }
+        // Add a soft clause for this error to be inactive
+        Clause clause;
+        clause.add_var(~err_x);
+        clause.weight = -std::log(e.arg_data[0] / (1 - e.arg_data[0]));
+        instance.add_clause(clause);
+      }
+      ++error_index;
+  });
+
+  // Add a hard clause for any observable to be flipped
+  Clause clause;
+  for (size_t i=0; i<num_observables; ++i) {
+    clause.add_var(observables_flipped[i]);
+  }
+  instance.add_clause(clause);
+
+  return instance.to_wdimacs(num_distinct_weights);
+}

--- a/src/stim/search/sat/wcnf.cc
+++ b/src/stim/search/sat/wcnf.cc
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 #include "stim/search/sat/wcnf.h"
-
 
 using namespace stim;
 
@@ -27,235 +25,254 @@ constexpr size_t BOOL_LITERAL_FALSE = SIZE_MAX - 1;
 constexpr size_t BOOL_LITERAL_TRUE = SIZE_MAX;
 
 struct BoolRef {
-  size_t variable = BOOL_LITERAL_FALSE;
-  bool negated = false;
-  BoolRef operator~() const {
-    return {variable, !negated};
-  }
-  static BoolRef False() {
-    return {BOOL_LITERAL_FALSE, false};
-  }
-  static BoolRef True() {
-    return {BOOL_LITERAL_TRUE, false};
-  }
+    size_t variable = BOOL_LITERAL_FALSE;
+    bool negated = false;
+    BoolRef operator~() const {
+        return {variable, !negated};
+    }
+    static BoolRef False() {
+        return {BOOL_LITERAL_FALSE, false};
+    }
+    static BoolRef True() {
+        return {BOOL_LITERAL_TRUE, false};
+    }
 };
 
 struct Clause {
-  std::vector<BoolRef> vars;
-  Weight weight = HARD_CLAUSE_WEIGHT;
-  void add_var(BoolRef x) {
-    vars.push_back(x);
-  }
+    std::vector<BoolRef> vars;
+    Weight weight = HARD_CLAUSE_WEIGHT;
+    void add_var(BoolRef x) {
+        vars.push_back(x);
+    }
 };
 
 struct MaxSATInstance {
-  size_t num_variables = 0;
-  Weight max_weight = 0;
-  std::vector<Clause> clauses;
-  BoolRef new_bool() {
-    return {num_variables++};
-  }
-  void add_clause(Clause& clause) {
-    if (clause.weight != HARD_CLAUSE_WEIGHT) {
-      if (clause.weight <= 0) {
-        throw std::invalid_argument("Clauses must have positive weight or HARD_CLAUSE_WEIGHT.");
-      }
-      max_weight = std::max(max_weight, clause.weight);
+    size_t num_variables = 0;
+    Weight max_weight = 0;
+    std::vector<Clause> clauses;
+    BoolRef new_bool() {
+        return {num_variables++};
     }
-    clauses.push_back(clause);
-  }
-  BoolRef Xor(BoolRef& x, BoolRef& y) {
-    if (x.variable == BOOL_LITERAL_FALSE) {
-      return y;
-    }
-    if (x.variable == BOOL_LITERAL_TRUE) {
-      return ~y;
-    }
-    if (y.variable == BOOL_LITERAL_FALSE) {
-      return x;
-    }
-    if (y.variable == BOOL_LITERAL_TRUE) {
-      return ~x;
-    }
-    BoolRef z = new_bool();
-    // Forbid strings (x, y, z) such that z != XOR(x, y)
-    {
-      Clause clause;
-      // hard clause (x, y, z) != (0, 0, 1)
-      clause.add_var(x);
-      clause.add_var(y);
-      clause.add_var(~z);
-      add_clause(clause);
-    }
-    {
-      Clause clause;
-      // hard clause (x, y, z) != (0, 1, 0)
-      clause.add_var(x);
-      clause.add_var(~y);
-      clause.add_var(z);
-      add_clause(clause);
-    }
-    {
-      Clause clause;
-      // hard clause (x, y, z) != (1, 0, 0)
-      clause.add_var(~x);
-      clause.add_var(y);
-      clause.add_var(z);
-      add_clause(clause);
-    }
-    {
-      Clause clause;
-      // hard clause (x, y, z) != (1, 1, 1)
-      clause.add_var(~x);
-      clause.add_var(~y);
-      clause.add_var(~z);
-      add_clause(clause);
-    }
-    return z;
-  }
-
-  size_t quantized_weight(bool weighted, size_t weight_scale_factor, size_t top, Weight weight) {
-    if (weight == HARD_CLAUSE_WEIGHT) {
-      // Hard clause
-      return top;
-    }
-    // Soft clause
-    if (!weighted) {
-      // For unweighted problems, all soft clauses have weight 1.
-      return 1;
-    }
-    return std::round(weight / max_weight * (double)weight_scale_factor);
-  }
-
-  std::string to_wdimacs(bool weighted, size_t weight_scale_factor) {
-    // 'top' is a special weight used to indicate a hard clause.
-    // Should be at least the sum of the weights of all soft clauses plus 1.
-    size_t top;
-    if (weighted) {
-      top = 1 + weight_scale_factor * clauses.size();
-    } else {
-      top = 1 + clauses.size();
-    }
-
-    // WDIMACS header format: p wcnf nbvar nbclauses top
-    // see http://www.maxhs.org/docs/wdimacs.html
-    std::stringstream ss;
-    ss << "p wcnf "<< num_variables << " "<<clauses.size() << " " << top << "\n";
-
-    // Add clauses, 1 on each line.
-    for (const auto& clause : clauses) {
-      // WDIMACS clause format: weight var1 var2 ...
-      // To show negation of a variable, the index should be negated.
-      size_t qw = quantized_weight(weighted, weight_scale_factor, top, clause.weight);
-      // There is no need to add a clause with zero weight.
-      // This can happen if the error has probability 0.5 or if the weight_scale_factor is too
-      // small to accomodate the entire dynamic range of weight values.
-      if (qw == 0) continue;
-      ss << qw;
-      for (size_t i=0; i<clause.vars.size(); ++i) {
-        BoolRef var = clause.vars[i];
-        // Variables are 1-indexed
-        if (var.negated) {
-          ss << " -" << (var.variable + 1);
-        } else {
-          ss << " " << (var.variable + 1);
+    void add_clause(Clause& clause) {
+        if (clause.weight != HARD_CLAUSE_WEIGHT) {
+            if (clause.weight <= 0) {
+                throw std::invalid_argument("Clauses must have positive weight or HARD_CLAUSE_WEIGHT.");
+            }
+            max_weight = std::max(max_weight, clause.weight);
         }
-      }
-      // Each clause ends with 0
-      ss << " 0\n";
+        clauses.push_back(clause);
     }
-    return ss.str();
-  }
+    BoolRef Xor(BoolRef& x, BoolRef& y) {
+        if (x.variable == BOOL_LITERAL_FALSE) {
+            return y;
+        }
+        if (x.variable == BOOL_LITERAL_TRUE) {
+            return ~y;
+        }
+        if (y.variable == BOOL_LITERAL_FALSE) {
+            return x;
+        }
+        if (y.variable == BOOL_LITERAL_TRUE) {
+            return ~x;
+        }
+        BoolRef z = new_bool();
+        // Forbid strings (x, y, z) such that z != XOR(x, y)
+        {
+            Clause clause;
+            // hard clause (x, y, z) != (0, 0, 1)
+            clause.add_var(x);
+            clause.add_var(y);
+            clause.add_var(~z);
+            add_clause(clause);
+        }
+        {
+            Clause clause;
+            // hard clause (x, y, z) != (0, 1, 0)
+            clause.add_var(x);
+            clause.add_var(~y);
+            clause.add_var(z);
+            add_clause(clause);
+        }
+        {
+            Clause clause;
+            // hard clause (x, y, z) != (1, 0, 0)
+            clause.add_var(~x);
+            clause.add_var(y);
+            clause.add_var(z);
+            add_clause(clause);
+        }
+        {
+            Clause clause;
+            // hard clause (x, y, z) != (1, 1, 1)
+            clause.add_var(~x);
+            clause.add_var(~y);
+            clause.add_var(~z);
+            add_clause(clause);
+        }
+        return z;
+    }
+
+    size_t quantized_weight(bool weighted, size_t quantization, size_t top, Weight weight) {
+        if (weight == HARD_CLAUSE_WEIGHT) {
+            // Hard clause
+            return top;
+        }
+        // Soft clause
+        if (!weighted) {
+            // For unweighted problems, all soft clauses have weight 1.
+            return 1;
+        }
+        return std::round(weight / max_weight * (double)quantization);
+    }
+
+    std::string to_wdimacs(bool weighted, size_t quantization) {
+        // 'top' is a special weight used to indicate a hard clause.
+        // Should be at least the sum of the weights of all soft clauses plus 1.
+        size_t top;
+        if (weighted) {
+            top = 1 + quantization * clauses.size();
+        } else {
+            top = 1 + clauses.size();
+        }
+
+        // WDIMACS header format: p wcnf nbvar nbclauses top
+        // see http://www.maxhs.org/docs/wdimacs.html
+        std::stringstream ss;
+        ss << "p wcnf " << num_variables << " " << clauses.size() << " " << top << "\n";
+
+        // Add clauses, 1 on each line.
+        for (const auto& clause : clauses) {
+            // WDIMACS clause format: weight var1 var2 ...
+            // To show negation of a variable, the index should be negated.
+            size_t qw = quantized_weight(weighted, quantization, top, clause.weight);
+            // There is no need to add a clause with zero weight.
+            // This can happen if the error has probability 0.5 or if the quantization is too
+            // small to accomodate the entire dynamic range of weight values.
+            if (qw == 0)
+                continue;
+            ss << qw;
+            for (size_t i = 0; i < clause.vars.size(); ++i) {
+                BoolRef var = clause.vars[i];
+                // Variables are 1-indexed
+                if (var.negated) {
+                    ss << " -" << (var.variable + 1);
+                } else {
+                    ss << " " << (var.variable + 1);
+                }
+            }
+            // Each clause ends with 0
+            ss << " 0\n";
+        }
+        return ss.str();
+    }
 };
 
-std::string stim::shortest_error_problem_as_wcnf_file(
-  const DetectorErrorModel &model, bool weighted, size_t weight_scale_factor) {
-  MaxSATInstance inst;
+std::string sat_problem_as_wcnf_string(const DetectorErrorModel& model, bool weighted, size_t quantization) {
+    MaxSATInstance inst;
 
-  if (weighted and weight_scale_factor < 1) {
-    throw std::invalid_argument("for weighted problems, weight_scale_factor must be >= 1");
-  }
-  if (!weighted and weight_scale_factor != 0) {
-    throw std::invalid_argument("for unweighted problems, weight_scale_factor must be == 0");
-  }
+    if (weighted and quantization < 1) {
+        throw std::invalid_argument("for weighted problems, quantization must be >= 1");
+    }
+    if (!weighted and quantization != 0) {
+        throw std::invalid_argument("for unweighted problems, quantization must be == 0");
+    }
 
-  size_t num_observables = model.count_observables();
-  size_t num_detectors = model.count_detectors();
-  size_t num_errors = model.count_errors();
-  if (num_observables == 0 or num_detectors == 0 or num_errors == 0) {
-    return UNSAT_WCNF_STR;
-  }
+    size_t num_observables = model.count_observables();
+    size_t num_detectors = model.count_detectors();
+    size_t num_errors = model.count_errors();
+    if (num_observables == 0 or num_detectors == 0 or num_errors == 0) {
+        return UNSAT_WCNF_STR;
+    }
 
-  MaxSATInstance instance;
-  // Create a boolean variable for each error, which indicates whether it is activated.
-  std::vector<BoolRef> errors_activated;
-  for (size_t i=0; i<num_errors; ++i) {
-    errors_activated.push_back(instance.new_bool());
-  }
+    MaxSATInstance instance;
+    // Create a boolean variable for each error, which indicates whether it is activated.
+    std::vector<BoolRef> errors_activated;
+    for (size_t i = 0; i < num_errors; ++i) {
+        errors_activated.push_back(instance.new_bool());
+    }
 
-  std::vector<BoolRef> detectors_activated(num_detectors, BoolRef::False());
-  std::vector<BoolRef> observables_flipped(num_observables, BoolRef::False());
+    std::vector<BoolRef> detectors_activated(num_detectors, BoolRef::False());
+    std::vector<BoolRef> observables_flipped(num_observables, BoolRef::False());
 
-  size_t error_index = 0;
-  model.iter_flatten_error_instructions([&](const DemInstruction &e) {
-      if (e.arg_data[0] != 0) {
-        BoolRef err_x = errors_activated[error_index];
-        // Add parity contribution to the detectors and observables
-        for (const auto &t : e.target_data) {
-            if (t.is_relative_detector_id()) {
-              detectors_activated[t.val()] = instance.Xor(detectors_activated[t.val()], err_x);
-            } else if (t.is_observable_id()) {
-              observables_flipped[t.val()] = instance.Xor(observables_flipped[t.val()], err_x);
+    size_t error_index = 0;
+    model.iter_flatten_error_instructions([&](const DemInstruction& e) {
+        if (e.arg_data[0] != 0) {
+            BoolRef err_x = errors_activated[error_index];
+            // Add parity contribution to the detectors and observables
+            for (const auto& t : e.target_data) {
+                if (t.is_relative_detector_id()) {
+                    detectors_activated[t.val()] = instance.Xor(detectors_activated[t.val()], err_x);
+                } else if (t.is_observable_id()) {
+                    observables_flipped[t.val()] = instance.Xor(observables_flipped[t.val()], err_x);
+                }
+            }
+            // Add a soft clause for this error
+            Clause clause;
+            double p = e.arg_data[0];
+            if (weighted) {
+                // Weighted search
+                if (p < 0.5) {
+                    // If the probability < 0.5, the weight should be positive
+                    // and we add the clause for the error to be inactive.
+                    clause.add_var(~err_x);
+                    clause.weight = -std::log(p / (1 - p));
+                    instance.add_clause(clause);
+                } else if (p == 0.5) {
+                    // If the probability == 0.5, the error can be included "for free"
+                    // so we don't bother adding any soft clause.
+                } else {
+                    // If the probability is > 0.5, the cost is negative so we emulate this by
+                    // inverting the sign of the weight and negating the clause so that the
+                    // clause has a positive weight.
+                    clause.add_var(err_x);
+                    clause.weight = -std::log((1 - p) / p);
+                    instance.add_clause(clause);
+                }
+            } else {
+                // For unweighted search the error should be soft clause should be that
+                // the error is inactive.
+                clause.add_var(~err_x);
+                clause.weight = -std::log(p / (1 - p));
+                instance.add_clause(clause);
             }
         }
-        // Add a soft clause for this error
+        ++error_index;
+    });
+    assert(error_index == num_errors);
+
+    // Add a hard clause for each detector to be inactive
+    for (size_t d = 0; d < num_detectors; ++d) {
         Clause clause;
-        double p = e.arg_data[0];
-        if (weighted) {
-          // Weighted search
-          if (p < 0.5) {
-            // If the probability < 0.5, the weight should be positive
-            // and we add the clause for the error to be inactive.
-            clause.add_var(~err_x);
-            clause.weight = -std::log(p / (1 - p));
-            instance.add_clause(clause);
-          } else if (p == 0.5) {
-            // If the probability == 0.5, the error can be included "for free"
-            // so we don't bother adding any soft clause.
-          } else {
-            // If the probability is > 0.5, the cost is negative so we emulate this by
-            // inverting the sign of the weight and negating the clause so that the
-            // clause has a positive weight.
-            clause.add_var(err_x);
-            clause.weight = -std::log((1 - p) / p);
-            instance.add_clause(clause);
-          }
-        } else {
-          // For unweighted search the error should be soft clause should be that
-          // the error is inactive.
-          clause.add_var(~err_x);
-          clause.weight = -std::log(p / (1 - p));
-          instance.add_clause(clause);
-        }
-      }
-      ++error_index;
-  });
-  assert(error_index == num_errors);
+        if (detectors_activated[d].variable == BOOL_LITERAL_FALSE)
+            continue;
+        clause.add_var(~detectors_activated[d]);
+        instance.add_clause(clause);
+    }
 
-  // Add a hard clause for each detector to be inactive
-  for (size_t d=0; d<num_detectors; ++d) {
-      Clause clause;
-      if (detectors_activated[d].variable == BOOL_LITERAL_FALSE) continue;
-      clause.add_var(~detectors_activated[d]);
-      instance.add_clause(clause);
-  }
+    // Add a hard clause for any observable to be flipped
+    Clause clause;
+    for (size_t i = 0; i < num_observables; ++i) {
+        clause.add_var(observables_flipped[i]);
+    }
+    instance.add_clause(clause);
 
-  // Add a hard clause for any observable to be flipped
-  Clause clause;
-  for (size_t i=0; i<num_observables; ++i) {
-    clause.add_var(observables_flipped[i]);
-  }
-  instance.add_clause(clause);
+    return instance.to_wdimacs(weighted, quantization);
+}
 
-  return instance.to_wdimacs(weighted, weight_scale_factor);
+// Should ignore weights entirely and minimize the cardinality.
+std::string stim::shortest_error_sat_problem(const DetectorErrorModel& model, std::string format) {
+    if (format != "WDIMACS") {
+        throw std::invalid_argument("Unsupported format.");
+    }
+    return sat_problem_as_wcnf_string(model, /*weighted=*/false, /*quantization=*/0);
+}
+
+std::string stim::likeliest_error_sat_problem(const DetectorErrorModel& model, int quantization, std::string format) {
+    if (format != "WDIMACS") {
+        throw std::invalid_argument("Unsupported format.");
+    }
+    if (quantization < 1) {
+        throw std::invalid_argument("Must have quantization >= 1");
+    }
+    return sat_problem_as_wcnf_string(model, /*weighted=*/true, quantization);
 }

--- a/src/stim/search/sat/wcnf.h
+++ b/src/stim/search/sat/wcnf.h
@@ -28,7 +28,8 @@ namespace stim {
 ///     users must separately manage the process of selecting and running the solver. This approach is designed to
 ///     sidestep the need for direct integration with any particular solver and allow
 ///     for experimentation with different solvers to achieve the best performance.
-std::string shortest_undetectable_logical_error_wcnf(const DetectorErrorModel &model, size_t num_distinct_weights=1);
+std::string shortest_error_problem_as_wcnf_file(
+  const DetectorErrorModel &model, bool weighted=false, size_t num_distinct_weights=1);
 
 }  // namespace stim
 

--- a/src/stim/search/sat/wcnf.h
+++ b/src/stim/search/sat/wcnf.h
@@ -1,0 +1,35 @@
+#ifndef _STIM_SEARCH_SAT_WCNF_H
+#define _STIM_SEARCH_SAT_WCNF_H
+
+#include <cstdint>
+
+#include "stim/dem/detector_error_model.h"
+
+namespace stim {
+
+/// Generates a maxSAT problem instance in .wcnf format from a DetectorErrorModel, such that the optimal value of the instance corresponds to the minimum distance of the protocol.
+///
+/// The .wcnf (weighted CNF) file format is widely
+/// accepted by numerous maxSAT solvers. For example, the solvers in the 2023 maxSAT competition: https://maxsat-evaluations.github.io/2023/descriptions.html
+/// Note that erformance can greatly vary among solvers.
+/// The conversion involves encoding XOR constraints into CNF clauses using standard techniques.
+///
+/// Args:
+///     model: The detector error model to be converted into .wcnf format for minimum distance calculation.
+///     num_distinct_weights: The number of different integer weight values for quantization (default = 1).
+///
+/// Returns:
+///     A string which is interpreted as the contents of a .wcnf file. This should be written to a file which can then be passed to various maxSAT
+///     solvers to determine the minimum distance of the protocol represented by the model. The optimal value found
+///     by the solver corresponds to the minimum distance of the error correction protocol. In other words, the smallest number of errors that cause a logical observable flip without any detection events.
+///
+/// Note:
+///     The use of .wcnf format offers significant flexibility in choosing a maxSAT solver, but it also means that
+///     users must separately manage the process of selecting and running the solver. This approach is designed to
+///     sidestep the need for direct integration with any particular solver and allow
+///     for experimentation with different solvers to achieve the best performance.
+std::string shortest_undetectable_logical_error_wcnf(const DetectorErrorModel &model, size_t num_distinct_weights=1);
+
+}  // namespace stim
+
+#endif

--- a/src/stim/search/sat/wcnf.h
+++ b/src/stim/search/sat/wcnf.h
@@ -16,7 +16,10 @@ namespace stim {
 ///
 /// Args:
 ///     model: The detector error model to be converted into .wcnf format for minimum distance calculation.
-///     num_distinct_weights: The number of different integer weight values for quantization (default = 1).
+///     weighted: (default = false) If false, all errors have cost 1. If true, errors are given a cost based
+///               on their likelihood cost scaled by the weight scale factor divided by the maximum cost value.
+///               if false, must set weight_scale_factor to 0. If true, must set weight_scale_factor >= 1.
+///     weight_scale_factor: The scaling factor used for quantization. (default = 0 for unweighted).
 ///
 /// Returns:
 ///     A string which is interpreted as the contents of a .wcnf file. This should be written to a file which can then be passed to various maxSAT
@@ -29,7 +32,7 @@ namespace stim {
 ///     sidestep the need for direct integration with any particular solver and allow
 ///     for experimentation with different solvers to achieve the best performance.
 std::string shortest_error_problem_as_wcnf_file(
-  const DetectorErrorModel &model, bool weighted=false, size_t num_distinct_weights=1);
+  const DetectorErrorModel &model, bool weighted=false, size_t weight_scale_factor=0);
 
 }  // namespace stim
 

--- a/src/stim/search/sat/wcnf.h
+++ b/src/stim/search/sat/wcnf.h
@@ -7,12 +7,13 @@
 
 namespace stim {
 
-/// Generates a maxSAT problem instance in .wcnf format from a DetectorErrorModel, such that the optimal value of the instance corresponds to the minimum distance of the protocol.
+/// Generates a maxSAT problem instance in .wcnf format from a DetectorErrorModel, such that the optimal value of the
+/// instance corresponds to the minimum distance of the protocol.
 ///
 /// The .wcnf (weighted CNF) file format is widely
-/// accepted by numerous maxSAT solvers. For example, the solvers in the 2023 maxSAT competition: https://maxsat-evaluations.github.io/2023/descriptions.html
-/// Note that erformance can greatly vary among solvers.
-/// The conversion involves encoding XOR constraints into CNF clauses using standard techniques.
+/// accepted by numerous maxSAT solvers. For example, the solvers in the 2023 maxSAT competition:
+/// https://maxsat-evaluations.github.io/2023/descriptions.html Note that erformance can greatly vary among solvers. The
+/// conversion involves encoding XOR constraints into CNF clauses using standard techniques.
 ///
 /// Args:
 ///     model: The detector error model to be converted into .wcnf format for minimum distance calculation.
@@ -22,17 +23,23 @@ namespace stim {
 ///     weight_scale_factor: The scaling factor used for quantization. (default = 0 for unweighted).
 ///
 /// Returns:
-///     A string which is interpreted as the contents of a .wcnf file. This should be written to a file which can then be passed to various maxSAT
-///     solvers to determine the minimum distance of the protocol represented by the model. The optimal value found
-///     by the solver corresponds to the minimum distance of the error correction protocol. In other words, the smallest number of errors that cause a logical observable flip without any detection events.
+///     A string which is interpreted as the contents of a .wcnf file. This should be written to a file which can then
+///     be passed to various maxSAT solvers to determine the minimum distance of the protocol represented by the model.
+///     The optimal value found by the solver corresponds to the minimum distance of the error correction protocol. In
+///     other words, the smallest number of errors that cause a logical observable flip without any detection events.
 ///
 /// Note:
 ///     The use of .wcnf format offers significant flexibility in choosing a maxSAT solver, but it also means that
 ///     users must separately manage the process of selecting and running the solver. This approach is designed to
 ///     sidestep the need for direct integration with any particular solver and allow
 ///     for experimentation with different solvers to achieve the best performance.
-std::string shortest_error_problem_as_wcnf_file(
-  const DetectorErrorModel &model, bool weighted=false, size_t weight_scale_factor=0);
+// std::string shortest_error_problem_as_wcnf_file(
+//   const DetectorErrorModel &model, bool weighted=false, size_t weight_scale_factor=0);
+
+std::string shortest_error_sat_problem(const DetectorErrorModel& model, std::string format = "WDIMACS");
+
+std::string likeliest_error_sat_problem(
+    const DetectorErrorModel& model, int quantization = 10, std::string format = "WDIMACS");
 
 }  // namespace stim
 

--- a/src/stim/search/sat/wcnf.test.cc
+++ b/src/stim/search/sat/wcnf.test.cc
@@ -4,9 +4,42 @@
 
 using namespace stim;
 
+const std::string unsatisfiable_wdimacs = "p wcnf 1 2 3\n3 -1 0\n3 1 0\n";
+
 TEST(shortest_error_sat_problem, no_error) {
     // No errors. Should get an unsatisfiable formula.
     ASSERT_EQ(stim::shortest_error_sat_problem(DetectorErrorModel()), "p wcnf 1 2 3\n3 -1 0\n3 1 0\n");
+}
+
+TEST(shortest_error_sat_problem, single_obs_no_dets) {
+    std::string wcnf = stim::shortest_error_sat_problem(DetectorErrorModel(R"DEM(
+        error(0.1) L0
+    )DEM"));
+    EXPECT_EQ(
+        wcnf,
+        R"WDIMACS(p wcnf 1 2 3
+1 -1 0
+3 1 0
+)WDIMACS");
+}
+
+TEST(shortest_error_sat_problem, single_dets_no_obs) {
+    std::string wcnf = stim::shortest_error_sat_problem(DetectorErrorModel(R"DEM(
+        error(0.1) D0
+    )DEM"));
+    EXPECT_EQ(wcnf, unsatisfiable_wdimacs);
+}
+
+TEST(shortest_error_sat_problem, no_dets_no_obs) {
+    std::string wcnf = stim::shortest_error_sat_problem(DetectorErrorModel(R"DEM(
+        error(0.1)
+    )DEM"));
+    EXPECT_EQ(wcnf, unsatisfiable_wdimacs);
+}
+
+TEST(shortest_error_sat_problem, no_errors) {
+    std::string wcnf = stim::shortest_error_sat_problem(DetectorErrorModel(R"DEM()DEM"));
+    EXPECT_EQ(wcnf, unsatisfiable_wdimacs);
 }
 
 TEST(shortest_error_sat_problem, single_detector_single_observable) {
@@ -78,7 +111,7 @@ TEST(shortest_error_sat_problem, single_detector_single_observable) {
 
 TEST(likeliest_error_sat_problem, no_error) {
     // No errors. Should get an unsatisfiable formula.
-    ASSERT_EQ(stim::likeliest_error_sat_problem(DetectorErrorModel()), "p wcnf 1 2 3\n3 -1 0\n3 1 0\n");
+    ASSERT_EQ(stim::likeliest_error_sat_problem(DetectorErrorModel()), unsatisfiable_wdimacs);
 }
 
 TEST(likeliest_error_sat_problem, single_detector_single_observable) {

--- a/src/stim/search/sat/wcnf.test.cc
+++ b/src/stim/search/sat/wcnf.test.cc
@@ -3,15 +3,15 @@
 
 using namespace stim;
 
-TEST(shortest_undetectable_logical_error_wcnf, no_error) {
-    // No error.
-    ASSERT_THROW(
-        { stim::shortest_undetectable_logical_error_wcnf(DetectorErrorModel()); },
-        std::invalid_argument);
+TEST(shortest_error_problem_as_wcnf_file, no_error) {
+    // No errors. Should get an unsatisfiable formula.
+    ASSERT_EQ(
+      stim::shortest_error_problem_as_wcnf_file(DetectorErrorModel()),
+      "p wcnf 1 2 3\n3 -1 0\n3 1 0\n");
 }
 
-TEST(shortest_undetectable_logical_error_wcnf, single_detector_single_observable) {
-  std::string wcnf = stim::shortest_undetectable_logical_error_wcnf(DetectorErrorModel(R"DEM(
+TEST(shortest_error_problem_as_wcnf_file, single_detector_single_observable) {
+  std::string wcnf = stim::shortest_error_problem_as_wcnf_file(DetectorErrorModel(R"DEM(
       error(0.1) D0 L0
       error(0.1) D0
     )DEM"));

--- a/src/stim/search/sat/wcnf.test.cc
+++ b/src/stim/search/sat/wcnf.test.cc
@@ -1,0 +1,49 @@
+#include "stim/search/sat/wcnf.h"
+#include "gtest/gtest.h"
+
+using namespace stim;
+
+TEST(shortest_undetectable_logical_error_wcnf, no_error) {
+    // No error.
+    ASSERT_THROW(
+        { stim::shortest_undetectable_logical_error_wcnf(DetectorErrorModel()); },
+        std::invalid_argument);
+}
+
+TEST(shortest_undetectable_logical_error_wcnf, single_detector_single_observable) {
+  std::string wcnf = stim::shortest_undetectable_logical_error_wcnf(DetectorErrorModel(R"DEM(
+      error(0.1) D0 L0
+      error(0.1) D0
+    )DEM"));
+  // There should be 3 variables: x = (x_0, x_1, x_2)
+  // x_0 -- error 0 occurred
+  // x_1 -- error 1 occurred
+  // x_2 -- XOR of x_0 and x_1
+  // There should be 2 soft clauses:
+  // soft clause NOT(x_0) with weight 1
+  // soft clause NOT(x_0) with weight 1
+  // There should be 4 hard clauses to forbid the strings such that x_2 != XOR(x_0, x_1):
+  // hard clause x != (0, 0, 1)
+  // hard clause x != (0, 1, 0)
+  // hard clause x != (1, 0, 0)
+  // hard clause x != (1, 1, 1)
+  // Plus 1 hard clause to ensure an observable is flipped:
+  // hard clause x_0
+  // This gives a total of 7 clauses
+  // The top value should be at least 1 + 1 + 1 = 3. In our implementation ends up being 8.
+  std::stringstream expected;
+  // WDIMACS header format: p wcnf nbvar nbclauses top
+  expected << "p wcnf 3 7 8\n";
+  // Soft clause
+  expected << "1 -0\n";
+  // Hard clauses
+  expected << "8 0 1 -2\n";
+  expected << "8 0 -1 2\n";
+  expected << "8 -0 1 2\n";
+  expected << "8 -0 -1 -2\n";
+  // Soft clause
+  expected << "1 -1\n";
+  // Hard clause for the observable flipped
+  expected << "8 0\n";
+  ASSERT_EQ(wcnf, expected.str());
+}

--- a/src/stim/search/sat/wcnf.test.cc
+++ b/src/stim/search/sat/wcnf.test.cc
@@ -27,23 +27,29 @@ TEST(shortest_undetectable_logical_error_wcnf, single_detector_single_observable
   // hard clause x != (0, 1, 0)
   // hard clause x != (1, 0, 0)
   // hard clause x != (1, 1, 1)
+  // Plus 1 hard clause to ensure detector is not flipped
+  // hard clause -x_2
   // Plus 1 hard clause to ensure an observable is flipped:
   // hard clause x_0
-  // This gives a total of 7 clauses
-  // The top value should be at least 1 + 1 + 1 = 3. In our implementation ends up being 8.
+  // This gives a total of 8 clauses
+  // The top value should be at least 1 + 1 + 1 = 3. In our implementation ends up being 9.
   std::stringstream expected;
   // WDIMACS header format: p wcnf nbvar nbclauses top
-  expected << "p wcnf 3 7 8\n";
+  expected << "p wcnf 3 8 9\n";
   // Soft clause
-  expected << "1 -0\n";
+  expected << "1 -1 0\n";
   // Hard clauses
-  expected << "8 0 1 -2\n";
-  expected << "8 0 -1 2\n";
-  expected << "8 -0 1 2\n";
-  expected << "8 -0 -1 -2\n";
+  expected << "9 1 2 -3 0\n";
+  expected << "9 1 -2 3 0\n";
+  expected << "9 -1 2 3 0\n";
+  expected << "9 -1 -2 -3 0\n";
   // Soft clause
-  expected << "1 -1\n";
+  expected << "1 -2 0\n";
+  // Hard clause for the detector not to be flipped
+  expected << "9 -3 0\n";
   // Hard clause for the observable flipped
-  expected << "8 0\n";
+  expected << "9 1 0\n";
   ASSERT_EQ(wcnf, expected.str());
+  // The optimal value of this wcnf file should be 2, but we don't have
+  // a maxSAT solver to be able to test it here.
 }

--- a/src/stim/search/sat/wcnf.test.cc
+++ b/src/stim/search/sat/wcnf.test.cc
@@ -1,55 +1,192 @@
 #include "stim/search/sat/wcnf.h"
+
 #include "gtest/gtest.h"
 
 using namespace stim;
 
-TEST(shortest_error_problem_as_wcnf_file, no_error) {
+TEST(shortest_error_sat_problem, no_error) {
     // No errors. Should get an unsatisfiable formula.
-    ASSERT_EQ(
-      stim::shortest_error_problem_as_wcnf_file(DetectorErrorModel()),
-      "p wcnf 1 2 3\n3 -1 0\n3 1 0\n");
+    ASSERT_EQ(stim::shortest_error_sat_problem(DetectorErrorModel()), "p wcnf 1 2 3\n3 -1 0\n3 1 0\n");
 }
 
-TEST(shortest_error_problem_as_wcnf_file, single_detector_single_observable) {
-  std::string wcnf = stim::shortest_error_problem_as_wcnf_file(DetectorErrorModel(R"DEM(
+TEST(shortest_error_sat_problem, single_detector_single_observable) {
+    std::string wcnf = stim::shortest_error_sat_problem(DetectorErrorModel(R"DEM(
       error(0.1) D0 L0
       error(0.1) D0
     )DEM"));
-  // There should be 3 variables: x = (x_0, x_1, x_2)
-  // x_0 -- error 0 occurred
-  // x_1 -- error 1 occurred
-  // x_2 -- XOR of x_0 and x_1
-  // There should be 2 soft clauses:
-  // soft clause NOT(x_0) with weight 1
-  // soft clause NOT(x_0) with weight 1
-  // There should be 4 hard clauses to forbid the strings such that x_2 != XOR(x_0, x_1):
-  // hard clause x != (0, 0, 1)
-  // hard clause x != (0, 1, 0)
-  // hard clause x != (1, 0, 0)
-  // hard clause x != (1, 1, 1)
-  // Plus 1 hard clause to ensure detector is not flipped
-  // hard clause -x_2
-  // Plus 1 hard clause to ensure an observable is flipped:
-  // hard clause x_0
-  // This gives a total of 8 clauses
-  // The top value should be at least 1 + 1 + 1 = 3. In our implementation ends up being 9.
-  std::stringstream expected;
-  // WDIMACS header format: p wcnf nbvar nbclauses top
-  expected << "p wcnf 3 8 9\n";
-  // Soft clause
-  expected << "1 -1 0\n";
-  // Hard clauses
-  expected << "9 1 2 -3 0\n";
-  expected << "9 1 -2 3 0\n";
-  expected << "9 -1 2 3 0\n";
-  expected << "9 -1 -2 -3 0\n";
-  // Soft clause
-  expected << "1 -2 0\n";
-  // Hard clause for the detector not to be flipped
-  expected << "9 -3 0\n";
-  // Hard clause for the observable flipped
-  expected << "9 1 0\n";
-  ASSERT_EQ(wcnf, expected.str());
-  // The optimal value of this wcnf file should be 2, but we don't have
-  // a maxSAT solver to be able to test it here.
+    // x_0 -- error 0 occurred
+    // x_1 -- error 1 occurred
+    // x_2 -- XOR of x_0 and x_1
+    // There should be 2 soft clauses:
+    // soft clause NOT(x_0) with weight 1
+    // soft clause NOT(x_0) with weight 1
+    // There should be 4 hard clauses to forbid the strings such that x_2 != XOR(x_0, x_1):
+    // hard clause x != (0, 0, 1)
+    // hard clause x != (0, 1, 0)
+    // hard clause x != (1, 0, 0)
+    // hard clause x != (1, 1, 1)
+    // Plus 1 hard clause to ensure detector is not flipped
+    // hard clause -x_2
+    // Plus 1 hard clause to ensure an observable is flipped:
+    // hard clause x_0
+    // This gives a total of 8 clauses
+    // The top value should be at least 1 + 1 + 1 = 3. In our implementation ends up being 9.
+    std::stringstream expected;
+    // WDIMACS header format: p wcnf nbvar nbclauses top
+    expected << "p wcnf 3 8 9\n";
+    // Soft clause
+    expected << "1 -1 0\n";
+    // Hard clauses
+    expected << "9 1 2 -3 0\n";
+    expected << "9 1 -2 3 0\n";
+    expected << "9 -1 2 3 0\n";
+    expected << "9 -1 -2 -3 0\n";
+    // Soft clause
+    expected << "1 -2 0\n";
+    // Hard clause for the detector not to be flipped
+    expected << "9 -3 0\n";
+    // Hard clause for the observable flipped
+    expected << "9 1 0\n";
+    ASSERT_EQ(wcnf, expected.str());
+    // The optimal value of this wcnf file should be 2, but we don't have
+    // a maxSAT solver to be able to test it here.
+}
+
+TEST(likeliest_error_sat_problem, no_error) {
+    // No errors. Should get an unsatisfiable formula.
+    ASSERT_EQ(stim::likeliest_error_sat_problem(DetectorErrorModel()), "p wcnf 1 2 3\n3 -1 0\n3 1 0\n");
+}
+
+TEST(likeliest_error_sat_problem, single_detector_single_observable) {
+    std::string wcnf = stim::likeliest_error_sat_problem(DetectorErrorModel(R"DEM(
+      error(0.1) D0 L0
+      error(0.1) D0
+    )DEM"));
+    // There should be 3 variables: x = (x_0, x_1, x_2)
+    // x_0 -- error 0 occurred
+    // x_1 -- error 1 occurred
+    // x_2 -- XOR of x_0 and x_1
+    // There should be 2 soft clauses:
+    // soft clause NOT(x_0) with weight 1
+    // soft clause NOT(x_0) with weight 1
+    // There should be 4 hard clauses to forbid the strings such that x_2 != XOR(x_0, x_1):
+    // hard clause x != (0, 0, 1)
+    // hard clause x != (0, 1, 0)
+    // hard clause x != (1, 0, 0)
+    // hard clause x != (1, 1, 1)
+    // Plus 1 hard clause to ensure detector is not flipped
+    // hard clause -x_2
+    // Plus 1 hard clause to ensure an observable is flipped:
+    // hard clause x_0
+    // This gives a total of 8 clauses
+    // The top value should be at least 1 + 1 + 1 = 3. In our implementation ends up being 9.
+    std::stringstream expected;
+    // WDIMACS header format: p wcnf nbvar nbclauses top
+    expected << "p wcnf 3 8 81\n";
+    // Soft clause
+    expected << "10 -1 0\n";
+    // Hard clauses
+    expected << "81 1 2 -3 0\n";
+    expected << "81 1 -2 3 0\n";
+    expected << "81 -1 2 3 0\n";
+    expected << "81 -1 -2 -3 0\n";
+    // Soft clause
+    expected << "10 -2 0\n";
+    // Hard clause for the detector not to be flipped
+    expected << "81 -3 0\n";
+    // Hard clause for the observable flipped
+    expected << "81 1 0\n";
+    ASSERT_EQ(wcnf, expected.str());
+    // The optimal value of this wcnf file should be 20, but we don't have
+    // a maxSAT solver to be able to test it here.
+}
+
+TEST(likeliest_error_sat_problem, single_detector_single_observable_large_probability) {
+    std::string wcnf = stim::likeliest_error_sat_problem(DetectorErrorModel(R"DEM(
+      error(0.1) D0 L0
+      error(0.9) D0
+    )DEM"));
+    // There should be 3 variables: x = (x_0, x_1, x_2)
+    // x_0 -- error 0 occurred
+    // x_1 -- error 1 occurred
+    // x_2 -- XOR of x_0 and x_1
+    // There should be 2 soft clauses:
+    // soft clause NOT(x_0) with weight 1
+    // soft clause NOT(x_0) with weight 1
+    // There should be 4 hard clauses to forbid the strings such that x_2 != XOR(x_0, x_1):
+    // hard clause x != (0, 0, 1)
+    // hard clause x != (0, 1, 0)
+    // hard clause x != (1, 0, 0)
+    // hard clause x != (1, 1, 1)
+    // Plus 1 hard clause to ensure detector is not flipped
+    // hard clause -x_2
+    // Plus 1 hard clause to ensure an observable is flipped:
+    // hard clause x_0
+    // This gives a total of 8 clauses
+    // The top value should be at least 1 + 1 + 1 = 3. In our implementation ends up being 9.
+    std::stringstream expected;
+    // WDIMACS header format: p wcnf nbvar nbclauses top
+    expected << "p wcnf 3 8 81\n";
+    // Soft clause
+    expected << "10 -1 0\n";
+    // Hard clauses
+    expected << "81 1 2 -3 0\n";
+    expected << "81 1 -2 3 0\n";
+    expected << "81 -1 2 3 0\n";
+    expected << "81 -1 -2 -3 0\n";
+    // Soft clause for the 2nd error to flip, with weight 10.
+    // This is because the probability of that error is 0.9.
+    expected << "10 2 0\n";
+    // Hard clause for the detector not to be flipped
+    expected << "81 -3 0\n";
+    // Hard clause for the observable flipped
+    expected << "81 1 0\n";
+    ASSERT_EQ(wcnf, expected.str());
+    // The optimal value of this wcnf file should be 20, but we don't have
+    // a maxSAT solver to be able to test it here.
+}
+
+TEST(likeliest_error_sat_problem, single_detector_single_observable_half_probability) {
+    std::string wcnf = stim::likeliest_error_sat_problem(DetectorErrorModel(R"DEM(
+      error(0.1) D0 L0
+      error(0.5) D0
+    )DEM"));
+    // There should be 3 variables: x = (x_0, x_1, x_2)
+    // x_0 -- error 0 occurred
+    // x_1 -- error 1 occurred
+    // x_2 -- XOR of x_0 and x_1
+    // There should be 2 soft clauses:
+    // soft clause NOT(x_0) with weight 1
+    // soft clause NOT(x_0) with weight 1
+    // There should be 4 hard clauses to forbid the strings such that x_2 != XOR(x_0, x_1):
+    // hard clause x != (0, 0, 1)
+    // hard clause x != (0, 1, 0)
+    // hard clause x != (1, 0, 0)
+    // hard clause x != (1, 1, 1)
+    // Plus 1 hard clause to ensure detector is not flipped
+    // hard clause -x_2
+    // Plus 1 hard clause to ensure an observable is flipped:
+    // hard clause x_0
+    // This gives a total of 8 clauses
+    // The top value should be at least 1 + 1 + 1 = 3. In our implementation ends up being 9.
+    std::stringstream expected;
+    // WDIMACS header format: p wcnf nbvar nbclauses top
+    expected << "p wcnf 3 7 71\n";
+    // Soft clause
+    expected << "10 -1 0\n";
+    // Hard clauses
+    expected << "71 1 2 -3 0\n";
+    expected << "71 1 -2 3 0\n";
+    expected << "71 -1 2 3 0\n";
+    expected << "71 -1 -2 -3 0\n";
+    // // Soft clause for the 2nd error to flip, with weight 10.
+    // // This is because the probability of that error is 0.9.
+    // expected << "10 2 0\n";
+    // Hard clause for the detector not to be flipped
+    expected << "71 -3 0\n";
+    // Hard clause for the observable flipped
+    expected << "71 1 0\n";
+    ASSERT_EQ(wcnf, expected.str());
+    // The optimal value of this wcnf file should be 20, but we don't have
+    // a maxSAT solver to be able to test it here.
 }

--- a/src/stim/search/search.h
+++ b/src/stim/search/search.h
@@ -19,5 +19,6 @@
 
 #include "stim/search/graphlike/algo.h"
 #include "stim/search/hyper/algo.h"
+#include "stim/search/sat/wcnf.h"
 
 #endif

--- a/src/stim/simulators/error_matcher.cc
+++ b/src/stim/simulators/error_matcher.cc
@@ -140,7 +140,8 @@ void ErrorMatcher::err_heralded_pauli_channel_1(const CircuitInstruction &op) {
         cur_loc.instruction_targets.target_range_end = k + 1;
 
         cur_loc.flipped_measurement.measurement_record_index = error_analyzer.tracker.num_measurements_in_past - 1;
-        SpanRef<const DemTarget> herald_symptoms = error_analyzer.tracker.rec_bits[error_analyzer.tracker.num_measurements_in_past - 1].range();
+        SpanRef<const DemTarget> herald_symptoms =
+            error_analyzer.tracker.rec_bits[error_analyzer.tracker.num_measurements_in_past - 1].range();
         SpanRef<const DemTarget> x_symptoms = error_analyzer.tracker.zs[q].range();
         SpanRef<const DemTarget> z_symptoms = error_analyzer.tracker.xs[q].range();
         if (op.args[0] != 0) {
@@ -254,7 +255,6 @@ void ErrorMatcher::err_m(const CircuitInstruction &op, uint32_t obs_mask) {
             start--;
         }
 
-
         SpanRef<const GateTarget> slice{t.begin() + start, t.begin() + end};
 
         cur_loc.instruction_targets.target_range_start = start;
@@ -313,12 +313,13 @@ void ErrorMatcher::rev_process_instruction(const CircuitInstruction &op) {
             err_atom(op2);
             cur_loc.flipped_pauli_product.clear();
             break;
-        } case GateType::X_ERROR:
+        }
+        case GateType::X_ERROR:
             err_xyz(op, TARGET_PAULI_X_BIT);
             break;
         case GateType::Y_ERROR:
             err_xyz(op, TARGET_PAULI_X_BIT | TARGET_PAULI_Z_BIT);
-                break;
+            break;
         case GateType::Z_ERROR:
             err_xyz(op, TARGET_PAULI_Z_BIT);
             break;
@@ -333,12 +334,14 @@ void ErrorMatcher::rev_process_instruction(const CircuitInstruction &op) {
             std::array<double, 4> spread{p, p, p, p};
             err_heralded_pauli_channel_1({op.gate_type, spread, op.targets});
             break;
-        } case GateType::DEPOLARIZE1: {
+        }
+        case GateType::DEPOLARIZE1: {
             float p = op.args[0];
             std::array<double, 3> spread{p, p, p};
             err_pauli_channel_1({op.gate_type, spread, op.targets});
             break;
-        } case GateType::PAULI_CHANNEL_2:
+        }
+        case GateType::PAULI_CHANNEL_2:
             err_pauli_channel_2(op);
             break;
         case GateType::DEPOLARIZE2: {
@@ -367,7 +370,8 @@ void ErrorMatcher::rev_process_instruction(const CircuitInstruction &op) {
             break;
         default:
             throw std::invalid_argument(
-                "Not implemented in ErrorMatcher::rev_process_instruction: " + std::string(GATE_DATA[op.gate_type].name));
+                "Not implemented in ErrorMatcher::rev_process_instruction: " +
+                std::string(GATE_DATA[op.gate_type].name));
     }
 }
 


### PR DESCRIPTION
## Summary
Adds a generator that outputs a .wcnf file string in [WDIMACS format](http://www.maxhs.org/docs/wdimacs.html).
Added a few tests as well.

## Demo for the surface code
Here is a demo:

**Step 1:** Generate the WCNF file
```python
import stim
c = stim.Circuit.generated(
            "surface_code:rotated_memory_z",
            distance=5,
            rounds=2,
            after_clifford_depolarization=0.001,
)
wcnf = c.shortest_error_sat_problem()
with open('d5problem.wcnf', 'w') as outfile:
    outfile.write(wcnf)
```

**Step 2:** Fetch a solver from the [2023 maxSAT competition](https://maxsat-evaluations.github.io/2023/)
```bash
wget https://maxsat-evaluations.github.io/2023/mse23-solver-src/exact/CASHWMaxSAT-CorePlus.zip
unzip CASHWMaxSAT-CorePlus.zip
```

**Step 3:** Run the solver on the produced file
```bash
time ./CASHWMaxSAT-CorePlus/bin/cashwmaxsatcoreplus -bm -m d5problem.wcnf 
c Parsing MaxSAT file...
c Using SCIP solver, version 8.0.3, https://www.scipopt.org
c scip_time = 0.000000
c Starting SCIP solver in a separate thread (with time-limit = 0s) ...
c Using COMiniSatPS SAT solver by Chanseok Oh (2016)
o 5
c ============================[  Problem Statistics ]============================
c |  Number of variables:           995                                         |
c |  Number of clauses:            4377 (incl.            5 soft in queue)      |
c ===============================================================================
c Optimal solution: 5
c _______________________________________________________________________________
c 
c restarts               : 881
c conflicts              : 88351          (20350 /sec)
c decisions              : 257865         (0.00 % random) (59394 /sec)
c propagations           : 6079046        (1400176 /sec)
c conflict literals      : 4980307        (6.84 % deleted)
c =======================[ UWrMaxSat resources usage ]===========================
c Memory used            : 164.00 MB
c CPU time               : 4.34163 s
c Wall clock time        : 3 s
c OptExp Enc: Srt/BDD/Add: 12 0 0
c _______________________________________________________________________________
v 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000110010100001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010100000100010000010010000000000001
s OPTIMUM FOUND

real	0m2.215s
user	0m4.345s
sys	0m0.051s
```

## Verifying distances of several quasicyclic codes
I ran this on some circuits from [this paper](https://arxiv.org/pdf/2308.07915.pdf), with help from @oscarhiggott to generate the circuits.
The log file is attached below:
[n72_n90_n103_quasicyclic_codes_have_expected_distances_6_8_8.txt](https://github.com/quantumlib/Stim/files/14427119/n72_n90_n103_quasicyclic_codes_have_expected_distances_6_8_8.txt)
So far, it has proven that the n=72, n=29, and n=103 circuits have the expected distance reported in [the paper](https://arxiv.org/pdf/2308.07915.pdf).
I am still running solvers on the n=144 and n=288 cases. My computer got rebooted so I had to start over. I am cautiously optimistic that the solvers will finish within a few weeks.