### PR TITLE
Fix observable predictions shape in sinter's MWPF and FussionBlossom decoder

### DIFF
--- a/glue/sample/src/sinter/_decoding/_decoding_fusion_blossom.py
+++ b/glue/sample/src/sinter/_decoding/_decoding_fusion_blossom.py
@@ -24,7 +24,7 @@ class FusionBlossomCompiledDecoder(CompiledDecoder):
             bit_packed_detection_event_data: 'np.ndarray',
     ) -> 'np.ndarray':
         num_shots = bit_packed_detection_event_data.shape[0]
-        predictions = np.zeros(shape=(num_shots, self.num_obs), dtype=np.uint8)
+        predictions = np.zeros(shape=(num_shots, (self.num_obs + 7) // 8), dtype=np.uint8)
         import fusion_blossom
         for shot in range(num_shots):
             dets_sparse = np.flatnonzero(np.unpackbits(bit_packed_detection_event_data[shot], count=self.num_dets, bitorder='little'))

--- a/glue/sample/src/sinter/_decoding/_decoding_mwpf.py
+++ b/glue/sample/src/sinter/_decoding/_decoding_mwpf.py
@@ -38,7 +38,7 @@ class MwpfCompiledDecoder(CompiledDecoder):
         bit_packed_detection_event_data: "np.ndarray",
     ) -> "np.ndarray":
         num_shots = bit_packed_detection_event_data.shape[0]
-        predictions = np.zeros(shape=(num_shots, self.num_obs), dtype=np.uint8)
+        predictions = np.zeros(shape=(num_shots, (self.num_obs + 7) // 8), dtype=np.uint8)
         import mwpf
 
         for shot in range(num_shots):


### PR DESCRIPTION
The packed obs predictions should be of shape `(num_shots, (self.num_obs + 7) // 8)` instead of `(num_shots, self.num_obs)`, which results in error `ValueError: predictions.shape[1] > actual_obs.shape[1] + 1` when simulating codes with multiple logical observables.