### PR TITLE
Add `stim.Circuit.flow_generators`

### DIFF
--- a/file_lists/test_files
+++ b/file_lists/test_files
@@ -79,6 +79,7 @@ src/stim/util_bot/probability_util.test.cc
 src/stim/util_bot/str_util.test.cc
 src/stim/util_bot/test_util.test.cc
 src/stim/util_bot/twiddle.test.cc
+src/stim/util_top/circuit_flow_generators.test.cc
 src/stim/util_top/circuit_inverse_qec.test.cc
 src/stim/util_top/circuit_inverse_unitary.test.cc
 src/stim/util_top/circuit_to_detecting_regions.test.cc

--- a/src/stim.h
+++ b/src/stim.h
@@ -105,6 +105,7 @@
 #include "stim/util_bot/probability_util.h"
 #include "stim/util_bot/str_util.h"
 #include "stim/util_bot/twiddle.h"
+#include "stim/util_top/circuit_flow_generators.h"
 #include "stim/util_top/circuit_inverse_qec.h"
 #include "stim/util_top/circuit_inverse_unitary.h"
 #include "stim/util_top/circuit_to_detecting_regions.h"

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -37,11 +37,11 @@
 #include "stim/simulators/measurements_to_detection_events.pybind.h"
 #include "stim/simulators/tableau_simulator.h"
 #include "stim/stabilizers/flow.h"
+#include "stim/util_top/circuit_flow_generators.h"
 #include "stim/util_top/circuit_inverse_qec.h"
 #include "stim/util_top/circuit_to_detecting_regions.h"
 #include "stim/util_top/circuit_vs_tableau.h"
 #include "stim/util_top/count_determined_measurements.h"
-#include "stim/util_top/circuit_flow_generators.h"
 #include "stim/util_top/export_crumble_url.h"
 #include "stim/util_top/export_qasm.h"
 #include "stim/util_top/export_quirk_url.h"
@@ -179,11 +179,7 @@ std::string py_likeliest_error_sat_problem(const Circuit &self, int quantization
     return stim::likeliest_error_sat_problem(dem, quantization, format);
 }
 
-void circuit_insert(
-    Circuit &self,
-    pybind11::ssize_t &index,
-    pybind11::object &operation) {
-
+void circuit_insert(Circuit &self, pybind11::ssize_t &index, pybind11::object &operation) {
     if (index < 0) {
         index += self.operations.size();
     }
@@ -1177,7 +1173,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
                     X 2
                 ''')
         )DOC")
-             .data());
+            .data());
 
     c.def(
         "append_from_stim_program_text",

--- a/src/stim/circuit/circuit_instruction.cc
+++ b/src/stim/circuit/circuit_instruction.cc
@@ -62,8 +62,10 @@ void CircuitInstruction::add_stats_to(CircuitStats &out, const Circuit *host) co
     for (auto t : targets) {
         auto v = t.data & TARGET_VALUE_MASK;
         // Qubit counting.
-        if (!(t.data & (TARGET_RECORD_BIT | TARGET_SWEEP_BIT))) {
-            out.num_qubits = std::max(out.num_qubits, v + 1);
+        if (gate_type != GateType::MPAD) {
+            if (!(t.data & (TARGET_RECORD_BIT | TARGET_SWEEP_BIT))) {
+                out.num_qubits = std::max(out.num_qubits, v + 1);
+            }
         }
         // Lookback counting.
         if (t.data & TARGET_RECORD_BIT) {

--- a/src/stim/circuit/circuit_instruction.pybind.cc
+++ b/src/stim/circuit/circuit_instruction.pybind.cc
@@ -162,6 +162,31 @@ void stim_pybind::pybind_circuit_instruction_methods(pybind11::module &m, pybind
         )DOC")
             .data());
 
+    c.def_property_readonly(
+        "num_measurements",
+        [](const PyCircuitInstruction &self) -> uint64_t {
+            return self.as_operation_ref().count_measurement_results();
+        },
+        clean_doc_string(R"DOC(
+            Returns the number of bits produced when running this instruction.
+
+            Examples:
+                >>> import stim
+                >>> stim.CircuitInstruction('H', [0]).num_measurements
+                0
+                >>> stim.CircuitInstruction('M', [0]).num_measurements
+                1
+                >>> stim.CircuitInstruction('M', [2, 3, 5, 7, 11]).num_measurements
+                5
+                >>> stim.CircuitInstruction('MXX', [0, 1, 4, 5, 11, 13]).num_measurements
+                3
+                >>> stim.Circuit('MPP X0*X1 X0*Z1*Y2')[0].num_measurements
+                2
+                >>> stim.CircuitInstruction('HERALDED_ERASE', [0]).num_measurements
+                1
+        )DOC")
+            .data());
+
     c.def(pybind11::self == pybind11::self, "Determines if two `stim.CircuitInstruction`s are identical.");
     c.def(pybind11::self != pybind11::self, "Determines if two `stim.CircuitInstruction`s are different.");
     c.def(

--- a/src/stim/circuit/circuit_instruction_pybind_test.py
+++ b/src/stim/circuit/circuit_instruction_pybind_test.py
@@ -50,3 +50,10 @@ def test_hashable():
     c = stim.CircuitInstruction("X_ERROR", [stim.GateTarget(5)], [0.5])
     assert hash(a) == hash(c)
     assert len({a, b, c}) == 2
+
+
+def test_num_measurements():
+    assert stim.CircuitInstruction("X", [1, 2, 3]).num_measurements == 0
+    assert stim.CircuitInstruction("MXX", [1, 2]).num_measurements == 1
+    assert stim.CircuitInstruction("M", [1, 2]).num_measurements == 2
+    assert stim.CircuitInstruction("MPAD", [0, 1, 0]).num_measurements == 3

--- a/src/stim/mem/sparse_xor_vec.h
+++ b/src/stim/mem/sparse_xor_vec.h
@@ -120,6 +120,25 @@ struct SparseXorVec;
 template <typename T>
 std::ostream &operator<<(std::ostream &out, const SparseXorVec<T> &v);
 
+template <typename T>
+inline void xor_item_into_sorted_vec(const T &item, std::vector<T> &sorted_items) {
+    // Just do a linear scan to find the insertion point, instead of a binary search.
+    // This is faster at small sizes, and complexity is linear anyways due to the shifting of later items.
+    for (size_t k = 0; k < sorted_items.size(); k++) {
+        const auto &v = sorted_items[k];
+        if (v < item) {
+            continue;
+        } else if (v == item) {
+            sorted_items.erase(sorted_items.begin() + k);
+            return;
+        } else {
+            sorted_items.insert(sorted_items.begin() + k, item);
+            return;
+        }
+    }
+    sorted_items.push_back(item);
+}
+
 /// A sparse set of integers that supports efficient xoring (computing the symmetric difference).
 template <typename T>
 struct SparseXorVec {
@@ -161,21 +180,7 @@ struct SparseXorVec {
     }
 
     void xor_item(const T &item) {
-        // Just do a linear scan to find the insertion point, instead of a binary search.
-        // This is faster at small sizes, and complexity is linear anyways due to the shifting of later items.
-        for (size_t k = 0; k < sorted_items.size(); k++) {
-            const auto &v = sorted_items[k];
-            if (v < item) {
-                continue;
-            } else if (v == item) {
-                sorted_items.erase(sorted_items.begin() + k);
-                return;
-            } else {
-                sorted_items.insert(sorted_items.begin() + k, item);
-                return;
-            }
-        }
-        sorted_items.push_back(item);
+        xor_item_into_sorted_vec(item, sorted_items);
     }
 
     SparseXorVec &operator^=(const SparseXorVec<T> &other) {

--- a/src/stim/py/compiled_detector_sampler.pybind.cc
+++ b/src/stim/py/compiled_detector_sampler.pybind.cc
@@ -32,7 +32,13 @@ CompiledDetectorSampler::CompiledDetectorSampler(Circuit init_circuit, std::mt19
 }
 
 pybind11::object CompiledDetectorSampler::sample_to_numpy(
-    size_t num_shots, bool prepend_observables, bool append_observables, bool separate_observables, bool bit_packed, pybind11::object dets_out, pybind11::object obs_out) {
+    size_t num_shots,
+    bool prepend_observables,
+    bool append_observables,
+    bool separate_observables,
+    bool bit_packed,
+    pybind11::object dets_out,
+    pybind11::object obs_out) {
     if (separate_observables && (append_observables || prepend_observables)) {
         throw std::invalid_argument(
             "Can't specify separate_observables=True with append_observables=True or prepend_observables=True");
@@ -50,7 +56,8 @@ pybind11::object CompiledDetectorSampler::sample_to_numpy(
 
     pybind11::object py_obs_data = pybind11::none();
     if (separate_observables || !obs_out.is_none()) {
-        py_obs_data = simd_bit_table_to_numpy(obs_data, circuit_stats.num_observables, num_shots, bit_packed, true, obs_out);
+        py_obs_data =
+            simd_bit_table_to_numpy(obs_data, circuit_stats.num_observables, num_shots, bit_packed, true, obs_out);
     }
 
     pybind11::object py_det_data = pybind11::none();
@@ -67,7 +74,8 @@ pybind11::object CompiledDetectorSampler::sample_to_numpy(
         }
         py_det_data = simd_bit_table_to_numpy(concat_data, num_concat, num_shots, bit_packed, true, dets_out);
     } else {
-        py_det_data = simd_bit_table_to_numpy(det_data, circuit_stats.num_detectors, num_shots, bit_packed, true, dets_out);
+        py_det_data =
+            simd_bit_table_to_numpy(det_data, circuit_stats.num_detectors, num_shots, bit_packed, true, dets_out);
     }
 
     if (separate_observables) {

--- a/src/stim/py/numpy.pybind.cc
+++ b/src/stim/py/numpy.pybind.cc
@@ -18,8 +18,10 @@ using namespace stim;
 using namespace stim_pybind;
 
 static pybind11::object transposed_simd_bit_table_to_numpy_uint8(
-    const simd_bit_table<MAX_BITWORD_WIDTH> &table, size_t num_major_in, size_t num_minor_in, pybind11::object out_buffer) {
-
+    const simd_bit_table<MAX_BITWORD_WIDTH> &table,
+    size_t num_major_in,
+    size_t num_minor_in,
+    pybind11::object out_buffer) {
     size_t num_major_bytes_in = (num_major_in + 7) / 8;
 
     if (out_buffer.is_none()) {
@@ -61,8 +63,10 @@ static pybind11::object transposed_simd_bit_table_to_numpy_uint8(
 }
 
 static pybind11::object transposed_simd_bit_table_to_numpy_bool8(
-    const simd_bit_table<MAX_BITWORD_WIDTH> &table, size_t num_major_in, size_t num_minor_in, pybind11::object out_buffer) {
-
+    const simd_bit_table<MAX_BITWORD_WIDTH> &table,
+    size_t num_major_in,
+    size_t num_minor_in,
+    pybind11::object out_buffer) {
     if (out_buffer.is_none()) {
         auto numpy = pybind11::module::import("numpy");
         out_buffer = numpy.attr("empty")(pybind11::make_tuple(num_minor_in, num_major_in), numpy.attr("bool_"));
@@ -99,7 +103,6 @@ static pybind11::object transposed_simd_bit_table_to_numpy_bool8(
 
 static pybind11::object simd_bit_table_to_numpy_uint8(
     const simd_bit_table<MAX_BITWORD_WIDTH> &table, size_t num_major, size_t num_minor, pybind11::object out_buffer) {
-
     size_t num_minor_bytes = (num_minor + 7) / 8;
     if (out_buffer.is_none()) {
         auto numpy = pybind11::module::import("numpy");
@@ -144,7 +147,6 @@ static pybind11::object simd_bit_table_to_numpy_uint8(
 
 static pybind11::object simd_bit_table_to_numpy_bool8(
     const simd_bit_table<MAX_BITWORD_WIDTH> &table, size_t num_major, size_t num_minor, pybind11::object out_buffer) {
-
     if (out_buffer.is_none()) {
         auto numpy = pybind11::module::import("numpy");
         out_buffer = numpy.attr("empty")(pybind11::make_tuple(num_major, num_minor), numpy.attr("bool_"));
@@ -179,7 +181,12 @@ static pybind11::object simd_bit_table_to_numpy_bool8(
 }
 
 pybind11::object stim_pybind::simd_bit_table_to_numpy(
-    const simd_bit_table<MAX_BITWORD_WIDTH> &table, size_t num_major, size_t num_minor, bool bit_pack_result, bool transposed, pybind11::object out_buffer) {
+    const simd_bit_table<MAX_BITWORD_WIDTH> &table,
+    size_t num_major,
+    size_t num_minor,
+    bool bit_pack_result,
+    bool transposed,
+    pybind11::object out_buffer) {
     if (transposed) {
         if (bit_pack_result) {
             return transposed_simd_bit_table_to_numpy_uint8(table, num_major, num_minor, out_buffer);

--- a/src/stim/simulators/dem_sampler.pybind.cc
+++ b/src/stim/simulators/dem_sampler.pybind.cc
@@ -72,8 +72,10 @@ pybind11::object dem_sampler_py_sample(
     if (return_errors) {
         err_out = simd_bit_table_to_numpy(self.err_buffer, self.num_errors, shots, bit_packed, true, pybind11::none());
     }
-    pybind11::object det_out = simd_bit_table_to_numpy(self.det_buffer, self.num_detectors, shots, bit_packed, true, pybind11::none());
-    pybind11::object obs_out = simd_bit_table_to_numpy(self.obs_buffer, self.num_observables, shots, bit_packed, true, pybind11::none());
+    pybind11::object det_out =
+        simd_bit_table_to_numpy(self.det_buffer, self.num_detectors, shots, bit_packed, true, pybind11::none());
+    pybind11::object obs_out =
+        simd_bit_table_to_numpy(self.obs_buffer, self.num_observables, shots, bit_packed, true, pybind11::none());
     return pybind11::make_tuple(det_out, obs_out, err_out);
 }
 

--- a/src/stim/simulators/frame_simulator.pybind.cc
+++ b/src/stim/simulators/frame_simulator.pybind.cc
@@ -138,7 +138,8 @@ pybind11::object sliced_table_to_numpy(
             auto data = table.read_across_majors_at_minor_index(0, num_major_exact, *minor_index);
             return simd_bits_to_numpy(data, num_major_exact, bit_packed);
         } else {
-            return simd_bit_table_to_numpy(table, num_major_exact, num_minor_exact, bit_packed, false, pybind11::none());
+            return simd_bit_table_to_numpy(
+                table, num_major_exact, num_minor_exact, bit_packed, false, pybind11::none());
         }
     }
 }

--- a/src/stim/simulators/measurements_to_detection_events.pybind.cc
+++ b/src/stim/simulators/measurements_to_detection_events.pybind.cc
@@ -129,7 +129,8 @@ pybind11::object CompiledMeasurementsToDetectionEventsConverter::convert(
                 obs_slice.clear();
             }
         }
-        obs_data = simd_bit_table_to_numpy(obs_table, circuit_stats.num_observables, num_shots, bit_pack_result, true, pybind11::none());
+        obs_data = simd_bit_table_to_numpy(
+            obs_table, circuit_stats.num_observables, num_shots, bit_pack_result, true, pybind11::none());
     }
 
     // Caution: only do this after extracting the observable data, lest it leak into the packed bytes.

--- a/src/stim/stabilizers/flow.h
+++ b/src/stim/stabilizers/flow.h
@@ -32,6 +32,7 @@ struct Flow {
     std::vector<int32_t> measurements;
 
     static Flow<W> from_str(std::string_view text);
+    bool operator<(const Flow<W> &other) const;
     bool operator==(const Flow<W> &other) const;
     bool operator!=(const Flow<W> &other) const;
     std::string str() const;

--- a/src/stim/stabilizers/flow.inl
+++ b/src/stim/stabilizers/flow.inl
@@ -75,6 +75,11 @@ Flow<W> Flow<W>::from_str(std::string_view text) {
         }
         PauliString<W> out(0);
         std::vector<int32_t> measurements;
+        bool flip_out = false;
+        if (parts[k].starts_with('-')) {
+            flip_out = true;
+            parts[k] = parts[k].substr(1);
+        }
         if (!parts[k].empty() && parts[k][0] != 'r') {
             out = parse_non_empty_pauli_string_allowing_i<W>(parts[k], &imag_out);
         } else {
@@ -84,6 +89,7 @@ Flow<W> Flow<W>::from_str(std::string_view text) {
             }
             measurements.push_back(rec);
         }
+        out.sign ^= flip_out;
         k++;
         while (k < parts.size()) {
             if (parts[k] != "xor" || k + 1 == parts.size()) {
@@ -111,6 +117,20 @@ Flow<W> Flow<W>::from_str(std::string_view text) {
 template <size_t W>
 bool Flow<W>::operator==(const Flow<W> &other) const {
     return input == other.input && output == other.output && measurements == other.measurements;
+}
+
+template <size_t W>
+bool Flow<W>::operator<(const Flow<W> &other) const {
+    if (input != other.input) {
+        return input < other.input;
+    }
+    if (output != other.output) {
+        return output < other.output;
+    }
+    if (measurements != other.measurements) {
+        return SpanRef<const int32_t>(measurements) < SpanRef<const int32_t>(other.measurements);
+    }
+    return false;
 }
 
 template <size_t W>

--- a/src/stim/stabilizers/flow.test.cc
+++ b/src/stim/stabilizers/flow.test.cc
@@ -1,24 +1,9 @@
-// Copyright 2021 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 #include "stim/stabilizers/flow.h"
 
 #include "gtest/gtest.h"
 
 #include "stim/circuit/circuit.h"
 #include "stim/mem/simd_word.test.h"
-#include "stim/util_bot/test_util.test.h"
 
 using namespace stim;
 
@@ -43,6 +28,13 @@ TEST_EACH_WORD_SIZE_W(stabilizer_flow, from_str, {
             .input = PauliString<W>::from_str(""),
             .output = PauliString<W>::from_str(""),
             .measurements = {},
+        }));
+    ASSERT_EQ(
+        Flow<W>::from_str("1 -> -rec[0]"),
+        (Flow<W>{
+            .input = PauliString<W>::from_str(""),
+            .output = PauliString<W>::from_str("-"),
+            .measurements = {0},
         }));
     ASSERT_EQ(
         Flow<W>::from_str("i -> -i"),
@@ -150,4 +142,14 @@ TEST_EACH_WORD_SIZE_W(stabilizer_flow, str_and_from_str, {
     ASSERT_EQ(
         Flow<W>::from_str("-1 -> -X xor rec[-1] xor rec[-3]"),
         (Flow<W>{PauliString<W>::from_str("-"), PauliString<W>::from_str("-X"), {-1, -3}}));
+})
+
+TEST_EACH_WORD_SIZE_W(stabilizer_flow, ordering, {
+    ASSERT_FALSE(Flow<W>::from_str("1 -> 1") < Flow<W>::from_str("1 -> 1"));
+    ASSERT_FALSE(Flow<W>::from_str("X -> 1") < Flow<W>::from_str("1 -> 1"));
+    ASSERT_FALSE(Flow<W>::from_str("1 -> X") < Flow<W>::from_str("1 -> 1"));
+    ASSERT_FALSE(Flow<W>::from_str("1 -> rec[-1]") < Flow<W>::from_str("1 -> 1"));
+    ASSERT_TRUE(Flow<W>::from_str("1 -> 1") < Flow<W>::from_str("X -> 1"));
+    ASSERT_TRUE(Flow<W>::from_str("1 -> 1") < Flow<W>::from_str("1 -> X"));
+    ASSERT_TRUE(Flow<W>::from_str("1 -> 1") < Flow<W>::from_str("1 -> rec[-1]"));
 })

--- a/src/stim/stabilizers/pauli_string.h
+++ b/src/stim/stabilizers/pauli_string.h
@@ -78,8 +78,15 @@ struct PauliString {
     /// Paulis are xz-encoded (P=xz: I=00, X=10, Y=11, Z=01) pairwise across the two bit vectors.
     simd_bits<W> xs, zs;
 
-    /// Identity constructor.
+    /// Standard constructors.
     explicit PauliString(size_t num_qubits);
+    PauliString(const PauliStringRef<W> &other);  // NOLINT(google-explicit-constructor)
+    PauliString(const PauliString<W> &other);
+    PauliString(PauliString<W> &&other) noexcept;
+    PauliString &operator=(const PauliStringRef<W> &other);
+    PauliString &operator=(const PauliString<W> &other);
+    PauliString &operator=(PauliString<W> &&other);
+
     /// Parse constructor.
     explicit PauliString(std::string_view text);
     /// Factory method for creating a PauliString whose Pauli entries are returned by a function.
@@ -89,17 +96,14 @@ struct PauliString {
     /// Factory method for creating a PauliString with uniformly random sign and Pauli entries.
     static PauliString<W> random(size_t num_qubits, std::mt19937_64 &rng);
 
-    /// Copy constructor.
-    PauliString(const PauliStringRef<W> &other);  // NOLINT(google-explicit-constructor)
-    /// Overwrite assignment.
-    PauliString &operator=(const PauliStringRef<W> &other) noexcept;
-
     /// Equality.
     bool operator==(const PauliStringRef<W> &other) const;
     bool operator==(const PauliString<W> &other) const;
     /// Inequality.
     bool operator!=(const PauliStringRef<W> &other) const;
     bool operator!=(const PauliString<W> &other) const;
+    bool operator<(const PauliStringRef<W> &other) const;
+    bool operator<(const PauliString<W> &other) const;
 
     /// Implicit conversion to a reference.
     operator PauliStringRef<W>();

--- a/src/stim/stabilizers/pauli_string.inl
+++ b/src/stim/stabilizers/pauli_string.inl
@@ -89,7 +89,6 @@ PauliString<W> &PauliString<W>::operator=(PauliString<W> &&other) {
     return *this;
 }
 
-
 template <size_t W>
 const PauliStringRef<W> PauliString<W>::ref() const {
     size_t nw = (num_qubits + W - 1) / W;

--- a/src/stim/stabilizers/pauli_string.inl
+++ b/src/stim/stabilizers/pauli_string.inl
@@ -46,6 +46,51 @@ PauliString<W>::PauliString(const PauliStringRef<W> &other)
 }
 
 template <size_t W>
+PauliString<W>::PauliString(const PauliString<W> &other)
+    : num_qubits(other.num_qubits), sign((bool)other.sign), xs(other.xs), zs(other.zs) {
+}
+
+template <size_t W>
+PauliString<W>::PauliString(PauliString<W> &&other) noexcept
+    : num_qubits(other.num_qubits), sign((bool)other.sign), xs(std::move(other.xs)), zs(std::move(other.zs)) {
+    other.num_qubits = 0;
+    other.sign = false;
+}
+
+template <size_t W>
+PauliString<W> &PauliString<W>::operator=(const PauliStringRef<W> &other) {
+    xs = other.xs;
+    zs = other.zs;
+    num_qubits = other.num_qubits;
+    sign = other.sign;
+    return *this;
+}
+
+template <size_t W>
+PauliString<W> &PauliString<W>::operator=(const PauliString<W> &other) {
+    xs = other.xs;
+    zs = other.zs;
+    num_qubits = other.num_qubits;
+    sign = other.sign;
+    return *this;
+}
+
+template <size_t W>
+PauliString<W> &PauliString<W>::operator=(PauliString<W> &&other) {
+    if (&other == this) {
+        return *this;
+    }
+    xs = std::move(other.xs);
+    zs = std::move(other.zs);
+    num_qubits = other.num_qubits;
+    sign = other.sign;
+    other.num_qubits = 0;
+    other.sign = false;
+    return *this;
+}
+
+
+template <size_t W>
 const PauliStringRef<W> PauliString<W>::ref() const {
     size_t nw = (num_qubits + W - 1) / W;
     return PauliStringRef<W>(
@@ -65,13 +110,6 @@ PauliStringRef<W> PauliString<W>::ref() {
 template <size_t W>
 std::string PauliString<W>::str() const {
     return ref().str();
-}
-
-template <size_t W>
-PauliString<W> &PauliString<W>::operator=(const PauliStringRef<W> &other) noexcept {
-    (*this).~PauliString();
-    new (this) PauliString(other);
-    return *this;
 }
 
 template <size_t W>
@@ -142,6 +180,16 @@ bool PauliString<W>::operator!=(const PauliStringRef<W> &other) const {
 template <size_t W>
 bool PauliString<W>::operator!=(const PauliString<W> &other) const {
     return ref() != other.ref();
+}
+
+template <size_t W>
+bool PauliString<W>::operator<(const PauliString<W> &other) const {
+    return ref() < other.ref();
+}
+
+template <size_t W>
+bool PauliString<W>::operator<(const PauliStringRef<W> &other) const {
+    return ref() < other;
 }
 
 template <size_t W>

--- a/src/stim/stabilizers/pauli_string_ref.h
+++ b/src/stim/stabilizers/pauli_string_ref.h
@@ -60,6 +60,7 @@ struct PauliStringRef {
     bool operator==(const PauliStringRef<W> &other) const;
     /// Inequality.
     bool operator!=(const PauliStringRef<W> &other) const;
+    bool operator<(const PauliStringRef<W> &other) const;
 
     /// Overwrite assignment.
     PauliStringRef<W> &operator=(const PauliStringRef<W> &other);

--- a/src/stim/stabilizers/pauli_string_ref.inl
+++ b/src/stim/stabilizers/pauli_string_ref.inl
@@ -449,7 +449,6 @@ void PauliStringRef<W>::do_instruction(const CircuitInstruction &inst) {
             check_avoids_MPP(inst);
             break;
 
-
         case GateType::SPP:
         case GateType::SPP_DAG:
             decompose_spp_or_spp_dag_operation(inst, num_qubits, false, [&](CircuitInstruction sub_inst) {
@@ -602,9 +601,13 @@ void PauliStringRef<W>::undo_instruction(const CircuitInstruction &inst) {
             std::vector<GateTarget> buf_targets;
             buf_targets.insert(buf_targets.end(), inst.targets.begin(), inst.targets.end());
             std::reverse(buf_targets.begin(), buf_targets.end());
-            decompose_spp_or_spp_dag_operation(CircuitInstruction{inst.gate_type, {}, buf_targets}, num_qubits, false, [&](CircuitInstruction sub_inst) {
-                undo_instruction(sub_inst);
-            });
+            decompose_spp_or_spp_dag_operation(
+                CircuitInstruction{inst.gate_type, {}, buf_targets},
+                num_qubits,
+                false,
+                [&](CircuitInstruction sub_inst) {
+                    undo_instruction(sub_inst);
+                });
             break;
         }
 

--- a/src/stim/util_top/circuit_flow_generators.h
+++ b/src/stim/util_top/circuit_flow_generators.h
@@ -1,0 +1,51 @@
+#ifndef _STIM_UTIL_TOP_CIRCUIT_FLOW_GENERATORS_H
+#define _STIM_UTIL_TOP_CIRCUIT_FLOW_GENERATORS_H
+
+#include "stim/circuit/circuit.h"
+
+namespace stim {
+
+/// Finds a basis of flows for the circuit.
+template <size_t W>
+std::vector<Flow<W>> circuit_flow_generators(const Circuit &circuit);
+
+template <size_t W>
+struct CircuitFlowGeneratorSolver {
+    std::vector<Flow<W>> table;
+    size_t num_qubits;
+    size_t num_measurements;
+    size_t num_measurements_in_past;
+    std::vector<Flow<W>> measurements_only_table;
+    std::vector<size_t> buf_for_rows_with;
+    std::vector<int32_t> buf_for_xor_merge;
+    std::vector<GateTarget> buf_targets;
+
+    CircuitFlowGeneratorSolver(CircuitStats stats);
+    Flow<W> &add_row();
+    void add_1q_measure_terms(CircuitInstruction inst, bool x, bool z);
+    void add_2q_measure_terms(CircuitInstruction inst, bool x, bool z);
+    void remove_single_qubit_reset_terms(CircuitInstruction inst);
+    void handle_anticommutations(std::span<const size_t> anticommutation_set);
+    void check_for_2q_anticommutations(CircuitInstruction inst, bool x, bool z);
+    void check_for_1q_anticommutations(CircuitInstruction inst, bool x, bool z);
+    void mult_row_into(size_t src_row, size_t dst_row);
+    void undo_mrb(CircuitInstruction inst, bool x, bool z);
+    void undo_mb(CircuitInstruction inst, bool x, bool z);
+    void undo_rb(CircuitInstruction inst, bool x, bool z);
+    void undo_2q_m(CircuitInstruction inst, bool x, bool z);
+    void undo_instruction(CircuitInstruction inst);
+    void elimination_step(std::span<const size_t> elimination_set, size_t &num_eliminated);
+    void canonicalize_over_qubits();
+    void final_canonicalize_into_table();
+    void undo_feedback_capable_instruction(CircuitInstruction inst, bool x, bool z);
+    std::span<const size_t> rows_anticommuting_with(uint32_t q, bool x, bool z);
+
+    template <typename PREDICATE>
+    std::span<const size_t> rows_with(PREDICATE predicate);
+};
+
+}  // namespace stim
+
+#include "stim/util_top/circuit_flow_generators.inl"
+
+#endif

--- a/src/stim/util_top/circuit_flow_generators.inl
+++ b/src/stim/util_top/circuit_flow_generators.inl
@@ -1,0 +1,477 @@
+#include "stim/util_top/circuit_inverse_qec.h"
+
+namespace stim {
+
+template <size_t W>
+CircuitFlowGeneratorSolver<W>::CircuitFlowGeneratorSolver(CircuitStats stats) :
+    table(),
+    num_qubits(stats.num_qubits),
+    num_measurements(stats.num_measurements),
+    num_measurements_in_past(stats.num_measurements),
+    measurements_only_table(),
+    buf_for_rows_with(),
+    buf_for_xor_merge() {
+    if (num_measurements_in_past > INT32_MAX) {
+        throw std::invalid_argument("Circuit is too large. Max flow measurement index is " + std::to_string(INT32_MAX));
+    }
+}
+
+template <size_t W>
+Flow<W> &CircuitFlowGeneratorSolver<W>::add_row() {
+    table.push_back(Flow<W>{
+        .input=PauliString<W>(num_qubits),
+        .output=PauliString<W>(num_qubits),
+        .measurements={},
+    });
+    return table.back();
+}
+
+template <size_t W>
+void CircuitFlowGeneratorSolver<W>::add_1q_measure_terms(CircuitInstruction inst, bool x, bool z) {
+    for (size_t k = inst.targets.size(); k--;) {
+        num_measurements_in_past--;
+
+        auto t = inst.targets[k];
+        if (!t.is_qubit_target()) {
+            throw std::invalid_argument("Bad target in " + inst.str());
+        }
+        uint32_t q = t.qubit_value();
+        auto &row = add_row();
+        row.measurements.push_back(num_measurements_in_past);
+        row.input.xs[q] = x;
+        row.input.zs[q] = z;
+        row.input.sign ^= t.is_inverted_result_target();
+    }
+}
+
+template <size_t W>
+void CircuitFlowGeneratorSolver<W>::add_2q_measure_terms(CircuitInstruction inst, bool x, bool z) {
+    size_t k = inst.targets.size();
+    while (k > 0) {
+        k -= 2;
+        num_measurements_in_past--;
+
+        auto t1 = inst.targets[k];
+        auto t2 = inst.targets[k + 1];
+        if (!t1.is_qubit_target() || !t2.is_qubit_target()) {
+            throw std::invalid_argument("Bad target in " + inst.str());
+        }
+        uint32_t q1 = t1.qubit_value();
+        uint32_t q2 = t2.qubit_value();
+        auto &row = add_row();
+        row.measurements.push_back(num_measurements_in_past);
+        row.input.xs[q1] = x;
+        row.input.zs[q1] = z;
+        row.input.xs[q2] = x;
+        row.input.zs[q2] = z;
+        row.input.sign ^= t1.is_inverted_result_target();
+        row.input.sign ^= t2.is_inverted_result_target();
+    }
+}
+
+template <size_t W>
+void CircuitFlowGeneratorSolver<W>::remove_single_qubit_reset_terms(CircuitInstruction inst) {
+    for (auto t : inst.targets) {
+        if (!t.is_qubit_target()) {
+            throw std::invalid_argument("Bad target in " + inst.str());
+        }
+        uint32_t q = t.qubit_value();
+        for (auto &row : table) {
+            row.input.xs[q] = 0;
+            row.input.zs[q] = 0;
+        }
+    }
+}
+
+template <size_t W>
+void CircuitFlowGeneratorSolver<W>::handle_anticommutations(std::span<const size_t> anticommutation_set) {
+    if (anticommutation_set.empty()) {
+        return;
+    }
+
+    // Sacrifice the first anticommutation to save the others.
+    for (size_t k = 1; k < buf_for_rows_with.size(); k++) {
+        mult_row_into(anticommutation_set[0], anticommutation_set[k]);
+    }
+    table.erase(table.begin() + anticommutation_set[0]);
+}
+
+template <size_t W>
+void CircuitFlowGeneratorSolver<W>::check_for_2q_anticommutations(CircuitInstruction inst, bool x, bool z) {
+    size_t k = inst.targets.size();
+    while (k > 0) {
+        k -= 2;
+
+        auto t1 = inst.targets[k];
+        auto t2 = inst.targets[k + 1];
+        if (!t1.is_qubit_target() || !t2.is_qubit_target()) {
+            throw std::invalid_argument("Bad target in " + inst.str());
+        }
+        uint32_t q1 = t1.qubit_value();
+        uint32_t q2 = t2.qubit_value();
+
+        auto anticommutations = rows_with([&](const Flow<W> &flow) {
+            bool anticommutes = false;
+            anticommutes ^= flow.input.xs[q1] & z;
+            anticommutes ^= flow.input.zs[q1] & x;
+            anticommutes ^= flow.input.xs[q2] & z;
+            anticommutes ^= flow.input.zs[q2] & x;
+            return anticommutes;
+        });
+
+        handle_anticommutations(anticommutations);
+    }
+}
+
+template <size_t W>
+void CircuitFlowGeneratorSolver<W>::check_for_1q_anticommutations(CircuitInstruction inst, bool x, bool z) {
+    for (auto t : inst.targets) {
+        if (!t.is_qubit_target()) {
+            throw std::invalid_argument("Bad target in " + inst.str());
+        }
+        uint32_t q = t.qubit_value();
+
+        handle_anticommutations(rows_anticommuting_with(q, x, z));
+    }
+}
+
+template <size_t W>
+void CircuitFlowGeneratorSolver<W>::mult_row_into(size_t src_row, size_t dst_row) {
+    auto &src = table[src_row];
+    auto &dst = table[dst_row];
+
+    // Combine the pauli strings.
+    uint8_t log_i = 0;
+    log_i += dst.input.ref().inplace_right_mul_returning_log_i_scalar(src.input);
+    log_i -= dst.output.ref().inplace_right_mul_returning_log_i_scalar(src.output);
+    if (log_i & 1) {
+        throw std::invalid_argument("Unexpected anticommutation while solving for flow generators.");
+    }
+    if (log_i & 2) {
+        dst.input.sign ^= 1;
+    }
+
+    // Xor-merge-sort the measurement indices.
+    buf_for_xor_merge.resize(std::max(buf_for_xor_merge.size(), dst.measurements.size() + src.measurements.size() + 1));
+    const int32_t *end = xor_merge_sort(SpanRef<const int32_t>(dst.measurements), SpanRef<const int32_t>(src.measurements), buf_for_xor_merge.data());
+    size_t n = end - buf_for_xor_merge.data();
+    dst.measurements.resize(n);
+    if (n > 0) {
+        memcpy(dst.measurements.data(), buf_for_xor_merge.data(), n * sizeof(int32_t));
+    }
+}
+
+template <size_t W>
+void CircuitFlowGeneratorSolver<W>::undo_mrb(CircuitInstruction inst, bool x, bool z) {
+    check_for_1q_anticommutations(inst, x, z);
+    remove_single_qubit_reset_terms(inst);
+    add_1q_measure_terms(inst, x, z);
+}
+template <size_t W>
+void CircuitFlowGeneratorSolver<W>::undo_mb(CircuitInstruction inst, bool x, bool z) {
+    check_for_1q_anticommutations(inst, x, z);
+    add_1q_measure_terms(inst, x, z);
+}
+template <size_t W>
+void CircuitFlowGeneratorSolver<W>::undo_rb(CircuitInstruction inst, bool x, bool z) {
+    check_for_1q_anticommutations(inst, x, z);
+    remove_single_qubit_reset_terms(inst);
+}
+template <size_t W>
+void CircuitFlowGeneratorSolver<W>::undo_2q_m(CircuitInstruction inst, bool x, bool z) {
+    check_for_2q_anticommutations(inst, x, z);
+    add_2q_measure_terms(inst, x, z);
+}
+
+template <size_t W>
+void CircuitFlowGeneratorSolver<W>::undo_feedback_capable_instruction(CircuitInstruction inst, bool x, bool z) {
+    size_t k = inst.targets.size();
+    while (k > 0) {
+        k -= 2;
+
+        auto t1 = inst.targets[k];
+        auto t2 = inst.targets[k + 1];
+        bool m1 = t1.is_measurement_record_target();
+        bool m2 = t2.is_measurement_record_target();
+        bool f1 = t1.is_qubit_target();
+        bool f2 = t2.is_qubit_target();
+        if ((m1 && f2) || (m2 && f1)) {
+            uint32_t q = f1 ? t1.qubit_value() : t2.qubit_value();
+            int32_t t = (m1 ? t1.value() : t2.value()) + num_measurements_in_past;
+            if (t < 0) {
+                throw std::invalid_argument("Referred to measurement before start of time in " + inst.str());
+            }
+            for (auto r : rows_anticommuting_with(q, x, z)) {
+                xor_item_into_sorted_vec(t, table[r].measurements);
+            }
+        } else if (f1 && f2) {
+            CircuitInstruction sub_inst = CircuitInstruction{inst.gate_type, {}, inst.targets.sub(k, k + 2)};
+            for (auto &row : table) {
+                row.input.ref().undo_instruction(sub_inst);
+            }
+        }
+    }
+}
+
+template <size_t W>
+void CircuitFlowGeneratorSolver<W>::undo_instruction(CircuitInstruction inst) {
+    if (table.size() > num_qubits * 3) {
+        canonicalize_over_qubits();
+    }
+
+    switch (inst.gate_type) {
+        case GateType::MRX:
+        case GateType::MRY:
+        case GateType::MR:
+            undo_mrb(inst, inst.gate_type != GateType::MR, inst.gate_type != GateType::MRX);
+            break;
+
+        case GateType::MX:
+        case GateType::MY:
+        case GateType::M:
+            undo_mb(inst, inst.gate_type != GateType::M, inst.gate_type != GateType::MX);
+            break;
+
+        case GateType::RX:
+        case GateType::RY:
+        case GateType::R:
+            undo_rb(inst, inst.gate_type != GateType::R, inst.gate_type != GateType::RX);
+            break;
+
+        case GateType::MXX:
+        case GateType::MYY:
+        case GateType::MZZ:
+            undo_2q_m(inst, inst.gate_type != GateType::MZZ, inst.gate_type != GateType::MXX);
+            break;
+
+        case GateType::DETECTOR:
+        case GateType::OBSERVABLE_INCLUDE:
+        case GateType::TICK:
+        case GateType::QUBIT_COORDS:
+        case GateType::SHIFT_COORDS:
+        case GateType::DEPOLARIZE1:
+        case GateType::DEPOLARIZE2:
+        case GateType::X_ERROR:
+        case GateType::Y_ERROR:
+        case GateType::Z_ERROR:
+        case GateType::PAULI_CHANNEL_1:
+        case GateType::PAULI_CHANNEL_2:
+        case GateType::E:
+        case GateType::ELSE_CORRELATED_ERROR:
+            // Ignored.
+            break;
+
+        case GateType::HERALDED_ERASE:
+        case GateType::HERALDED_PAULI_CHANNEL_1:
+            // Heralds.
+            for (auto t : inst.targets) {
+                num_measurements_in_past--;
+                if (!t.is_qubit_target()) {
+                    throw std::invalid_argument("Bad target in " + inst.str());
+                }
+                auto &row = add_row();
+                row.measurements.push_back(num_measurements_in_past);
+            }
+            break;
+
+        case GateType::MPAD:
+            // Pads.
+            for (auto t : inst.targets) {
+                num_measurements_in_past--;
+                if (!t.is_qubit_target()) {
+                    throw std::invalid_argument("Bad target in " + inst.str());
+                }
+                auto &row = add_row();
+                row.measurements.push_back(num_measurements_in_past);
+                if (t.qubit_value()) {
+                    row.output.sign = 1;
+                }
+            }
+            break;
+
+        case GateType::CX:
+        case GateType::XCZ:
+            undo_feedback_capable_instruction(inst, true, false);
+            break;
+
+        case GateType::YCZ:
+        case GateType::CY:
+            undo_feedback_capable_instruction(inst, true, true);
+            break;
+
+        case GateType::CZ:
+            undo_feedback_capable_instruction(inst, false, true);
+            break;
+
+        case GateType::XCX:
+        case GateType::XCY:
+        case GateType::YCX:
+        case GateType::YCY:
+        case GateType::H:
+        case GateType::H_XY:
+        case GateType::H_YZ:
+        case GateType::I:
+        case GateType::X:
+        case GateType::Y:
+        case GateType::Z:
+        case GateType::C_XYZ:
+        case GateType::C_ZYX:
+        case GateType::SQRT_X:
+        case GateType::SQRT_X_DAG:
+        case GateType::SQRT_Y:
+        case GateType::SQRT_Y_DAG:
+        case GateType::S:
+        case GateType::S_DAG:
+        case GateType::SQRT_XX:
+        case GateType::SQRT_XX_DAG:
+        case GateType::SQRT_YY:
+        case GateType::SQRT_YY_DAG:
+        case GateType::SQRT_ZZ:
+        case GateType::SQRT_ZZ_DAG:
+        case GateType::SPP:
+        case GateType::SPP_DAG:
+        case GateType::SWAP:
+        case GateType::ISWAP:
+        case GateType::CXSWAP:
+        case GateType::SWAPCX:
+        case GateType::CZSWAP:
+        case GateType::ISWAP_DAG:
+            for (auto &row : table) {
+                row.input.ref().undo_instruction(inst);
+            }
+            break;
+
+        case GateType::MPP:
+            buf_targets.clear();
+            buf_targets.insert(buf_targets.end(), inst.targets.begin(), inst.targets.end());
+            std::reverse(buf_targets.begin(), buf_targets.end());
+            decompose_mpp_operation(
+                CircuitInstruction{inst.gate_type, {}, buf_targets},
+                num_qubits,
+                [&](CircuitInstruction sub_inst) { undo_instruction(sub_inst); });
+            break;
+
+        default:
+            throw std::invalid_argument("Not handled by circuit flow generators method: " + inst.str());
+    }
+}
+
+template <size_t W>
+std::span<const size_t> CircuitFlowGeneratorSolver<W>::rows_anticommuting_with(uint32_t q, bool x, bool z) {
+    return rows_with([&](const Flow<W> &flow) {
+        bool anticommutes = false;
+        anticommutes ^= flow.input.xs[q] & z;
+        anticommutes ^= flow.input.zs[q] & x;
+        return anticommutes;
+    });
+}
+
+template <size_t W>
+template <typename PREDICATE>
+std::span<const size_t> CircuitFlowGeneratorSolver<W>::rows_with(PREDICATE predicate) {
+    buf_for_rows_with.clear();
+    for (size_t r = 0; r < table.size(); r++) {
+        if (predicate(table[r])) {
+            buf_for_rows_with.push_back(r);
+        }
+    }
+    return buf_for_rows_with;
+}
+
+template <size_t W>
+void CircuitFlowGeneratorSolver<W>::elimination_step(std::span<const size_t> elimination_set, size_t &num_eliminated) {
+    size_t pivot = SIZE_MAX;
+    for (auto p : elimination_set) {
+        if (p >= num_eliminated) {
+            pivot = p;
+            break;
+        }
+    }
+    if (pivot == SIZE_MAX) {
+        return;
+    }
+
+    for (auto p : elimination_set) {
+        if (p != pivot) {
+            mult_row_into(pivot, p);
+        }
+    }
+    std::swap(table[pivot], table[num_eliminated]);
+    num_eliminated++;
+}
+
+template <size_t W>
+void CircuitFlowGeneratorSolver<W>::canonicalize_over_qubits() {
+    size_t num_eliminated = 0;
+    for (size_t q = 0; q < num_qubits; q++) {
+        elimination_step(rows_with([&](const Flow<W> &flow) { return flow.input.xs[q]; }), num_eliminated);
+        elimination_step(rows_with([&](const Flow<W> &flow) { return flow.input.zs[q]; }), num_eliminated);
+        elimination_step(rows_with([&](const Flow<W> &flow) { return flow.output.xs[q]; }), num_eliminated);
+        elimination_step(rows_with([&](const Flow<W> &flow) { return flow.output.zs[q]; }), num_eliminated);
+    }
+
+    for (size_t r = 0; r < table.size(); r++) {
+        if (table[r].input.ref().has_no_pauli_terms() && table[r].output.ref().has_no_pauli_terms()) {
+            measurements_only_table.push_back(std::move(table[r]));
+            std::swap(table[r], table.back());
+            table.pop_back();
+            r--;
+        }
+    }
+}
+
+template <size_t W>
+void CircuitFlowGeneratorSolver<W>::final_canonicalize_into_table() {
+    for (auto &row : measurements_only_table) {
+        table.push_back(std::move(row));
+    }
+
+    size_t num_eliminated = 0;
+    for (size_t q = 0; q < num_qubits; q++) {
+        elimination_step(rows_with([&](const Flow<W> &flow) { return flow.input.xs[q]; }), num_eliminated);
+        elimination_step(rows_with([&](const Flow<W> &flow) { return flow.input.zs[q]; }), num_eliminated);
+    }
+    for (size_t q = 0; q < num_qubits; q++) {
+        elimination_step(rows_with([&](const Flow<W> &flow) { return flow.output.xs[q]; }), num_eliminated);
+        elimination_step(rows_with([&](const Flow<W> &flow) { return flow.output.zs[q]; }), num_eliminated);
+    }
+    for (size_t m = 0; m < num_measurements; m++) {
+        elimination_step(rows_with([&](const Flow<W> &flow) {
+            return std::find(flow.measurements.begin(), flow.measurements.end(), (int32_t)m) != flow.measurements.end();
+        }), num_eliminated);
+    }
+    for (auto &row : table) {
+        row.output.sign ^= row.input.sign;
+        row.input.sign = 0;
+        if (row.input.ref().has_no_pauli_terms()) {
+            row.input.xs.destructive_resize(0);
+            row.input.zs.destructive_resize(0);
+            row.input.num_qubits = 0;
+        }
+        if (row.output.ref().has_no_pauli_terms()) {
+            row.output.xs.destructive_resize(0);
+            row.output.zs.destructive_resize(0);
+            row.output.num_qubits = 0;
+        }
+    }
+
+    std::sort(table.begin(), table.end());
+}
+
+template <size_t W>
+std::vector<Flow<W>> circuit_flow_generators(const Circuit &circuit) {
+    CircuitFlowGeneratorSolver<W> solver(circuit.compute_stats());
+    for (size_t q = 0; q < solver.num_qubits; q++) {
+        auto &x = solver.add_row();
+        x.output.xs[q] = 1;
+        x.input.xs[q] = 1;
+        auto &z = solver.add_row();
+        z.output.zs[q] = 1;
+        z.input.zs[q] = 1;
+    }
+    circuit.for_each_operation_reverse([&](CircuitInstruction inst) { solver.undo_instruction(inst); });
+    solver.final_canonicalize_into_table();
+    return solver.table;
+}
+
+}

--- a/src/stim/util_top/circuit_flow_generators.test.cc
+++ b/src/stim/util_top/circuit_flow_generators.test.cc
@@ -2,23 +2,22 @@
 
 #include "gtest/gtest.h"
 
-#include "stim/util_top/has_flow.h"
 #include "stim/circuit/circuit.test.h"
 #include "stim/gen/gen_surface_code.h"
 #include "stim/mem/simd_word.test.h"
 #include "stim/util_top/circuit_inverse_qec.h"
+#include "stim/util_top/has_flow.h"
 
 using namespace stim;
 
 TEST_EACH_WORD_SIZE_W(circuit_flow_generators, various, {
-    EXPECT_EQ(circuit_flow_generators<W>(
-        Circuit(R"CIRCUIT(
+    EXPECT_EQ(
+        circuit_flow_generators<W>(Circuit(R"CIRCUIT(
         )CIRCUIT")),
-        (std::vector<Flow<W>>{
-        }));
+        (std::vector<Flow<W>>{}));
 
-    EXPECT_EQ(circuit_flow_generators<W>(
-        Circuit(R"CIRCUIT(
+    EXPECT_EQ(
+        circuit_flow_generators<W>(Circuit(R"CIRCUIT(
             X 0
         )CIRCUIT")),
         (std::vector<Flow<W>>{
@@ -26,8 +25,8 @@ TEST_EACH_WORD_SIZE_W(circuit_flow_generators, various, {
             Flow<W>::from_str("Z -> -Z"),
         }));
 
-    EXPECT_EQ(circuit_flow_generators<W>(
-        Circuit(R"CIRCUIT(
+    EXPECT_EQ(
+        circuit_flow_generators<W>(Circuit(R"CIRCUIT(
             H 0
         )CIRCUIT")),
         (std::vector<Flow<W>>{
@@ -35,8 +34,8 @@ TEST_EACH_WORD_SIZE_W(circuit_flow_generators, various, {
             Flow<W>::from_str("Z -> X"),
         }));
 
-    EXPECT_EQ(circuit_flow_generators<W>(
-        Circuit(R"CIRCUIT(
+    EXPECT_EQ(
+        circuit_flow_generators<W>(Circuit(R"CIRCUIT(
             M 0
         )CIRCUIT")),
         (std::vector<Flow<W>>{
@@ -44,8 +43,8 @@ TEST_EACH_WORD_SIZE_W(circuit_flow_generators, various, {
             Flow<W>::from_str("Z -> rec[0]"),
         }));
 
-    EXPECT_EQ(circuit_flow_generators<W>(
-        Circuit(R"CIRCUIT(
+    EXPECT_EQ(
+        circuit_flow_generators<W>(Circuit(R"CIRCUIT(
             M 0 0
         )CIRCUIT")),
         (std::vector<Flow<W>>{
@@ -54,8 +53,8 @@ TEST_EACH_WORD_SIZE_W(circuit_flow_generators, various, {
             Flow<W>::from_str("Z -> rec[1]"),
         }));
 
-    EXPECT_EQ(circuit_flow_generators<W>(
-        Circuit(R"CIRCUIT(
+    EXPECT_EQ(
+        circuit_flow_generators<W>(Circuit(R"CIRCUIT(
             MXX 2 0
         )CIRCUIT")),
         (std::vector<Flow<W>>{
@@ -67,8 +66,8 @@ TEST_EACH_WORD_SIZE_W(circuit_flow_generators, various, {
             Flow<W>::from_str("Z_Z -> Z_Z"),
         }));
 
-    EXPECT_EQ(circuit_flow_generators<W>(
-        Circuit(R"CIRCUIT(
+    EXPECT_EQ(
+        circuit_flow_generators<W>(Circuit(R"CIRCUIT(
             MYY 3 1 2 3
         )CIRCUIT")),
         (std::vector<Flow<W>>{
@@ -82,8 +81,8 @@ TEST_EACH_WORD_SIZE_W(circuit_flow_generators, various, {
             Flow<W>::from_str("Z___ -> Z___"),
         }));
 
-    EXPECT_EQ(circuit_flow_generators<W>(
-        Circuit(R"CIRCUIT(
+    EXPECT_EQ(
+        circuit_flow_generators<W>(Circuit(R"CIRCUIT(
             MZZ 3 1 2 3
         )CIRCUIT")),
         (std::vector<Flow<W>>{
@@ -97,8 +96,8 @@ TEST_EACH_WORD_SIZE_W(circuit_flow_generators, various, {
             Flow<W>::from_str("Z___ -> Z___"),
         }));
 
-    EXPECT_EQ(circuit_flow_generators<W>(
-        Circuit(R"CIRCUIT(
+    EXPECT_EQ(
+        circuit_flow_generators<W>(Circuit(R"CIRCUIT(
             ISWAP 3 1 2 3
         )CIRCUIT")),
         (std::vector<Flow<W>>{
@@ -112,8 +111,8 @@ TEST_EACH_WORD_SIZE_W(circuit_flow_generators, various, {
             Flow<W>::from_str("Z___ -> Z___"),
         }));
 
-    EXPECT_EQ(circuit_flow_generators<W>(
-        Circuit(R"CIRCUIT(
+    EXPECT_EQ(
+        circuit_flow_generators<W>(Circuit(R"CIRCUIT(
             S 0
         )CIRCUIT")),
         (std::vector<Flow<W>>{
@@ -121,8 +120,8 @@ TEST_EACH_WORD_SIZE_W(circuit_flow_generators, various, {
             Flow<W>::from_str("Z -> Z"),
         }));
 
-    EXPECT_EQ(circuit_flow_generators<W>(
-        Circuit(R"CIRCUIT(
+    EXPECT_EQ(
+        circuit_flow_generators<W>(Circuit(R"CIRCUIT(
             S_DAG 0
         )CIRCUIT")),
         (std::vector<Flow<W>>{
@@ -130,8 +129,8 @@ TEST_EACH_WORD_SIZE_W(circuit_flow_generators, various, {
             Flow<W>::from_str("Z -> Z"),
         }));
 
-    EXPECT_EQ(circuit_flow_generators<W>(
-        Circuit(R"CIRCUIT(
+    EXPECT_EQ(
+        circuit_flow_generators<W>(Circuit(R"CIRCUIT(
             SPP Z0
         )CIRCUIT")),
         (std::vector<Flow<W>>{
@@ -139,8 +138,8 @@ TEST_EACH_WORD_SIZE_W(circuit_flow_generators, various, {
             Flow<W>::from_str("Z -> Z"),
         }));
 
-    EXPECT_EQ(circuit_flow_generators<W>(
-        Circuit(R"CIRCUIT(
+    EXPECT_EQ(
+        circuit_flow_generators<W>(Circuit(R"CIRCUIT(
             SQRT_X 0
             S 0
         )CIRCUIT")),
@@ -148,8 +147,8 @@ TEST_EACH_WORD_SIZE_W(circuit_flow_generators, various, {
             Flow<W>::from_str("X -> Y"),
             Flow<W>::from_str("Z -> X"),
         }));
-    EXPECT_EQ(circuit_flow_generators<W>(
-        Circuit(R"CIRCUIT(
+    EXPECT_EQ(
+        circuit_flow_generators<W>(Circuit(R"CIRCUIT(
             SPP X0 Z0
         )CIRCUIT")),
         (std::vector<Flow<W>>{
@@ -157,8 +156,8 @@ TEST_EACH_WORD_SIZE_W(circuit_flow_generators, various, {
             Flow<W>::from_str("Z -> X"),
         }));
 
-    EXPECT_EQ(circuit_flow_generators<W>(
-        Circuit(R"CIRCUIT(
+    EXPECT_EQ(
+        circuit_flow_generators<W>(Circuit(R"CIRCUIT(
             SPP X0*X1
         )CIRCUIT")),
         (std::vector<Flow<W>>{
@@ -168,8 +167,8 @@ TEST_EACH_WORD_SIZE_W(circuit_flow_generators, various, {
             Flow<W>::from_str("Z_ -> -YX"),
         }));
 
-    EXPECT_EQ(circuit_flow_generators<W>(
-        Circuit(R"CIRCUIT(
+    EXPECT_EQ(
+        circuit_flow_generators<W>(Circuit(R"CIRCUIT(
             SPP_DAG Z0
         )CIRCUIT")),
         (std::vector<Flow<W>>{
@@ -177,8 +176,8 @@ TEST_EACH_WORD_SIZE_W(circuit_flow_generators, various, {
             Flow<W>::from_str("Z -> Z"),
         }));
 
-    EXPECT_EQ(circuit_flow_generators<W>(
-        Circuit(R"CIRCUIT(
+    EXPECT_EQ(
+        circuit_flow_generators<W>(Circuit(R"CIRCUIT(
             M 0
             CX rec[-1] 0
         )CIRCUIT")),
@@ -187,16 +186,16 @@ TEST_EACH_WORD_SIZE_W(circuit_flow_generators, various, {
             Flow<W>::from_str("Z -> rec[0]"),
         }));
 
-    EXPECT_EQ(circuit_flow_generators<W>(
-        Circuit(R"CIRCUIT(
+    EXPECT_EQ(
+        circuit_flow_generators<W>(Circuit(R"CIRCUIT(
             R 0
         )CIRCUIT")),
         (std::vector<Flow<W>>{
             Flow<W>::from_str("1 -> Z"),
         }));
 
-    EXPECT_EQ(circuit_flow_generators<W>(
-        Circuit(R"CIRCUIT(
+    EXPECT_EQ(
+        circuit_flow_generators<W>(Circuit(R"CIRCUIT(
             MR 0
         )CIRCUIT")),
         (std::vector<Flow<W>>{
@@ -204,8 +203,8 @@ TEST_EACH_WORD_SIZE_W(circuit_flow_generators, various, {
             Flow<W>::from_str("Z -> rec[0]"),
         }));
 
-    EXPECT_EQ(circuit_flow_generators<W>(
-        Circuit(R"CIRCUIT(
+    EXPECT_EQ(
+        circuit_flow_generators<W>(Circuit(R"CIRCUIT(
             M 0
             XCZ 0 rec[-1]
         )CIRCUIT")),
@@ -214,8 +213,8 @@ TEST_EACH_WORD_SIZE_W(circuit_flow_generators, various, {
             Flow<W>::from_str("Z -> rec[0]"),
         }));
 
-    EXPECT_EQ(circuit_flow_generators<W>(
-        Circuit(R"CIRCUIT(
+    EXPECT_EQ(
+        circuit_flow_generators<W>(Circuit(R"CIRCUIT(
             MPAD 0 1 1 0
         )CIRCUIT")),
         (std::vector<Flow<W>>{
@@ -225,8 +224,8 @@ TEST_EACH_WORD_SIZE_W(circuit_flow_generators, various, {
             Flow<W>::from_str("1 -> -rec[2]"),
         }));
 
-    EXPECT_EQ(circuit_flow_generators<W>(
-        Circuit(R"CIRCUIT(
+    EXPECT_EQ(
+        circuit_flow_generators<W>(Circuit(R"CIRCUIT(
             M 0
             CY rec[-1] 1
         )CIRCUIT")),
@@ -237,8 +236,8 @@ TEST_EACH_WORD_SIZE_W(circuit_flow_generators, various, {
             Flow<W>::from_str("Z_ -> rec[0]"),
         }));
 
-    EXPECT_EQ(circuit_flow_generators<W>(
-        Circuit(R"CIRCUIT(
+    EXPECT_EQ(
+        circuit_flow_generators<W>(Circuit(R"CIRCUIT(
             HERALDED_ERASE(0.04) 1
             HERALDED_PAULI_CHANNEL_1(0.01, 0.02, 0.03, 0.04) 1
             TICK
@@ -254,7 +253,6 @@ TEST_EACH_WORD_SIZE_W(circuit_flow_generators, various, {
             Flow<W>::from_str("XXX -> _ZY xor rec[2]"),
             Flow<W>::from_str("Z_X -> _ZX xor rec[3]"),
         }));
-
 })
 
 TEST_EACH_WORD_SIZE_W(circuit_flow_generators, all_operations, {

--- a/src/stim/util_top/circuit_flow_generators.test.cc
+++ b/src/stim/util_top/circuit_flow_generators.test.cc
@@ -1,0 +1,268 @@
+#include "stim/util_top/circuit_flow_generators.h"
+
+#include "gtest/gtest.h"
+
+#include "stim/util_top/has_flow.h"
+#include "stim/circuit/circuit.test.h"
+#include "stim/gen/gen_surface_code.h"
+#include "stim/mem/simd_word.test.h"
+#include "stim/util_top/circuit_inverse_qec.h"
+
+using namespace stim;
+
+TEST_EACH_WORD_SIZE_W(circuit_flow_generators, various, {
+    EXPECT_EQ(circuit_flow_generators<W>(
+        Circuit(R"CIRCUIT(
+        )CIRCUIT")),
+        (std::vector<Flow<W>>{
+        }));
+
+    EXPECT_EQ(circuit_flow_generators<W>(
+        Circuit(R"CIRCUIT(
+            X 0
+        )CIRCUIT")),
+        (std::vector<Flow<W>>{
+            Flow<W>::from_str("X -> X"),
+            Flow<W>::from_str("Z -> -Z"),
+        }));
+
+    EXPECT_EQ(circuit_flow_generators<W>(
+        Circuit(R"CIRCUIT(
+            H 0
+        )CIRCUIT")),
+        (std::vector<Flow<W>>{
+            Flow<W>::from_str("X -> Z"),
+            Flow<W>::from_str("Z -> X"),
+        }));
+
+    EXPECT_EQ(circuit_flow_generators<W>(
+        Circuit(R"CIRCUIT(
+            M 0
+        )CIRCUIT")),
+        (std::vector<Flow<W>>{
+            Flow<W>::from_str("1 -> Z xor rec[0]"),
+            Flow<W>::from_str("Z -> rec[0]"),
+        }));
+
+    EXPECT_EQ(circuit_flow_generators<W>(
+        Circuit(R"CIRCUIT(
+            M 0 0
+        )CIRCUIT")),
+        (std::vector<Flow<W>>{
+            Flow<W>::from_str("1 -> rec[0] xor rec[1]"),
+            Flow<W>::from_str("1 -> Z xor rec[1]"),
+            Flow<W>::from_str("Z -> rec[1]"),
+        }));
+
+    EXPECT_EQ(circuit_flow_generators<W>(
+        Circuit(R"CIRCUIT(
+            MXX 2 0
+        )CIRCUIT")),
+        (std::vector<Flow<W>>{
+            Flow<W>::from_str("1 -> X_X xor rec[0]"),
+            Flow<W>::from_str("__X -> __X"),
+            Flow<W>::from_str("_X_ -> _X_"),
+            Flow<W>::from_str("_Z_ -> _Z_"),
+            Flow<W>::from_str("X__ -> __X xor rec[0]"),
+            Flow<W>::from_str("Z_Z -> Z_Z"),
+        }));
+
+    EXPECT_EQ(circuit_flow_generators<W>(
+        Circuit(R"CIRCUIT(
+            MYY 3 1 2 3
+        )CIRCUIT")),
+        (std::vector<Flow<W>>{
+            Flow<W>::from_str("1 -> __YY xor rec[1]"),
+            Flow<W>::from_str("1 -> _Y_Y xor rec[0]"),
+            Flow<W>::from_str("___Y -> ___Y"),
+            Flow<W>::from_str("__Y_ -> ___Y xor rec[1]"),
+            Flow<W>::from_str("_XZZ -> _ZZX xor rec[0]"),
+            Flow<W>::from_str("_ZZZ -> _ZZZ"),
+            Flow<W>::from_str("X___ -> X___"),
+            Flow<W>::from_str("Z___ -> Z___"),
+        }));
+
+    EXPECT_EQ(circuit_flow_generators<W>(
+        Circuit(R"CIRCUIT(
+            MZZ 3 1 2 3
+        )CIRCUIT")),
+        (std::vector<Flow<W>>{
+            Flow<W>::from_str("1 -> __ZZ xor rec[1]"),
+            Flow<W>::from_str("1 -> _Z_Z xor rec[0]"),
+            Flow<W>::from_str("___Z -> ___Z"),
+            Flow<W>::from_str("__Z_ -> ___Z xor rec[1]"),
+            Flow<W>::from_str("_XXX -> _XXX"),
+            Flow<W>::from_str("_Z__ -> ___Z xor rec[0]"),
+            Flow<W>::from_str("X___ -> X___"),
+            Flow<W>::from_str("Z___ -> Z___"),
+        }));
+
+    EXPECT_EQ(circuit_flow_generators<W>(
+        Circuit(R"CIRCUIT(
+            ISWAP 3 1 2 3
+        )CIRCUIT")),
+        (std::vector<Flow<W>>{
+            Flow<W>::from_str("___X -> _YZ_"),
+            Flow<W>::from_str("___Z -> _Z__"),
+            Flow<W>::from_str("__X_ -> __ZY"),
+            Flow<W>::from_str("__Z_ -> ___Z"),
+            Flow<W>::from_str("_X__ -> -_ZXZ"),
+            Flow<W>::from_str("_Z__ -> __Z_"),
+            Flow<W>::from_str("X___ -> X___"),
+            Flow<W>::from_str("Z___ -> Z___"),
+        }));
+
+    EXPECT_EQ(circuit_flow_generators<W>(
+        Circuit(R"CIRCUIT(
+            S 0
+        )CIRCUIT")),
+        (std::vector<Flow<W>>{
+            Flow<W>::from_str("X -> Y"),
+            Flow<W>::from_str("Z -> Z"),
+        }));
+
+    EXPECT_EQ(circuit_flow_generators<W>(
+        Circuit(R"CIRCUIT(
+            S_DAG 0
+        )CIRCUIT")),
+        (std::vector<Flow<W>>{
+            Flow<W>::from_str("X -> -Y"),
+            Flow<W>::from_str("Z -> Z"),
+        }));
+
+    EXPECT_EQ(circuit_flow_generators<W>(
+        Circuit(R"CIRCUIT(
+            SPP Z0
+        )CIRCUIT")),
+        (std::vector<Flow<W>>{
+            Flow<W>::from_str("X -> Y"),
+            Flow<W>::from_str("Z -> Z"),
+        }));
+
+    EXPECT_EQ(circuit_flow_generators<W>(
+        Circuit(R"CIRCUIT(
+            SQRT_X 0
+            S 0
+        )CIRCUIT")),
+        (std::vector<Flow<W>>{
+            Flow<W>::from_str("X -> Y"),
+            Flow<W>::from_str("Z -> X"),
+        }));
+    EXPECT_EQ(circuit_flow_generators<W>(
+        Circuit(R"CIRCUIT(
+            SPP X0 Z0
+        )CIRCUIT")),
+        (std::vector<Flow<W>>{
+            Flow<W>::from_str("X -> Y"),
+            Flow<W>::from_str("Z -> X"),
+        }));
+
+    EXPECT_EQ(circuit_flow_generators<W>(
+        Circuit(R"CIRCUIT(
+            SPP X0*X1
+        )CIRCUIT")),
+        (std::vector<Flow<W>>{
+            Flow<W>::from_str("_X -> _X"),
+            Flow<W>::from_str("_Z -> -XY"),
+            Flow<W>::from_str("X_ -> X_"),
+            Flow<W>::from_str("Z_ -> -YX"),
+        }));
+
+    EXPECT_EQ(circuit_flow_generators<W>(
+        Circuit(R"CIRCUIT(
+            SPP_DAG Z0
+        )CIRCUIT")),
+        (std::vector<Flow<W>>{
+            Flow<W>::from_str("X -> -Y"),
+            Flow<W>::from_str("Z -> Z"),
+        }));
+
+    EXPECT_EQ(circuit_flow_generators<W>(
+        Circuit(R"CIRCUIT(
+            M 0
+            CX rec[-1] 0
+        )CIRCUIT")),
+        (std::vector<Flow<W>>{
+            Flow<W>::from_str("1 -> Z"),
+            Flow<W>::from_str("Z -> rec[0]"),
+        }));
+
+    EXPECT_EQ(circuit_flow_generators<W>(
+        Circuit(R"CIRCUIT(
+            R 0
+        )CIRCUIT")),
+        (std::vector<Flow<W>>{
+            Flow<W>::from_str("1 -> Z"),
+        }));
+
+    EXPECT_EQ(circuit_flow_generators<W>(
+        Circuit(R"CIRCUIT(
+            MR 0
+        )CIRCUIT")),
+        (std::vector<Flow<W>>{
+            Flow<W>::from_str("1 -> Z"),
+            Flow<W>::from_str("Z -> rec[0]"),
+        }));
+
+    EXPECT_EQ(circuit_flow_generators<W>(
+        Circuit(R"CIRCUIT(
+            M 0
+            XCZ 0 rec[-1]
+        )CIRCUIT")),
+        (std::vector<Flow<W>>{
+            Flow<W>::from_str("1 -> Z"),
+            Flow<W>::from_str("Z -> rec[0]"),
+        }));
+
+    EXPECT_EQ(circuit_flow_generators<W>(
+        Circuit(R"CIRCUIT(
+            MPAD 0 1 1 0
+        )CIRCUIT")),
+        (std::vector<Flow<W>>{
+            Flow<W>::from_str("1 -> rec[0]"),
+            Flow<W>::from_str("1 -> rec[3]"),
+            Flow<W>::from_str("1 -> -rec[1]"),
+            Flow<W>::from_str("1 -> -rec[2]"),
+        }));
+
+    EXPECT_EQ(circuit_flow_generators<W>(
+        Circuit(R"CIRCUIT(
+            M 0
+            CY rec[-1] 1
+        )CIRCUIT")),
+        (std::vector<Flow<W>>{
+            Flow<W>::from_str("1 -> Z_ xor rec[0]"),
+            Flow<W>::from_str("_X -> _X xor rec[0]"),
+            Flow<W>::from_str("_Z -> _Z xor rec[0]"),
+            Flow<W>::from_str("Z_ -> rec[0]"),
+        }));
+
+    EXPECT_EQ(circuit_flow_generators<W>(
+        Circuit(R"CIRCUIT(
+            HERALDED_ERASE(0.04) 1
+            HERALDED_PAULI_CHANNEL_1(0.01, 0.02, 0.03, 0.04) 1
+            TICK
+            MPP X0*Y1*Z2 Z0*Z1
+        )CIRCUIT")),
+        (std::vector<Flow<W>>{
+            Flow<W>::from_str("1 -> rec[0]"),
+            Flow<W>::from_str("1 -> rec[1]"),
+            Flow<W>::from_str("1 -> XYZ xor rec[2]"),
+            Flow<W>::from_str("1 -> ZZ_ xor rec[3]"),
+            Flow<W>::from_str("__Z -> __Z"),
+            Flow<W>::from_str("_ZX -> _ZX"),
+            Flow<W>::from_str("XXX -> _ZY xor rec[2]"),
+            Flow<W>::from_str("Z_X -> _ZX xor rec[3]"),
+        }));
+
+})
+
+TEST_EACH_WORD_SIZE_W(circuit_flow_generators, all_operations, {
+    auto circuit = generate_test_circuit_with_all_operations();
+    auto generators = circuit_flow_generators<W>(circuit);
+    auto rng = externally_seeded_rng();
+    auto passes = sample_if_circuit_has_stabilizer_flows<W>(256, rng, circuit, generators);
+    for (size_t k = 0; k < passes.size(); k++) {
+        EXPECT_TRUE(passes[k]) << k << ": " << generators[k];
+    }
+})

--- a/src/stim/util_top/circuit_inverse_qec.test.cc
+++ b/src/stim/util_top/circuit_inverse_qec.test.cc
@@ -2,7 +2,7 @@
 
 #include "gtest/gtest.h"
 
-#include "circuit_to_detecting_regions.h"
+#include "stim/util_top/circuit_to_detecting_regions.h"
 #include "stim/gen/gen_surface_code.h"
 #include "stim/mem/simd_word.test.h"
 

--- a/src/stim/util_top/circuit_inverse_qec.test.cc
+++ b/src/stim/util_top/circuit_inverse_qec.test.cc
@@ -2,9 +2,9 @@
 
 #include "gtest/gtest.h"
 
-#include "stim/util_top/circuit_to_detecting_regions.h"
 #include "stim/gen/gen_surface_code.h"
 #include "stim/mem/simd_word.test.h"
+#include "stim/util_top/circuit_to_detecting_regions.h"
 
 using namespace stim;
 

--- a/src/stim/util_top/export_qasm.test.cc
+++ b/src/stim/util_top/export_qasm.test.cc
@@ -196,7 +196,7 @@ TEST(export_qasm, export_open_qasm_mpad) {
     ASSERT_EQ(out.str(), R"QASM(OPENQASM 3.0;
 include "stdgates.inc";
 
-qreg q[2];
+qreg q[1];
 creg rec[4];
 
 h q[0];

--- a/src/stim/util_top/has_flow.inl
+++ b/src/stim/util_top/has_flow.inl
@@ -38,7 +38,7 @@ static GateTarget measurement_index_to_target(int32_t m, uint64_t num_measuremen
 }
 
 template <size_t W>
-bool _sample_if_circuit_has_stabilizer_flow(
+bool _sample_if_noiseless_circuit_has_stabilizer_flow(
     size_t num_samples, std::mt19937_64 &rng, const Circuit &circuit, const Flow<W> &flow) {
     uint32_t num_qubits = (uint32_t)circuit.count_qubits();
     uint64_t num_measurements = circuit.count_measurements();
@@ -76,9 +76,10 @@ bool _sample_if_circuit_has_stabilizer_flow(
 template <size_t W>
 std::vector<bool> sample_if_circuit_has_stabilizer_flows(
     size_t num_samples, std::mt19937_64 &rng, const Circuit &circuit, std::span<const Flow<W>> flows) {
+    const auto &noiseless = circuit.aliased_noiseless_circuit();
     std::vector<bool> result;
     for (const auto &flow : flows) {
-        result.push_back(_sample_if_circuit_has_stabilizer_flow(num_samples, rng, circuit, flow));
+        result.push_back(_sample_if_noiseless_circuit_has_stabilizer_flow(num_samples, rng, noiseless, flow));
     }
     return result;
 }

--- a/src/stim/util_top/reference_sample_tree.cc
+++ b/src/stim/util_top/reference_sample_tree.cc
@@ -9,7 +9,7 @@ bool ReferenceSampleTree::empty() const {
     if (!prefix_bits.empty()) {
         return false;
     }
-    for (const auto &child: suffix_children) {
+    for (const auto &child : suffix_children) {
         if (!child.empty()) {
             return false;
         }
@@ -48,7 +48,7 @@ void ReferenceSampleTree::flatten_and_simplify_into(std::vector<ReferenceSampleT
         if (dst.prefix_bits == src.prefix_bits && dst.suffix_children == src.suffix_children) {
             dst.repetitions += src.repetitions;
 
-        // Fuse children with unrepeated contents if they can be fused.
+            // Fuse children with unrepeated contents if they can be fused.
         } else if (src.repetitions == 1 && dst.repetitions == 1 && dst.suffix_children.empty()) {
             dst.suffix_children = std::move(src.suffix_children);
             dst.prefix_bits.insert(dst.prefix_bits.end(), src.prefix_bits.begin(), src.prefix_bits.end());
@@ -78,9 +78,9 @@ void ReferenceSampleTree::flatten_and_simplify_into(std::vector<ReferenceSampleT
         out.push_back(std::move(result));
     } else {
         out.push_back(ReferenceSampleTree{
-            .prefix_bits={},
-            .suffix_children=std::move(fused),
-            .repetitions=repetitions,
+            .prefix_bits = {},
+            .suffix_children = std::move(fused),
+            .repetitions = repetitions,
         });
     }
 }
@@ -90,7 +90,8 @@ uint64_t stim::max_feedback_lookback_in_loop(const Circuit &loop) {
     uint64_t furthest_lookback = 0;
     for (const auto &inst : loop.operations) {
         if (inst.gate_type == GateType::REPEAT) {
-            furthest_lookback = std::max(furthest_lookback, max_feedback_lookback_in_loop(inst.repeat_block_body(loop)));
+            furthest_lookback =
+                std::max(furthest_lookback, max_feedback_lookback_in_loop(inst.repeat_block_body(loop)));
         } else {
             auto f = GATE_DATA[inst.gate_type].flags;
             if ((f & GateFlags::GATE_CAN_TARGET_BITS) && (f & GateFlags::GATE_TARGETS_PAIRS)) {
@@ -136,10 +137,10 @@ ReferenceSampleTree ReferenceSampleTree::simplified() const {
     ReferenceSampleTree result;
     result.repetitions = 1;
 
-     // Take payload from first child.
+    // Take payload from first child.
     if (flat[0].repetitions == 1 && flat[0].suffix_children.empty()) {
-         result = std::move(flat[0]);
-         flat.erase(flat.begin());
+        result = std::move(flat[0]);
+        flat.erase(flat.begin());
     }
 
     result.suffix_children = std::move(flat);
@@ -148,7 +149,7 @@ ReferenceSampleTree ReferenceSampleTree::simplified() const {
 
 size_t ReferenceSampleTree::size() const {
     size_t result = prefix_bits.size();
-    for (const auto &child: suffix_children) {
+    for (const auto &child : suffix_children) {
         result += child.size();
     }
     return result * repetitions;
@@ -157,7 +158,7 @@ size_t ReferenceSampleTree::size() const {
 void ReferenceSampleTree::decompress_into(std::vector<bool> &output) const {
     for (uint64_t k = 0; k < repetitions; k++) {
         output.insert(output.end(), prefix_bits.begin(), prefix_bits.end());
-        for (const auto &child: suffix_children) {
+        for (const auto &child : suffix_children) {
             child.decompress_into(output);
         }
     }
@@ -166,12 +167,8 @@ void ReferenceSampleTree::decompress_into(std::vector<bool> &output) const {
 ReferenceSampleTree ReferenceSampleTree::from_circuit_reference_sample(const Circuit &circuit) {
     auto stats = circuit.compute_stats();
     std::mt19937_64 irrelevant_rng{0};
-    CompressedReferenceSampleHelper<MAX_BITWORD_WIDTH> helper(
-        TableauSimulator<MAX_BITWORD_WIDTH>(
-            std::move(irrelevant_rng),
-            stats.num_qubits,
-            +1,
-            MeasureRecord(stats.max_lookback)));
+    CompressedReferenceSampleHelper<MAX_BITWORD_WIDTH> helper(TableauSimulator<MAX_BITWORD_WIDTH>(
+        std::move(irrelevant_rng), stats.num_qubits, +1, MeasureRecord(stats.max_lookback)));
     return helper.do_loop_with_tortoise_hare_folding(circuit, 1).simplified();
 }
 
@@ -182,8 +179,7 @@ std::string ReferenceSampleTree::str() const {
 }
 
 bool ReferenceSampleTree::operator==(const ReferenceSampleTree &other) const {
-    return repetitions == other.repetitions &&
-           prefix_bits == other.prefix_bits &&
+    return repetitions == other.repetitions && prefix_bits == other.prefix_bits &&
            suffix_children == other.suffix_children;
 }
 bool ReferenceSampleTree::operator!=(const ReferenceSampleTree &other) const {

--- a/src/stim/util_top/reference_sample_tree.h
+++ b/src/stim/util_top/reference_sample_tree.h
@@ -60,21 +60,15 @@ struct CompressedReferenceSampleHelper {
     ///
     /// Loops containing within the body of this loop (or circuit body) may
     /// still be compressed. Only the top-level loop is not folded.
-    ReferenceSampleTree do_loop_with_no_folding(
-        const Circuit &loop,
-        uint64_t reps);
+    ReferenceSampleTree do_loop_with_no_folding(const Circuit &loop, uint64_t reps);
 
     /// Runs tortoise-and-hare analysis of the loop while simulating its
     /// reference sample, in order to attempt to return a compressed
     /// representation.
-    ReferenceSampleTree do_loop_with_tortoise_hare_folding(
-        const Circuit &loop,
-        uint64_t reps);
+    ReferenceSampleTree do_loop_with_tortoise_hare_folding(const Circuit &loop, uint64_t reps);
 
     bool in_same_recent_state_as(
-        const CompressedReferenceSampleHelper<W> &other,
-        uint64_t max_record_lookback,
-        bool allow_false_negative) const;
+        const CompressedReferenceSampleHelper<W> &other, uint64_t max_record_lookback, bool allow_false_negative) const;
 };
 
 uint64_t max_feedback_lookback_in_loop(const Circuit &loop);

--- a/src/stim/util_top/reference_sample_tree.inl
+++ b/src/stim/util_top/reference_sample_tree.inl
@@ -26,7 +26,7 @@ ReferenceSampleTree CompressedReferenceSampleHelper<W>::do_loop_with_no_folding(
         for (const auto &inst : loop.operations) {
             if (inst.gate_type == GateType::REPEAT) {
                 uint64_t repeats = inst.repeat_block_rep_count();
-                const auto& block = inst.repeat_block_body(loop);
+                const auto &block = inst.repeat_block_body(loop);
                 flush_recorded_into_result();
                 result.suffix_children.push_back(do_loop_with_tortoise_hare_folding(block, repeats));
                 start_size = sim.measurement_record.storage.size();
@@ -41,7 +41,8 @@ ReferenceSampleTree CompressedReferenceSampleHelper<W>::do_loop_with_no_folding(
 }
 
 template <size_t W>
-ReferenceSampleTree CompressedReferenceSampleHelper<W>::do_loop_with_tortoise_hare_folding(const Circuit &loop, uint64_t reps) {
+ReferenceSampleTree CompressedReferenceSampleHelper<W>::do_loop_with_tortoise_hare_folding(
+    const Circuit &loop, uint64_t reps) {
     if (reps < 10) {
         // Probably not worth the overhead of tortoise-and-hare. Just run it raw.
         return do_loop_with_no_folding(loop, reps);
@@ -99,7 +100,9 @@ ReferenceSampleTree CompressedReferenceSampleHelper<W>::do_loop_with_tortoise_ha
     // Add skipped iterations' measurement data into the sim's measurement record.
     loop_contents.repetitions = 1;
     sim.measurement_record.discard_results_past_max_lookback();
-    for (size_t k = 0; k < period_steps_left && sim.measurement_record.storage.size() < sim.measurement_record.max_lookback * 2; k++) {
+    for (size_t k = 0;
+         k < period_steps_left && sim.measurement_record.storage.size() < sim.measurement_record.max_lookback * 2;
+         k++) {
         loop_contents.decompress_into(sim.measurement_record.storage);
     }
     sim.measurement_record.discard_results_past_max_lookback();
@@ -116,9 +119,7 @@ ReferenceSampleTree CompressedReferenceSampleHelper<W>::do_loop_with_tortoise_ha
 
 template <size_t W>
 bool CompressedReferenceSampleHelper<W>::in_same_recent_state_as(
-    const CompressedReferenceSampleHelper<W> &other,
-    uint64_t max_record_lookback,
-    bool allow_false_negative) const {
+    const CompressedReferenceSampleHelper<W> &other, uint64_t max_record_lookback, bool allow_false_negative) const {
     const auto &s1 = sim.measurement_record.storage;
     const auto &s2 = other.sim.measurement_record.storage;
 

--- a/src/stim/util_top/reference_sample_tree.perf.cc
+++ b/src/stim/util_top/reference_sample_tree.perf.cc
@@ -14,8 +14,7 @@ BENCHMARK(reference_sample_tree_surface_code_d31_r1000000000) {
     benchmark_go([&]() {
         auto result = ReferenceSampleTree::from_circuit_reference_sample(circuit);
         total += result.empty();
-    })
-        .goal_millis(25);
+    }).goal_millis(25);
     if (total) {
         std::cerr << "data dependence";
     }
@@ -44,8 +43,7 @@ BENCHMARK(reference_sample_tree_nested_circuit) {
     benchmark_go([&]() {
         auto result = ReferenceSampleTree::from_circuit_reference_sample(circuit);
         total += result.empty();
-    })
-        .goal_micros(230);
+    }).goal_micros(230);
     if (total) {
         std::cerr << "data dependence";
     }

--- a/src/stim/util_top/reference_sample_tree.test.cc
+++ b/src/stim/util_top/reference_sample_tree.test.cc
@@ -19,72 +19,83 @@ void expect_tree_matches_normal_reference_sample_of(const ReferenceSampleTree &t
 
 TEST(ReferenceSampleTree, equality) {
     ReferenceSampleTree empty1{
-        .prefix_bits={},
-        .suffix_children={},
-        .repetitions=0,
+        .prefix_bits = {},
+        .suffix_children = {},
+        .repetitions = 0,
     };
     ReferenceSampleTree empty2;
     ASSERT_EQ(empty1, empty2);
 
     ASSERT_FALSE(empty1 != empty2);
-    ASSERT_NE(empty1, (ReferenceSampleTree{.prefix_bits={},.suffix_children{},.repetitions=1}));
-    ASSERT_NE(empty1, (ReferenceSampleTree{.prefix_bits={0},.suffix_children{},.repetitions=0}));
-    ASSERT_NE(empty1, (ReferenceSampleTree{.prefix_bits={},.suffix_children{{}},.repetitions=0}));
+    ASSERT_NE(empty1, (ReferenceSampleTree{.prefix_bits = {}, .suffix_children{}, .repetitions = 1}));
+    ASSERT_NE(empty1, (ReferenceSampleTree{.prefix_bits = {0}, .suffix_children{}, .repetitions = 0}));
+    ASSERT_NE(empty1, (ReferenceSampleTree{.prefix_bits = {}, .suffix_children{{}}, .repetitions = 0}));
 }
 
 TEST(ReferenceSampleTree, str) {
-    ASSERT_EQ((ReferenceSampleTree{
-        .prefix_bits={},
-        .suffix_children={},
-        .repetitions=0,
-    }.str()), "0*('')");
+    ASSERT_EQ(
+        (ReferenceSampleTree{
+            .prefix_bits = {},
+            .suffix_children = {},
+            .repetitions = 0,
+        }
+             .str()),
+        "0*('')");
 
-    ASSERT_EQ((ReferenceSampleTree{
-        .prefix_bits={1, 1, 0, 1},
-        .suffix_children={},
-        .repetitions=0,
-    }.str()), "0*('1101')");
+    ASSERT_EQ(
+        (ReferenceSampleTree{
+            .prefix_bits = {1, 1, 0, 1},
+            .suffix_children = {},
+            .repetitions = 0,
+        }
+             .str()),
+        "0*('1101')");
 
-    ASSERT_EQ((ReferenceSampleTree{
-        .prefix_bits={1, 1, 0, 1},
-        .suffix_children={},
-        .repetitions=2,
-    }.str()), "2*('1101')");
+    ASSERT_EQ(
+        (ReferenceSampleTree{
+            .prefix_bits = {1, 1, 0, 1},
+            .suffix_children = {},
+            .repetitions = 2,
+        }
+             .str()),
+        "2*('1101')");
 
-    ASSERT_EQ((ReferenceSampleTree{
-        .prefix_bits={1, 1, 0, 1},
-        .suffix_children={
-            ReferenceSampleTree{
-                .prefix_bits={1},
-                .suffix_children={},
-                .repetitions=5,
-            }
-        },
-        .repetitions=2,
-    }.str()), "2*('1101'+5*('1'))");
+    ASSERT_EQ(
+        (ReferenceSampleTree{
+            .prefix_bits = {1, 1, 0, 1},
+            .suffix_children = {ReferenceSampleTree{
+                .prefix_bits = {1},
+                .suffix_children = {},
+                .repetitions = 5,
+            }},
+            .repetitions = 2,
+        }
+             .str()),
+        "2*('1101'+5*('1'))");
 }
 
 TEST(ReferenceSampleTree, simplified) {
     ReferenceSampleTree raw{
-        .prefix_bits={},
-        .suffix_children={
-            ReferenceSampleTree{
-                .prefix_bits={},
-                .suffix_children={},
-                .repetitions=1,
+        .prefix_bits = {},
+        .suffix_children =
+            {
+                ReferenceSampleTree{
+                    .prefix_bits = {},
+                    .suffix_children = {},
+                    .repetitions = 1,
+                },
+                ReferenceSampleTree{
+                    .prefix_bits = {1, 0, 1},
+                    .suffix_children = {{}},
+                    .repetitions = 0,
+                },
+                ReferenceSampleTree{
+                    .prefix_bits = {1, 1, 1},
+                    .suffix_children = {},
+                    .repetitions = 2,
+                },
             },
-            ReferenceSampleTree{
-                .prefix_bits={1, 0, 1},
-                .suffix_children={{}},
-                .repetitions=0,
-            },
-            ReferenceSampleTree{
-                .prefix_bits={1, 1, 1},
-                .suffix_children={},
-                .repetitions=2,
-            },
-        },
-        .repetitions=3,
+        .repetitions = 3,
     };
     ASSERT_EQ(raw.simplified().str(), "6*('111')");
 }
@@ -92,36 +103,38 @@ TEST(ReferenceSampleTree, simplified) {
 TEST(ReferenceSampleTree, decompress_into) {
     std::vector<bool> result;
     ReferenceSampleTree{
-        .prefix_bits={1, 1, 0, 1},
-        .suffix_children={
-            ReferenceSampleTree{
-                .prefix_bits={1},
-                .suffix_children={},
-                .repetitions=5,
-            }
-        },
-        .repetitions=2,
-    }.decompress_into(result);
+        .prefix_bits = {1, 1, 0, 1},
+        .suffix_children = {ReferenceSampleTree{
+            .prefix_bits = {1},
+            .suffix_children = {},
+            .repetitions = 5,
+        }},
+        .repetitions = 2,
+    }
+        .decompress_into(result);
     ASSERT_EQ(result, (std::vector<bool>{1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1}));
 
     result.clear();
     ReferenceSampleTree{
-        .prefix_bits={1, 1, 0, 1},
-        .suffix_children={
-            ReferenceSampleTree{
-                .prefix_bits={1, 0, 1},
-                .suffix_children={},
-                .repetitions=8,
+        .prefix_bits = {1, 1, 0, 1},
+        .suffix_children =
+            {
+                ReferenceSampleTree{
+                    .prefix_bits = {1, 0, 1},
+                    .suffix_children = {},
+                    .repetitions = 8,
+                },
+                ReferenceSampleTree{
+                    .prefix_bits = {0, 0},
+                    .suffix_children = {},
+                    .repetitions = 1,
+                },
             },
-            ReferenceSampleTree{
-                .prefix_bits={0, 0},
-                .suffix_children={},
-                .repetitions=1,
-            },
-        },
-        .repetitions=1,
-    }.decompress_into(result);
-    ASSERT_EQ(result, (std::vector<bool>{1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 0, 0}));
+        .repetitions = 1,
+    }
+        .decompress_into(result);
+    ASSERT_EQ(result, (std::vector<bool>{1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0,
+                                         1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 0, 0}));
 }
 
 TEST(ReferenceSampleTree, simple_circuit) {
@@ -186,7 +199,8 @@ TEST(ReferenceSampleTree, feedback) {
 TEST(max_feedback_lookback_in_loop, simple) {
     ASSERT_EQ(max_feedback_lookback_in_loop(Circuit()), 0);
 
-    ASSERT_EQ(max_feedback_lookback_in_loop(Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        max_feedback_lookback_in_loop(Circuit(R"CIRCUIT(
         REPEAT 100 {
             REPEAT 100 {
                 M 0
@@ -200,27 +214,36 @@ TEST(max_feedback_lookback_in_loop, simple) {
             X 1
             CX 1 0
         }
-    )CIRCUIT")), 0);
+    )CIRCUIT")),
+        0);
 
-    ASSERT_EQ(max_feedback_lookback_in_loop(Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        max_feedback_lookback_in_loop(Circuit(R"CIRCUIT(
         CX rec[-1] 0
-    )CIRCUIT")), 1);
+    )CIRCUIT")),
+        1);
 
-    ASSERT_EQ(max_feedback_lookback_in_loop(Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        max_feedback_lookback_in_loop(Circuit(R"CIRCUIT(
         CZ 0 rec[-2]
-    )CIRCUIT")), 2);
+    )CIRCUIT")),
+        2);
 
-    ASSERT_EQ(max_feedback_lookback_in_loop(Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        max_feedback_lookback_in_loop(Circuit(R"CIRCUIT(
         CZ 0 rec[-2]
         CY 0 rec[-3]
-    )CIRCUIT")), 3);
+    )CIRCUIT")),
+        3);
 
-    ASSERT_EQ(max_feedback_lookback_in_loop(Circuit(R"CIRCUIT(
+    ASSERT_EQ(
+        max_feedback_lookback_in_loop(Circuit(R"CIRCUIT(
         CZ 0 rec[-2]
         REPEAT 100 {
             CX rec[-5] 0
         }
-    )CIRCUIT")), 5);
+    )CIRCUIT")),
+        5);
 }
 
 TEST(ReferenceSampleTree, nested_loops) {
@@ -240,7 +263,10 @@ TEST(ReferenceSampleTree, nested_loops) {
     )CIRCUIT");
     auto ref = ReferenceSampleTree::from_circuit_reference_sample(circuit);
     expect_tree_matches_normal_reference_sample_of(ref, circuit);
-    ASSERT_EQ(ref.str(), "1*(''+50*('0110')+200*('0')+50*('1001')+200*('1')+50*('1001')+200*('1')+50*('0110')+200*('0')+24*(''+50*('0110')+200*('0')+50*('1001')+200*('1')+50*('1001')+200*('1')+50*('0110')+200*('0')))");
+    ASSERT_EQ(
+        ref.str(),
+        "1*(''+50*('0110')+200*('0')+50*('1001')+200*('1')+50*('1001')+200*('1')+50*('0110')+200*('0')+24*(''+50*('"
+        "0110')+200*('0')+50*('1001')+200*('1')+50*('1001')+200*('1')+50*('0110')+200*('0')))");
 }
 
 TEST(ReferenceSampleTree, surface_code) {

--- a/src/stim/util_top/stabilizers_to_tableau.inl
+++ b/src/stim/util_top/stabilizers_to_tableau.inl
@@ -97,7 +97,7 @@ Tableau<W> stabilizers_to_tableau(
             if (!allow_redundant) {
                 std::stringstream ss;
                 ss << "Some of the given stabilizers are redundant.";
-                ss<< "\nTo allow redundant stabilizers, pass the argument allow_redundant=True.";
+                ss << "\nTo allow redundant stabilizers, pass the argument allow_redundant=True.";
                 ss << "\n";
                 ss << "\nFor example:";
                 ss << "\n    stabilizers[" << k << "] = " << stabilizers[k];


### PR DESCRIPTION
- Fix MPAD targets counting towards circuit.num_qubits
- Fix `stim::PauliString` move constructor not clearing `num_qubits`
- Fix `stim.has_flow` not ignoring noise
- Add `stim.CircuitInstruction.num_measurements`
- Add `stim::PauliString::operator<`
- Fix `SPP` and `SPP_DAG` not being supported by `stim.PauliString.after/before`