### PR TITLE
Add some `stim.FlipSimulator` methods and diagram niceties

### DIFF
--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -1084,11 +1084,19 @@ class Circuit:
 
                 Passing `range(A, B)` for a time slice will show the
                 operations between tick A and tick B.
-            filter_coords: A set of acceptable coordinate prefixes, or
-                desired stim.DemTargets. For detector slice diagrams, only
-                detectors match one of the filters are included. If no filter
-                is specified, all detectors are included (but no observables).
-                To include an observable, add it as one of the filters.
+            rows: In diagrams that have multiple separate pieces, such as timeslice
+                diagrams and detslice diagrams, this controls how many rows of
+                pieces there will be. If not specified, a number of rows that creates
+                a roughly square layout will be chosen.
+            filter_coords: A list of things to include in the diagram. Different
+                effects depending on the diagram.
+
+                For detslice diagrams, the filter defaults to showing all detectors
+                and no observables. When specified, each list entry can be a collection
+                of floats (detectors whose coordinates start with the same numbers will
+                be included), a stim.DemTarget (specifying a detector or observable
+                to include), a string like "D5" or "L0" specifying a detector or
+                observable to include.
 
         Returns:
             An object whose `__str__` method returns the diagram, so that
@@ -4145,15 +4153,45 @@ class DemInstruction:
     def args_copy(
         self,
     ) -> List[float]:
-        """Returns a copy of the list of numbers parameterizing the instruction (e.g. the probability of an error).
+        """Returns a copy of the list of numbers parameterizing the instruction.
+
+        For example, this would be coordinates of a detector instruction or the
+        probability of an error instruction. The result is a copy, meaning that
+        editing it won't change the instruction's targets or future copies.
+
+        Examples:
+            >>> import stim
+            >>> instruction = stim.DetectorErrorModel('''
+            ...     error(0.125) D0
+            ... ''')[0]
+            >>> instruction.args_copy()
+            [0.125]
+
+            >>> instruction.args_copy() == instruction.args_copy()
+            True
+            >>> instruction.args_copy() is instruction.args_copy()
+            False
         """
     def targets_copy(
         self,
     ) -> List[Union[int, stim.DemTarget]]:
         """Returns a copy of the instruction's targets.
 
-        (Making a copy is enforced to make it clear that editing the result won't change
-        the instruction's targets.)
+        The result is a copy, meaning that editing it won't change the instruction's
+        targets or future copies.
+
+        Examples:
+            >>> import stim
+            >>> instruction = stim.DetectorErrorModel('''
+            ...     error(0.125) D0 L2
+            ... ''')[0]
+            >>> instruction.targets_copy()
+            [stim.DemTarget('D0'), stim.DemTarget('L2')]
+
+            >>> instruction.targets_copy() == instruction.targets_copy()
+            True
+            >>> instruction.targets_copy() is instruction.targets_copy()
+            False
         """
     @property
     def type(
@@ -5575,6 +5613,76 @@ class FlipSimulator:
             >>> sim.peek_pauli_flips()
             [stim.PauliString("+X_Y"), stim.PauliString("+Z_Y")]
         """
+    def copy(
+        self,
+        *,
+        copy_rng: bool = False,
+        seed: Optional[int] = None,
+    ) -> stim.FlipSimulator:
+        """Returns a simulator with the same internal state, except perhaps its prng.
+
+        Args:
+            copy_rng: Defaults to False. When False, the copy's pseudo random number
+                generator is reinitialized with a random seed instead of being a copy
+                of the original simulator's pseudo random number generator. This
+                causes the copy and the original to sample independent randomness,
+                instead of identical randomness, for future random operations. When set
+                to true, the copy will have the exact same pseudo random number
+                generator state as the original, and so will produce identical results
+                if told to do the same noisy operations. This argument is incompatible
+                with the `seed` argument.
+
+            seed: PARTIALLY determines simulation results by deterministically seeding
+                the random number generator.
+
+                Must be None or an integer in range(2**64).
+
+                Defaults to None. When None, the prng state is either copied from the
+                original simulator or reseeded from system entropy, depending on the
+                copy_rng argument.
+
+                When set to an integer, making the exact same series calls on the exact
+                same machine with the exact same version of Stim will produce the exact
+                same simulation results.
+
+                CAUTION: simulation results *WILL NOT* be consistent between versions of
+                Stim. This restriction is present to make it possible to have future
+                optimizations to the random sampling, and is enforced by introducing
+                intentional differences in the seeding strategy from version to version.
+
+                CAUTION: simulation results *MAY NOT* be consistent across machines that
+                differ in the width of supported SIMD instructions. For example, using
+                the same seed on a machine that supports AVX instructions and one that
+                only supports SSE instructions may produce different simulation results.
+
+                CAUTION: simulation results *MAY NOT* be consistent if you vary how the
+                circuit is executed. For example, reordering whether a reset on one
+                qubit happens before or after a reset on another qubit can result in
+                different measurement results being observed starting from the same
+                seed.
+
+        Returns:
+            The copy of the simulator.
+
+        Examples:
+            >>> import stim
+            >>> import numpy as np
+
+            >>> s1 = stim.FlipSimulator(batch_size=256)
+            >>> s1.set_pauli_flip('X', qubit_index=2, instance_index=3)
+            >>> s2 = s1.copy()
+            >>> s2 is s1
+            False
+            >>> s2.peek_pauli_flips() == s1.peek_pauli_flips()
+            True
+
+            >>> s1 = stim.FlipSimulator(batch_size=256)
+            >>> s2 = s1.copy(copy_rng=True)
+            >>> s1.do(stim.Circuit("X_ERROR(0.25) 0 \n M 0"))
+            >>> s2.do(stim.Circuit("X_ERROR(0.25) 0 \n M 0"))
+            >>> np.array_equal(s1.get_measurement_flips(), s2.get_measurement_flips())
+            True
+        """
     def do(
         self,
         obj: Union[stim.Circuit, stim.CircuitInstruction, stim.CircuitRepeatBlock],
@@ -5947,6 +6055,31 @@ class FlipSimulator:
             >>> flips: stim.PauliString = sim.peek_pauli_flips(instance_index=0)
             >>> sorted(set(str(flips)))  # Should have Zs from stabilizer randomization
             ['+', 'Z', '_']
+        """
+    def reset(
+        self,
+    ) -> None:
+        """Resets the simulator's state, so it can be reused for another simulation.
+
+        This empties the measurement flip history, empties the detector flip history,
+        and zeroes the observable flip state. It also resets all qubits to |0>. If
+        stabilizer randomization is disabled, this zeros all pauli flips data. Otherwise
+        it randomizes all pauli flips to be I or Z with equal probability.
+
+        Examples:
+            >>> import stim
+            >>> sim = stim.FlipSimulator(batch_size=256)
+            >>> sim.do(stim.Circuit("M(0.1) 9"))
+            >>> sim.num_qubits
+            10
+            >>> sim.get_measurement_flips().shape
+            (1, 256)
+
+            >>> sim.reset()
+            >>> sim.num_qubits
+            10
+            >>> sim.get_measurement_flips().shape
+            (0, 256)
         """
     def set_pauli_flip(
         self,
@@ -7401,6 +7534,13 @@ class PauliString:
         self,
     ) -> int:
         """Returns the length the pauli string; the number of qubits it operates on.
+
+        Examples:
+            >>> import stim
+            >>> len(stim.PauliString("XY_ZZ"))
+            5
+            >>> len(stim.PauliString("X0*Z99"))
+            100
         """
     def __mul__(
         self,
@@ -8306,6 +8446,12 @@ class Tableau:
         self,
     ) -> int:
         """Returns the number of qubits operated on by the tableau.
+
+        Examples:
+            >>> import stim
+            >>> t = stim.Tableau.from_named_gate("CNOT")
+            >>> len(t)
+            2
         """
     def __mul__(
         self,

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -1084,11 +1084,19 @@ class Circuit:
 
                 Passing `range(A, B)` for a time slice will show the
                 operations between tick A and tick B.
-            filter_coords: A set of acceptable coordinate prefixes, or
-                desired stim.DemTargets. For detector slice diagrams, only
-                detectors match one of the filters are included. If no filter
-                is specified, all detectors are included (but no observables).
-                To include an observable, add it as one of the filters.
+            rows: In diagrams that have multiple separate pieces, such as timeslice
+                diagrams and detslice diagrams, this controls how many rows of
+                pieces there will be. If not specified, a number of rows that creates
+                a roughly square layout will be chosen.
+            filter_coords: A list of things to include in the diagram. Different
+                effects depending on the diagram.
+
+                For detslice diagrams, the filter defaults to showing all detectors
+                and no observables. When specified, each list entry can be a collection
+                of floats (detectors whose coordinates start with the same numbers will
+                be included), a stim.DemTarget (specifying a detector or observable
+                to include), a string like "D5" or "L0" specifying a detector or
+                observable to include.
 
         Returns:
             An object whose `__str__` method returns the diagram, so that
@@ -4145,15 +4153,45 @@ class DemInstruction:
     def args_copy(
         self,
     ) -> List[float]:
-        """Returns a copy of the list of numbers parameterizing the instruction (e.g. the probability of an error).
+        """Returns a copy of the list of numbers parameterizing the instruction.
+
+        For example, this would be coordinates of a detector instruction or the
+        probability of an error instruction. The result is a copy, meaning that
+        editing it won't change the instruction's targets or future copies.
+
+        Examples:
+            >>> import stim
+            >>> instruction = stim.DetectorErrorModel('''
+            ...     error(0.125) D0
+            ... ''')[0]
+            >>> instruction.args_copy()
+            [0.125]
+
+            >>> instruction.args_copy() == instruction.args_copy()
+            True
+            >>> instruction.args_copy() is instruction.args_copy()
+            False
         """
     def targets_copy(
         self,
     ) -> List[Union[int, stim.DemTarget]]:
         """Returns a copy of the instruction's targets.
 
-        (Making a copy is enforced to make it clear that editing the result won't change
-        the instruction's targets.)
+        The result is a copy, meaning that editing it won't change the instruction's
+        targets or future copies.
+
+        Examples:
+            >>> import stim
+            >>> instruction = stim.DetectorErrorModel('''
+            ...     error(0.125) D0 L2
+            ... ''')[0]
+            >>> instruction.targets_copy()
+            [stim.DemTarget('D0'), stim.DemTarget('L2')]
+
+            >>> instruction.targets_copy() == instruction.targets_copy()
+            True
+            >>> instruction.targets_copy() is instruction.targets_copy()
+            False
         """
     @property
     def type(
@@ -5575,6 +5613,76 @@ class FlipSimulator:
             >>> sim.peek_pauli_flips()
             [stim.PauliString("+X_Y"), stim.PauliString("+Z_Y")]
         """
+    def copy(
+        self,
+        *,
+        copy_rng: bool = False,
+        seed: Optional[int] = None,
+    ) -> stim.FlipSimulator:
+        """Returns a simulator with the same internal state, except perhaps its prng.
+
+        Args:
+            copy_rng: Defaults to False. When False, the copy's pseudo random number
+                generator is reinitialized with a random seed instead of being a copy
+                of the original simulator's pseudo random number generator. This
+                causes the copy and the original to sample independent randomness,
+                instead of identical randomness, for future random operations. When set
+                to true, the copy will have the exact same pseudo random number
+                generator state as the original, and so will produce identical results
+                if told to do the same noisy operations. This argument is incompatible
+                with the `seed` argument.
+
+            seed: PARTIALLY determines simulation results by deterministically seeding
+                the random number generator.
+
+                Must be None or an integer in range(2**64).
+
+                Defaults to None. When None, the prng state is either copied from the
+                original simulator or reseeded from system entropy, depending on the
+                copy_rng argument.
+
+                When set to an integer, making the exact same series calls on the exact
+                same machine with the exact same version of Stim will produce the exact
+                same simulation results.
+
+                CAUTION: simulation results *WILL NOT* be consistent between versions of
+                Stim. This restriction is present to make it possible to have future
+                optimizations to the random sampling, and is enforced by introducing
+                intentional differences in the seeding strategy from version to version.
+
+                CAUTION: simulation results *MAY NOT* be consistent across machines that
+                differ in the width of supported SIMD instructions. For example, using
+                the same seed on a machine that supports AVX instructions and one that
+                only supports SSE instructions may produce different simulation results.
+
+                CAUTION: simulation results *MAY NOT* be consistent if you vary how the
+                circuit is executed. For example, reordering whether a reset on one
+                qubit happens before or after a reset on another qubit can result in
+                different measurement results being observed starting from the same
+                seed.
+
+        Returns:
+            The copy of the simulator.
+
+        Examples:
+            >>> import stim
+            >>> import numpy as np
+
+            >>> s1 = stim.FlipSimulator(batch_size=256)
+            >>> s1.set_pauli_flip('X', qubit_index=2, instance_index=3)
+            >>> s2 = s1.copy()
+            >>> s2 is s1
+            False
+            >>> s2.peek_pauli_flips() == s1.peek_pauli_flips()
+            True
+
+            >>> s1 = stim.FlipSimulator(batch_size=256)
+            >>> s2 = s1.copy(copy_rng=True)
+            >>> s1.do(stim.Circuit("X_ERROR(0.25) 0 \n M 0"))
+            >>> s2.do(stim.Circuit("X_ERROR(0.25) 0 \n M 0"))
+            >>> np.array_equal(s1.get_measurement_flips(), s2.get_measurement_flips())
+            True
+        """
     def do(
         self,
         obj: Union[stim.Circuit, stim.CircuitInstruction, stim.CircuitRepeatBlock],
@@ -5947,6 +6055,31 @@ class FlipSimulator:
             >>> flips: stim.PauliString = sim.peek_pauli_flips(instance_index=0)
             >>> sorted(set(str(flips)))  # Should have Zs from stabilizer randomization
             ['+', 'Z', '_']
+        """
+    def reset(
+        self,
+    ) -> None:
+        """Resets the simulator's state, so it can be reused for another simulation.
+
+        This empties the measurement flip history, empties the detector flip history,
+        and zeroes the observable flip state. It also resets all qubits to |0>. If
+        stabilizer randomization is disabled, this zeros all pauli flips data. Otherwise
+        it randomizes all pauli flips to be I or Z with equal probability.
+
+        Examples:
+            >>> import stim
+            >>> sim = stim.FlipSimulator(batch_size=256)
+            >>> sim.do(stim.Circuit("M(0.1) 9"))
+            >>> sim.num_qubits
+            10
+            >>> sim.get_measurement_flips().shape
+            (1, 256)
+
+            >>> sim.reset()
+            >>> sim.num_qubits
+            10
+            >>> sim.get_measurement_flips().shape
+            (0, 256)
         """
     def set_pauli_flip(
         self,
@@ -7401,6 +7534,13 @@ class PauliString:
         self,
     ) -> int:
         """Returns the length the pauli string; the number of qubits it operates on.
+
+        Examples:
+            >>> import stim
+            >>> len(stim.PauliString("XY_ZZ"))
+            5
+            >>> len(stim.PauliString("X0*Z99"))
+            100
         """
     def __mul__(
         self,
@@ -8306,6 +8446,12 @@ class Tableau:
         self,
     ) -> int:
         """Returns the number of qubits operated on by the tableau.
+
+        Examples:
+            >>> import stim
+            >>> t = stim.Tableau.from_named_gate("CNOT")
+            >>> len(t)
+            2
         """
     def __mul__(
         self,

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -3267,6 +3267,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
         pybind11::arg("type") = "timeline-text",
         pybind11::kw_only(),
         pybind11::arg("tick") = pybind11::none(),
+        pybind11::arg("rows") = pybind11::none(),
         pybind11::arg("filter_coords") = pybind11::none(),
         clean_doc_string(R"DOC(
             @signature def diagram(self, type: str = 'timeline-text', *, tick: Union[None, int, range] = None, filter_coords: Iterable[Union[Iterable[float], stim.DemTarget]] = ((),)) -> 'stim._DiagramHelper':
@@ -3343,11 +3344,19 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
 
                     Passing `range(A, B)` for a time slice will show the
                     operations between tick A and tick B.
-                filter_coords: A set of acceptable coordinate prefixes, or
-                    desired stim.DemTargets. For detector slice diagrams, only
-                    detectors match one of the filters are included. If no filter
-                    is specified, all detectors are included (but no observables).
-                    To include an observable, add it as one of the filters.
+                rows: In diagrams that have multiple separate pieces, such as timeslice
+                    diagrams and detslice diagrams, this controls how many rows of
+                    pieces there will be. If not specified, a number of rows that creates
+                    a roughly square layout will be chosen.
+                filter_coords: A list of things to include in the diagram. Different
+                    effects depending on the diagram.
+
+                    For detslice diagrams, the filter defaults to showing all detectors
+                    and no observables. When specified, each list entry can be a collection
+                    of floats (detectors whose coordinates start with the same numbers will
+                    be included), a stim.DemTarget (specifying a detector or observable
+                    to include), a string like "D5" or "L0" specifying a detector or
+                    observable to include.
 
             Returns:
                 An object whose `__str__` method returns the diagram, so that

--- a/src/stim/cmd/command_diagram.pybind.cc
+++ b/src/stim/cmd/command_diagram.pybind.cc
@@ -213,12 +213,18 @@ DiagramHelper stim_pybind::circuit_diagram(
     const Circuit &circuit,
     std::string_view type,
     const pybind11::object &tick,
+    const pybind11::object &rows,
     const pybind11::object &filter_coords_obj) {
     std::vector<CoordFilter> filter_coords;
     try {
         filter_coords = item_to_filter_multi(filter_coords_obj);
     } catch (const std::exception &_) {
         throw std::invalid_argument("filter_coords wasn't an Iterable[stim.DemTarget | Iterable[float]].");
+    }
+
+    size_t num_rows = 0;
+    if (!rows.is_none()) {
+        num_rows = pybind11::cast<size_t>(rows);
     }
 
     uint64_t tick_min;
@@ -262,7 +268,7 @@ DiagramHelper stim_pybind::circuit_diagram(
         type == "timeslice" || type == "time-slice") {
         std::stringstream out;
         DiagramTimelineSvgDrawer::make_diagram_write_to(
-            circuit, out, tick_min, num_ticks, DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_SLICE, filter_coords);
+            circuit, out, tick_min, num_ticks, DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_SLICE, filter_coords, num_rows);
         DiagramType d_type =
             type.find("html") != std::string::npos ? DiagramType::DIAGRAM_TYPE_SVG_HTML : DiagramType::DIAGRAM_TYPE_SVG;
         return DiagramHelper{d_type, out.str()};
@@ -270,7 +276,7 @@ DiagramHelper stim_pybind::circuit_diagram(
         type == "detslice-svg" || type == "detslice" || type == "detslice-html" || type == "detslice-svg-html" ||
         type == "detector-slice-svg" || type == "detector-slice") {
         std::stringstream out;
-        DetectorSliceSet::from_circuit_ticks(circuit, tick_min, num_ticks, filter_coords).write_svg_diagram_to(out);
+        DetectorSliceSet::from_circuit_ticks(circuit, tick_min, num_ticks, filter_coords).write_svg_diagram_to(out, num_rows);
         DiagramType d_type =
             type.find("html") != std::string::npos ? DiagramType::DIAGRAM_TYPE_SVG_HTML : DiagramType::DIAGRAM_TYPE_SVG;
         return DiagramHelper{d_type, out.str()};
@@ -284,7 +290,8 @@ DiagramHelper stim_pybind::circuit_diagram(
             tick_min,
             num_ticks,
             DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_DETECTOR_SLICE,
-            filter_coords);
+            filter_coords,
+            num_rows);
         DiagramType d_type =
             type.find("html") != std::string::npos ? DiagramType::DIAGRAM_TYPE_SVG_HTML : DiagramType::DIAGRAM_TYPE_SVG;
         return DiagramHelper{d_type, out.str()};

--- a/src/stim/cmd/command_diagram.pybind.h
+++ b/src/stim/cmd/command_diagram.pybind.h
@@ -42,6 +42,7 @@ DiagramHelper circuit_diagram(
     const stim::Circuit &circuit,
     std::string_view type,
     const pybind11::object &tick,
+    const pybind11::object &rows,
     const pybind11::object &filter_coords_obj);
 
 }  // namespace stim_pybind

--- a/src/stim/dem/detector_error_model_instruction.pybind.cc
+++ b/src/stim/dem/detector_error_model_instruction.pybind.cc
@@ -14,7 +14,6 @@
 
 #include "stim/dem/detector_error_model_instruction.pybind.h"
 
-#include "stim/dem/detector_error_model.pybind.h"
 #include "stim/dem/detector_error_model_target.pybind.h"
 #include "stim/py/base.pybind.h"
 #include "stim/util_bot/str_util.h"
@@ -183,7 +182,29 @@ void stim_pybind::pybind_detector_error_model_instruction_methods(
     c.def(
         "args_copy",
         &ExposedDemInstruction::args_copy,
-        "Returns a copy of the list of numbers parameterizing the instruction (e.g. the probability of an error).");
+        clean_doc_string(R"DOC(
+            @signature def args_copy(self) -> List[float]:
+            Returns a copy of the list of numbers parameterizing the instruction.
+
+            For example, this would be coordinates of a detector instruction or the
+            probability of an error instruction. The result is a copy, meaning that
+            editing it won't change the instruction's targets or future copies.
+
+            Examples:
+                >>> import stim
+                >>> instruction = stim.DetectorErrorModel('''
+                ...     error(0.125) D0
+                ... ''')[0]
+                >>> instruction.args_copy()
+                [0.125]
+
+                >>> instruction.args_copy() == instruction.args_copy()
+                True
+                >>> instruction.args_copy() is instruction.args_copy()
+                False
+        )DOC")
+            .data());
+
     c.def(
         "targets_copy",
         &ExposedDemInstruction::targets_copy,
@@ -191,8 +212,21 @@ void stim_pybind::pybind_detector_error_model_instruction_methods(
             @signature def targets_copy(self) -> List[Union[int, stim.DemTarget]]:
             Returns a copy of the instruction's targets.
 
-            (Making a copy is enforced to make it clear that editing the result won't change
-            the instruction's targets.)
+            The result is a copy, meaning that editing it won't change the instruction's
+            targets or future copies.
+
+            Examples:
+                >>> import stim
+                >>> instruction = stim.DetectorErrorModel('''
+                ...     error(0.125) D0 L2
+                ... ''')[0]
+                >>> instruction.targets_copy()
+                [stim.DemTarget('D0'), stim.DemTarget('L2')]
+
+                >>> instruction.targets_copy() == instruction.targets_copy()
+                True
+                >>> instruction.targets_copy() is instruction.targets_copy()
+                False
         )DOC")
             .data());
     c.def_property_readonly(

--- a/src/stim/diagram/detector_slice/detector_slice_set.h
+++ b/src/stim/diagram/detector_slice/detector_slice_set.h
@@ -65,7 +65,7 @@ struct DetectorSliceSet {
     std::string str() const;
 
     void write_text_diagram_to(std::ostream &out) const;
-    void write_svg_diagram_to(std::ostream &out) const;
+    void write_svg_diagram_to(std::ostream &out, size_t num_rows = 0) const;
     void write_svg_contents_to(
         std::ostream &out,
         const std::function<Coord<2>(uint32_t qubit)> &unscaled_coords,

--- a/src/stim/diagram/timeline/timeline_svg_drawer.h
+++ b/src/stim/diagram/timeline/timeline_svg_drawer.h
@@ -64,7 +64,8 @@ struct DiagramTimelineSvgDrawer {
         uint64_t tick_slice_start,
         uint64_t tick_slice_num,
         DiagramTimelineSvgDrawerMode mode,
-        stim::SpanRef<const CoordFilter> det_coord_filter);
+        stim::SpanRef<const CoordFilter> det_coord_filter,
+        size_t num_rows = 0);
 
     void do_start_repeat(const CircuitTimelineLoopData &loop_data);
     void do_end_repeat(const CircuitTimelineLoopData &loop_data);

--- a/src/stim/mem/bitword_128_sse.h
+++ b/src/stim/mem/bitword_128_sse.h
@@ -53,6 +53,8 @@ struct bitword<128> {
     }
     inline bitword<128>(__m128i val) : val(val) {
     }
+    inline bitword<128>(std::array<uint64_t, 2> val) : val{_mm_set_epi64x(val[1], val[0])} {
+    }
     inline bitword<128>(uint64_t val) : val{_mm_set_epi64x(0, val)} {
     }
     inline bitword<128>(int64_t val) : val{_mm_set_epi64x(-(val < 0), val)} {

--- a/src/stim/mem/bitword_256_avx.h
+++ b/src/stim/mem/bitword_256_avx.h
@@ -52,6 +52,8 @@ struct bitword<256> {
     }
     inline bitword<256>(__m256i val) : val(val) {
     }
+    inline bitword<256>(std::array<uint64_t, 4> val) : val{_mm256_set_epi64x(val[3], val[2], val[1], val[0])} {
+    }
     inline bitword<256>(uint64_t val) : val{_mm256_set_epi64x(0, 0, 0, val)} {
     }
     inline bitword<256>(int64_t val) : val{_mm256_set_epi64x(-(val < 0), -(val < 0), -(val < 0), val)} {

--- a/src/stim/mem/bitword_64.h
+++ b/src/stim/mem/bitword_64.h
@@ -47,6 +47,8 @@ struct bitword<64> {
 
     inline constexpr bitword<64>() : val{} {
     }
+    inline bitword<64>(std::array<uint64_t, 1> val) : val{val[0]} {
+    }
     inline constexpr bitword<64>(uint64_t v) : val{v} {
     }
     inline constexpr bitword<64>(int64_t v) : val{(uint64_t)v} {

--- a/src/stim/mem/simd_word.test.cc
+++ b/src/stim/mem/simd_word.test.cc
@@ -149,3 +149,13 @@ TEST_EACH_WORD_SIZE_W(simd_word, ordering, {
     ASSERT_TRUE(!(simd_word<W>(2) < simd_word<W>(2)));
     ASSERT_TRUE(!(simd_word<W>(3) < simd_word<W>(2)));
 })
+
+TEST_EACH_WORD_SIZE_W(simd_word, from_u64_array, {
+    std::array<uint64_t, W / 64> expected;
+    for (size_t k = 0; k < expected.size(); k++) {
+        expected[k] = k * 3 + 1;
+    }
+    simd_word<W> w(expected);
+    std::array<uint64_t, W / 64> actual = w.to_u64_array();
+    ASSERT_EQ(actual, expected);
+})

--- a/src/stim/stabilizers/pauli_string.pybind.cc
+++ b/src/stim/stabilizers/pauli_string.pybind.cc
@@ -826,6 +826,13 @@ void stim_pybind::pybind_pauli_string_methods(pybind11::module &m, pybind11::cla
         },
         clean_doc_string(R"DOC(
             Returns the length the pauli string; the number of qubits it operates on.
+
+            Examples:
+                >>> import stim
+                >>> len(stim.PauliString("XY_ZZ"))
+                5
+                >>> len(stim.PauliString("X0*Z99"))
+                100
         )DOC")
             .data());
 

--- a/src/stim/stabilizers/tableau.pybind.cc
+++ b/src/stim/stabilizers/tableau.pybind.cc
@@ -838,7 +838,16 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
         [](const Tableau<MAX_BITWORD_WIDTH> &self) {
             return self.num_qubits;
         },
-        "Returns the number of qubits operated on by the tableau.");
+        clean_doc_string(R"DOC(
+            Returns the number of qubits operated on by the tableau.
+
+            Examples:
+                >>> import stim
+                >>> t = stim.Tableau.from_named_gate("CNOT")
+                >>> len(t)
+                2
+        )DOC")
+            .data());
 
     c.def("__str__", &Tableau<MAX_BITWORD_WIDTH>::str, "Returns a text description.");
 

--- a/src/stim/util_top/circuit_vs_amplitudes.cc
+++ b/src/stim/util_top/circuit_vs_amplitudes.cc
@@ -1,6 +1,6 @@
 #include "stim/util_top/circuit_vs_amplitudes.h"
 
-#include "circuit_inverse_unitary.h"
+#include "stim/util_top/circuit_inverse_unitary.h"
 #include "stim/simulators/tableau_simulator.h"
 #include "stim/simulators/vector_simulator.h"
 #include "stim/util_bot/twiddle.h"

--- a/testdata/anticommuting_detslice.svg
+++ b/testdata/anticommuting_detslice.svg
@@ -42,9 +42,13 @@
 <rect x="508.8" y="240" width="32" height="32" stroke="black" fill="black"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="524.8" y="256" fill="white">M</text>
 <g id="tick_borders">
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="80" y="-282">Tick 0</text>
 <rect id="tick_border:0:0_0:0" x="0" y="0" width="288" height="160" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_0:0" x="0" y="176" width="288" height="160" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_1:0" x="316.8" y="0" width="288" height="160" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_1:0" x="316.8" y="176" width="288" height="160" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="80" y="-598.8">Tick 1</text>
+<rect id="tick_border:1:0_1:1" x="316.8" y="0" width="288" height="160" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="256" y="-282">Tick 2</text>
+<rect id="tick_border:2:1_0:2" x="0" y="176" width="288" height="160" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="256" y="-598.8">Tick 3</text>
+<rect id="tick_border:3:1_1:3" x="316.8" y="176" width="288" height="160" stroke="black" fill="none"/>
 </g>
 </svg>

--- a/testdata/bezier_time_slice.svg
+++ b/testdata/bezier_time_slice.svg
@@ -26,7 +26,9 @@
 <circle cx="659.2" cy="80" r="12" stroke="black" fill="white"/>
 <path d="M647.2,80 L671.2,80 M659.2,68 L659.2,92 " stroke="black"/>
 <g id="tick_borders">
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="80" y="-346">Tick 0</text>
 <rect id="tick_border:0:0_0:0" x="0" y="0" width="352" height="160" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_1:0" x="387.2" y="0" width="352" height="160" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="80" y="-733.2">Tick 1</text>
+<rect id="tick_border:1:0_1:1" x="387.2" y="0" width="352" height="160" stroke="black" fill="none"/>
 </g>
 </svg>

--- a/testdata/circuit_all_ops_detslice.svg
+++ b/testdata/circuit_all_ops_detslice.svg
@@ -561,19 +561,33 @@
 <rect x="1430.4" y="1172.8" width="32" height="32" stroke="black" fill="lightgray"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="1446.4" y="1188.8">Z<tspan baseline-shift="super" font-size="10">rec</tspan></text>
 <g id="tick_borders">
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="168" y="-1178">Tick 0</text>
 <rect id="tick_border:0:0_0:0" x="0" y="0" width="1184" height="336" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_0:0" x="0" y="369.6" width="1184" height="336" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_0:0" x="0" y="739.2" width="1184" height="336" stroke="black" fill="none"/>
-<rect id="tick_border:0:3_0:0" x="0" y="1108.8" width="1184" height="336" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_1:0" x="1302.4" y="0" width="1184" height="336" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_1:0" x="1302.4" y="369.6" width="1184" height="336" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_1:0" x="1302.4" y="739.2" width="1184" height="336" stroke="black" fill="none"/>
-<rect id="tick_border:0:3_1:0" x="1302.4" y="1108.8" width="1184" height="336" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_2:0" x="2604.8" y="0" width="1184" height="336" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_2:0" x="2604.8" y="369.6" width="1184" height="336" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_2:0" x="2604.8" y="739.2" width="1184" height="336" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_3:0" x="3907.2" y="0" width="1184" height="336" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_3:0" x="3907.2" y="369.6" width="1184" height="336" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_3:0" x="3907.2" y="739.2" width="1184" height="336" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="168" y="-2480.4">Tick 1</text>
+<rect id="tick_border:1:0_1:1" x="1302.4" y="0" width="1184" height="336" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="168" y="-3782.8">Tick 2</text>
+<rect id="tick_border:2:0_2:2" x="2604.8" y="0" width="1184" height="336" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="168" y="-5085.2">Tick 3</text>
+<rect id="tick_border:3:0_3:3" x="3907.2" y="0" width="1184" height="336" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="537.6" y="-1178">Tick 4</text>
+<rect id="tick_border:4:1_0:4" x="0" y="369.6" width="1184" height="336" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="537.6" y="-2480.4">Tick 5</text>
+<rect id="tick_border:5:1_1:5" x="1302.4" y="369.6" width="1184" height="336" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="537.6" y="-3782.8">Tick 6</text>
+<rect id="tick_border:6:1_2:6" x="2604.8" y="369.6" width="1184" height="336" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="537.6" y="-5085.2">Tick 7</text>
+<rect id="tick_border:7:1_3:7" x="3907.2" y="369.6" width="1184" height="336" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="907.2" y="-1178">Tick 8</text>
+<rect id="tick_border:8:2_0:8" x="0" y="739.2" width="1184" height="336" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="907.2" y="-2480.4">Tick 9</text>
+<rect id="tick_border:9:2_1:9" x="1302.4" y="739.2" width="1184" height="336" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="907.2" y="-3782.8">Tick 10</text>
+<rect id="tick_border:10:2_2:10" x="2604.8" y="739.2" width="1184" height="336" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="907.2" y="-5085.2">Tick 11</text>
+<rect id="tick_border:11:2_3:11" x="3907.2" y="739.2" width="1184" height="336" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1276.8" y="-1178">Tick 12</text>
+<rect id="tick_border:12:3_0:12" x="0" y="1108.8" width="1184" height="336" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1276.8" y="-2480.4">Tick 13</text>
+<rect id="tick_border:13:3_1:13" x="1302.4" y="1108.8" width="1184" height="336" stroke="black" fill="none"/>
 </g>
 </svg>

--- a/testdata/circuit_all_ops_timeslice.svg
+++ b/testdata/circuit_all_ops_timeslice.svg
@@ -561,19 +561,33 @@
 <rect x="1430.4" y="1172.8" width="32" height="32" stroke="black" fill="lightgray"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="12" x="1446.4" y="1188.8">Z<tspan baseline-shift="super" font-size="10">rec</tspan></text>
 <g id="tick_borders">
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="168" y="-1178">Tick 0</text>
 <rect id="tick_border:0:0_0:0" x="0" y="0" width="1184" height="336" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_0:0" x="0" y="369.6" width="1184" height="336" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_0:0" x="0" y="739.2" width="1184" height="336" stroke="black" fill="none"/>
-<rect id="tick_border:0:3_0:0" x="0" y="1108.8" width="1184" height="336" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_1:0" x="1302.4" y="0" width="1184" height="336" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_1:0" x="1302.4" y="369.6" width="1184" height="336" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_1:0" x="1302.4" y="739.2" width="1184" height="336" stroke="black" fill="none"/>
-<rect id="tick_border:0:3_1:0" x="1302.4" y="1108.8" width="1184" height="336" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_2:0" x="2604.8" y="0" width="1184" height="336" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_2:0" x="2604.8" y="369.6" width="1184" height="336" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_2:0" x="2604.8" y="739.2" width="1184" height="336" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_3:0" x="3907.2" y="0" width="1184" height="336" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_3:0" x="3907.2" y="369.6" width="1184" height="336" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_3:0" x="3907.2" y="739.2" width="1184" height="336" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="168" y="-2480.4">Tick 1</text>
+<rect id="tick_border:1:0_1:1" x="1302.4" y="0" width="1184" height="336" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="168" y="-3782.8">Tick 2</text>
+<rect id="tick_border:2:0_2:2" x="2604.8" y="0" width="1184" height="336" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="168" y="-5085.2">Tick 3</text>
+<rect id="tick_border:3:0_3:3" x="3907.2" y="0" width="1184" height="336" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="537.6" y="-1178">Tick 4</text>
+<rect id="tick_border:4:1_0:4" x="0" y="369.6" width="1184" height="336" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="537.6" y="-2480.4">Tick 5</text>
+<rect id="tick_border:5:1_1:5" x="1302.4" y="369.6" width="1184" height="336" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="537.6" y="-3782.8">Tick 6</text>
+<rect id="tick_border:6:1_2:6" x="2604.8" y="369.6" width="1184" height="336" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="537.6" y="-5085.2">Tick 7</text>
+<rect id="tick_border:7:1_3:7" x="3907.2" y="369.6" width="1184" height="336" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="907.2" y="-1178">Tick 8</text>
+<rect id="tick_border:8:2_0:8" x="0" y="739.2" width="1184" height="336" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="907.2" y="-2480.4">Tick 9</text>
+<rect id="tick_border:9:2_1:9" x="1302.4" y="739.2" width="1184" height="336" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="907.2" y="-3782.8">Tick 10</text>
+<rect id="tick_border:10:2_2:10" x="2604.8" y="739.2" width="1184" height="336" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="907.2" y="-5085.2">Tick 11</text>
+<rect id="tick_border:11:2_3:11" x="3907.2" y="739.2" width="1184" height="336" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1276.8" y="-1178">Tick 12</text>
+<rect id="tick_border:12:3_0:12" x="0" y="1108.8" width="1184" height="336" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1276.8" y="-2480.4">Tick 13</text>
+<rect id="tick_border:13:3_1:13" x="1302.4" y="1108.8" width="1184" height="336" stroke="black" fill="none"/>
 </g>
 </svg>

--- a/testdata/circuit_diagram_timeline_svg_chained_loops.svg
+++ b/testdata/circuit_diagram_timeline_svg_chained_loops.svg
@@ -46,16 +46,27 @@
 <rect x="620.8" y="416" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="636.8" y="432">Z</text>
 <g id="tick_borders">
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="80" y="-218">Tick 0</text>
 <rect id="tick_border:0:0_0:0" x="0" y="0" width="224" height="160" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_0:0" x="0" y="176" width="224" height="160" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_0:0" x="0" y="352" width="224" height="160" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_1:0" x="246.4" y="0" width="224" height="160" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_1:0" x="246.4" y="176" width="224" height="160" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_1:0" x="246.4" y="352" width="224" height="160" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_2:0" x="492.8" y="0" width="224" height="160" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_2:0" x="492.8" y="176" width="224" height="160" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_2:0" x="492.8" y="352" width="224" height="160" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_3:0" x="739.2" y="0" width="224" height="160" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_3:0" x="739.2" y="176" width="224" height="160" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="80" y="-464.4">Tick 1</text>
+<rect id="tick_border:1:0_1:1" x="246.4" y="0" width="224" height="160" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="80" y="-710.8">Tick 2</text>
+<rect id="tick_border:2:0_2:2" x="492.8" y="0" width="224" height="160" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="80" y="-957.2">Tick 3</text>
+<rect id="tick_border:3:0_3:3" x="739.2" y="0" width="224" height="160" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="256" y="-218">Tick 4</text>
+<rect id="tick_border:4:1_0:4" x="0" y="176" width="224" height="160" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="256" y="-464.4">Tick 5</text>
+<rect id="tick_border:5:1_1:5" x="246.4" y="176" width="224" height="160" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="256" y="-710.8">Tick 6</text>
+<rect id="tick_border:6:1_2:6" x="492.8" y="176" width="224" height="160" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="256" y="-957.2">Tick 7</text>
+<rect id="tick_border:7:1_3:7" x="739.2" y="176" width="224" height="160" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="432" y="-218">Tick 8</text>
+<rect id="tick_border:8:2_0:8" x="0" y="352" width="224" height="160" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="432" y="-464.4">Tick 9</text>
+<rect id="tick_border:9:2_1:9" x="246.4" y="352" width="224" height="160" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="432" y="-710.8">Tick 10</text>
+<rect id="tick_border:10:2_2:10" x="492.8" y="352" width="224" height="160" stroke="black" fill="none"/>
 </g>
 </svg>

--- a/testdata/detslice-with-ops_surface_code.svg
+++ b/testdata/detslice-with-ops_surface_code.svg
@@ -1271,19 +1271,33 @@
 <rect x="719.701" y="1759.57" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="735.701" y="1775.57">H</text>
 <g id="tick_borders">
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="215.764" y="-425.529">Tick 0</text>
 <rect id="tick_border:0:0_0:0" x="0" y="0" width="431.529" height="431.529" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_0:0" x="0" y="474.682" width="431.529" height="431.529" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_0:0" x="0" y="949.364" width="431.529" height="431.529" stroke="black" fill="none"/>
-<rect id="tick_border:0:3_0:0" x="0" y="1424.05" width="431.529" height="431.529" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_1:0" x="474.682" y="0" width="431.529" height="431.529" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_1:0" x="474.682" y="474.682" width="431.529" height="431.529" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_1:0" x="474.682" y="949.364" width="431.529" height="431.529" stroke="black" fill="none"/>
-<rect id="tick_border:0:3_1:0" x="474.682" y="1424.05" width="431.529" height="431.529" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_2:0" x="949.364" y="0" width="431.529" height="431.529" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_2:0" x="949.364" y="474.682" width="431.529" height="431.529" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_2:0" x="949.364" y="949.364" width="431.529" height="431.529" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_3:0" x="1424.05" y="0" width="431.529" height="431.529" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_3:0" x="1424.05" y="474.682" width="431.529" height="431.529" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_3:0" x="1424.05" y="949.364" width="431.529" height="431.529" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="215.764" y="-900.211">Tick 1</text>
+<rect id="tick_border:1:0_1:1" x="474.682" y="0" width="431.529" height="431.529" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="215.764" y="-1374.89">Tick 2</text>
+<rect id="tick_border:2:0_2:2" x="949.364" y="0" width="431.529" height="431.529" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="215.764" y="-1849.57">Tick 3</text>
+<rect id="tick_border:3:0_3:3" x="1424.05" y="0" width="431.529" height="431.529" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="690.446" y="-425.529">Tick 4</text>
+<rect id="tick_border:4:1_0:4" x="0" y="474.682" width="431.529" height="431.529" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="690.446" y="-900.211">Tick 5</text>
+<rect id="tick_border:5:1_1:5" x="474.682" y="474.682" width="431.529" height="431.529" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="690.446" y="-1374.89">Tick 6</text>
+<rect id="tick_border:6:1_2:6" x="949.364" y="474.682" width="431.529" height="431.529" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="690.446" y="-1849.57">Tick 7</text>
+<rect id="tick_border:7:1_3:7" x="1424.05" y="474.682" width="431.529" height="431.529" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1165.13" y="-425.529">Tick 8</text>
+<rect id="tick_border:8:2_0:8" x="0" y="949.364" width="431.529" height="431.529" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1165.13" y="-900.211">Tick 9</text>
+<rect id="tick_border:9:2_1:9" x="474.682" y="949.364" width="431.529" height="431.529" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1165.13" y="-1374.89">Tick 10</text>
+<rect id="tick_border:10:2_2:10" x="949.364" y="949.364" width="431.529" height="431.529" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1165.13" y="-1849.57">Tick 11</text>
+<rect id="tick_border:11:2_3:11" x="1424.05" y="949.364" width="431.529" height="431.529" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1639.81" y="-425.529">Tick 12</text>
+<rect id="tick_border:12:3_0:12" x="0" y="1424.05" width="431.529" height="431.529" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1639.81" y="-900.211">Tick 13</text>
+<rect id="tick_border:13:3_1:13" x="474.682" y="1424.05" width="431.529" height="431.529" stroke="black" fill="none"/>
 </g>
 </svg>

--- a/testdata/observable_slices.svg
+++ b/testdata/observable_slices.svg
@@ -145,18 +145,31 @@
 <rect x="154.51" y="741.341" width="32" height="32" stroke="black" fill="black"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="170.51" y="757.341" fill="white">M</text>
 <g id="tick_borders">
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="102.627" y="-244.51">Tick 0</text>
 <rect id="tick_border:0:0_0:0" x="0" y="0" width="250.51" height="205.255" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_0:0" x="0" y="225.78" width="250.51" height="205.255" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_0:0" x="0" y="451.561" width="250.51" height="205.255" stroke="black" fill="none"/>
-<rect id="tick_border:0:3_0:0" x="0" y="677.341" width="250.51" height="205.255" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_1:0" x="275.561" y="0" width="250.51" height="205.255" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_1:0" x="275.561" y="225.78" width="250.51" height="205.255" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_1:0" x="275.561" y="451.561" width="250.51" height="205.255" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_2:0" x="551.121" y="0" width="250.51" height="205.255" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_2:0" x="551.121" y="225.78" width="250.51" height="205.255" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_2:0" x="551.121" y="451.561" width="250.51" height="205.255" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_3:0" x="826.682" y="0" width="250.51" height="205.255" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_3:0" x="826.682" y="225.78" width="250.51" height="205.255" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_3:0" x="826.682" y="451.561" width="250.51" height="205.255" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="102.627" y="-520.07">Tick 1</text>
+<rect id="tick_border:1:0_1:1" x="275.561" y="0" width="250.51" height="205.255" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="102.627" y="-795.631">Tick 2</text>
+<rect id="tick_border:2:0_2:2" x="551.121" y="0" width="250.51" height="205.255" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="102.627" y="-1071.19">Tick 3</text>
+<rect id="tick_border:3:0_3:3" x="826.682" y="0" width="250.51" height="205.255" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="328.408" y="-244.51">Tick 4</text>
+<rect id="tick_border:4:1_0:4" x="0" y="225.78" width="250.51" height="205.255" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="328.408" y="-520.07">Tick 5</text>
+<rect id="tick_border:5:1_1:5" x="275.561" y="225.78" width="250.51" height="205.255" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="328.408" y="-795.631">Tick 6</text>
+<rect id="tick_border:6:1_2:6" x="551.121" y="225.78" width="250.51" height="205.255" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="328.408" y="-1071.19">Tick 7</text>
+<rect id="tick_border:7:1_3:7" x="826.682" y="225.78" width="250.51" height="205.255" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="554.188" y="-244.51">Tick 8</text>
+<rect id="tick_border:8:2_0:8" x="0" y="451.561" width="250.51" height="205.255" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="554.188" y="-520.07">Tick 9</text>
+<rect id="tick_border:9:2_1:9" x="275.561" y="451.561" width="250.51" height="205.255" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="554.188" y="-795.631">Tick 10</text>
+<rect id="tick_border:10:2_2:10" x="551.121" y="451.561" width="250.51" height="205.255" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="554.188" y="-1071.19">Tick 11</text>
+<rect id="tick_border:11:2_3:11" x="826.682" y="451.561" width="250.51" height="205.255" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="779.968" y="-244.51">Tick 12</text>
+<rect id="tick_border:12:3_0:12" x="0" y="677.341" width="250.51" height="205.255" stroke="black" fill="none"/>
 </g>
 </svg>

--- a/testdata/surface_code_full_time_detector_slice.svg
+++ b/testdata/surface_code_full_time_detector_slice.svg
@@ -2823,41 +2823,77 @@
 <rect x="2608" y="2608" width="32" height="32" stroke="black" fill="black"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="2624" y="2624" fill="white">M</text>
 <g id="tick_borders">
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="208" y="-410">Tick 0</text>
 <rect id="tick_border:0:0_0:0" x="0" y="0" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_0:0" x="0" y="457.6" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_0:0" x="0" y="915.2" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:3_0:0" x="0" y="1372.8" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:4_0:0" x="0" y="1830.4" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:5_0:0" x="0" y="2288" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_1:0" x="457.6" y="0" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_1:0" x="457.6" y="457.6" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_1:0" x="457.6" y="915.2" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:3_1:0" x="457.6" y="1372.8" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:4_1:0" x="457.6" y="1830.4" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:5_1:0" x="457.6" y="2288" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_2:0" x="915.2" y="0" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_2:0" x="915.2" y="457.6" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_2:0" x="915.2" y="915.2" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:3_2:0" x="915.2" y="1372.8" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:4_2:0" x="915.2" y="1830.4" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:5_2:0" x="915.2" y="2288" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_3:0" x="1372.8" y="0" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_3:0" x="1372.8" y="457.6" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_3:0" x="1372.8" y="915.2" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:3_3:0" x="1372.8" y="1372.8" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:4_3:0" x="1372.8" y="1830.4" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:5_3:0" x="1372.8" y="2288" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_4:0" x="1830.4" y="0" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_4:0" x="1830.4" y="457.6" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_4:0" x="1830.4" y="915.2" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:3_4:0" x="1830.4" y="1372.8" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:4_4:0" x="1830.4" y="1830.4" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:5_4:0" x="1830.4" y="2288" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_5:0" x="2288" y="0" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_5:0" x="2288" y="457.6" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_5:0" x="2288" y="915.2" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:3_5:0" x="2288" y="1372.8" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:4_5:0" x="2288" y="1830.4" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:5_5:0" x="2288" y="2288" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="208" y="-867.6">Tick 1</text>
+<rect id="tick_border:1:0_1:1" x="457.6" y="0" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="208" y="-1325.2">Tick 2</text>
+<rect id="tick_border:2:0_2:2" x="915.2" y="0" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="208" y="-1782.8">Tick 3</text>
+<rect id="tick_border:3:0_3:3" x="1372.8" y="0" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="208" y="-2240.4">Tick 4</text>
+<rect id="tick_border:4:0_4:4" x="1830.4" y="0" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="208" y="-2698">Tick 5</text>
+<rect id="tick_border:5:0_5:5" x="2288" y="0" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="665.6" y="-410">Tick 6</text>
+<rect id="tick_border:6:1_0:6" x="0" y="457.6" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="665.6" y="-867.6">Tick 7</text>
+<rect id="tick_border:7:1_1:7" x="457.6" y="457.6" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="665.6" y="-1325.2">Tick 8</text>
+<rect id="tick_border:8:1_2:8" x="915.2" y="457.6" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="665.6" y="-1782.8">Tick 9</text>
+<rect id="tick_border:9:1_3:9" x="1372.8" y="457.6" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="665.6" y="-2240.4">Tick 10</text>
+<rect id="tick_border:10:1_4:10" x="1830.4" y="457.6" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="665.6" y="-2698">Tick 11</text>
+<rect id="tick_border:11:1_5:11" x="2288" y="457.6" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1123.2" y="-410">Tick 12</text>
+<rect id="tick_border:12:2_0:12" x="0" y="915.2" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1123.2" y="-867.6">Tick 13</text>
+<rect id="tick_border:13:2_1:13" x="457.6" y="915.2" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1123.2" y="-1325.2">Tick 14</text>
+<rect id="tick_border:14:2_2:14" x="915.2" y="915.2" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1123.2" y="-1782.8">Tick 15</text>
+<rect id="tick_border:15:2_3:15" x="1372.8" y="915.2" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1123.2" y="-2240.4">Tick 16</text>
+<rect id="tick_border:16:2_4:16" x="1830.4" y="915.2" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1123.2" y="-2698">Tick 17</text>
+<rect id="tick_border:17:2_5:17" x="2288" y="915.2" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1580.8" y="-410">Tick 18</text>
+<rect id="tick_border:18:3_0:18" x="0" y="1372.8" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1580.8" y="-867.6">Tick 19</text>
+<rect id="tick_border:19:3_1:19" x="457.6" y="1372.8" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1580.8" y="-1325.2">Tick 20</text>
+<rect id="tick_border:20:3_2:20" x="915.2" y="1372.8" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1580.8" y="-1782.8">Tick 21</text>
+<rect id="tick_border:21:3_3:21" x="1372.8" y="1372.8" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1580.8" y="-2240.4">Tick 22</text>
+<rect id="tick_border:22:3_4:22" x="1830.4" y="1372.8" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1580.8" y="-2698">Tick 23</text>
+<rect id="tick_border:23:3_5:23" x="2288" y="1372.8" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="2038.4" y="-410">Tick 24</text>
+<rect id="tick_border:24:4_0:24" x="0" y="1830.4" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="2038.4" y="-867.6">Tick 25</text>
+<rect id="tick_border:25:4_1:25" x="457.6" y="1830.4" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="2038.4" y="-1325.2">Tick 26</text>
+<rect id="tick_border:26:4_2:26" x="915.2" y="1830.4" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="2038.4" y="-1782.8">Tick 27</text>
+<rect id="tick_border:27:4_3:27" x="1372.8" y="1830.4" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="2038.4" y="-2240.4">Tick 28</text>
+<rect id="tick_border:28:4_4:28" x="1830.4" y="1830.4" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="2038.4" y="-2698">Tick 29</text>
+<rect id="tick_border:29:4_5:29" x="2288" y="1830.4" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="2496" y="-410">Tick 30</text>
+<rect id="tick_border:30:5_0:30" x="0" y="2288" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="2496" y="-867.6">Tick 31</text>
+<rect id="tick_border:31:5_1:31" x="457.6" y="2288" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="2496" y="-1325.2">Tick 32</text>
+<rect id="tick_border:32:5_2:32" x="915.2" y="2288" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="2496" y="-1782.8">Tick 33</text>
+<rect id="tick_border:33:5_3:33" x="1372.8" y="2288" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="2496" y="-2240.4">Tick 34</text>
+<rect id="tick_border:34:5_4:34" x="1830.4" y="2288" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="2496" y="-2698">Tick 35</text>
+<rect id="tick_border:35:5_5:35" x="2288" y="2288" width="416" height="416" stroke="black" fill="none"/>
 </g>
 </svg>

--- a/testdata/surface_code_time_detector_slice.svg
+++ b/testdata/surface_code_time_detector_slice.svg
@@ -749,16 +749,27 @@
 <rect x="1171.2" y="1235.2" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1187.2" y="1251.2">H</text>
 <g id="tick_borders">
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="208" y="-410">Tick 5</text>
 <rect id="tick_border:0:0_0:5" x="0" y="0" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_0:5" x="0" y="457.6" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_0:5" x="0" y="915.2" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_1:5" x="457.6" y="0" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_1:5" x="457.6" y="457.6" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_1:5" x="457.6" y="915.2" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_2:5" x="915.2" y="0" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_2:5" x="915.2" y="457.6" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_2:5" x="915.2" y="915.2" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_3:5" x="1372.8" y="0" width="416" height="416" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_3:5" x="1372.8" y="457.6" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="208" y="-867.6">Tick 6</text>
+<rect id="tick_border:1:0_1:6" x="457.6" y="0" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="208" y="-1325.2">Tick 7</text>
+<rect id="tick_border:2:0_2:7" x="915.2" y="0" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="208" y="-1782.8">Tick 8</text>
+<rect id="tick_border:3:0_3:8" x="1372.8" y="0" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="665.6" y="-410">Tick 9</text>
+<rect id="tick_border:4:1_0:9" x="0" y="457.6" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="665.6" y="-867.6">Tick 10</text>
+<rect id="tick_border:5:1_1:10" x="457.6" y="457.6" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="665.6" y="-1325.2">Tick 11</text>
+<rect id="tick_border:6:1_2:11" x="915.2" y="457.6" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="665.6" y="-1782.8">Tick 12</text>
+<rect id="tick_border:7:1_3:12" x="1372.8" y="457.6" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1123.2" y="-410">Tick 13</text>
+<rect id="tick_border:8:2_0:13" x="0" y="915.2" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1123.2" y="-867.6">Tick 14</text>
+<rect id="tick_border:9:2_1:14" x="457.6" y="915.2" width="416" height="416" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1123.2" y="-1325.2">Tick 15</text>
+<rect id="tick_border:10:2_2:15" x="915.2" y="915.2" width="416" height="416" stroke="black" fill="none"/>
 </g>
 </svg>

--- a/testdata/surface_code_time_slice.svg
+++ b/testdata/surface_code_time_slice.svg
@@ -373,16 +373,27 @@
 <rect x="1194.38" y="1284.89" width="32" height="32" stroke="black" fill="white"/>
 <text dominant-baseline="central" text-anchor="middle" font-family="monospace" font-size="30" x="1210.38" y="1300.89">H</text>
 <g id="tick_borders">
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="215.764" y="-425.529">Tick 5</text>
 <rect id="tick_border:0:0_0:5" x="0" y="0" width="431.529" height="431.529" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_0:5" x="0" y="474.682" width="431.529" height="431.529" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_0:5" x="0" y="949.364" width="431.529" height="431.529" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_1:5" x="474.682" y="0" width="431.529" height="431.529" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_1:5" x="474.682" y="474.682" width="431.529" height="431.529" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_1:5" x="474.682" y="949.364" width="431.529" height="431.529" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_2:5" x="949.364" y="0" width="431.529" height="431.529" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_2:5" x="949.364" y="474.682" width="431.529" height="431.529" stroke="black" fill="none"/>
-<rect id="tick_border:0:2_2:5" x="949.364" y="949.364" width="431.529" height="431.529" stroke="black" fill="none"/>
-<rect id="tick_border:0:0_3:5" x="1424.05" y="0" width="431.529" height="431.529" stroke="black" fill="none"/>
-<rect id="tick_border:0:1_3:5" x="1424.05" y="474.682" width="431.529" height="431.529" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="215.764" y="-900.211">Tick 6</text>
+<rect id="tick_border:1:0_1:6" x="474.682" y="0" width="431.529" height="431.529" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="215.764" y="-1374.89">Tick 7</text>
+<rect id="tick_border:2:0_2:7" x="949.364" y="0" width="431.529" height="431.529" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="215.764" y="-1849.57">Tick 8</text>
+<rect id="tick_border:3:0_3:8" x="1424.05" y="0" width="431.529" height="431.529" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="690.446" y="-425.529">Tick 9</text>
+<rect id="tick_border:4:1_0:9" x="0" y="474.682" width="431.529" height="431.529" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="690.446" y="-900.211">Tick 10</text>
+<rect id="tick_border:5:1_1:10" x="474.682" y="474.682" width="431.529" height="431.529" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="690.446" y="-1374.89">Tick 11</text>
+<rect id="tick_border:6:1_2:11" x="949.364" y="474.682" width="431.529" height="431.529" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="690.446" y="-1849.57">Tick 12</text>
+<rect id="tick_border:7:1_3:12" x="1424.05" y="474.682" width="431.529" height="431.529" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1165.13" y="-425.529">Tick 13</text>
+<rect id="tick_border:8:2_0:13" x="0" y="949.364" width="431.529" height="431.529" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1165.13" y="-900.211">Tick 14</text>
+<rect id="tick_border:9:2_1:14" x="474.682" y="949.364" width="431.529" height="431.529" stroke="black" fill="none"/>
+<text dominant-baseline="hanging" text-anchor="middle" font-family="serif" font-size="18" transform="rotate(90)" x="1165.13" y="-1374.89">Tick 15</text>
+<rect id="tick_border:10:2_2:15" x="949.364" y="949.364" width="431.529" height="431.529" stroke="black" fill="none"/>
 </g>
 </svg>


### PR DESCRIPTION
- Add "rows" argument to `stim.Circuit.diagram` to control layout of multi-row diagrams
- Add "tick" labels to timeslice diagrams
- Add stim.FlipSimulator.copy
- Add stim.FlipSimulator.reset

Fixes https://github.com/quantumlib/Stim/issues/672
