### PR TITLE
Fix `HERALDED_PAULI_CHANNEL_1` permuting X/Y/Z error argument components

### DIFF
--- a/file_lists/test_files
+++ b/file_lists/test_files
@@ -82,6 +82,7 @@ src/stim/util_bot/twiddle.test.cc
 src/stim/util_top/circuit_flow_generators.test.cc
 src/stim/util_top/circuit_inverse_qec.test.cc
 src/stim/util_top/circuit_inverse_unitary.test.cc
+src/stim/util_top/circuit_to_dem.test.cc
 src/stim/util_top/circuit_to_detecting_regions.test.cc
 src/stim/util_top/circuit_vs_amplitudes.test.cc
 src/stim/util_top/circuit_vs_tableau.test.cc

--- a/src/stim.h
+++ b/src/stim.h
@@ -108,6 +108,7 @@
 #include "stim/util_top/circuit_flow_generators.h"
 #include "stim/util_top/circuit_inverse_qec.h"
 #include "stim/util_top/circuit_inverse_unitary.h"
+#include "stim/util_top/circuit_to_dem.h"
 #include "stim/util_top/circuit_to_detecting_regions.h"
 #include "stim/util_top/circuit_vs_amplitudes.h"
 #include "stim/util_top/circuit_vs_tableau.h"

--- a/src/stim/cmd/command_diagram.pybind.cc
+++ b/src/stim/cmd/command_diagram.pybind.cc
@@ -268,7 +268,13 @@ DiagramHelper stim_pybind::circuit_diagram(
         type == "timeslice" || type == "time-slice") {
         std::stringstream out;
         DiagramTimelineSvgDrawer::make_diagram_write_to(
-            circuit, out, tick_min, num_ticks, DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_SLICE, filter_coords, num_rows);
+            circuit,
+            out,
+            tick_min,
+            num_ticks,
+            DiagramTimelineSvgDrawerMode::SVG_MODE_TIME_SLICE,
+            filter_coords,
+            num_rows);
         DiagramType d_type =
             type.find("html") != std::string::npos ? DiagramType::DIAGRAM_TYPE_SVG_HTML : DiagramType::DIAGRAM_TYPE_SVG;
         return DiagramHelper{d_type, out.str()};
@@ -276,7 +282,8 @@ DiagramHelper stim_pybind::circuit_diagram(
         type == "detslice-svg" || type == "detslice" || type == "detslice-html" || type == "detslice-svg-html" ||
         type == "detector-slice-svg" || type == "detector-slice") {
         std::stringstream out;
-        DetectorSliceSet::from_circuit_ticks(circuit, tick_min, num_ticks, filter_coords).write_svg_diagram_to(out, num_rows);
+        DetectorSliceSet::from_circuit_ticks(circuit, tick_min, num_ticks, filter_coords)
+            .write_svg_diagram_to(out, num_rows);
         DiagramType d_type =
             type.find("html") != std::string::npos ? DiagramType::DIAGRAM_TYPE_SVG_HTML : DiagramType::DIAGRAM_TYPE_SVG;
         return DiagramHelper{d_type, out.str()};

--- a/src/stim/dem/detector_error_model_target.pybind.cc
+++ b/src/stim/dem/detector_error_model_target.pybind.cc
@@ -28,7 +28,6 @@ pybind11::class_<ExposedDemTarget> stim_pybind::pybind_detector_error_model_targ
 
 void stim_pybind::pybind_detector_error_model_target_methods(
     pybind11::module &m, pybind11::class_<ExposedDemTarget> &c) {
-
     c.def(
         pybind11::init([](const pybind11::object &arg) -> ExposedDemTarget {
             if (pybind11::isinstance<ExposedDemTarget>(arg)) {

--- a/src/stim/gates/gates.cc
+++ b/src/stim/gates/gates.cc
@@ -47,110 +47,110 @@ GateDataMap::GateDataMap() {
 
 GateType Gate::hadamard_conjugated(bool ignoring_sign) const {
     switch (id) {
-    case GateType::DETECTOR:
-    case GateType::OBSERVABLE_INCLUDE:
-    case GateType::TICK:
-    case GateType::QUBIT_COORDS:
-    case GateType::SHIFT_COORDS:
-    case GateType::MPAD:
-    case GateType::H:
-    case GateType::DEPOLARIZE1:
-    case GateType::DEPOLARIZE2:
-    case GateType::Y_ERROR:
-    case GateType::I:
-    case GateType::Y:
-    case GateType::SQRT_YY:
-    case GateType::SQRT_YY_DAG:
-    case GateType::MYY:
-    case GateType::SWAP:
-        return id;
+        case GateType::DETECTOR:
+        case GateType::OBSERVABLE_INCLUDE:
+        case GateType::TICK:
+        case GateType::QUBIT_COORDS:
+        case GateType::SHIFT_COORDS:
+        case GateType::MPAD:
+        case GateType::H:
+        case GateType::DEPOLARIZE1:
+        case GateType::DEPOLARIZE2:
+        case GateType::Y_ERROR:
+        case GateType::I:
+        case GateType::Y:
+        case GateType::SQRT_YY:
+        case GateType::SQRT_YY_DAG:
+        case GateType::MYY:
+        case GateType::SWAP:
+            return id;
 
-    case GateType::MY:
-    case GateType::MRY:
-    case GateType::RY:
-    case GateType::YCY:
-        return ignoring_sign ? id : GateType::NOT_A_GATE;
+        case GateType::MY:
+        case GateType::MRY:
+        case GateType::RY:
+        case GateType::YCY:
+            return ignoring_sign ? id : GateType::NOT_A_GATE;
 
-    case GateType::ISWAP:
-    case GateType::CZSWAP:
-    case GateType::ISWAP_DAG:
-        return GateType::NOT_A_GATE;
+        case GateType::ISWAP:
+        case GateType::CZSWAP:
+        case GateType::ISWAP_DAG:
+            return GateType::NOT_A_GATE;
 
-    case GateType::XCY:
-        return ignoring_sign ? GateType::CY : GateType::NOT_A_GATE;
-    case GateType::CY:
-        return ignoring_sign ? GateType::XCY : GateType::NOT_A_GATE;
-    case GateType::YCX:
-        return ignoring_sign ? GateType::YCZ : GateType::NOT_A_GATE;
-    case GateType::YCZ:
-        return ignoring_sign ? GateType::YCX : GateType::NOT_A_GATE;
-    case GateType::C_XYZ:
-        return ignoring_sign ? GateType::C_ZYX : GateType::NOT_A_GATE;
-    case GateType::C_ZYX:
-        return ignoring_sign ? GateType::C_XYZ : GateType::NOT_A_GATE;
-    case GateType::H_XY:
-        return ignoring_sign ? GateType::H_YZ : GateType::NOT_A_GATE;
-    case GateType::H_YZ:
-        return ignoring_sign ? GateType::H_XY : GateType::NOT_A_GATE;
+        case GateType::XCY:
+            return ignoring_sign ? GateType::CY : GateType::NOT_A_GATE;
+        case GateType::CY:
+            return ignoring_sign ? GateType::XCY : GateType::NOT_A_GATE;
+        case GateType::YCX:
+            return ignoring_sign ? GateType::YCZ : GateType::NOT_A_GATE;
+        case GateType::YCZ:
+            return ignoring_sign ? GateType::YCX : GateType::NOT_A_GATE;
+        case GateType::C_XYZ:
+            return ignoring_sign ? GateType::C_ZYX : GateType::NOT_A_GATE;
+        case GateType::C_ZYX:
+            return ignoring_sign ? GateType::C_XYZ : GateType::NOT_A_GATE;
+        case GateType::H_XY:
+            return ignoring_sign ? GateType::H_YZ : GateType::NOT_A_GATE;
+        case GateType::H_YZ:
+            return ignoring_sign ? GateType::H_XY : GateType::NOT_A_GATE;
 
-    case GateType::X:
-        return GateType::Z;
-    case GateType::Z:
-        return GateType::X;
-    case GateType::SQRT_Y:
-        return GateType::SQRT_Y_DAG;
-    case GateType::SQRT_Y_DAG:
-        return GateType::SQRT_Y;
-    case GateType::MX:
-        return GateType::M;
-    case GateType::M:
-        return GateType::MX;
-    case GateType::MRX:
-        return GateType::MR;
-    case GateType::MR:
-        return GateType::MRX;
-    case GateType::RX:
-        return GateType::R;
-    case GateType::R:
-        return GateType::RX;
-    case GateType::XCX:
-        return GateType::CZ;
-    case GateType::XCZ:
-        return GateType::CX;
-    case GateType::CX:
-        return GateType::XCZ;
-    case GateType::CZ:
-        return GateType::XCX;
-    case GateType::X_ERROR:
-        return GateType::Z_ERROR;
-    case GateType::Z_ERROR:
-        return GateType::X_ERROR;
-    case GateType::SQRT_X:
-        return GateType::S;
-    case GateType::SQRT_X_DAG:
-        return GateType::S_DAG;
-    case GateType::S:
-        return GateType::SQRT_X;
-    case GateType::S_DAG:
-        return GateType::SQRT_X_DAG;
-    case GateType::SQRT_XX:
-        return GateType::SQRT_ZZ;
-    case GateType::SQRT_XX_DAG:
-        return GateType::SQRT_ZZ_DAG;
-    case GateType::SQRT_ZZ:
-        return GateType::SQRT_XX;
-    case GateType::SQRT_ZZ_DAG:
-        return GateType::SQRT_XX_DAG;
-    case GateType::CXSWAP:
-        return GateType::SWAPCX;
-    case GateType::SWAPCX:
-        return GateType::CXSWAP;
-    case GateType::MXX:
-        return GateType::MZZ;
-    case GateType::MZZ:
-        return GateType::MXX;
-    default:
-        return GateType::NOT_A_GATE;
+        case GateType::X:
+            return GateType::Z;
+        case GateType::Z:
+            return GateType::X;
+        case GateType::SQRT_Y:
+            return GateType::SQRT_Y_DAG;
+        case GateType::SQRT_Y_DAG:
+            return GateType::SQRT_Y;
+        case GateType::MX:
+            return GateType::M;
+        case GateType::M:
+            return GateType::MX;
+        case GateType::MRX:
+            return GateType::MR;
+        case GateType::MR:
+            return GateType::MRX;
+        case GateType::RX:
+            return GateType::R;
+        case GateType::R:
+            return GateType::RX;
+        case GateType::XCX:
+            return GateType::CZ;
+        case GateType::XCZ:
+            return GateType::CX;
+        case GateType::CX:
+            return GateType::XCZ;
+        case GateType::CZ:
+            return GateType::XCX;
+        case GateType::X_ERROR:
+            return GateType::Z_ERROR;
+        case GateType::Z_ERROR:
+            return GateType::X_ERROR;
+        case GateType::SQRT_X:
+            return GateType::S;
+        case GateType::SQRT_X_DAG:
+            return GateType::S_DAG;
+        case GateType::S:
+            return GateType::SQRT_X;
+        case GateType::S_DAG:
+            return GateType::SQRT_X_DAG;
+        case GateType::SQRT_XX:
+            return GateType::SQRT_ZZ;
+        case GateType::SQRT_XX_DAG:
+            return GateType::SQRT_ZZ_DAG;
+        case GateType::SQRT_ZZ:
+            return GateType::SQRT_XX;
+        case GateType::SQRT_ZZ_DAG:
+            return GateType::SQRT_XX_DAG;
+        case GateType::CXSWAP:
+            return GateType::SWAPCX;
+        case GateType::SWAPCX:
+            return GateType::CXSWAP;
+        case GateType::MXX:
+            return GateType::MZZ;
+        case GateType::MZZ:
+            return GateType::MXX;
+        default:
+            return GateType::NOT_A_GATE;
     }
 }
 

--- a/src/stim/gates/gates.test.cc
+++ b/src/stim/gates/gates.test.cc
@@ -22,8 +22,8 @@
 #include "stim/simulators/tableau_simulator.h"
 #include "stim/util_bot/str_util.h"
 #include "stim/util_bot/test_util.test.h"
-#include "stim/util_top/has_flow.h"
 #include "stim/util_top/circuit_flow_generators.h"
+#include "stim/util_top/has_flow.h"
 
 using namespace stim;
 
@@ -375,8 +375,10 @@ TEST(gate_data, hadamard_conjugated_vs_flow_generators_of_two_qubit_gates) {
             GateType actual_s = g.hadamard_conjugated(false);
             GateType actual_u = g.hadamard_conjugated(true);
             bool found = std::find(other_us.begin(), other_us.end(), actual_u) != other_us.end();
-            EXPECT_EQ(actual_s, expected_s) << "signed " << g.name << " -> " << GATE_DATA[actual_s].name << " != " << GATE_DATA[expected_s].name;
-            EXPECT_TRUE(found) << "unsigned " << g.name << " -> " << GATE_DATA[actual_u].name << " not in " << GATE_DATA[other_us[0]].name;
+            EXPECT_EQ(actual_s, expected_s)
+                << "signed " << g.name << " -> " << GATE_DATA[actual_s].name << " != " << GATE_DATA[expected_s].name;
+            EXPECT_TRUE(found) << "unsigned " << g.name << " -> " << GATE_DATA[actual_u].name << " not in "
+                               << GATE_DATA[other_us[0]].name;
         }
     }
 }

--- a/src/stim/simulators/error_analyzer.h
+++ b/src/stim/simulators/error_analyzer.h
@@ -329,7 +329,8 @@ struct ErrorAnalyzer {
     void undo_MXX_disjoint_controls_segment(const CircuitInstruction &inst);
     void undo_MYY_disjoint_controls_segment(const CircuitInstruction &inst);
     void undo_MZZ_disjoint_controls_segment(const CircuitInstruction &inst);
-    void check_can_approximate_disjoint(const char *op_name, SpanRef<const double> probabilities) const;
+    void check_can_approximate_disjoint(
+        const char *op_name, SpanRef<const double> probabilities, bool allow_single_component) const;
     void add_composite_error(double probability, SpanRef<const GateTarget> targets);
     void correlated_error_block(const std::vector<CircuitInstruction> &dats);
 };

--- a/src/stim/simulators/matched_error.pybind.cc
+++ b/src/stim/simulators/matched_error.pybind.cc
@@ -383,7 +383,8 @@ void stim_pybind::pybind_flipped_measurement_methods(
     });
     c.def(
         pybind11::init(
-            [](const pybind11::object &measurement_record_index, const pybind11::object &measured_observable) -> FlippedMeasurement {
+            [](const pybind11::object &measurement_record_index,
+               const pybind11::object &measured_observable) -> FlippedMeasurement {
                 uint64_t u;
                 if (measurement_record_index.is_none()) {
                     u = UINT64_MAX;

--- a/src/stim/util_top/circuit_to_dem.h
+++ b/src/stim/util_top/circuit_to_dem.h
@@ -1,0 +1,30 @@
+#ifndef _STIM_UTIL_TOP_CIRCUIT_TO_DEM_H
+#define _STIM_UTIL_TOP_CIRCUIT_TO_DEM_H
+
+#include "stim/simulators/error_analyzer.h"
+
+namespace stim {
+
+struct DemOptions {
+    bool decompose_errors = false;
+    bool flatten_loops = true;
+    bool allow_gauge_detectors = false;
+    double approximate_disjoint_errors_threshold = 0;
+    bool ignore_decomposition_failures = false;
+    bool block_decomposition_from_introducing_remnant_edges = false;
+};
+
+inline DetectorErrorModel circuit_to_dem(const Circuit &circuit, DemOptions options = {}) {
+    return ErrorAnalyzer::circuit_to_detector_error_model(
+        circuit,
+        options.decompose_errors,
+        !options.flatten_loops,
+        options.allow_gauge_detectors,
+        options.approximate_disjoint_errors_threshold,
+        options.ignore_decomposition_failures,
+        options.block_decomposition_from_introducing_remnant_edges);
+}
+
+}  // namespace stim
+
+#endif

--- a/src/stim/util_top/circuit_to_dem.test.cc
+++ b/src/stim/util_top/circuit_to_dem.test.cc
@@ -1,0 +1,115 @@
+#include "stim/util_top/circuit_to_dem.h"
+
+#include "gtest/gtest.h"
+
+using namespace stim;
+
+TEST(circuit_to_dem, heralded_noise_basis) {
+    ASSERT_EQ(
+        circuit_to_dem(Circuit(R"CIRCUIT(
+            MXX 0 1
+            MZZ 0 1
+            HERALDED_PAULI_CHANNEL_1(0.25, 0, 0, 0) 0
+            MXX 0 1
+            MZZ 0 1
+            DETECTOR(2) rec[-3]
+            DETECTOR(3) rec[-2] rec[-5]
+            DETECTOR(5) rec[-1] rec[-4]
+        )CIRCUIT")),
+        DetectorErrorModel(R"DEM(
+            error(0.25) D0
+            detector(2) D0
+            detector(3) D1
+            detector(5) D2
+        )DEM"));
+
+    ASSERT_EQ(
+        circuit_to_dem(Circuit(R"CIRCUIT(
+            MXX 0 1
+            MZZ 0 1
+            HERALDED_PAULI_CHANNEL_1(0, 0.25, 0, 0) 0
+            MXX 0 1
+            MZZ 0 1
+            DETECTOR(2) rec[-3]
+            DETECTOR(3) rec[-2] rec[-5]
+            DETECTOR(5) rec[-1] rec[-4]
+        )CIRCUIT")),
+        DetectorErrorModel(R"DEM(
+            error(0.25) D0 D2
+            detector(2) D0
+            detector(3) D1
+            detector(5) D2
+        )DEM"));
+
+    ASSERT_EQ(
+        circuit_to_dem(Circuit(R"CIRCUIT(
+            MXX 0 1
+            MZZ 0 1
+            HERALDED_PAULI_CHANNEL_1(0, 0, 0.25, 0) 0
+            MXX 0 1
+            MZZ 0 1
+            DETECTOR(2) rec[-3]
+            DETECTOR(3) rec[-2] rec[-5]
+            DETECTOR(5) rec[-1] rec[-4]
+        )CIRCUIT")),
+        DetectorErrorModel(R"DEM(
+            error(0.25) D0 D1 D2
+            detector(2) D0
+            detector(3) D1
+            detector(5) D2
+        )DEM"));
+
+    ASSERT_EQ(
+        circuit_to_dem(Circuit(R"CIRCUIT(
+            MXX 0 1
+            MZZ 0 1
+            HERALDED_PAULI_CHANNEL_1(0, 0, 0, 0.25) 0
+            MXX 0 1
+            MZZ 0 1
+            DETECTOR(2) rec[-3]
+            DETECTOR(3) rec[-2] rec[-5]
+            DETECTOR(5) rec[-1] rec[-4]
+        )CIRCUIT")),
+        DetectorErrorModel(R"DEM(
+            error(0.25) D0 D1
+            detector(2) D0
+            detector(3) D1
+            detector(5) D2
+        )DEM"));
+
+    ASSERT_EQ(
+        circuit_to_dem(
+            Circuit(R"CIRCUIT(
+            MXX 0 1
+            MZZ 0 1
+            HERALDED_PAULI_CHANNEL_1(0.125, 0, 0.25, 0) 0
+            MXX 0 1
+            MZZ 0 1
+            DETECTOR(2) rec[-3]
+            DETECTOR(3) rec[-2] rec[-5]
+            DETECTOR(5) rec[-1] rec[-4]
+        )CIRCUIT"),
+            {.approximate_disjoint_errors_threshold = 1}),
+        DetectorErrorModel(R"DEM(
+            error(0.125) D0
+            error(0.25) D0 D1 D2
+            detector(2) D0
+            detector(3) D1
+            detector(5) D2
+        )DEM"));
+
+    ASSERT_THROW(
+        {
+            circuit_to_dem(Circuit(R"CIRCUIT(
+            MXX 0 1
+            MZZ 0 1
+            HERALDED_PAULI_CHANNEL_1(0.125, 0, 0.25, 0) 0
+            MXX 0 1
+            MZZ 0 1
+            DETECTOR(2) rec[-3]
+            DETECTOR(3) rec[-2] rec[-5]
+            DETECTOR(5) rec[-1] rec[-4]
+        )CIRCUIT"));
+        },
+        std::invalid_argument);
+}

--- a/src/stim/util_top/circuit_vs_amplitudes.cc
+++ b/src/stim/util_top/circuit_vs_amplitudes.cc
@@ -1,9 +1,9 @@
 #include "stim/util_top/circuit_vs_amplitudes.h"
 
-#include "stim/util_top/circuit_inverse_unitary.h"
 #include "stim/simulators/tableau_simulator.h"
 #include "stim/simulators/vector_simulator.h"
 #include "stim/util_bot/twiddle.h"
+#include "stim/util_top/circuit_inverse_unitary.h"
 
 using namespace stim;
 


### PR DESCRIPTION
- :foreheadslap:
- autoformat
- Add `stim::circuit_to_dem` to the C++ API for easier conversions with named arguments via a struct
- There was a unit test checking this... but it was also permuted. Added unit tests that check it channel by channel.