### PR TITLE
Fix docstring typo in `to_qasm`

### DIFF
--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -3339,8 +3339,8 @@ def to_qasm(
             This should be set to 2 or to 3.
 
             Differences between the versions are:
-                - Support for operations on classical bits operations (only version
-                    3). This means DETECTOR and OBSERVABLE_INCLUDE only work with
+                - Support for operations on classical bits (only version 3).
+                    This means DETECTOR and OBSERVABLE_INCLUDE only work with
                     version 3.
                 - Support for feedback operations (only version 3).
                 - Support for subroutines (only version 3). Without subroutines,

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -2573,8 +2573,8 @@ class Circuit:
                 This should be set to 2 or to 3.
 
                 Differences between the versions are:
-                    - Support for operations on classical bits operations (only version
-                        3). This means DETECTOR and OBSERVABLE_INCLUDE only work with
+                    - Support for operations on classical bits (only version 3).
+                        This means DETECTOR and OBSERVABLE_INCLUDE only work with
                         version 3.
                     - Support for feedback operations (only version 3).
                     - Support for subroutines (only version 3). Without subroutines,

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -2573,8 +2573,8 @@ class Circuit:
                 This should be set to 2 or to 3.
 
                 Differences between the versions are:
-                    - Support for operations on classical bits operations (only version
-                        3). This means DETECTOR and OBSERVABLE_INCLUDE only work with
+                    - Support for operations on classical bits (only version 3).
+                        This means DETECTOR and OBSERVABLE_INCLUDE only work with
                         version 3.
                     - Support for feedback operations (only version 3).
                     - Support for subroutines (only version 3). Without subroutines,

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -1663,8 +1663,8 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
                     This should be set to 2 or to 3.
 
                     Differences between the versions are:
-                        - Support for operations on classical bits operations (only version
-                            3). This means DETECTOR and OBSERVABLE_INCLUDE only work with
+                        - Support for operations on classical bits (only version 3).
+                            This means DETECTOR and OBSERVABLE_INCLUDE only work with
                             version 3.
                         - Support for feedback operations (only version 3).
                         - Support for subroutines (only version 3). Without subroutines,


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Stim/issues/691