### PR TITLE
Fixing Extra Semicolon

### DIFF
--- a/src/stim/diagram/json_obj.cc
+++ b/src/stim/diagram/json_obj.cc
@@ -48,8 +48,8 @@ JsonObj::JsonObj(std::map<std::string, JsonObj> map) : map(map), type(JsonTypeMa
 }
 
 JsonObj::JsonObj(std::vector<JsonObj> arr) : arr(arr), type(JsonTypeArray) {
+}
 
-};
 JsonObj::JsonObj(bool boolean) : val_boolean(boolean), type(JsonTypeBool) {
 }
 


### PR DESCRIPTION
* Removing unnecessary `;` on `JsonObj::JsonObj(std::vector<JsonObj>)`.
  * Trips off `-Wpedantic` and other warnings.
* Fixing newlines around function definition.