### PR TITLE
Add `stim.GateData.{is_symmetric_gate,hadamard_conjugated}`

### DIFF
--- a/dev/doctest_proper.py
+++ b/dev/doctest_proper.py
@@ -90,6 +90,8 @@ def main():
         out = {}
         gen(obj=module, fullname=module_name, out=out)
         for k, v in out.items():
+            if v.__doc__ is None:
+                continue
             v = v.__doc__.lower()
             if '\n' in v.strip() and 'examples:' not in v and 'example:' not in v and '[deprecated]' not in v:
                 if k.split('.')[-1] not in ['__next__', '__iter__', '__init_subclass__', '__module__', '__eq__', '__ne__', '__str__', '__repr__']:

--- a/dev/doctest_proper.py
+++ b/dev/doctest_proper.py
@@ -89,6 +89,13 @@ def main():
         module = __import__(module_name)
         out = {}
         gen(obj=module, fullname=module_name, out=out)
+        for k, v in out.items():
+            v = v.__doc__.lower()
+            if '\n' in v.strip() and 'examples:' not in v and 'example:' not in v and '[deprecated]' not in v:
+                if k.split('.')[-1] not in ['__next__', '__iter__', '__init_subclass__', '__module__', '__eq__', '__ne__', '__str__', '__repr__']:
+                    if all(not (e.startswith('_') and not e.startswith('__')) for e in k.split('.')):
+                        print(f"    Warning: Missing 'examples:' section in docstring of {k!r}", file=sys.stderr)
+
         module.__test__ = {k: v for k, v in out.items()}
         if doctest.testmod(module, globs=globs).failed:
             any_failed = True

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -2001,8 +2001,8 @@ class Circuit:
         Examples:
             >>> import stim
             >>> stim.Circuit('''
-            ...    X 1
-            ...    M 0 1
+            ...     X 1
+            ...     M 0 1
             ... ''').reference_sample()
             array([False,  True])
         """
@@ -2717,6 +2717,26 @@ class Circuit:
         """
 class CircuitErrorLocation:
     """Describes the location of an error mechanism from a stim circuit.
+
+    Examples:
+        >>> import stim
+        >>> circuit = stim.Circuit.generated(
+        ...     "repetition_code:memory",
+        ...     distance=5,
+        ...     rounds=5,
+        ...     before_round_data_depolarization=1e-3,
+        ... )
+        >>> logical_error = circuit.shortest_graphlike_error()
+        >>> error_location = logical_error[0].circuit_error_locations[0]
+        >>> print(error_location)
+        CircuitErrorLocation {
+            flipped_pauli_product: X0
+            Circuit location stack trace:
+                (after 1 TICKs)
+                at instruction #3 (DEPOLARIZE1) in the circuit
+                at target #1 of the instruction
+                resolving to DEPOLARIZE1(0.001) 0
+        }
     """
     def __init__(
         self,
@@ -2728,20 +2748,88 @@ class CircuitErrorLocation:
         stack_frames: List[stim.CircuitErrorLocationStackFrame],
     ) -> None:
         """Creates a stim.CircuitErrorLocation.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.CircuitErrorLocation(
+            ...     tick_offset=1,
+            ...     flipped_pauli_product=(
+            ...         stim.GateTargetWithCoords(
+            ...             gate_target=stim.target_x(0),
+            ...             coords=[],
+            ...         ),
+            ...     ),
+            ...     flipped_measurement=stim.FlippedMeasurement(
+            ...         record_index=None,
+            ...         observable=(),
+            ...     ),
+            ...     instruction_targets=stim.CircuitTargetsInsideInstruction(
+            ...         gate='DEPOLARIZE1',
+            ...         args=[0.001],
+            ...         target_range_start=0,
+            ...         target_range_end=1,
+            ...         targets_in_range=(stim.GateTargetWithCoords(
+            ...             gate_target=0,
+            ...             coords=[],
+            ...         ),)
+            ...     ),
+            ...     stack_frames=(
+            ...         stim.CircuitErrorLocationStackFrame(
+            ...             instruction_offset=2,
+            ...             iteration_index=0,
+            ...             instruction_repetitions_arg=0,
+            ...         ),
+            ...     ),
+            ... )
+            >>> print(err)
+            CircuitErrorLocation {
+                flipped_pauli_product: X0
+                Circuit location stack trace:
+                    (after 1 TICKs)
+                    at instruction #3 (DEPOLARIZE1) in the circuit
+                    at target #1 of the instruction
+                    resolving to DEPOLARIZE1(0.001) 0
+            }
         """
     @property
     def flipped_measurement(
         self,
     ) -> Optional[stim.FlippedMeasurement]:
         """The measurement that was flipped by the error mechanism.
+
         If the error isn't a measurement error, this will be None.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.Circuit('''
+            ...     R 0
+            ...     M(0.125) 0
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ... ''').shortest_graphlike_error()
+            >>> err[0].circuit_error_locations[0].flipped_measurement
+            stim.FlippedMeasurement(
+                record_index=0,
+                observable=(stim.GateTargetWithCoords(stim.target_z(0), []),),
+            )
         """
     @property
     def flipped_pauli_product(
         self,
     ) -> List[stim.GateTargetWithCoords]:
         """The Pauli errors that the error mechanism applied to qubits.
+
         When the error is a measurement error, this will be an empty list.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.Circuit('''
+            ...     R 0
+            ...     Y_ERROR(0.125) 0
+            ...     M 0
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ... ''').shortest_graphlike_error()
+            >>> err[0].circuit_error_locations[0].flipped_pauli_product
+            [stim.GateTargetWithCoords(stim.target_y(0), [])]
         """
     @property
     def instruction_targets(
@@ -2755,15 +2843,48 @@ class CircuitErrorLocation:
     def stack_frames(
         self,
     ) -> List[stim.CircuitErrorLocationStackFrame]:
-        """Where in the circuit's execution does the error mechanism occur,
-        accounting for things like nested loops that iterate multiple times.
+        """Describes where in the circuit's execution the error happened.
+
+        Multiple frames are needed because the error may occur within a loop,
+        or a loop nested inside a loop, or etc.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.Circuit('''
+            ...     R 0
+            ...     TICK
+            ...     Y_ERROR(0.125) 0
+            ...     M 0
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ... ''').shortest_graphlike_error()
+            >>> err[0].circuit_error_locations[0].stack_frames
+            [stim.CircuitErrorLocationStackFrame(
+                instruction_offset=2,
+                iteration_index=0,
+                instruction_repetitions_arg=0,
+            )]
         """
     @property
     def tick_offset(
         self,
     ) -> int:
-        """The number of TICKs that executed before the error mechanism being discussed,
-        including TICKs that occurred multiple times during loops.
+        """The number of TICKs that executed before the error happened.
+
+        This counts TICKs occurring multiple times during loops.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.Circuit('''
+            ...     R 0
+            ...     TICK
+            ...     TICK
+            ...     TICK
+            ...     Y_ERROR(0.125) 0
+            ...     M 0
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ... ''').shortest_graphlike_error()
+            >>> err[0].circuit_error_locations[0].tick_offset
+            3
         """
 class CircuitErrorLocationStackFrame:
     """Describes the location of an instruction being executed within a
@@ -4098,6 +4219,18 @@ class DemRepeatBlock:
         self,
     ) -> stim.DetectorErrorModel:
         """Returns a copy of the block's body, as a stim.DetectorErrorModel.
+
+        Examples:
+            >>> import stim
+            >>> body = stim.DetectorErrorModel('''
+            ...     error(0.125) D0 D1
+            ...     shift_detectors 1
+            ... ''')
+            >>> repeat_block = stim.DemRepeatBlock(100, body)
+            >>> repeat_block.body_copy() == body
+            True
+            >>> repeat_block.body_copy() is repeat_block.body_copy()
+            False
         """
     @property
     def repeat_count(
@@ -4137,6 +4270,26 @@ class DemTarget:
     ) -> bool:
         """Determines if two `stim.DemTarget`s are identical.
         """
+    def __init__(
+        self,
+        arg: object,
+        /,
+    ) -> None:
+        """Creates a stim.DemTarget from the given object.
+
+        Args:
+            arg: A string to parse as a stim.DemTarget, or some other object to
+                convert into a stim.DemTarget.
+
+        Examples:
+            >>> import stim
+            >>> stim.DemTarget("D5") == stim.target_relative_detector_id(5)
+            True
+            >>> stim.DemTarget("L2") == stim.target_logical_observable_id(2)
+            True
+            >>> stim.DemTarget("^") == stim.target_separator()
+            True
+        """
     def __ne__(
         self,
         arg0: stim.DemTarget,
@@ -4160,6 +4313,15 @@ class DemTarget:
 
         In a detector error model file, observable targets are prefixed by `L`. For
         example, in `error(0.25) D0 L1` the `L1` is an observable target.
+
+        Examples:
+            >>> import stim
+            >>> stim.DemTarget("L2").is_logical_observable_id()
+            True
+            >>> stim.DemTarget("D3").is_logical_observable_id()
+            False
+            >>> stim.DemTarget("^").is_logical_observable_id()
+            False
         """
     def is_relative_detector_id(
         self,
@@ -4168,6 +4330,15 @@ class DemTarget:
 
         In a detector error model file, detectors are prefixed by `D`. For
         example, in `error(0.25) D0 L1` the `D0` is a relative detector target.
+
+        Examples:
+            >>> import stim
+            >>> stim.DemTarget("L2").is_relative_detector_id()
+            False
+            >>> stim.DemTarget("D3").is_relative_detector_id()
+            True
+            >>> stim.DemTarget("^").is_relative_detector_id()
+            False
         """
     def is_separator(
         self,
@@ -4176,6 +4347,15 @@ class DemTarget:
 
         Separates separate the components of a suggested decompositions within an error.
         For example, the `^` in `error(0.25) D1 D2 ^ D3 D4` is the separator.
+
+        Examples:
+            >>> import stim
+            >>> stim.DemTarget("L2").is_separator()
+            False
+            >>> stim.DemTarget("D3").is_separator()
+            False
+            >>> stim.DemTarget("^").is_separator()
+            True
         """
     @staticmethod
     def logical_observable_id(
@@ -4248,11 +4428,10 @@ class DemTarget:
         """Returns the target's integer value.
 
         Example:
-
             >>> import stim
-            >>> stim.target_relative_detector_id(5).val
+            >>> stim.DemTarget("D5").val
             5
-            >>> stim.target_logical_observable_id(6).val
+            >>> stim.DemTarget("L6").val
             6
         """
 class DemTargetWithCoords:
@@ -5806,11 +5985,21 @@ class FlippedMeasurement:
     """
     def __init__(
         self,
-        *,
-        record_index: int,
-        observable: object,
-    ) -> None:
+        measurement_record_index: Optional[int],
+        measured_observable: Iterable[stim.GateTargetWithCoords],
+    ):
         """Creates a stim.FlippedMeasurement.
+
+        Examples:
+            >>> import stim
+            >>> print(stim.FlippedMeasurement(
+            ...     record_index=5,
+            ...     observable=[],
+            ... ))
+            stim.FlippedMeasurement(
+                record_index=5,
+                observable=(),
+            )
         """
     @property
     def observable(
@@ -6128,6 +6317,60 @@ class GateData:
             >>> stim.gate_data('TICK').generalized_inverse
             stim.gate_data('TICK')
         """
+    def hadamard_conjugated(
+        self,
+        *,
+        unsigned: bool = False,
+    ) -> Optional[stim.GateData]:
+        """Returns a stim gate equivalent to this gate conjugated by Hadamard gates.
+
+        The Hadamard conjugate can be thought of as the XZ dual of the gate; the gate
+        you get by exchanging the X and Z bases. For example, a SQRT_X will become a
+        SQRT_Z and a CX gate will switch directions into an XCZ.
+
+        If stim doesn't define a gate equivalent to conjugating this gate by Hadamards,
+        the value `None` is returned.
+
+        Args:
+            unsigned: Defaults to False. When False, the returned gate must be *exactly*
+                the Hadamard conjugation of this gate. When True, the returned gate must
+                have the same flows but the sign of the flows can be different (i.e.
+                the returned gate must be the Hadamard conjugate up to Pauli gate
+                differences).
+
+        Returns:
+            A stim.GateData instance of the Hadamard conjugate, if it exists in stim.
+
+            None, if stim doesn't define a gate equal to the Hadamard conjugate.
+
+        Examples:
+            >>> import stim
+
+            >>> stim.gate_data('X').hadamard_conjugated()
+            stim.gate_data('Z')
+            >>> stim.gate_data('CX').hadamard_conjugated()
+            stim.gate_data('XCZ')
+            >>> stim.gate_data('RY').hadamard_conjugated() is None
+            True
+            >>> stim.gate_data('RY').hadamard_conjugated(unsigned=True)
+            stim.gate_data('RY')
+            >>> stim.gate_data('ISWAP').hadamard_conjugated(unsigned=True) is None
+            True
+            >>> stim.gate_data('SWAP').hadamard_conjugated()
+            stim.gate_data('SWAP')
+            >>> stim.gate_data('CXSWAP').hadamard_conjugated()
+            stim.gate_data('SWAPCX')
+            >>> stim.gate_data('MXX').hadamard_conjugated()
+            stim.gate_data('MZZ')
+            >>> stim.gate_data('DEPOLARIZE1').hadamard_conjugated()
+            stim.gate_data('DEPOLARIZE1')
+            >>> stim.gate_data('X_ERROR').hadamard_conjugated()
+            stim.gate_data('Z_ERROR')
+            >>> stim.gate_data('H_XY').hadamard_conjugated(unsigned=True)
+            stim.gate_data('H_YZ')
+            >>> stim.gate_data('DETECTOR').hadamard_conjugated(unsigned=True)
+            stim.gate_data('DETECTOR')
+        """
     @property
     def inverse(
         self,
@@ -6277,6 +6520,55 @@ class GateData:
             False
         """
     @property
+    def is_symmetric_gate(
+        self,
+    ) -> bool:
+        """Returns whether or not the gate is the same when its targets are swapped.
+
+        A two qubit gate is symmetric if it doesn't matter if you swap its targets. It
+        is unaffected when conjugated by the SWAP gate.
+
+        Single qubit gates are vacuously symmetric. A multi-qubit gate is symmetric if
+        swapping any two of its targets has no effect.
+
+        Note that this method is for symmetry *without broadcasting*. For example, SWAP
+        is symmetric even though SWAP 1 2 3 4 isn't equal to SWAP 1 3 2 4.
+
+        Returns:
+            True if the gate is symmetric.
+            False if the gate isn't symmetric.
+
+        Examples:
+            >>> import stim
+
+            >>> stim.gate_data('CX').is_symmetric_gate
+            False
+            >>> stim.gate_data('CZ').is_symmetric_gate
+            True
+            >>> stim.gate_data('ISWAP').is_symmetric_gate
+            True
+            >>> stim.gate_data('CXSWAP').is_symmetric_gate
+            False
+            >>> stim.gate_data('MXX').is_symmetric_gate
+            True
+            >>> stim.gate_data('DEPOLARIZE2').is_symmetric_gate
+            True
+            >>> stim.gate_data('PAULI_CHANNEL_2').is_symmetric_gate
+            False
+            >>> stim.gate_data('H').is_symmetric_gate
+            True
+            >>> stim.gate_data('R').is_symmetric_gate
+            True
+            >>> stim.gate_data('X_ERROR').is_symmetric_gate
+            True
+            >>> stim.gate_data('CORRELATED_ERROR').is_symmetric_gate
+            False
+            >>> stim.gate_data('MPP').is_symmetric_gate
+            False
+            >>> stim.gate_data('DETECTOR').is_symmetric_gate
+            False
+        """
+    @property
     def is_two_qubit_gate(
         self,
     ) -> bool:
@@ -6286,6 +6578,10 @@ class GateData:
 
         Variable-qubit gates like CORRELATED_ERROR and MPP are not
         considered two qubit gates.
+
+        Returns:
+            True if the gate is a two qubit gate.
+            False if the gate isn't a two qubit gate.
 
         Examples:
             >>> import stim
@@ -6852,7 +7148,6 @@ class GateTargetWithCoords:
     """
     def __init__(
         self,
-        *,
         gate_target: object,
         coords: List[float],
     ) -> None:

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -2001,8 +2001,8 @@ class Circuit:
         Examples:
             >>> import stim
             >>> stim.Circuit('''
-            ...    X 1
-            ...    M 0 1
+            ...     X 1
+            ...     M 0 1
             ... ''').reference_sample()
             array([False,  True])
         """
@@ -2717,6 +2717,26 @@ class Circuit:
         """
 class CircuitErrorLocation:
     """Describes the location of an error mechanism from a stim circuit.
+
+    Examples:
+        >>> import stim
+        >>> circuit = stim.Circuit.generated(
+        ...     "repetition_code:memory",
+        ...     distance=5,
+        ...     rounds=5,
+        ...     before_round_data_depolarization=1e-3,
+        ... )
+        >>> logical_error = circuit.shortest_graphlike_error()
+        >>> error_location = logical_error[0].circuit_error_locations[0]
+        >>> print(error_location)
+        CircuitErrorLocation {
+            flipped_pauli_product: X0
+            Circuit location stack trace:
+                (after 1 TICKs)
+                at instruction #3 (DEPOLARIZE1) in the circuit
+                at target #1 of the instruction
+                resolving to DEPOLARIZE1(0.001) 0
+        }
     """
     def __init__(
         self,
@@ -2728,20 +2748,88 @@ class CircuitErrorLocation:
         stack_frames: List[stim.CircuitErrorLocationStackFrame],
     ) -> None:
         """Creates a stim.CircuitErrorLocation.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.CircuitErrorLocation(
+            ...     tick_offset=1,
+            ...     flipped_pauli_product=(
+            ...         stim.GateTargetWithCoords(
+            ...             gate_target=stim.target_x(0),
+            ...             coords=[],
+            ...         ),
+            ...     ),
+            ...     flipped_measurement=stim.FlippedMeasurement(
+            ...         record_index=None,
+            ...         observable=(),
+            ...     ),
+            ...     instruction_targets=stim.CircuitTargetsInsideInstruction(
+            ...         gate='DEPOLARIZE1',
+            ...         args=[0.001],
+            ...         target_range_start=0,
+            ...         target_range_end=1,
+            ...         targets_in_range=(stim.GateTargetWithCoords(
+            ...             gate_target=0,
+            ...             coords=[],
+            ...         ),)
+            ...     ),
+            ...     stack_frames=(
+            ...         stim.CircuitErrorLocationStackFrame(
+            ...             instruction_offset=2,
+            ...             iteration_index=0,
+            ...             instruction_repetitions_arg=0,
+            ...         ),
+            ...     ),
+            ... )
+            >>> print(err)
+            CircuitErrorLocation {
+                flipped_pauli_product: X0
+                Circuit location stack trace:
+                    (after 1 TICKs)
+                    at instruction #3 (DEPOLARIZE1) in the circuit
+                    at target #1 of the instruction
+                    resolving to DEPOLARIZE1(0.001) 0
+            }
         """
     @property
     def flipped_measurement(
         self,
     ) -> Optional[stim.FlippedMeasurement]:
         """The measurement that was flipped by the error mechanism.
+
         If the error isn't a measurement error, this will be None.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.Circuit('''
+            ...     R 0
+            ...     M(0.125) 0
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ... ''').shortest_graphlike_error()
+            >>> err[0].circuit_error_locations[0].flipped_measurement
+            stim.FlippedMeasurement(
+                record_index=0,
+                observable=(stim.GateTargetWithCoords(stim.target_z(0), []),),
+            )
         """
     @property
     def flipped_pauli_product(
         self,
     ) -> List[stim.GateTargetWithCoords]:
         """The Pauli errors that the error mechanism applied to qubits.
+
         When the error is a measurement error, this will be an empty list.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.Circuit('''
+            ...     R 0
+            ...     Y_ERROR(0.125) 0
+            ...     M 0
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ... ''').shortest_graphlike_error()
+            >>> err[0].circuit_error_locations[0].flipped_pauli_product
+            [stim.GateTargetWithCoords(stim.target_y(0), [])]
         """
     @property
     def instruction_targets(
@@ -2755,15 +2843,48 @@ class CircuitErrorLocation:
     def stack_frames(
         self,
     ) -> List[stim.CircuitErrorLocationStackFrame]:
-        """Where in the circuit's execution does the error mechanism occur,
-        accounting for things like nested loops that iterate multiple times.
+        """Describes where in the circuit's execution the error happened.
+
+        Multiple frames are needed because the error may occur within a loop,
+        or a loop nested inside a loop, or etc.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.Circuit('''
+            ...     R 0
+            ...     TICK
+            ...     Y_ERROR(0.125) 0
+            ...     M 0
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ... ''').shortest_graphlike_error()
+            >>> err[0].circuit_error_locations[0].stack_frames
+            [stim.CircuitErrorLocationStackFrame(
+                instruction_offset=2,
+                iteration_index=0,
+                instruction_repetitions_arg=0,
+            )]
         """
     @property
     def tick_offset(
         self,
     ) -> int:
-        """The number of TICKs that executed before the error mechanism being discussed,
-        including TICKs that occurred multiple times during loops.
+        """The number of TICKs that executed before the error happened.
+
+        This counts TICKs occurring multiple times during loops.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.Circuit('''
+            ...     R 0
+            ...     TICK
+            ...     TICK
+            ...     TICK
+            ...     Y_ERROR(0.125) 0
+            ...     M 0
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ... ''').shortest_graphlike_error()
+            >>> err[0].circuit_error_locations[0].tick_offset
+            3
         """
 class CircuitErrorLocationStackFrame:
     """Describes the location of an instruction being executed within a
@@ -4098,6 +4219,18 @@ class DemRepeatBlock:
         self,
     ) -> stim.DetectorErrorModel:
         """Returns a copy of the block's body, as a stim.DetectorErrorModel.
+
+        Examples:
+            >>> import stim
+            >>> body = stim.DetectorErrorModel('''
+            ...     error(0.125) D0 D1
+            ...     shift_detectors 1
+            ... ''')
+            >>> repeat_block = stim.DemRepeatBlock(100, body)
+            >>> repeat_block.body_copy() == body
+            True
+            >>> repeat_block.body_copy() is repeat_block.body_copy()
+            False
         """
     @property
     def repeat_count(
@@ -4137,6 +4270,26 @@ class DemTarget:
     ) -> bool:
         """Determines if two `stim.DemTarget`s are identical.
         """
+    def __init__(
+        self,
+        arg: object,
+        /,
+    ) -> None:
+        """Creates a stim.DemTarget from the given object.
+
+        Args:
+            arg: A string to parse as a stim.DemTarget, or some other object to
+                convert into a stim.DemTarget.
+
+        Examples:
+            >>> import stim
+            >>> stim.DemTarget("D5") == stim.target_relative_detector_id(5)
+            True
+            >>> stim.DemTarget("L2") == stim.target_logical_observable_id(2)
+            True
+            >>> stim.DemTarget("^") == stim.target_separator()
+            True
+        """
     def __ne__(
         self,
         arg0: stim.DemTarget,
@@ -4160,6 +4313,15 @@ class DemTarget:
 
         In a detector error model file, observable targets are prefixed by `L`. For
         example, in `error(0.25) D0 L1` the `L1` is an observable target.
+
+        Examples:
+            >>> import stim
+            >>> stim.DemTarget("L2").is_logical_observable_id()
+            True
+            >>> stim.DemTarget("D3").is_logical_observable_id()
+            False
+            >>> stim.DemTarget("^").is_logical_observable_id()
+            False
         """
     def is_relative_detector_id(
         self,
@@ -4168,6 +4330,15 @@ class DemTarget:
 
         In a detector error model file, detectors are prefixed by `D`. For
         example, in `error(0.25) D0 L1` the `D0` is a relative detector target.
+
+        Examples:
+            >>> import stim
+            >>> stim.DemTarget("L2").is_relative_detector_id()
+            False
+            >>> stim.DemTarget("D3").is_relative_detector_id()
+            True
+            >>> stim.DemTarget("^").is_relative_detector_id()
+            False
         """
     def is_separator(
         self,
@@ -4176,6 +4347,15 @@ class DemTarget:
 
         Separates separate the components of a suggested decompositions within an error.
         For example, the `^` in `error(0.25) D1 D2 ^ D3 D4` is the separator.
+
+        Examples:
+            >>> import stim
+            >>> stim.DemTarget("L2").is_separator()
+            False
+            >>> stim.DemTarget("D3").is_separator()
+            False
+            >>> stim.DemTarget("^").is_separator()
+            True
         """
     @staticmethod
     def logical_observable_id(
@@ -4248,11 +4428,10 @@ class DemTarget:
         """Returns the target's integer value.
 
         Example:
-
             >>> import stim
-            >>> stim.target_relative_detector_id(5).val
+            >>> stim.DemTarget("D5").val
             5
-            >>> stim.target_logical_observable_id(6).val
+            >>> stim.DemTarget("L6").val
             6
         """
 class DemTargetWithCoords:
@@ -5806,11 +5985,21 @@ class FlippedMeasurement:
     """
     def __init__(
         self,
-        *,
-        record_index: int,
-        observable: object,
-    ) -> None:
+        measurement_record_index: Optional[int],
+        measured_observable: Iterable[stim.GateTargetWithCoords],
+    ):
         """Creates a stim.FlippedMeasurement.
+
+        Examples:
+            >>> import stim
+            >>> print(stim.FlippedMeasurement(
+            ...     record_index=5,
+            ...     observable=[],
+            ... ))
+            stim.FlippedMeasurement(
+                record_index=5,
+                observable=(),
+            )
         """
     @property
     def observable(
@@ -6128,6 +6317,60 @@ class GateData:
             >>> stim.gate_data('TICK').generalized_inverse
             stim.gate_data('TICK')
         """
+    def hadamard_conjugated(
+        self,
+        *,
+        unsigned: bool = False,
+    ) -> Optional[stim.GateData]:
+        """Returns a stim gate equivalent to this gate conjugated by Hadamard gates.
+
+        The Hadamard conjugate can be thought of as the XZ dual of the gate; the gate
+        you get by exchanging the X and Z bases. For example, a SQRT_X will become a
+        SQRT_Z and a CX gate will switch directions into an XCZ.
+
+        If stim doesn't define a gate equivalent to conjugating this gate by Hadamards,
+        the value `None` is returned.
+
+        Args:
+            unsigned: Defaults to False. When False, the returned gate must be *exactly*
+                the Hadamard conjugation of this gate. When True, the returned gate must
+                have the same flows but the sign of the flows can be different (i.e.
+                the returned gate must be the Hadamard conjugate up to Pauli gate
+                differences).
+
+        Returns:
+            A stim.GateData instance of the Hadamard conjugate, if it exists in stim.
+
+            None, if stim doesn't define a gate equal to the Hadamard conjugate.
+
+        Examples:
+            >>> import stim
+
+            >>> stim.gate_data('X').hadamard_conjugated()
+            stim.gate_data('Z')
+            >>> stim.gate_data('CX').hadamard_conjugated()
+            stim.gate_data('XCZ')
+            >>> stim.gate_data('RY').hadamard_conjugated() is None
+            True
+            >>> stim.gate_data('RY').hadamard_conjugated(unsigned=True)
+            stim.gate_data('RY')
+            >>> stim.gate_data('ISWAP').hadamard_conjugated(unsigned=True) is None
+            True
+            >>> stim.gate_data('SWAP').hadamard_conjugated()
+            stim.gate_data('SWAP')
+            >>> stim.gate_data('CXSWAP').hadamard_conjugated()
+            stim.gate_data('SWAPCX')
+            >>> stim.gate_data('MXX').hadamard_conjugated()
+            stim.gate_data('MZZ')
+            >>> stim.gate_data('DEPOLARIZE1').hadamard_conjugated()
+            stim.gate_data('DEPOLARIZE1')
+            >>> stim.gate_data('X_ERROR').hadamard_conjugated()
+            stim.gate_data('Z_ERROR')
+            >>> stim.gate_data('H_XY').hadamard_conjugated(unsigned=True)
+            stim.gate_data('H_YZ')
+            >>> stim.gate_data('DETECTOR').hadamard_conjugated(unsigned=True)
+            stim.gate_data('DETECTOR')
+        """
     @property
     def inverse(
         self,
@@ -6277,6 +6520,55 @@ class GateData:
             False
         """
     @property
+    def is_symmetric_gate(
+        self,
+    ) -> bool:
+        """Returns whether or not the gate is the same when its targets are swapped.
+
+        A two qubit gate is symmetric if it doesn't matter if you swap its targets. It
+        is unaffected when conjugated by the SWAP gate.
+
+        Single qubit gates are vacuously symmetric. A multi-qubit gate is symmetric if
+        swapping any two of its targets has no effect.
+
+        Note that this method is for symmetry *without broadcasting*. For example, SWAP
+        is symmetric even though SWAP 1 2 3 4 isn't equal to SWAP 1 3 2 4.
+
+        Returns:
+            True if the gate is symmetric.
+            False if the gate isn't symmetric.
+
+        Examples:
+            >>> import stim
+
+            >>> stim.gate_data('CX').is_symmetric_gate
+            False
+            >>> stim.gate_data('CZ').is_symmetric_gate
+            True
+            >>> stim.gate_data('ISWAP').is_symmetric_gate
+            True
+            >>> stim.gate_data('CXSWAP').is_symmetric_gate
+            False
+            >>> stim.gate_data('MXX').is_symmetric_gate
+            True
+            >>> stim.gate_data('DEPOLARIZE2').is_symmetric_gate
+            True
+            >>> stim.gate_data('PAULI_CHANNEL_2').is_symmetric_gate
+            False
+            >>> stim.gate_data('H').is_symmetric_gate
+            True
+            >>> stim.gate_data('R').is_symmetric_gate
+            True
+            >>> stim.gate_data('X_ERROR').is_symmetric_gate
+            True
+            >>> stim.gate_data('CORRELATED_ERROR').is_symmetric_gate
+            False
+            >>> stim.gate_data('MPP').is_symmetric_gate
+            False
+            >>> stim.gate_data('DETECTOR').is_symmetric_gate
+            False
+        """
+    @property
     def is_two_qubit_gate(
         self,
     ) -> bool:
@@ -6286,6 +6578,10 @@ class GateData:
 
         Variable-qubit gates like CORRELATED_ERROR and MPP are not
         considered two qubit gates.
+
+        Returns:
+            True if the gate is a two qubit gate.
+            False if the gate isn't a two qubit gate.
 
         Examples:
             >>> import stim
@@ -6852,7 +7148,6 @@ class GateTargetWithCoords:
     """
     def __init__(
         self,
-        *,
         gate_target: object,
         coords: List[float],
     ) -> None:

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -721,8 +721,8 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
             Examples:
                 >>> import stim
                 >>> stim.Circuit('''
-                ...    X 1
-                ...    M 0 1
+                ...     X 1
+                ...     M 0 1
                 ... ''').reference_sample()
                 array([False,  True])
         )DOC")

--- a/src/stim/dem/dem_instruction.cc
+++ b/src/stim/dem/dem_instruction.cc
@@ -11,9 +11,6 @@ using namespace stim;
 constexpr uint64_t OBSERVABLE_BIT = uint64_t{1} << 63;
 constexpr uint64_t SEPARATOR_SYGIL = UINT64_MAX;
 
-constexpr uint64_t MAX_OBS = 0xFFFFFFFF;
-constexpr uint64_t MAX_DET = (uint64_t{1} << 62) - 1;
-
 DemTarget DemTarget::observable_id(uint64_t id) {
     if (id > MAX_OBS) {
         throw std::invalid_argument("id > 0xFFFFFFFF");
@@ -79,6 +76,9 @@ void DemTarget::shift_if_detector_id(int64_t offset) {
     }
 }
 DemTarget DemTarget::from_text(std::string_view text) {
+    if (text == "^") {
+        return DemTarget::separator();
+    }
     if (!text.empty()) {
         bool is_det = text[0] == 'D';
         bool is_obs = text[0] == 'L';
@@ -86,9 +86,9 @@ DemTarget DemTarget::from_text(std::string_view text) {
             int64_t parsed = 0;
             if (parse_int64(text.substr(1), &parsed)) {
                 if (parsed >= 0) {
-                    if (is_det && parsed <= (int64_t)MAX_DET) {
+                    if (is_det && (uint64_t)parsed <= MAX_DET) {
                         return DemTarget::relative_detector_id(parsed);
-                    } else if (is_obs && parsed <= (int64_t)MAX_OBS) {
+                    } else if (is_obs && (uint64_t)parsed <= MAX_OBS) {
                         return DemTarget::observable_id(parsed);
                     }
                 }

--- a/src/stim/dem/dem_instruction.h
+++ b/src/stim/dem/dem_instruction.h
@@ -10,6 +10,9 @@
 
 namespace stim {
 
+constexpr uint64_t MAX_OBS = 0xFFFFFFFF;
+constexpr uint64_t MAX_DET = (uint64_t{1} << 62) - 1;
+
 enum class DemInstructionType : uint8_t {
     DEM_ERROR,
     DEM_SHIFT_DETECTORS,

--- a/src/stim/dem/detector_error_model_pybind_test.py
+++ b/src/stim/dem/detector_error_model_pybind_test.py
@@ -155,7 +155,7 @@ def test_append_bad():
     m.append("shift_detectors", [], [5])
     m += m * 3
 
-    with pytest.raises(ValueError, match=r"Bad target 'stim.target_relative_detector_id\(0\)' for instruction 'shift_detectors'"):
+    with pytest.raises(ValueError, match=r"Bad target 'stim.DemTarget\('D0'\)' for instruction 'shift_detectors'"):
         m.append("shift_detectors", [0.125, 0.25], [stim.target_relative_detector_id(0)])
     with pytest.raises(ValueError, match="takes 1 argument"):
         m.append("error", [0.125, 0.25], [stim.target_relative_detector_id(0)])

--- a/src/stim/dem/detector_error_model_repeat_block.pybind.cc
+++ b/src/stim/dem/detector_error_model_repeat_block.pybind.cc
@@ -78,6 +78,18 @@ void stim_pybind::pybind_detector_error_model_repeat_block_methods(
         &ExposedDemRepeatBlock::body_copy,
         clean_doc_string(R"DOC(
             Returns a copy of the block's body, as a stim.DetectorErrorModel.
+
+            Examples:
+                >>> import stim
+                >>> body = stim.DetectorErrorModel('''
+                ...     error(0.125) D0 D1
+                ...     shift_detectors 1
+                ... ''')
+                >>> repeat_block = stim.DemRepeatBlock(100, body)
+                >>> repeat_block.body_copy() == body
+                True
+                >>> repeat_block.body_copy() is repeat_block.body_copy()
+                False
         )DOC")
             .data());
     c.def_property_readonly(

--- a/src/stim/dem/detector_error_model_target_pybind_test.py
+++ b/src/stim/dem/detector_error_model_target_pybind_test.py
@@ -75,3 +75,23 @@ def test_hashable():
     c = stim.DemTarget.relative_detector_id(3)
     assert hash(a) == hash(c)
     assert len({a, b, c}) == 2
+
+
+def test_init():
+    assert stim.DemTarget("D0") == stim.target_relative_detector_id(0)
+    assert stim.DemTarget("D5") == stim.target_relative_detector_id(5)
+    assert stim.DemTarget("L0") == stim.target_logical_observable_id(0)
+    assert stim.DemTarget("L5") == stim.target_logical_observable_id(5)
+    assert stim.DemTarget("^") == stim.target_separator()
+    assert stim.DemTarget(f"D{2**62 - 1}") == stim.target_relative_detector_id(2**62 - 1)
+    assert stim.DemTarget(f"L{0xFFFFFFFF}") == stim.target_logical_observable_id(0xFFFFFFFF)
+    with pytest.raises(ValueError, match="Failed to parse"):
+        _ = stim.DemTarget(f"D{2**62}")
+    with pytest.raises(ValueError, match="Failed to parse"):
+        _ = stim.DemTarget(f"L{0x100000000}")
+    with pytest.raises(ValueError, match="Failed to parse"):
+        _ = stim.DemTarget(f"L-1")
+    with pytest.raises(ValueError, match="Failed to parse"):
+        _ = stim.DemTarget(f"X5")
+    with pytest.raises(ValueError, match="Failed to parse"):
+        _ = stim.DemTarget(f"5")

--- a/src/stim/gates/gates.cc
+++ b/src/stim/gates/gates.cc
@@ -45,6 +45,148 @@ GateDataMap::GateDataMap() {
     }
 }
 
+GateType Gate::hadamard_conjugated(bool ignoring_sign) const {
+    switch (id) {
+    case GateType::DETECTOR:
+    case GateType::OBSERVABLE_INCLUDE:
+    case GateType::TICK:
+    case GateType::QUBIT_COORDS:
+    case GateType::SHIFT_COORDS:
+    case GateType::MPAD:
+    case GateType::H:
+    case GateType::DEPOLARIZE1:
+    case GateType::DEPOLARIZE2:
+    case GateType::Y_ERROR:
+    case GateType::I:
+    case GateType::Y:
+    case GateType::SQRT_YY:
+    case GateType::SQRT_YY_DAG:
+    case GateType::MYY:
+    case GateType::SWAP:
+        return id;
+
+    case GateType::MY:
+    case GateType::MRY:
+    case GateType::RY:
+    case GateType::YCY:
+        return ignoring_sign ? id : GateType::NOT_A_GATE;
+
+    case GateType::ISWAP:
+    case GateType::CZSWAP:
+    case GateType::ISWAP_DAG:
+        return GateType::NOT_A_GATE;
+
+    case GateType::XCY:
+        return ignoring_sign ? GateType::CY : GateType::NOT_A_GATE;
+    case GateType::CY:
+        return ignoring_sign ? GateType::XCY : GateType::NOT_A_GATE;
+    case GateType::YCX:
+        return ignoring_sign ? GateType::YCZ : GateType::NOT_A_GATE;
+    case GateType::YCZ:
+        return ignoring_sign ? GateType::YCX : GateType::NOT_A_GATE;
+    case GateType::C_XYZ:
+        return ignoring_sign ? GateType::C_ZYX : GateType::NOT_A_GATE;
+    case GateType::C_ZYX:
+        return ignoring_sign ? GateType::C_XYZ : GateType::NOT_A_GATE;
+    case GateType::H_XY:
+        return ignoring_sign ? GateType::H_YZ : GateType::NOT_A_GATE;
+    case GateType::H_YZ:
+        return ignoring_sign ? GateType::H_XY : GateType::NOT_A_GATE;
+
+    case GateType::X:
+        return GateType::Z;
+    case GateType::Z:
+        return GateType::X;
+    case GateType::SQRT_Y:
+        return GateType::SQRT_Y_DAG;
+    case GateType::SQRT_Y_DAG:
+        return GateType::SQRT_Y;
+    case GateType::MX:
+        return GateType::M;
+    case GateType::M:
+        return GateType::MX;
+    case GateType::MRX:
+        return GateType::MR;
+    case GateType::MR:
+        return GateType::MRX;
+    case GateType::RX:
+        return GateType::R;
+    case GateType::R:
+        return GateType::RX;
+    case GateType::XCX:
+        return GateType::CZ;
+    case GateType::XCZ:
+        return GateType::CX;
+    case GateType::CX:
+        return GateType::XCZ;
+    case GateType::CZ:
+        return GateType::XCX;
+    case GateType::X_ERROR:
+        return GateType::Z_ERROR;
+    case GateType::Z_ERROR:
+        return GateType::X_ERROR;
+    case GateType::SQRT_X:
+        return GateType::S;
+    case GateType::SQRT_X_DAG:
+        return GateType::S_DAG;
+    case GateType::S:
+        return GateType::SQRT_X;
+    case GateType::S_DAG:
+        return GateType::SQRT_X_DAG;
+    case GateType::SQRT_XX:
+        return GateType::SQRT_ZZ;
+    case GateType::SQRT_XX_DAG:
+        return GateType::SQRT_ZZ_DAG;
+    case GateType::SQRT_ZZ:
+        return GateType::SQRT_XX;
+    case GateType::SQRT_ZZ_DAG:
+        return GateType::SQRT_XX_DAG;
+    case GateType::CXSWAP:
+        return GateType::SWAPCX;
+    case GateType::SWAPCX:
+        return GateType::CXSWAP;
+    case GateType::MXX:
+        return GateType::MZZ;
+    case GateType::MZZ:
+        return GateType::MXX;
+    default:
+        return GateType::NOT_A_GATE;
+    }
+}
+
+bool Gate::is_symmetric() const {
+    if (flags & GATE_IS_SINGLE_QUBIT_GATE) {
+        return true;
+    }
+
+    if (flags & GATE_TARGETS_PAIRS) {
+        switch (id) {
+            case GateType::XCX:
+            case GateType::YCY:
+            case GateType::CZ:
+            case GateType::DEPOLARIZE2:
+            case GateType::SWAP:
+            case GateType::ISWAP:
+            case GateType::CZSWAP:
+            case GateType::ISWAP_DAG:
+            case GateType::MXX:
+            case GateType::MYY:
+            case GateType::MZZ:
+            case GateType::SQRT_XX:
+            case GateType::SQRT_YY:
+            case GateType::SQRT_ZZ:
+            case GateType::SQRT_XX_DAG:
+            case GateType::SQRT_YY_DAG:
+            case GateType::SQRT_ZZ_DAG:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    return false;
+}
+
 std::array<float, 3> Gate::to_euler_angles() const {
     if (unitary_data.size() != 2) {
         throw std::out_of_range(std::string(name) + " doesn't have 1q unitary data.");

--- a/src/stim/gates/gates.h
+++ b/src/stim/gates/gates.h
@@ -282,6 +282,9 @@ struct Gate {
 
     std::vector<std::vector<std::complex<float>>> unitary() const;
 
+    bool is_symmetric() const;
+    GateType hadamard_conjugated(bool ignoring_sign) const;
+
     /// Converts a single qubit unitary gate into an euler-angles rotation.
     ///
     /// Returns:

--- a/src/stim/gates/gates.test.cc
+++ b/src/stim/gates/gates.test.cc
@@ -23,6 +23,7 @@
 #include "stim/util_bot/str_util.h"
 #include "stim/util_bot/test_util.test.h"
 #include "stim/util_top/has_flow.h"
+#include "stim/util_top/circuit_flow_generators.h"
 
 using namespace stim;
 
@@ -302,6 +303,80 @@ TEST(gate_data, to_euler_angles_axis_reference) {
             auto u1 = reconstruct_unitary_from_data(g);
             auto u2 = reconstruct_unitary_from_euler_angles_via_vector_sim_for_axis_reference(g);
             expect_unitaries_close_up_global_phase(g, u1, u2);
+        }
+    }
+}
+
+TEST(gate_data, is_symmetric_vs_flow_generators_of_two_qubit_gates) {
+    for (const auto &g : GATE_DATA.items) {
+        if ((g.flags & stim::GATE_IS_NOISY) && !(g.flags & stim::GATE_PRODUCES_RESULTS)) {
+            continue;
+        }
+        if (g.flags & GATE_TARGETS_PAIRS) {
+            Circuit c1;
+            Circuit c2;
+            c1.safe_append_u(g.name, {0, 1}, {});
+            c2.safe_append_u(g.name, {1, 0}, {});
+            auto f1 = circuit_flow_generators<64>(c1);
+            auto f2 = circuit_flow_generators<64>(c2);
+            EXPECT_EQ(g.is_symmetric(), f1 == f2) << g.name;
+        }
+    }
+}
+
+TEST(gate_data, hadamard_conjugated_vs_flow_generators_of_two_qubit_gates) {
+    auto flow_key = [](const Circuit &circuit, bool ignore_sign) {
+        auto f = circuit_flow_generators<64>(circuit);
+        if (ignore_sign) {
+            for (auto &e : f) {
+                e.input.sign = false;
+                e.output.sign = false;
+            }
+        }
+        std::stringstream ss;
+        ss << comma_sep(f);
+        return ss.str();
+    };
+    std::map<std::string, GateType> known_flows_s;
+    std::map<std::string, std::vector<GateType>> known_flows_u;
+
+    for (const auto &g : GATE_DATA.items) {
+        if (g.arg_count != 0 && g.arg_count != ARG_COUNT_SYGIL_ZERO_OR_ONE && g.arg_count != ARG_COUNT_SYGIL_ANY) {
+            continue;
+        }
+        if ((g.flags & GATE_TARGETS_PAIRS) || (g.flags & GATE_IS_SINGLE_QUBIT_GATE)) {
+            Circuit c;
+            c.safe_append_u(g.name, {0, 1}, {});
+            auto key_s = flow_key(c, false);
+            auto key_u = flow_key(c, true);
+            ASSERT_EQ(known_flows_s.find(key_s), known_flows_s.end());
+            known_flows_s[key_s] = g.id;
+            known_flows_u[key_u].push_back(g.id);
+        }
+    }
+    for (const auto &g : GATE_DATA.items) {
+        if (g.arg_count != 0 && g.arg_count != ARG_COUNT_SYGIL_ZERO_OR_ONE && g.arg_count != ARG_COUNT_SYGIL_ANY) {
+            continue;
+        }
+        if ((g.flags & GATE_TARGETS_PAIRS) || (g.flags & GATE_IS_SINGLE_QUBIT_GATE)) {
+            Circuit c;
+            c.safe_append_u("H", {0, 1}, {});
+            c.safe_append_u(g.name, {0, 1}, {});
+            c.safe_append_u("H", {0, 1}, {});
+            auto key_s = flow_key(c, false);
+            auto key_u = flow_key(c, true);
+            auto other_s = known_flows_s.find(key_s);
+            auto &other_us = known_flows_u[key_u];
+            if (other_us.empty()) {
+                other_us.push_back(GateType::NOT_A_GATE);
+            }
+
+            GateType expected_s = other_s == known_flows_s.end() ? GateType::NOT_A_GATE : other_s->second;
+            GateType actual_s = g.hadamard_conjugated(false);
+            GateType actual_u = g.hadamard_conjugated(true);
+            bool found = std::find(other_us.begin(), other_us.end(), actual_u) != other_us.end();
+            EXPECT_EQ(actual_s, expected_s) << "signed " << g.name << " -> " << GATE_DATA[actual_s].name << " != " << GATE_DATA[expected_s].name;
+            EXPECT_TRUE(found) << "unsigned " << g.name << " -> " << GATE_DATA[actual_u].name << " not in " << GATE_DATA[other_us[0]].name;
         }
     }
 }

--- a/src/stim/gates/gates_test.py
+++ b/src/stim/gates/gates_test.py
@@ -81,3 +81,20 @@ def test_gate_data_flows():
         stim.Flow("X -> Z"),
         stim.Flow("Z -> X"),
     ]
+
+
+def test_gate_is_symmetric():
+    assert stim.GateData('SWAP').is_symmetric_gate
+    assert stim.GateData('H').is_symmetric_gate
+    assert stim.GateData('MYY').is_symmetric_gate
+    assert stim.GateData('DEPOLARIZE2').is_symmetric_gate
+    assert not stim.GateData('PAULI_CHANNEL_2').is_symmetric_gate
+    assert not stim.GateData('DETECTOR').is_symmetric_gate
+    assert not stim.GateData('TICK').is_symmetric_gate
+
+
+def test_gate_hadamard_conjugated():
+    assert stim.GateData('CZSWAP').hadamard_conjugated(unsigned=True) is None
+    assert stim.GateData('TICK').hadamard_conjugated() == stim.GateData('TICK')
+    assert stim.GateData('MYY').hadamard_conjugated() == stim.GateData('MYY')
+    assert stim.GateData('XCZ').hadamard_conjugated() == stim.GateData('CX')


### PR DESCRIPTION
- Add some missing example sections to docstrings
- Add a warning about missing example sections when running documentation tests
- Add `stim.GateData.is_symmetric_gate`
- Add `stim.GateData.hadamard_conjugated(unsigned=False)`
- Add `stim.DemTarget.__init__` with support for parsing strings

Fixes https://github.com/quantumlib/Stim/issues/795