### PR TITLE
Fix exception when sampling with post-selection

### DIFF
--- a/glue/sample/src/sinter/_decoding/_stim_then_decode_sampler.py
+++ b/glue/sample/src/sinter/_decoding/_stim_then_decode_sampler.py
@@ -197,8 +197,8 @@ class _CompiledStimThenDecodeSampler(CompiledSampler):
             raise ValueError("predictions.dtype != np.uint8")
         if len(predictions.shape) != 2:
             raise ValueError("len(predictions.shape) != 2")
-        if predictions.shape[0] != num_shots:
-            raise ValueError("predictions.shape[0] != num_shots")
+        if predictions.shape[0] != num_shots - num_discards_1:
+            raise ValueError("predictions.shape[0] != num_shots - num_discards_1")
         if predictions.shape[1] < actual_obs.shape[1]:
             raise ValueError("predictions.shape[1] < actual_obs.shape[1]")
         if predictions.shape[1] > actual_obs.shape[1] + 1:


### PR DESCRIPTION
Calling sinter.collect() for tasks including a postselection_mask raises an exception. This is caused because the decoder predictions are compared to the total number of shots without excluding discarded shots.