### PR TITLE
Remove the constraint that stim.Tableau.from_state_vector inputs must be normalized

### DIFF
--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -11665,7 +11665,7 @@ def from_state_vector(
     Args:
         state_vector: A list of complex amplitudes specifying a superposition. The
             vector must correspond to a state that is reachable using Clifford
-            operations, and must be normalized (i.e. it must be a unit vector).
+            operations, and can be unnormalized.
         endian:
             "little": state vector is in little endian order, where higher index
                 qubits correspond to larger changes in the state index.

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -9169,7 +9169,7 @@ class Tableau:
         Args:
             state_vector: A list of complex amplitudes specifying a superposition. The
                 vector must correspond to a state that is reachable using Clifford
-                operations, and must be normalized (i.e. it must be a unit vector).
+                operations, and can be unnormalized.
             endian:
                 "little": state vector is in little endian order, where higher index
                     qubits correspond to larger changes in the state index.

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -9169,7 +9169,7 @@ class Tableau:
         Args:
             state_vector: A list of complex amplitudes specifying a superposition. The
                 vector must correspond to a state that is reachable using Clifford
-                operations, and must be normalized (i.e. it must be a unit vector).
+                operations, and can be unnormalized.
             endian:
                 "little": state vector is in little endian order, where higher index
                     qubits correspond to larger changes in the state index.

--- a/src/stim/stabilizers/tableau.pybind.cc
+++ b/src/stim/stabilizers/tableau.pybind.cc
@@ -2130,16 +2130,8 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
             }
 
             std::vector<std::complex<float>> v;
-            double weight = 0;
             for (const auto &obj : state_vector) {
                 v.push_back(pybind11::cast<std::complex<float>>(obj));
-                weight += std::norm(v.back());
-            }
-            if (weight != 1.0 && weight > 0.0) {
-                std::complex<float> scale = (float)sqrt(1.0 / weight);
-                for (auto &amplitude : v) {
-                    amplitude *= scale;
-                }
             }
 
             return circuit_to_tableau<MAX_BITWORD_WIDTH>(
@@ -2155,7 +2147,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
             Args:
                 state_vector: A list of complex amplitudes specifying a superposition. The
                     vector must correspond to a state that is reachable using Clifford
-                    operations.
+                    operations, and can be unnormalized.
                 endian:
                     "little": state vector is in little endian order, where higher index
                         qubits correspond to larger changes in the state index.

--- a/src/stim/stabilizers/tableau.pybind.cc
+++ b/src/stim/stabilizers/tableau.pybind.cc
@@ -2130,8 +2130,16 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
             }
 
             std::vector<std::complex<float>> v;
+            double weight = 0;
             for (const auto &obj : state_vector) {
                 v.push_back(pybind11::cast<std::complex<float>>(obj));
+                weight += std::norm(v.back());
+            }
+            if (weight != 1.0 && weight > 0.0) {
+                std::complex<float> scale = (float)sqrt(1.0 / weight);
+                for (auto &amplitude : v) {
+                    amplitude *= scale;
+                }
             }
 
             return circuit_to_tableau<MAX_BITWORD_WIDTH>(
@@ -2147,7 +2155,7 @@ void stim_pybind::pybind_tableau_methods(pybind11::module &m, pybind11::class_<T
             Args:
                 state_vector: A list of complex amplitudes specifying a superposition. The
                     vector must correspond to a state that is reachable using Clifford
-                    operations, and must be normalized (i.e. it must be a unit vector).
+                    operations.
                 endian:
                     "little": state vector is in little endian order, where higher index
                         qubits correspond to larger changes in the state index.

--- a/src/stim/stabilizers/tableau_pybind_test.py
+++ b/src/stim/stabilizers/tableau_pybind_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import random
 import re
 
 import numpy as np
@@ -57,18 +58,12 @@ def test_from_named_gate():
         stim.Tableau.from_named_gate("X_ERROR")
 
 
-def test_from_state_vector():
-    t = stim.Tableau.from_state_vector([
-        0.5**0.5,
-        0,
-        0,
-        0.5**0.5,
-    ], endian='little')
-    assert len(t) == 2
-    assert t.x_output(0) == stim.PauliString("Z_")
-    assert t.x_output(1) == stim.PauliString("_X")
-    assert t.z_output(0) == stim.PauliString("XX")
-    assert t.z_output(1) == stim.PauliString("ZZ")
+def test_from_state_vector_fuzz():
+    for n in range(1, 7):
+        t = stim.Tableau.random(n)
+        v = t.to_state_vector() * (random.random() + 1j*random.random())
+        t2 = stim.Tableau.from_state_vector(v, endian='little')
+        np.testing.assert_array_equal(t.to_stabilizers(canonicalize=True), t2.to_stabilizers(canonicalize=True))
 
 
 def test_identity():

--- a/src/stim/stabilizers/tableau_pybind_test.py
+++ b/src/stim/stabilizers/tableau_pybind_test.py
@@ -1,3 +1,5 @@
+# Copyright 2021 Google LLC
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -54,6 +56,7 @@ def test_from_named_gate():
     with pytest.raises(IndexError, match="not unitary"):
         stim.Tableau.from_named_gate("X_ERROR")
 
+
 def test_from_state_vector():
     t = stim.Tableau.from_state_vector([
         0.5**0.5,
@@ -66,14 +69,6 @@ def test_from_state_vector():
     assert t.x_output(1) == stim.PauliString("_X")
     assert t.z_output(0) == stim.PauliString("XX")
     assert t.z_output(1) == stim.PauliString("ZZ")
-
-    unnormalized = stim.Tableau.from_state_vector([
-        1,
-        0,
-        0,
-        1
-    ], endian='little')
-    assert unnormalized == t
 
 
 def test_identity():

--- a/src/stim/stabilizers/tableau_pybind_test.py
+++ b/src/stim/stabilizers/tableau_pybind_test.py
@@ -1,5 +1,3 @@
-# Copyright 2021 Google LLC
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -55,6 +53,27 @@ def test_from_named_gate():
         stim.Tableau.from_named_gate("not a gate")
     with pytest.raises(IndexError, match="not unitary"):
         stim.Tableau.from_named_gate("X_ERROR")
+
+def test_from_state_vector():
+    t = stim.Tableau.from_state_vector([
+        0.5**0.5,
+        0,
+        0,
+        0.5**0.5,
+    ], endian='little')
+    assert len(t) == 2
+    assert t.x_output(0) == stim.PauliString("Z_")
+    assert t.x_output(1) == stim.PauliString("_X")
+    assert t.z_output(0) == stim.PauliString("XX")
+    assert t.z_output(1) == stim.PauliString("ZZ")
+
+    unnormalized = stim.Tableau.from_state_vector([
+        1,
+        0,
+        0,
+        1
+    ], endian='little')
+    assert unnormalized == t
 
 
 def test_identity():

--- a/src/stim/util_top/circuit_vs_amplitudes.cc
+++ b/src/stim/util_top/circuit_vs_amplitudes.cc
@@ -40,15 +40,6 @@ Circuit stim::stabilizer_state_vector_to_circuit(
     }
 
     uint8_t num_qubits = floor_lg2(state_vector.size());
-    double weight = 0;
-    for (const auto &c : state_vector) {
-        weight += std::norm(c);
-    }
-    if (abs(weight - 1) > 0.125) {
-        throw std::invalid_argument(
-            "The given state vector wasn't a unit vector. It had a length of " + std::to_string(weight) + ".");
-    }
-
     VectorSimulator sim(num_qubits);
     sim.state = state_vector;
 
@@ -73,7 +64,7 @@ Circuit stim::stabilizer_state_vector_to_circuit(
             {});
     };
 
-    // Move biggest amplitude to start of state vector..
+    // Move biggest amplitude to start of state vector.
     size_t pivot = biggest_index(state_vector);
     for (size_t q = 0; q < num_qubits; q++) {
         if ((pivot >> q) & 1) {

--- a/src/stim/util_top/circuit_vs_amplitudes.h
+++ b/src/stim/util_top/circuit_vs_amplitudes.h
@@ -8,7 +8,8 @@ namespace stim {
 /// Synthesizes a circuit to generate the given state vector.
 ///
 /// Args:
-///     stabilizer_state_vector: The vector of amplitudes to produce using a circuit.
+///     stabilizer_state_vector: The vector of amplitudes to produce using a circuit. Does not need to be a unit vector,
+///     but must be non-zero.
 ///     little_endian: Whether the vector is using little endian or big endian ordering.
 ///     inverted_circuit: If false, returns a circuit that sends |000...0> to the state vector.
 ///         If true, returns a circuit that sends the state vector to |000...0> instead of a cir.


### PR DESCRIPTION
Just taking a stab at fixing https://github.com/quantumlib/Stim/issues/638. Note, I don't fully understand how Tableau should work but I wrote the tests based on the examples, so I think this should be correct.

- Adds normalization code by scaling each amplitude by the square root of the inverse of the state vector norm
- Adds tests to match the examples from `from_state_vector` including an unnormalized version