### PR TITLE
Add `stim::ReferenceSampleTree` to support loop folded reference sampling

### DIFF
--- a/file_lists/perf_files
+++ b/file_lists/perf_files
@@ -18,4 +18,5 @@ src/stim/stabilizers/tableau.perf.cc
 src/stim/stabilizers/tableau_iter.perf.cc
 src/stim/util_bot/error_decomp.perf.cc
 src/stim/util_bot/probability_util.perf.cc
+src/stim/util_top/reference_sample_tree.perf.cc
 src/stim/util_top/stabilizers_to_tableau.perf.cc

--- a/file_lists/source_files_no_main
+++ b/file_lists/source_files_no_main
@@ -94,5 +94,6 @@ src/stim/util_top/circuit_vs_amplitudes.cc
 src/stim/util_top/export_crumble_url.cc
 src/stim/util_top/export_qasm.cc
 src/stim/util_top/export_quirk_url.cc
+src/stim/util_top/reference_sample_tree.cc
 src/stim/util_top/simplified_circuit.cc
 src/stim/util_top/transform_without_feedback.cc

--- a/file_lists/test_files
+++ b/file_lists/test_files
@@ -89,6 +89,7 @@ src/stim/util_top/export_crumble_url.test.cc
 src/stim/util_top/export_qasm.test.cc
 src/stim/util_top/export_quirk_url.test.cc
 src/stim/util_top/has_flow.test.cc
+src/stim/util_top/reference_sample_tree.test.cc
 src/stim/util_top/simplified_circuit.test.cc
 src/stim/util_top/stabilizers_to_tableau.test.cc
 src/stim/util_top/stabilizers_vs_amplitudes.test.cc

--- a/src/stim.h
+++ b/src/stim.h
@@ -115,6 +115,7 @@
 #include "stim/util_top/export_qasm.h"
 #include "stim/util_top/export_quirk_url.h"
 #include "stim/util_top/has_flow.h"
+#include "stim/util_top/reference_sample_tree.h"
 #include "stim/util_top/simplified_circuit.h"
 #include "stim/util_top/stabilizers_to_tableau.h"
 #include "stim/util_top/stabilizers_vs_amplitudes.h"

--- a/src/stim/io/measure_record.cc
+++ b/src/stim/io/measure_record.cc
@@ -53,3 +53,22 @@ void MeasureRecord::record_result(bool result) {
     storage.push_back(result);
     unwritten++;
 }
+
+void MeasureRecord::record_results(const std::vector<bool> &results) {
+    storage.insert(storage.end(), results.begin(), results.end());
+    unwritten += results.size();
+}
+
+void MeasureRecord::clear() {
+    unwritten = 0;
+    storage.clear();
+}
+
+void MeasureRecord::discard_results_past_max_lookback() {
+    if (storage.size() > max_lookback) {
+        storage.erase(storage.begin(), storage.end() - max_lookback);
+    }
+    if (unwritten > max_lookback) {
+        unwritten = max_lookback;
+    }
+}

--- a/src/stim/io/measure_record.h
+++ b/src/stim/io/measure_record.h
@@ -47,8 +47,14 @@ struct MeasureRecord {
     /// Args:
     ///     lookback: How far back the measurement is. lookback=1 is the latest measurement, 2 the second latest, etc.
     bool lookback(size_t lookback) const;
+    /// Batch record.
+    void record_results(const std::vector<bool> &results);
     /// Appends a measurement to the record.
     void record_result(bool result);
+    /// Clear the record.
+    void clear();
+    /// Truncates the record to only include bits within the lookback limit.
+    void discard_results_past_max_lookback();
 };
 
 }  // namespace stim

--- a/src/stim/simulators/tableau_simulator.perf.cc
+++ b/src/stim/simulators/tableau_simulator.perf.cc
@@ -14,6 +14,7 @@
 
 #include "stim/simulators/tableau_simulator.h"
 
+#include "stim/gen/circuit_gen_params.h"
 #include "stim/perf.perf.h"
 
 using namespace stim;

--- a/src/stim/util_top/reference_sample_tree.cc
+++ b/src/stim/util_top/reference_sample_tree.cc
@@ -130,7 +130,7 @@ ReferenceSampleTree ReferenceSampleTree::simplified() const {
     if (flat.empty()) {
         return ReferenceSampleTree();
     } else if (flat.size() == 1) {
-        return flat[0];
+        return std::move(flat[0]);
     }
 
     ReferenceSampleTree result;

--- a/src/stim/util_top/reference_sample_tree.cc
+++ b/src/stim/util_top/reference_sample_tree.cc
@@ -1,0 +1,152 @@
+#include "stim/util_top/reference_sample_tree.h"
+
+using namespace stim;
+
+bool ReferenceSampleTree::empty() const {
+    if (repetitions == 0) {
+        return true;
+    }
+    if (!prefix_bits.empty()) {
+        return false;
+    }
+    for (const auto &child: suffix_children) {
+        if (!child.empty()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void ReferenceSampleTree::flatten_and_simplify_into(std::vector<ReferenceSampleTree> &out) const {
+    if (repetitions == 0) {
+        return;
+    }
+
+    std::vector<ReferenceSampleTree> flattened;
+    if (!prefix_bits.empty()) {
+        flattened.push_back(ReferenceSampleTree{
+            .prefix_bits = prefix_bits,
+            .suffix_children = {},
+            .repetitions = 1,
+        });
+    }
+    for (const auto &child : suffix_children) {
+        child.flatten_and_simplify_into(flattened);
+    }
+
+    // Fuse children.
+    auto &f = flattened;
+    for (size_t k = 0; k < f.size(); k++) {
+        while (k + 1 < f.size() && f[k].repetitions == 1 && f[k].suffix_children.empty() && f[k + 1].repetitions == 1) {
+            f[k].suffix_children = std::move(f[k + 1].suffix_children);
+            f[k].prefix_bits.insert(f[k].prefix_bits.end(), f[k + 1].prefix_bits.begin(), f[k + 1].prefix_bits.end());
+            f.erase(f.begin() + k + 1);
+        }
+    }
+
+    if (repetitions == 1) {
+        // Un-nest all the children.
+        for (auto &e : flattened) {
+            out.push_back(e);
+        }
+    } else if (flattened.size() == 1) {
+        // Merge with single child.
+        flattened[0].repetitions *= repetitions;
+        out.push_back(std::move(flattened[0]));
+    } else if (flattened.empty()) {
+        // Nothing to report.
+    } else if (flattened[0].suffix_children.empty() && flattened[0].repetitions == 1) {
+        // Take payload from first child.
+        auto result = std::move(flattened[0]);
+        flattened.erase(flattened.begin());
+        result.repetitions = repetitions;
+        result.suffix_children = std::move(flattened);
+        out.push_back(std::move(result));
+    } else {
+        out.push_back(ReferenceSampleTree{
+            .prefix_bits={},
+            .suffix_children=std::move(flattened),
+            .repetitions=repetitions,
+        });
+    }
+}
+
+ReferenceSampleTree ReferenceSampleTree::simplified() const {
+    std::vector<ReferenceSampleTree> flat;
+    flatten_and_simplify_into(flat);
+    if (flat.empty()) {
+        return ReferenceSampleTree();
+    } else if (flat.size() == 1) {
+        return flat[0];
+    }
+
+    ReferenceSampleTree result;
+    result.repetitions = 1;
+    if (flat[0].repetitions == 1 && flat[0].suffix_children.empty()) {
+         // Take payload from first child.
+         result = std::move(flat[0]);
+         flat.erase(flat.begin());
+    }
+    result.suffix_children = std::move(flat);
+    return result;
+}
+
+size_t ReferenceSampleTree::size() const {
+    size_t result = prefix_bits.size();
+    for (const auto &child: suffix_children) {
+        result += child.size();
+    }
+    return result * repetitions;
+}
+
+void ReferenceSampleTree::decompress_into(std::vector<bool> &output) const {
+    for (uint64_t k = 0; k < repetitions; k++) {
+        output.insert(output.end(), prefix_bits.begin(), prefix_bits.end());
+        for (const auto &child: suffix_children) {
+            child.decompress_into(output);
+        }
+    }
+}
+
+ReferenceSampleTree ReferenceSampleTree::from_circuit_reference_sample(const Circuit &circuit) {
+    auto stats = circuit.compute_stats();
+    std::mt19937_64 irrelevant_rng{0};
+    CompressedReferenceSampleHelper<MAX_BITWORD_WIDTH> helper(
+        TableauSimulator<MAX_BITWORD_WIDTH>(
+            std::move(irrelevant_rng),
+            stats.num_qubits,
+            +1,
+            MeasureRecord(stats.max_lookback)));
+    return helper.do_loop_with_tortoise_hare_folding(circuit, 1).simplified();
+}
+
+std::string ReferenceSampleTree::str() const {
+    std::stringstream ss;
+    ss << *this;
+    return ss.str();
+}
+
+bool ReferenceSampleTree::operator==(const ReferenceSampleTree &other) const {
+    return repetitions == other.repetitions &&
+           prefix_bits == other.prefix_bits &&
+           suffix_children == other.suffix_children;
+}
+bool ReferenceSampleTree::operator!=(const ReferenceSampleTree &other) const {
+    return !(*this == other);
+}
+
+std::ostream &stim::operator<<(std::ostream &out, const ReferenceSampleTree &v) {
+    out << v.repetitions << "*";
+    out << "(";
+    out << "'";
+    for (auto b : v.prefix_bits) {
+        out << "01"[b];
+    }
+    out << "'";
+    for (const auto &child : v.suffix_children) {
+        out << "+";
+        out << child;
+    }
+    out << ")";
+    return out;
+}

--- a/src/stim/util_top/reference_sample_tree.h
+++ b/src/stim/util_top/reference_sample_tree.h
@@ -33,6 +33,8 @@ struct ReferenceSampleTree {
     /// Writes the contents of the tree into the given output vector.
     void decompress_into(std::vector<bool> &output) const;
 
+    void try_factorize(size_t period_factor);
+
    private:
     void flatten_and_simplify_into(std::vector<ReferenceSampleTree> &out) const;
 };
@@ -60,6 +62,11 @@ struct CompressedReferenceSampleHelper {
     ReferenceSampleTree do_loop_with_tortoise_hare_folding(
         const Circuit &loop,
         uint64_t reps);
+
+    bool in_same_recent_state_as(
+        const CompressedReferenceSampleHelper<W> &other,
+        uint64_t max_record_lookback,
+        bool allow_false_negative) const;
 };
 
 }  // namespace stim

--- a/src/stim/util_top/reference_sample_tree.h
+++ b/src/stim/util_top/reference_sample_tree.h
@@ -1,0 +1,69 @@
+#ifndef _STIM_UTIL_TOP_REFERENCE_SAMPLE_TREE_H
+#define _STIM_UTIL_TOP_REFERENCE_SAMPLE_TREE_H
+
+#include "stim/simulators/tableau_simulator.h"
+
+namespace stim {
+
+/// A compressed tree representation of a reference sample.
+struct ReferenceSampleTree {
+    /// Bits to repeatedly output before outputting bits for the children.
+    std::vector<bool> prefix_bits;
+    /// Compressed representations of additional bits to output after the prefix.
+    std::vector<ReferenceSampleTree> suffix_children;
+    /// The number of times to repeatedly output the prefix and suffix bits.
+    size_t repetitions = 0;
+
+    /// Initializes a reference sample tree containing a reference sample for the given circuit.
+    static ReferenceSampleTree from_circuit_reference_sample(const Circuit &circuit);
+
+    /// Returns a tree with the same compressed contents, but a simpler tree structure.
+    ReferenceSampleTree simplified() const;
+
+    /// Determines whether the tree contains any bits at all.
+    bool empty() const;
+
+    bool operator==(const ReferenceSampleTree &other) const;
+    bool operator!=(const ReferenceSampleTree &other) const;
+    std::string str() const;
+
+    /// Computes the total size of the uncompressed bits represented by the tree.
+    size_t size() const;
+
+    /// Writes the contents of the tree into the given output vector.
+    void decompress_into(std::vector<bool> &output) const;
+
+   private:
+    void flatten_and_simplify_into(std::vector<ReferenceSampleTree> &out) const;
+};
+std::ostream &operator<<(std::ostream &out, const ReferenceSampleTree &v);
+
+/// Helper class for computing compressed reference samples.
+template <size_t W>
+struct CompressedReferenceSampleHelper {
+    TableauSimulator<W> sim;
+
+    CompressedReferenceSampleHelper(TableauSimulator<MAX_BITWORD_WIDTH> sim) : sim(sim) {
+    }
+
+    /// Processes a loop with no top-level folding.
+    ///
+    /// Loops containing within the body of this loop (or circuit body) may
+    /// still be compressed. Only the top-level loop is not folded.
+    ReferenceSampleTree do_loop_with_no_folding(
+        const Circuit &loop,
+        uint64_t reps);
+
+    /// Runs tortoise-and-hare analysis of the loop while simulating its
+    /// reference sample, in order to attempt to return a compressed
+    /// representation.
+    ReferenceSampleTree do_loop_with_tortoise_hare_folding(
+        const Circuit &loop,
+        uint64_t reps);
+};
+
+}  // namespace stim
+
+#include "stim/util_top/reference_sample_tree.inl"
+
+#endif

--- a/src/stim/util_top/reference_sample_tree.inl
+++ b/src/stim/util_top/reference_sample_tree.inl
@@ -1,0 +1,115 @@
+#include "stim/util_top/reference_sample_tree.h"
+
+namespace stim {
+
+template <size_t W>
+ReferenceSampleTree CompressedReferenceSampleHelper<W>::do_loop_with_no_folding(const Circuit &loop, uint64_t reps) {
+    ReferenceSampleTree result;
+    result.repetitions = 1;
+    size_t start_size = sim.measurement_record.storage.size();
+
+    auto flush_recorded_into_result = [&]() {
+        size_t end_size = sim.measurement_record.storage.size();
+        if (end_size > start_size) {
+            result.suffix_children.push_back({});
+            auto &child = result.suffix_children.back();
+            child.repetitions = 1;
+            child.prefix_bits.insert(
+                child.prefix_bits.end(),
+                sim.measurement_record.storage.begin() + start_size,
+                sim.measurement_record.storage.begin() + end_size);
+        }
+        start_size = end_size;
+    };
+
+    for (size_t k = 0; k < reps; k++) {
+        for (const auto &inst : loop.operations) {
+            if (inst.gate_type == GateType::REPEAT) {
+                uint64_t repeats = inst.repeat_block_rep_count();
+                const auto& block = inst.repeat_block_body(loop);
+                flush_recorded_into_result();
+                result.suffix_children.push_back(do_loop_with_tortoise_hare_folding(block, repeats));
+                start_size = sim.measurement_record.storage.size();
+            } else {
+                sim.do_gate(inst);
+            }
+        }
+    }
+
+    flush_recorded_into_result();
+    return result;
+}
+
+template <size_t W>
+ReferenceSampleTree CompressedReferenceSampleHelper<W>::do_loop_with_tortoise_hare_folding(const Circuit &loop, uint64_t reps) {
+    if (reps < 10) {
+        return do_loop_with_no_folding(loop, reps);
+    }
+
+    ReferenceSampleTree result;
+    result.repetitions = 1;
+
+    CompressedReferenceSampleHelper<W> tortoise(sim);
+    CompressedReferenceSampleHelper<W> hare(std::move(sim));
+    uint64_t tortoise_steps = 0;
+    uint64_t hare_steps = 0;
+    while (hare_steps < reps) {
+        hare_steps++;
+        result.suffix_children.push_back(hare.do_loop_with_no_folding(loop, 1));
+        assert(result.suffix_children.size() == hare_steps);
+
+        if (hare_steps < 10) {
+            // Start with cheap equality checks that can have false negatives.
+            if (tortoise.sim.inv_state == hare.sim.inv_state) {
+                break;
+            }
+        } else {
+            // For higher repetition counts, transition to more expensive equality checks.
+            if (tortoise.sim.canonical_stabilizers() == hare.sim.canonical_stabilizers()) {
+                break;
+            }
+        }
+
+        // Tortoise advances half as quickly.
+        if (hare_steps & 1) {
+            tortoise_steps++;
+            tortoise.do_loop_with_no_folding(loop, 1);
+        }
+    }
+
+    sim = std::move(hare.sim);
+
+    if (hare_steps == reps) {
+        // No loop found.
+        return result;
+    }
+
+    // Move the loop steps out of the hare and into a loop node.
+    ReferenceSampleTree loop_contents;
+    uint64_t period = hare_steps - tortoise_steps;
+    size_t period_steps_left = (reps - hare_steps) / period;
+    for (size_t k = tortoise_steps; k < hare_steps; k++) {
+        loop_contents.suffix_children.push_back(std::move(result.suffix_children[k]));
+    }
+    result.suffix_children.resize(tortoise_steps);
+
+    // Add any remaining measurement data into the sim's measurement record.
+    loop_contents.repetitions = 1;
+    sim.measurement_record.discard_results_past_max_lookback();
+    for (size_t k = 0; k < period_steps_left && sim.measurement_record.storage.size() < sim.measurement_record.max_lookback * 2; k++) {
+        loop_contents.decompress_into(sim.measurement_record.storage);
+    }
+    sim.measurement_record.discard_results_past_max_lookback();
+
+    // Add the loop node to the output data.
+    loop_contents.repetitions = period_steps_left + 1;
+    result.suffix_children.push_back(std::move(loop_contents));
+    hare_steps += period * period_steps_left;
+
+    // Process any iterations remaining in the loop.
+    result.suffix_children.push_back(do_loop_with_no_folding(loop, reps - hare_steps));
+
+    return result;
+}
+
+}  // namespace stim

--- a/src/stim/util_top/reference_sample_tree.inl
+++ b/src/stim/util_top/reference_sample_tree.inl
@@ -72,7 +72,7 @@ ReferenceSampleTree CompressedReferenceSampleHelper<W>::do_loop_with_tortoise_ha
     }
 
     if (hare_steps == reps) {
-        // No loop found.
+        // No periodic state found before reaching the end of the loop.
         sim = std::move(hare.sim);
         return result;
     }

--- a/src/stim/util_top/reference_sample_tree.perf.cc
+++ b/src/stim/util_top/reference_sample_tree.perf.cc
@@ -1,0 +1,23 @@
+#include "stim/util_top/reference_sample_tree.h"
+
+#include "stim/gen/circuit_gen_params.h"
+#include "stim/gen/gen_surface_code.h"
+#include "stim/perf.perf.h"
+
+using namespace stim;
+
+BENCHMARK(reference_sample_tree_surface_code_d31_r1000000000) {
+    CircuitGenParameters params(1000000000, 31, "rotated_memory_x");
+    auto circuit = generate_surface_code_circuit(params).circuit;
+    simd_bits<MAX_BITWORD_WIDTH> ref(0);
+    auto total = 0;
+    benchmark_go([&]() {
+        auto result = ReferenceSampleTree::from_circuit_reference_sample(circuit);
+        total += result.empty();
+    })
+        .goal_millis(25)
+        .show_rate("Samples", circuit.count_measurements());
+    if (total) {
+        std::cerr << "data dependence";
+    }
+}

--- a/src/stim/util_top/reference_sample_tree.perf.cc
+++ b/src/stim/util_top/reference_sample_tree.perf.cc
@@ -15,8 +15,37 @@ BENCHMARK(reference_sample_tree_surface_code_d31_r1000000000) {
         auto result = ReferenceSampleTree::from_circuit_reference_sample(circuit);
         total += result.empty();
     })
-        .goal_millis(25)
-        .show_rate("Samples", circuit.count_measurements());
+        .goal_millis(25);
+    if (total) {
+        std::cerr << "data dependence";
+    }
+}
+
+BENCHMARK(reference_sample_tree_nested_circuit) {
+    Circuit circuit(R"CIRCUIT(
+        M 0
+        REPEAT 100000 {
+            REPEAT 100000 {
+                REPEAT 100000 {
+                    X 0
+                    M 0
+                }
+                X 0
+                M 0
+            }
+            X 0
+            M 0
+        }
+        X 0
+        M 0
+    )CIRCUIT");
+    simd_bits<MAX_BITWORD_WIDTH> ref(0);
+    auto total = 0;
+    benchmark_go([&]() {
+        auto result = ReferenceSampleTree::from_circuit_reference_sample(circuit);
+        total += result.empty();
+    })
+        .goal_micros(230);
     if (total) {
         std::cerr << "data dependence";
     }

--- a/src/stim/util_top/reference_sample_tree.test.cc
+++ b/src/stim/util_top/reference_sample_tree.test.cc
@@ -1,0 +1,216 @@
+#include "stim/util_top/reference_sample_tree.h"
+
+#include "gtest/gtest.h"
+
+#include "stim/gen/gen_surface_code.h"
+
+using namespace stim;
+
+TEST(ReferenceSampleTree, equality) {
+    ReferenceSampleTree empty1{
+        .prefix_bits={},
+        .suffix_children={},
+        .repetitions=0,
+    };
+    ReferenceSampleTree empty2;
+    ASSERT_EQ(empty1, empty2);
+
+    ASSERT_FALSE(empty1 != empty2);
+    ASSERT_NE(empty1, (ReferenceSampleTree{.prefix_bits={},.suffix_children{},.repetitions=1}));
+    ASSERT_NE(empty1, (ReferenceSampleTree{.prefix_bits={0},.suffix_children{},.repetitions=0}));
+    ASSERT_NE(empty1, (ReferenceSampleTree{.prefix_bits={},.suffix_children{{}},.repetitions=0}));
+}
+
+TEST(ReferenceSampleTree, str) {
+    ASSERT_EQ((ReferenceSampleTree{
+        .prefix_bits={},
+        .suffix_children={},
+        .repetitions=0,
+    }.str()), "0*('')");
+
+    ASSERT_EQ((ReferenceSampleTree{
+        .prefix_bits={1, 1, 0, 1},
+        .suffix_children={},
+        .repetitions=0,
+    }.str()), "0*('1101')");
+
+    ASSERT_EQ((ReferenceSampleTree{
+        .prefix_bits={1, 1, 0, 1},
+        .suffix_children={},
+        .repetitions=2,
+    }.str()), "2*('1101')");
+
+    ASSERT_EQ((ReferenceSampleTree{
+        .prefix_bits={1, 1, 0, 1},
+        .suffix_children={
+            ReferenceSampleTree{
+                .prefix_bits={1},
+                .suffix_children={},
+                .repetitions=5,
+            }
+        },
+        .repetitions=2,
+    }.str()), "2*('1101'+5*('1'))");
+}
+
+TEST(ReferenceSampleTree, simplified) {
+    ReferenceSampleTree raw{
+        .prefix_bits={},
+        .suffix_children={
+            ReferenceSampleTree{
+                .prefix_bits={},
+                .suffix_children={},
+                .repetitions=1,
+            },
+            ReferenceSampleTree{
+                .prefix_bits={1, 0, 1},
+                .suffix_children={{}},
+                .repetitions=0,
+            },
+            ReferenceSampleTree{
+                .prefix_bits={1, 1, 1},
+                .suffix_children={},
+                .repetitions=2,
+            },
+        },
+        .repetitions=3,
+    };
+    ASSERT_EQ(raw.simplified().str(), "6*('111')");
+}
+
+TEST(ReferenceSampleTree, decompress_into) {
+    std::vector<bool> result;
+    ReferenceSampleTree{
+        .prefix_bits={1, 1, 0, 1},
+        .suffix_children={
+            ReferenceSampleTree{
+                .prefix_bits={1},
+                .suffix_children={},
+                .repetitions=5,
+            }
+        },
+        .repetitions=2,
+    }.decompress_into(result);
+    ASSERT_EQ(result, (std::vector<bool>{1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1}));
+
+    result.clear();
+    ReferenceSampleTree{
+        .prefix_bits={1, 1, 0, 1},
+        .suffix_children={
+            ReferenceSampleTree{
+                .prefix_bits={1, 0, 1},
+                .suffix_children={},
+                .repetitions=8,
+            },
+            ReferenceSampleTree{
+                .prefix_bits={0, 0},
+                .suffix_children={},
+                .repetitions=1,
+            },
+        },
+        .repetitions=1,
+    }.decompress_into(result);
+    ASSERT_EQ(result, (std::vector<bool>{1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 0, 0}));
+}
+
+TEST(ReferenceSampleTree, simple_circuit) {
+    Circuit circuit(R"CIRCUIT(
+        M 0
+        X 0
+        M 0
+    )CIRCUIT");
+    auto ref = ReferenceSampleTree::from_circuit_reference_sample(circuit);
+    ASSERT_EQ(ref.str(), "1*('01')");
+}
+
+TEST(ReferenceSampleTree, simple_loop) {
+    Circuit circuit(R"CIRCUIT(
+        REPEAT 50 {
+            M 0
+            X 0
+            M 0
+        }
+    )CIRCUIT");
+    auto ref = ReferenceSampleTree::from_circuit_reference_sample(circuit);
+    ASSERT_EQ(ref.str(), "1*('01'+24*('1001')+1*('10'))");
+}
+
+TEST(ReferenceSampleTree, period4_loop) {
+    Circuit circuit(R"CIRCUIT(
+        M 0
+        X 0
+        M 0
+        REPEAT 50 {
+            CX 0 1 1 2 2 3
+            M 0 1 2 3
+        }
+        X 0
+        M 0
+        X 2
+        M 2 2 2 2 2
+    )CIRCUIT");
+    auto ref = ReferenceSampleTree::from_circuit_reference_sample(circuit);
+    ASSERT_EQ(ref.size(), circuit.count_measurements());
+    ASSERT_EQ(ref.str(), "1*('01111110101100'+11*('1000111110101100')+1*('100011111010000000'))");
+}
+
+TEST(ReferenceSampleTree, nested_loops) {
+    Circuit circuit(R"CIRCUIT(
+        REPEAT 100 {
+            REPEAT 100 {
+                M 0
+                X 0
+                M 0
+            }
+            REPEAT 200 {
+                M 0
+            }
+            X 1
+            CX 1 0
+        }
+    )CIRCUIT");
+    auto ref = ReferenceSampleTree::from_circuit_reference_sample(circuit);
+    ASSERT_EQ(ref.str(), "1*('01'+49*('1001')+1*('10')+200*('0')+1*('10')+49*('0110')+1*('01')+200*('1')+1*('10')+49*('0110')+1*('01')+200*('1')+24*('01'+49*('1001')+1*('10')+200*('0')+1*('01')+49*('1001')+1*('10')+200*('0')+1*('10')+49*('0110')+1*('01')+200*('1')+1*('10')+49*('0110')+1*('01')+200*('1'))+1*('01')+49*('1001')+1*('10')+200*('0'))");
+
+    std::vector<bool> ref_uncompressed;
+    ref.decompress_into(ref_uncompressed);
+    simd_bits<MAX_BITWORD_WIDTH> ref_flat(ref_uncompressed.size());
+    for (size_t k = 0; k < ref_uncompressed.size(); k++) {
+        ref_flat[k] = ref_uncompressed[k];
+    }
+    auto ref2 = TableauSimulator<MAX_BITWORD_WIDTH>::reference_sample_circuit(circuit);
+    ASSERT_EQ(ref_flat, ref2);
+}
+
+TEST(ReferenceSampleTree, surface_code) {
+    CircuitGenParameters params(10000, 5, "rotated_memory_x");
+    auto circuit = generate_surface_code_circuit(params).circuit;
+    auto ref = ReferenceSampleTree::from_circuit_reference_sample(circuit);
+    ASSERT_EQ(ref.str(), "1*('000000000000000000000000000000000000000000000000'+4999*('000000000000000000000000000000000000000000000000')+1*('0000000000000000000000000'))");
+}
+
+TEST(ReferenceSampleTree, surface_code_with_pauli) {
+    CircuitGenParameters params(10000, 3, "rotated_memory_x");
+    auto circuit = generate_surface_code_circuit(params).circuit;
+    circuit.blocks[0].append_from_text("X 10 11 12 13");
+    auto ref = ReferenceSampleTree::from_circuit_reference_sample(circuit);
+    ASSERT_EQ(ref.str(), "1*('0000000000000000'+4999*('0110000000110000')+1*('000000000'))");
+}
+
+TEST(ReferenceSampleTree, surface_code_with_pauli_vs_normal_reference_sample) {
+    CircuitGenParameters params(20, 3, "rotated_memory_x");
+    auto circuit = generate_surface_code_circuit(params).circuit;
+    circuit.blocks[0].append_from_text("X 10 11 12 13");
+    auto ref = ReferenceSampleTree::from_circuit_reference_sample(circuit);
+    ASSERT_EQ(ref.size(), circuit.count_measurements());
+
+    std::vector<bool> ref_uncompressed;
+    ref.decompress_into(ref_uncompressed);
+    simd_bits<MAX_BITWORD_WIDTH> ref_flat(ref_uncompressed.size());
+    for (size_t k = 0; k < ref_uncompressed.size(); k++) {
+        ref_flat[k] = ref_uncompressed[k];
+    }
+
+    auto ref2 = TableauSimulator<MAX_BITWORD_WIDTH>::reference_sample_circuit(circuit);
+    ASSERT_EQ(ref_flat, ref2);
+}

--- a/src/stim/util_top/reference_sample_tree.test.cc
+++ b/src/stim/util_top/reference_sample_tree.test.cc
@@ -183,6 +183,46 @@ TEST(ReferenceSampleTree, feedback) {
     ASSERT_EQ(ref.str(), "1*('0010'+2*('0')+4*('1')+1*('01011001000111')+12*('101011001000111'))");
 }
 
+TEST(max_feedback_lookback_in_loop, simple) {
+    ASSERT_EQ(max_feedback_lookback_in_loop(Circuit()), 0);
+
+    ASSERT_EQ(max_feedback_lookback_in_loop(Circuit(R"CIRCUIT(
+        REPEAT 100 {
+            REPEAT 100 {
+                M 0
+                X 0
+                M 0
+            }
+            REPEAT 200 {
+                M 0
+                DETECTOR rec[-1]
+            }
+            X 1
+            CX 1 0
+        }
+    )CIRCUIT")), 0);
+
+    ASSERT_EQ(max_feedback_lookback_in_loop(Circuit(R"CIRCUIT(
+        CX rec[-1] 0
+    )CIRCUIT")), 1);
+
+    ASSERT_EQ(max_feedback_lookback_in_loop(Circuit(R"CIRCUIT(
+        CZ 0 rec[-2]
+    )CIRCUIT")), 2);
+
+    ASSERT_EQ(max_feedback_lookback_in_loop(Circuit(R"CIRCUIT(
+        CZ 0 rec[-2]
+        CY 0 rec[-3]
+    )CIRCUIT")), 3);
+
+    ASSERT_EQ(max_feedback_lookback_in_loop(Circuit(R"CIRCUIT(
+        CZ 0 rec[-2]
+        REPEAT 100 {
+            CX rec[-5] 0
+        }
+    )CIRCUIT")), 5);
+}
+
 TEST(ReferenceSampleTree, nested_loops) {
     Circuit circuit(R"CIRCUIT(
         REPEAT 100 {

--- a/src/stim/util_top/reference_sample_tree.test.cc
+++ b/src/stim/util_top/reference_sample_tree.test.cc
@@ -264,14 +264,5 @@ TEST(ReferenceSampleTree, surface_code_with_pauli_vs_normal_reference_sample) {
     circuit.blocks[0].append_from_text("X 10 11 12 13");
     auto ref = ReferenceSampleTree::from_circuit_reference_sample(circuit);
     ASSERT_EQ(ref.size(), circuit.count_measurements());
-
-    std::vector<bool> ref_uncompressed;
-    ref.decompress_into(ref_uncompressed);
-    simd_bits<MAX_BITWORD_WIDTH> ref_flat(ref_uncompressed.size());
-    for (size_t k = 0; k < ref_uncompressed.size(); k++) {
-        ref_flat[k] = ref_uncompressed[k];
-    }
-
-    auto ref2 = TableauSimulator<MAX_BITWORD_WIDTH>::reference_sample_circuit(circuit);
-    ASSERT_EQ(ref_flat, ref2);
+    expect_tree_matches_normal_reference_sample_of(ref, circuit);
 }


### PR DESCRIPTION
Get a compressed tree representation of the reference sample by using `stim::ReferenceSampleTree::from_circuit_reference_sample(circuit)`.

The reason for a tree, instead of raw run length encoding, is to support nested loops (e.g. physical surface code rounds repeating within repeated logical operations).

Example test:

```
    CircuitGenParameters params(10000, 3, "rotated_memory_x");
    auto circuit = generate_surface_code_circuit(params).circuit;
    circuit.blocks[0].append_from_text("X 10 11 12 13");
    auto ref = ReferenceSampleTree::from_circuit_reference_sample(circuit);
    ASSERT_EQ(ref.str(), "1*(''+2*('00000000')+4999*('0110000000110000')+1*('000000000'))");
```

Example benchmark (25 milliseconds to do a distance 31 surface code with a billion rounds):

```
    CircuitGenParameters params(1000000000, 31, "rotated_memory_x");
    auto circuit = generate_surface_code_circuit(params).circuit;
    simd_bits<MAX_BITWORD_WIDTH> ref(0);
    auto total = 0;
    benchmark_go([&]() {
        auto result = ReferenceSampleTree::from_circuit_reference_sample(circuit);
        total += result.empty();
    })
        .goal_millis(25);
```

Part of https://github.com/quantumlib/Stim/issues/768