### PR TITLE
Fix odd-target-count-for-two-qubit-gate error message

### DIFF
--- a/src/stim/circuit/circuit_instruction.cc
+++ b/src/stim/circuit/circuit_instruction.cc
@@ -138,7 +138,7 @@ void CircuitInstruction::validate() const {
                     "Two qubit gate " + std::string(gate.name) +
                     " requires an even number of targets but was given "
                     "(" +
-                    comma_sep(args).str() + ").");
+                    comma_sep(targets).str() + ").");
             }
             for (size_t k = 0; k < targets.size(); k += 2) {
                 if (targets[k] == targets[k + 1]) {

--- a/src/stim/circuit/circuit_pybind_test.py
+++ b/src/stim/circuit/circuit_pybind_test.py
@@ -1879,3 +1879,8 @@ def test_insert():
         M 2
         H 1
     """)
+
+
+def test_circuit_create_with_odd_cx():
+    with pytest.raises(ValueError, match="0, 1, 2"):
+        stim.Circuit("CX 0 1 2")


### PR DESCRIPTION
- Was writing the arguments instead of the targets into the message

Fixes https://github.com/quantumlib/Stim/issues/817