### PR TITLE
Fix cirq-to-stim conversion not adding `TICK`s for multi-moment single-rep `CircuitOperation`s

### DIFF
--- a/glue/cirq/stimcirq/_cirq_to_stim.py
+++ b/glue/cirq/stimcirq/_cirq_to_stim.py
@@ -409,7 +409,8 @@ class CirqToStimHelper:
 
     def process_circuit_operation_into_repeat_block(self, op: cirq.CircuitOperation) -> None:
         if self.flatten or op.repetitions == 1:
-            self.process_operations(cirq.decompose_once(op))
+            moments = cirq.unroll_circuit_op(cirq.Circuit(op), deep=False, tags_to_check=None).moments
+            self.process_moments(moments)
             return
 
         child = CirqToStimHelper()

--- a/glue/cirq/stimcirq/_cirq_to_stim.py
+++ b/glue/cirq/stimcirq/_cirq_to_stim.py
@@ -411,6 +411,7 @@ class CirqToStimHelper:
         if self.flatten or op.repetitions == 1:
             moments = cirq.unroll_circuit_op(cirq.Circuit(op), deep=False, tags_to_check=None).moments
             self.process_moments(moments)
+            self.out = self.out[:-1] # Remove a trailing TICK (to avoid double TICK)
             return
 
         child = CirqToStimHelper()

--- a/glue/cirq/stimcirq/_cirq_to_stim_test.py
+++ b/glue/cirq/stimcirq/_cirq_to_stim_test.py
@@ -339,27 +339,30 @@ def test_on_loop():
     result = stimcirq.StimSampler().run(c)
     assert result.measurements.keys() == {'0:a', '0:b', '1:a', '1:b', '2:a', '2:b'}
 
-def test_loop_with_one_rep():
-    q0 = cirq.q(0)
+
+def test_multi_moment_circuit_operation():
+    q0 = cirq.LineQubit(0)
     cc = cirq.Circuit(
         cirq.CircuitOperation(
-        cirq.FrozenCircuit(
-            cirq.Moment(cirq.H(q0)),
-            cirq.Moment(cirq.H(q0)),
-            cirq.Moment(cirq.H(q0)),
-            cirq.Moment(cirq.H(q0)),
-        )
+            cirq.FrozenCircuit(
+                cirq.Moment(cirq.H(q0)),
+                cirq.Moment(cirq.H(q0)),
+                cirq.Moment(cirq.H(q0)),
+                cirq.Moment(cirq.H(q0)),
+            )
         )
     )
-    sc = stimcirq.cirq_circuit_to_stim_circuit(cc)
-    assert str(sc) == """H 0
-TICK
-H 0
-TICK
-H 0
-TICK
-H 0
-TICK"""
+    assert stimcirq.cirq_circuit_to_stim_circuit(cc) == stim.Circuit("""
+        H 0
+        TICK
+        H 0
+        TICK
+        H 0
+        TICK
+        H 0
+        TICK
+    """)
+
 
 def test_on_tagged_loop():
     a, b = cirq.LineQubit.range(2)

--- a/glue/cirq/stimcirq/_cirq_to_stim_test.py
+++ b/glue/cirq/stimcirq/_cirq_to_stim_test.py
@@ -352,7 +352,14 @@ def test_loop_with_one_rep():
         )
     )
     sc = stimcirq.cirq_circuit_to_stim_circuit(cc)
-    assert str(sc).splitlines().count('TICK') > 1
+    assert str(sc) == """H 0
+TICK
+H 0
+TICK
+H 0
+TICK
+H 0
+TICK"""
 
 def test_on_tagged_loop():
     a, b = cirq.LineQubit.range(2)

--- a/glue/cirq/stimcirq/_cirq_to_stim_test.py
+++ b/glue/cirq/stimcirq/_cirq_to_stim_test.py
@@ -339,6 +339,21 @@ def test_on_loop():
     result = stimcirq.StimSampler().run(c)
     assert result.measurements.keys() == {'0:a', '0:b', '1:a', '1:b', '2:a', '2:b'}
 
+def test_loop_with_one_rep():
+    q0 = cirq.q(0)
+    cc = cirq.Circuit(
+        cirq.CircuitOperation(
+        cirq.FrozenCircuit(
+            cirq.Moment(cirq.H(q0)),
+            cirq.Moment(cirq.H(q0)),
+            cirq.Moment(cirq.H(q0)),
+            cirq.Moment(cirq.H(q0)),
+        )
+        )
+    )
+    sc = stimcirq.cirq_circuit_to_stim_circuit(cc)
+    assert str(sc).splitlines().count('TICK') > 1
+
 def test_on_tagged_loop():
     a, b = cirq.LineQubit.range(2)
     c = cirq.Circuit(


### PR DESCRIPTION
Currently in `main` when we convert a cirq circuit to stim with a `CircuitOperation` with a single repetition (or with `flatten=True`) no TICK instructions are inserted since the moments are removed in the `cirq.decompose_once(op)` command.