### PR TITLE
Change return type of CircuitRepeatBlock.name to str

### DIFF
--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -2840,7 +2840,7 @@ class CircuitRepeatBlock:
     @property
     def name(
         self,
-    ) -> object:
+    ) -> str:
         """Returns the name "REPEAT".
 
         This is a duck-typing convenience method. It exists so that code that doesn't


### PR DESCRIPTION
The correct return type for this method should be `str` as the documentation guarantees that this specific method returns `"REPEAT"`.

Fixes #776 