### PR TITLE
Add `stim.Circuit.insert` and numpy 2 compat

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,10 +1,12 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@pybind11_bazel//:python_configure.bzl", "python_configure")
+
 http_archive(
     name = "pybind11",
     build_file = "@pybind11_bazel//:pybind11.BUILD",
-    sha256 = "d475978da0cdc2d43b73f30910786759d593a9d8ee05b1b6846d1eb16c6d2e0c",
-    strip_prefix = "pybind11-2.11.1",
-    urls = ["https://github.com/pybind/pybind11/archive/refs/tags/v2.11.1.tar.gz"],
+    sha256 = "bf8f242abd1abcd375d516a7067490fb71abd79519a282d22b6e4d19282185a7",
+    strip_prefix = "pybind11-2.12.0",
+    urls = ["https://github.com/pybind/pybind11/archive/refs/tags/v2.12.0.tar.gz"],
 )
-load("@pybind11_bazel//:python_configure.bzl", "python_configure")
+
 python_configure(name = "local_config_python")

--- a/dev/util_gen_stub_file.py
+++ b/dev/util_gen_stub_file.py
@@ -94,6 +94,12 @@ class DescribedObject:
 
 
 def splay_signature(sig: str) -> List[str]:
+    # Maintain backwards compatibility with python 3.6
+    sig = sig.replace('list[', 'List[')
+    sig = sig.replace('dict[', 'Dict[')
+    sig = sig.replace('tuple[', 'Tuple[')
+    sig = sig.replace('set[', 'Set[')
+
     assert sig.startswith('def')
     out = []
 

--- a/doc/gates.md
+++ b/doc/gates.md
@@ -3111,7 +3111,7 @@ Decomposition (into H, S, CX, M, R):
 <a name="SPP_DAG"></a>
 ### The 'SPP_DAG' Instruction
 
-The generalized S gate. Phases the -1 eigenspace of Pauli product observables by i.
+The generalized S_DAG gate. Phases the -1 eigenspace of Pauli product observables by -i.
 
 Parens Arguments:
 

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -39,6 +39,7 @@ API references for stable versions are kept on the [stim github wiki](https://gi
     - [`stim.Circuit.get_final_qubit_coordinates`](#stim.Circuit.get_final_qubit_coordinates)
     - [`stim.Circuit.has_all_flows`](#stim.Circuit.has_all_flows)
     - [`stim.Circuit.has_flow`](#stim.Circuit.has_flow)
+    - [`stim.Circuit.insert`](#stim.Circuit.insert)
     - [`stim.Circuit.inverse`](#stim.Circuit.inverse)
     - [`stim.Circuit.likeliest_error_sat_problem`](#stim.Circuit.likeliest_error_sat_problem)
     - [`stim.Circuit.num_detectors`](#stim.Circuit.num_detectors)
@@ -2220,6 +2221,64 @@ def has_flow(
         positive, and a 0% chance of a false negative. So, when the method returns
         True, there is technically still a 2^-256 chance the circuit doesn't have
         the flow. This is lower than the chance of a cosmic ray flipping the result.
+    """
+```
+
+<a name="stim.Circuit.insert"></a>
+```python
+# stim.Circuit.insert
+
+# (in class stim.Circuit)
+def insert(
+    self,
+    index: int,
+    operation: Union[stim.CircuitInstruction, stim.Circuit],
+) -> None:
+    """Inserts an operation at the given index, pushing existing operations forward.
+
+    Note that, unlike when appending operations or parsing stim circuit files,
+    inserted operations aren't automatically fused into the preceding operation.
+    This is to avoid creating complicated situations where it's difficult to reason
+    about how the indices of operations change in response to insertions.
+
+    Args:
+        index: The index to insert at.
+
+            Must satisfy -len(circuit) <= index < len(circuit). Negative indices
+            are made non-negative by adding len(circuit) to them, so they refer to
+            indices relative to the end of the circuit instead of the start.
+
+            Instructions before the index are not shifted. Instructions that
+            were at or after the index are shifted forwards.
+        operation: The object to insert. This can be a single
+            stim.CircuitInstruction or an entire stim.Circuit.
+
+    Examples:
+        >>> import stim
+        >>> c = stim.Circuit('''
+        ...     H 0
+        ...     S 1
+        ...     X 2
+        ... ''')
+        >>> c.insert(1, stim.CircuitInstruction("Y", [3, 4, 5]))
+        >>> c
+        stim.Circuit('''
+            H 0
+            Y 3 4 5
+            S 1
+            X 2
+        ''')
+        >>> c.insert(-1, stim.Circuit("S 999\nCX 0 1\nCZ 2 3"))
+        >>> c
+        stim.Circuit('''
+            H 0
+            Y 3 4 5
+            S 1
+            S 999
+            CX 0 1
+            CZ 2 3
+            X 2
+        ''')
     """
 ```
 

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -2635,7 +2635,7 @@ def reference_sample(
         ...    X 1
         ...    M 0 1
         ... ''').reference_sample()
-        array([False, True])
+        array([False,  True])
     """
 ```
 

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -2628,6 +2628,14 @@ def reference_sample(
 
     Returns:
         reference_sample: reference sample sampled from the given circuit.
+
+    Examples:
+        >>> import stim
+        >>> stim.Circuit('''
+        ...    X 1
+        ...    M 0 1
+        ... ''').reference_sample()
+        array([False, True])
     """
 ```
 
@@ -13891,15 +13899,18 @@ def state_vector(
         >>> import numpy as np
         >>> s = stim.TableauSimulator()
         >>> s.x(2)
-        >>> list(s.state_vector(endian='little'))
-        [0j, 0j, 0j, 0j, (1+0j), 0j, 0j, 0j]
+        >>> s.state_vector(endian='little')
+        array([0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+              dtype=complex64)
 
-        >>> list(s.state_vector(endian='big'))
-        [0j, (1+0j), 0j, 0j, 0j, 0j, 0j, 0j]
+        >>> s.state_vector(endian='big')
+        array([0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+              dtype=complex64)
 
         >>> s.sqrt_x(1, 2)
-        >>> list(s.state_vector())
-        [(0.5+0j), 0j, -0.5j, 0j, 0.5j, 0j, (0.5+0j), 0j]
+        >>> s.state_vector()
+        array([0.5+0.j , 0. +0.j , 0. -0.5j, 0. +0.j , 0. +0.5j, 0. +0.j ,
+               0.5+0.j , 0. +0.j ], dtype=complex64)
     """
 ```
 

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -1936,6 +1936,14 @@ class Circuit:
 
         Returns:
             reference_sample: reference sample sampled from the given circuit.
+
+        Examples:
+            >>> import stim
+            >>> stim.Circuit('''
+            ...    X 1
+            ...    M 0 1
+            ... ''').reference_sample()
+            array([False, True])
         """
     def search_for_undetectable_logical_errors(
         self,
@@ -10902,15 +10910,18 @@ class TableauSimulator:
             >>> import numpy as np
             >>> s = stim.TableauSimulator()
             >>> s.x(2)
-            >>> list(s.state_vector(endian='little'))
-            [0j, 0j, 0j, 0j, (1+0j), 0j, 0j, 0j]
+            >>> s.state_vector(endian='little')
+            array([0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+                  dtype=complex64)
 
-            >>> list(s.state_vector(endian='big'))
-            [0j, (1+0j), 0j, 0j, 0j, 0j, 0j, 0j]
+            >>> s.state_vector(endian='big')
+            array([0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+                  dtype=complex64)
 
             >>> s.sqrt_x(1, 2)
-            >>> list(s.state_vector())
-            [(0.5+0j), 0j, -0.5j, 0j, 0.5j, 0j, (0.5+0j), 0j]
+            >>> s.state_vector()
+            array([0.5+0.j , 0. +0.j , 0. -0.5j, 0. +0.j , 0. +0.5j, 0. +0.j ,
+                   0.5+0.j , 0. +0.j ], dtype=complex64)
         """
     def swap(
         self,

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -1943,7 +1943,7 @@ class Circuit:
             ...    X 1
             ...    M 0 1
             ... ''').reference_sample()
-            array([False, True])
+            array([False,  True])
         """
     def search_for_undetectable_logical_errors(
         self,

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -1600,6 +1600,57 @@ class Circuit:
             True, there is technically still a 2^-256 chance the circuit doesn't have
             the flow. This is lower than the chance of a cosmic ray flipping the result.
         """
+    def insert(
+        self,
+        index: int,
+        operation: Union[stim.CircuitInstruction, stim.Circuit],
+    ) -> None:
+        """Inserts an operation at the given index, pushing existing operations forward.
+
+        Note that, unlike when appending operations or parsing stim circuit files,
+        inserted operations aren't automatically fused into the preceding operation.
+        This is to avoid creating complicated situations where it's difficult to reason
+        about how the indices of operations change in response to insertions.
+
+        Args:
+            index: The index to insert at.
+
+                Must satisfy -len(circuit) <= index < len(circuit). Negative indices
+                are made non-negative by adding len(circuit) to them, so they refer to
+                indices relative to the end of the circuit instead of the start.
+
+                Instructions before the index are not shifted. Instructions that
+                were at or after the index are shifted forwards.
+            operation: The object to insert. This can be a single
+                stim.CircuitInstruction or an entire stim.Circuit.
+
+        Examples:
+            >>> import stim
+            >>> c = stim.Circuit('''
+            ...     H 0
+            ...     S 1
+            ...     X 2
+            ... ''')
+            >>> c.insert(1, stim.CircuitInstruction("Y", [3, 4, 5]))
+            >>> c
+            stim.Circuit('''
+                H 0
+                Y 3 4 5
+                S 1
+                X 2
+            ''')
+            >>> c.insert(-1, stim.Circuit("S 999\nCX 0 1\nCZ 2 3"))
+            >>> c
+            stim.Circuit('''
+                H 0
+                Y 3 4 5
+                S 1
+                S 999
+                CX 0 1
+                CZ 2 3
+                X 2
+            ''')
+        """
     def inverse(
         self,
     ) -> stim.Circuit:

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -1936,6 +1936,14 @@ class Circuit:
 
         Returns:
             reference_sample: reference sample sampled from the given circuit.
+
+        Examples:
+            >>> import stim
+            >>> stim.Circuit('''
+            ...    X 1
+            ...    M 0 1
+            ... ''').reference_sample()
+            array([False, True])
         """
     def search_for_undetectable_logical_errors(
         self,
@@ -10902,15 +10910,18 @@ class TableauSimulator:
             >>> import numpy as np
             >>> s = stim.TableauSimulator()
             >>> s.x(2)
-            >>> list(s.state_vector(endian='little'))
-            [0j, 0j, 0j, 0j, (1+0j), 0j, 0j, 0j]
+            >>> s.state_vector(endian='little')
+            array([0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+                  dtype=complex64)
 
-            >>> list(s.state_vector(endian='big'))
-            [0j, (1+0j), 0j, 0j, 0j, 0j, 0j, 0j]
+            >>> s.state_vector(endian='big')
+            array([0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+                  dtype=complex64)
 
             >>> s.sqrt_x(1, 2)
-            >>> list(s.state_vector())
-            [(0.5+0j), 0j, -0.5j, 0j, 0.5j, 0j, (0.5+0j), 0j]
+            >>> s.state_vector()
+            array([0.5+0.j , 0. +0.j , 0. -0.5j, 0. +0.j , 0. +0.5j, 0. +0.j ,
+                   0.5+0.j , 0. +0.j ], dtype=complex64)
         """
     def swap(
         self,

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -1943,7 +1943,7 @@ class Circuit:
             ...    X 1
             ...    M 0 1
             ... ''').reference_sample()
-            array([False, True])
+            array([False,  True])
         """
     def search_for_undetectable_logical_errors(
         self,

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -1600,6 +1600,57 @@ class Circuit:
             True, there is technically still a 2^-256 chance the circuit doesn't have
             the flow. This is lower than the chance of a cosmic ray flipping the result.
         """
+    def insert(
+        self,
+        index: int,
+        operation: Union[stim.CircuitInstruction, stim.Circuit],
+    ) -> None:
+        """Inserts an operation at the given index, pushing existing operations forward.
+
+        Note that, unlike when appending operations or parsing stim circuit files,
+        inserted operations aren't automatically fused into the preceding operation.
+        This is to avoid creating complicated situations where it's difficult to reason
+        about how the indices of operations change in response to insertions.
+
+        Args:
+            index: The index to insert at.
+
+                Must satisfy -len(circuit) <= index < len(circuit). Negative indices
+                are made non-negative by adding len(circuit) to them, so they refer to
+                indices relative to the end of the circuit instead of the start.
+
+                Instructions before the index are not shifted. Instructions that
+                were at or after the index are shifted forwards.
+            operation: The object to insert. This can be a single
+                stim.CircuitInstruction or an entire stim.Circuit.
+
+        Examples:
+            >>> import stim
+            >>> c = stim.Circuit('''
+            ...     H 0
+            ...     S 1
+            ...     X 2
+            ... ''')
+            >>> c.insert(1, stim.CircuitInstruction("Y", [3, 4, 5]))
+            >>> c
+            stim.Circuit('''
+                H 0
+                Y 3 4 5
+                S 1
+                X 2
+            ''')
+            >>> c.insert(-1, stim.Circuit("S 999\nCX 0 1\nCZ 2 3"))
+            >>> c
+            stim.Circuit('''
+                H 0
+                Y 3 4 5
+                S 1
+                S 999
+                CX 0 1
+                CZ 2 3
+                X 2
+            ''')
+        """
     def inverse(
         self,
     ) -> stim.Circuit:

--- a/glue/sample/src/sinter/_probability_util.py
+++ b/glue/sample/src/sinter/_probability_util.py
@@ -64,8 +64,8 @@ def log_binomial(*, p: Union[float, np.ndarray], n: int, hits: int) -> np.ndarra
         result[p_clipped == 1] = -np.inf
 
     # Multiply p**hits and (1-p)**misses onto the total, in log space.
-    result[p_clipped != 0] += np.log(p_clipped[p_clipped != 0]) * hits
-    result[p_clipped != 1] += np.log1p(-p_clipped[p_clipped != 1]) * misses
+    result[p_clipped != 0] += np.log(p_clipped[p_clipped != 0]) * float(hits)
+    result[p_clipped != 1] += np.log1p(-p_clipped[p_clipped != 1]) * float(misses)
 
     # Multiply (n choose hits) onto the total, in log space.
     log_n_choose_hits = log_factorial(n) - log_factorial(misses) - log_factorial(hits)

--- a/glue/sample/src/sinter/_probability_util.py
+++ b/glue/sample/src/sinter/_probability_util.py
@@ -7,7 +7,16 @@ import numpy as np
 
 if TYPE_CHECKING:
     import sinter
-    from scipy.stats._stats_mstats_common import LinregressResult
+
+    # Go on a magical journey looking for scipy's linear regression type.
+    try:
+        from scipy.stats._stats_py import LinregressResult
+    except ImportError:
+        try:
+            from scipy.stats._stats_mstats_common import LinregressResult
+        except ImportError:
+            from scipy.stats import linregress
+            LinregressResult = type(linregress([0, 1], [0, 1]))
 
 
 def log_binomial(*, p: Union[float, np.ndarray], n: int, hits: int) -> np.ndarray:
@@ -150,7 +159,10 @@ def least_squares_cost(*, xs: np.ndarray, ys: np.ndarray, intercept: float, slop
 def least_squares_through_point(*, xs: np.ndarray, ys: np.ndarray, required_x: float, required_y: float) -> 'LinregressResult':
     # Local import to reduce initial cost of importing sinter.
     from scipy.optimize import leastsq
-    from scipy.stats._stats_mstats_common import LinregressResult
+    from scipy.stats import linregress
+
+    # HACK: get scipy's linear regression result type
+    LinregressResult = type(linregress([0, 1], [0, 1]))
 
     xs2 = xs - required_x
     ys2 = ys - required_y
@@ -169,7 +181,11 @@ def least_squares_with_slope(*, xs: np.ndarray, ys: np.ndarray, required_slope: 
 
     # Local import to reduce initial cost of importing sinter.
     from scipy.optimize import leastsq
-    from scipy.stats._stats_mstats_common import LinregressResult
+
+    # HACK: get scipy's linear regression result type
+    from scipy.stats import linregress
+    LinregressResult = type(linregress([0, 1], [0, 1]))
+
     (best_intercept,), _ = leastsq(func=err, x0=0.0)
     return LinregressResult(required_slope, best_intercept, None, None, None, intercept_stderr=False)
 

--- a/src/stim/circuit/circuit.h
+++ b/src/stim/circuit/circuit.h
@@ -119,6 +119,10 @@ struct Circuit {
     /// Safely moves a repeat block to the end of the circuit.
     void append_repeat_block(uint64_t repeat_count, Circuit &&body);
 
+    void safe_insert(size_t index, const CircuitInstruction &instruction);
+    void safe_insert_repeat_block(size_t index, uint64_t repeat_count, const Circuit &block);
+    void safe_insert(size_t index, const Circuit &circuit);
+
     /// Appends the given gate, but with targets reversed.
     void safe_append_reversed_targets(
         GateType gate, SpanRef<const GateTarget> targets, SpanRef<const double> args, bool reverse_in_pairs);

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -720,6 +720,14 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
 
             Returns:
                 reference_sample: reference sample sampled from the given circuit.
+
+            Examples:
+                >>> import stim
+                >>> stim.Circuit('''
+                ...    X 1
+                ...    M 0 1
+                ... ''').reference_sample()
+                array([False, True])
         )DOC")
             .data());
 

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -186,7 +186,7 @@ void circuit_insert(
     if (index < 0) {
         index += self.operations.size();
     }
-    if (index < 0 || index > self.operations.size()) {
+    if (index < 0 || (uint64_t)index > self.operations.size()) {
         std::stringstream ss;
         ss << "Index is out of range. Need -len(circuit) <= index <= len(circuit).";
         ss << "\n    index=" << index;
@@ -727,7 +727,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
                 ...    X 1
                 ...    M 0 1
                 ... ''').reference_sample()
-                array([False, True])
+                array([False,  True])
         )DOC")
             .data());
 

--- a/src/stim/circuit/circuit_pybind_test.py
+++ b/src/stim/circuit/circuit_pybind_test.py
@@ -1814,3 +1814,68 @@ def test_detecting_regions_mzz():
             1: stim.PauliString("__Z"),
         },
     }
+
+
+def test_insert():
+    c = stim.Circuit()
+    with pytest.raises(ValueError, match='type'):
+        c.insert(0, object())
+    with pytest.raises(ValueError, match='index <'):
+        c.insert(1, stim.CircuitInstruction("H", [1]))
+    with pytest.raises(ValueError, match='index <'):
+        c.insert(-1, stim.CircuitInstruction("H", [1]))
+    c.insert(0, stim.CircuitInstruction("H", [1]))
+    assert c == stim.Circuit("""
+        H 1
+    """)
+
+    with pytest.raises(ValueError, match='index <'):
+        c.insert(2, stim.CircuitInstruction("S", [2]))
+    with pytest.raises(ValueError, match='index <'):
+        c.insert(-2, stim.CircuitInstruction("S", [2]))
+    c.insert(0, stim.CircuitInstruction("S", [2, 3]))
+    assert c == stim.Circuit("""
+        S 2 3
+        H 1
+    """)
+
+    c.insert(-1, stim.Circuit("H 5\nM 2"))
+    assert c == stim.Circuit("""
+        S 2 3
+        H 5
+        M 2
+        H 1
+    """)
+
+    c.insert(2, stim.Circuit("""
+        REPEAT 100 {
+            M 3
+        }
+    """))
+    assert c == stim.Circuit("""
+        S 2 3
+        H 5
+        REPEAT 100 {
+            M 3
+        }
+        M 2
+        H 1
+    """)
+
+    c.insert(2, stim.Circuit("""
+        REPEAT 100 {
+            M 3
+        }
+    """)[0])
+    assert c == stim.Circuit("""
+        S 2 3
+        H 5
+        REPEAT 100 {
+            M 3
+        }
+        REPEAT 100 {
+            M 3
+        }
+        M 2
+        H 1
+    """)

--- a/src/stim/gates/gate_data_pauli_product.cc
+++ b/src/stim/gates/gate_data_pauli_product.cc
@@ -177,7 +177,7 @@ CX 2 1
             .flags = (GateFlags)(GATE_TARGETS_PAULI_STRING | GATE_TARGETS_COMBINERS),
             .category = "P_Generalized Pauli Product Gates",
             .help = R"MARKDOWN(
-The generalized S gate. Phases the -1 eigenspace of Pauli product observables by i.
+The generalized S_DAG gate. Phases the -1 eigenspace of Pauli product observables by -i.
 
 Parens Arguments:
 

--- a/src/stim/simulators/tableau_simulator.pybind.cc
+++ b/src/stim/simulators/tableau_simulator.pybind.cc
@@ -323,7 +323,6 @@ void stim_pybind::pybind_tableau_simulator_methods(
                 array([0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
                       dtype=complex64)
 
-
                 >>> s.state_vector(endian='big')
                 array([0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
                       dtype=complex64)

--- a/src/stim/simulators/tableau_simulator.pybind.cc
+++ b/src/stim/simulators/tableau_simulator.pybind.cc
@@ -319,15 +319,19 @@ void stim_pybind::pybind_tableau_simulator_methods(
                 >>> import numpy as np
                 >>> s = stim.TableauSimulator()
                 >>> s.x(2)
-                >>> list(s.state_vector(endian='little'))
-                [0j, 0j, 0j, 0j, (1+0j), 0j, 0j, 0j]
+                >>> s.state_vector(endian='little')
+                array([0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+                      dtype=complex64)
 
-                >>> list(s.state_vector(endian='big'))
-                [0j, (1+0j), 0j, 0j, 0j, 0j, 0j, 0j]
+
+                >>> s.state_vector(endian='big')
+                array([0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+                      dtype=complex64)
 
                 >>> s.sqrt_x(1, 2)
-                >>> list(s.state_vector())
-                [(0.5+0j), 0j, -0.5j, 0j, 0.5j, 0j, (0.5+0j), 0j]
+                >>> s.state_vector()
+                array([0.5+0.j , 0. +0.j , 0. -0.5j, 0. +0.j , 0. +0.5j, 0. +0.j ,
+                       0.5+0.j , 0. +0.j ], dtype=complex64)
         )DOC")
             .data());
 


### PR DESCRIPTION
- Also fix an issue where enormous stats cause sinter to fail to plot
- Also fix an issue where circuits with the same blocks could be considered not equal if their internal representation was different
- Also bump pybind version to make numpy 2 start working
- Also fix an issue where the scipy linear regression type was accessed from a private module; use the public API as a fallback

Fixes https://github.com/quantumlib/Stim/issues/780

Fixes https://github.com/quantumlib/Stim/issues/779
