### PR TITLE
Add stimcirq tag conversions

### DIFF
--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -831,6 +831,8 @@ def append(
     name: str,
     targets: Union[int, stim.GateTarget, Iterable[Union[int, stim.GateTarget]]],
     arg: Union[float, Iterable[float]],
+    *,
+    tag: str = "",
 ) -> None:
     pass
 @overload
@@ -844,6 +846,8 @@ def append(
     name: object,
     targets: object = (),
     arg: object = None,
+    *,
+    tag: str = '',
 ) -> None:
     """Appends an operation into the circuit.
 
@@ -894,6 +898,7 @@ def append(
             compatibility reasons, `cirq.append_operation` (but not
             `cirq.append`) will default to a single 0.0 argument for gates that
             take exactly one argument.
+        tag: A customizable string attached to the instruction.
     """
 ```
 

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -303,6 +303,8 @@ class Circuit:
         name: str,
         targets: Union[int, stim.GateTarget, Iterable[Union[int, stim.GateTarget]]],
         arg: Union[float, Iterable[float]],
+        *,
+        tag: str = "",
     ) -> None:
         pass
     @overload
@@ -316,6 +318,8 @@ class Circuit:
         name: object,
         targets: object = (),
         arg: object = None,
+        *,
+        tag: str = '',
     ) -> None:
         """Appends an operation into the circuit.
 
@@ -366,6 +370,7 @@ class Circuit:
                 compatibility reasons, `cirq.append_operation` (but not
                 `cirq.append`) will default to a single 0.0 argument for gates that
                 take exactly one argument.
+            tag: A customizable string attached to the instruction.
         """
     def append_from_stim_program_text(
         self,
@@ -398,6 +403,8 @@ class Circuit:
         name: object,
         targets: object = (),
         arg: object = None,
+        *,
+        tag: str = '',
     ) -> None:
         """[DEPRECATED] use stim.Circuit.append instead
         """

--- a/glue/cirq/stimcirq/_cirq_to_stim.py
+++ b/glue/cirq/stimcirq/_cirq_to_stim.py
@@ -150,7 +150,7 @@ def gate_to_stim_append_func() -> Dict[cirq.Gate, Callable[[stim.Circuit, List[i
     ny = (cirq.Y, True)
     nz = (cirq.Z, True)
 
-    def do_nothing(_gates, _targets, _tag):
+    def do_nothing(_gates, _targets, tag):
         pass
 
     def use(

--- a/glue/cirq/stimcirq/_cirq_to_stim.py
+++ b/glue/cirq/stimcirq/_cirq_to_stim.py
@@ -7,8 +7,18 @@ import cirq
 import stim
 
 
+def _forward_single_str_tag(op: cirq.CircuitOperation) -> str:
+    tags = [tag for tag in op.tags if isinstance(tag, str)]
+    if len(tags) == 1:
+        return tags[0]
+    return ""
+
+
 def cirq_circuit_to_stim_circuit(
-    circuit: cirq.AbstractCircuit, *, qubit_to_index_dict: Optional[Dict[cirq.Qid, int]] = None
+    circuit: cirq.AbstractCircuit,
+    *,
+    qubit_to_index_dict: Optional[Dict[cirq.Qid, int]] = None,
+    tag_func: Callable[[cirq.Operation], str] = _forward_single_str_tag,
 ) -> stim.Circuit:
     """Converts a cirq circuit into an equivalent stim circuit.
 
@@ -33,6 +43,10 @@ def cirq_circuit_to_stim_circuit(
         circuit: The circuit to convert.
         qubit_to_index_dict: Optional. Which integer each qubit should get mapped to. If not specified, defaults to
             indexing qubits in the circuit in sorted order.
+        tag_func: Controls the tag attached to the stim instructions the cirq operation turns
+            into. If not specified, defaults to checking for string tags on the circuit operation
+            and if there is exactly one string tag then using that tag (otherwise not specifying a
+            tag).
 
     Returns:
         The converted circuit.
@@ -85,21 +99,29 @@ def cirq_circuit_to_stim_circuit(
                 # The indices of qubits the gate is operating on.
                 targets: List[int],
 
+                # A custom string associated with the operation, which can be tagged
+                # onto any operations appended to the stim circuit.
+                tag: str,
+
                 # Forward compatibility with future arguments.
                 **kwargs):
 
             edit_circuit.append_operation("H", targets)
     """
-    return cirq_circuit_to_stim_data(circuit, q2i=qubit_to_index_dict, flatten=False)[0]
+    return cirq_circuit_to_stim_data(circuit, q2i=qubit_to_index_dict, flatten=False, tag_func=tag_func)[0]
 
 
 def cirq_circuit_to_stim_data(
-    circuit: cirq.AbstractCircuit, *, q2i: Optional[Dict[cirq.Qid, int]] = None, flatten: bool = False,
+    circuit: cirq.AbstractCircuit,
+    *,
+    q2i: Optional[Dict[cirq.Qid, int]] = None,
+    flatten: bool = False,
+    tag_func: Callable[[cirq.Operation], str] = _forward_single_str_tag,
 ) -> Tuple[stim.Circuit, List[Tuple[str, int]]]:
     """Converts a Cirq circuit into a Stim circuit and also metadata about where measurements go."""
     if q2i is None:
         q2i = {q: i for i, q in enumerate(sorted(circuit.all_qubits()))}
-    helper = CirqToStimHelper()
+    helper = CirqToStimHelper(tag_func=tag_func)
     helper.q2i = q2i
     helper.flatten = flatten
 
@@ -115,11 +137,11 @@ def cirq_circuit_to_stim_data(
     return helper.out, helper.key_out
 
 
-StimTypeHandler = Callable[[stim.Circuit, cirq.Gate, List[int]], None]
+StimTypeHandler = Callable[[stim.Circuit, cirq.Gate, List[int], str], None]
 
 
 @functools.lru_cache(maxsize=1)
-def gate_to_stim_append_func() -> Dict[cirq.Gate, Callable[[stim.Circuit, List[int]], None]]:
+def gate_to_stim_append_func() -> Dict[cirq.Gate, Callable[[stim.Circuit, List[int], str], None]]:
     """A dictionary mapping specific gate instances to stim circuit appending functions."""
     x = (cirq.X, False)
     y = (cirq.Y, False)
@@ -128,29 +150,29 @@ def gate_to_stim_append_func() -> Dict[cirq.Gate, Callable[[stim.Circuit, List[i
     ny = (cirq.Y, True)
     nz = (cirq.Z, True)
 
-    def do_nothing(c, t):
+    def do_nothing(_gates, _targets, _tag):
         pass
 
     def use(
         *gates: str, individuals: Sequence[Tuple[str, int]] = ()
-    ) -> Callable[[stim.Circuit, List[int]], None]:
+    ) -> Callable[[stim.Circuit, List[int], str], None]:
         if len(gates) == 1 and not individuals:
             (g,) = gates
-            return lambda c, t: c.append_operation(g, t)
+            return lambda c, t, tag: c.append(g, t, tag=tag)
 
         if not individuals:
 
-            def do(c, t):
+            def do(c, t, tag: str):
                 for g in gates:
-                    c.append_operation(g, t)
+                    c.append(g, t, tag=tag)
 
         else:
 
-            def do(c, t):
+            def do(c, t, tag: str):
                 for g in gates:
-                    c.append_operation(g, t)
+                    c.append(g, t, tag=tag)
                 for g, k in individuals:
-                    c.append_operation(g, [t[k]])
+                    c.append(g, [t[k]], tag=tag)
 
         return do
 
@@ -238,14 +260,14 @@ def gate_type_to_stim_append_func() -> Dict[Type[cirq.Gate], StimTypeHandler]:
         cirq.AsymmetricDepolarizingChannel: cast(
             StimTypeHandler, _stim_append_asymmetric_depolarizing_channel
         ),
-        cirq.BitFlipChannel: lambda c, g, t: c.append_operation(
-            "X_ERROR", t, cast(cirq.BitFlipChannel, g).p
+        cirq.BitFlipChannel: lambda c, g, t, tag: c.append(
+            "X_ERROR", t, cast(cirq.BitFlipChannel, g).p, tag=tag
         ),
-        cirq.PhaseFlipChannel: lambda c, g, t: c.append_operation(
-            "Z_ERROR", t, cast(cirq.PhaseFlipChannel, g).p
+        cirq.PhaseFlipChannel: lambda c, g, t, tag: c.append(
+            "Z_ERROR", t, cast(cirq.PhaseFlipChannel, g).p, tag=tag
         ),
-        cirq.PhaseDampingChannel: lambda c, g, t: c.append_operation(
-            "Z_ERROR", t, 0.5 - math.sqrt(1 - cast(cirq.PhaseDampingChannel, g).gamma) / 2
+        cirq.PhaseDampingChannel: lambda c, g, t, tag: c.append(
+            "Z_ERROR", t, 0.5 - math.sqrt(1 - cast(cirq.PhaseDampingChannel, g).gamma) / 2, tag=tag
         ),
         cirq.RandomGateChannel: cast(StimTypeHandler, _stim_append_random_gate_channel),
         cirq.DepolarizingChannel: cast(StimTypeHandler, _stim_append_depolarizing_channel),
@@ -253,16 +275,16 @@ def gate_type_to_stim_append_func() -> Dict[Type[cirq.Gate], StimTypeHandler]:
 
 
 def _stim_append_measurement_gate(
-    circuit: stim.Circuit, gate: cirq.MeasurementGate, targets: List[int]
+    circuit: stim.Circuit, gate: cirq.MeasurementGate, targets: List[int], tag: str
 ):
     for i, b in enumerate(gate.invert_mask):
         if b:
             targets[i] = stim.target_inv(targets[i])
-    circuit.append_operation("M", targets)
+    circuit.append("M", targets, tag=tag)
 
 
 def _stim_append_pauli_measurement_gate(
-    circuit: stim.Circuit, gate: cirq.PauliMeasurementGate, targets: List[int]
+    circuit: stim.Circuit, gate: cirq.PauliMeasurementGate, targets: List[int], tag: str
 ):
     obs: cirq.DensePauliString = gate.observable()
 
@@ -287,11 +309,11 @@ def _stim_append_pauli_measurement_gate(
     if obs.coefficient != 1 and obs.coefficient != -1:
         raise NotImplementedError(f"obs.coefficient={obs.coefficient!r} not in [1, -1]")
 
-    circuit.append_operation("MPP", new_targets)
+    circuit.append("MPP", new_targets, tag=tag)
 
 
 def _stim_append_spp_gate(
-    circuit: stim.Circuit, gate: cirq.PauliStringPhasorGate, targets: List[int]
+    circuit: stim.Circuit, gate: cirq.PauliStringPhasorGate, targets: List[int], tag: str
 ):
     obs: cirq.DensePauliString = gate.dense_pauli_string
     a = gate.exponent_neg
@@ -312,26 +334,26 @@ def _stim_append_spp_gate(
         return False
     new_targets.pop()
 
-    circuit.append_operation("SPP" if d == 0.5 else "SPP_DAG", new_targets)
+    circuit.append("SPP" if d == 0.5 else "SPP_DAG", new_targets, tag=tag)
     return True
 
 
 def _stim_append_dense_pauli_string_gate(
-    c: stim.Circuit, g: cirq.BaseDensePauliString, t: List[int]
+    c: stim.Circuit, g: cirq.BaseDensePauliString, t: List[int], tag: str
 ):
     gates = [None, "X", "Y", "Z"]
     for p, k in zip(g.pauli_mask, t):
         if p:
-            c.append_operation(gates[p], [k])
+            c.append(gates[p], [k], tag=tag)
 
 
 def _stim_append_asymmetric_depolarizing_channel(
-    c: stim.Circuit, g: cirq.AsymmetricDepolarizingChannel, t: List[int]
+    c: stim.Circuit, g: cirq.AsymmetricDepolarizingChannel, t: List[int], tag: str
 ):
     if cirq.num_qubits(g) == 1:
-        c.append_operation("PAULI_CHANNEL_1", t, [g.p_x, g.p_y, g.p_z])
+        c.append("PAULI_CHANNEL_1", t, [g.p_x, g.p_y, g.p_z], tag=tag)
     elif cirq.num_qubits(g) == 2:
-        c.append_operation(
+        c.append(
             "PAULI_CHANNEL_2",
             t,
             [
@@ -350,33 +372,34 @@ def _stim_append_asymmetric_depolarizing_channel(
                 g.error_probabilities.get('ZX', 0),
                 g.error_probabilities.get('ZY', 0),
                 g.error_probabilities.get('ZZ', 0),
-            ]
+            ],
+            tag=tag,
         )
     else:
         raise NotImplementedError(f'cirq-to-stim gate {g!r}')
 
 
-def _stim_append_depolarizing_channel(c: stim.Circuit, g: cirq.DepolarizingChannel, t: List[int]):
+def _stim_append_depolarizing_channel(c: stim.Circuit, g: cirq.DepolarizingChannel, t: List[int], tag: str):
     if g.num_qubits() == 1:
-        c.append_operation("DEPOLARIZE1", t, g.p)
+        c.append("DEPOLARIZE1", t, g.p, tag=tag)
     elif g.num_qubits() == 2:
-        c.append_operation("DEPOLARIZE2", t, g.p)
+        c.append("DEPOLARIZE2", t, g.p, tag=tag)
     else:
         raise TypeError(f"Don't know how to turn {g!r} into Stim operations.")
 
 
-def _stim_append_controlled_gate(c: stim.Circuit, g: cirq.ControlledGate, t: List[int]):
+def _stim_append_controlled_gate(c: stim.Circuit, g: cirq.ControlledGate, t: List[int], tag: str):
     if isinstance(g.sub_gate, cirq.BaseDensePauliString) and g.num_controls() == 1:
         gates = [None, "CX", "CY", "CZ"]
         for p, k in zip(g.sub_gate.pauli_mask, t[1:]):
             if p:
-                c.append_operation(gates[p], [t[0], k])
+                c.append(gates[p], [t[0], k], tag=tag)
         if g.sub_gate.coefficient == 1j:
-            c.append_operation("S", t[:1])
+            c.append("S", t[:1], tag=tag)
         elif g.sub_gate.coefficient == -1:
-            c.append_operation("Z", t[:1])
+            c.append("Z", t[:1], tag=tag)
         elif g.sub_gate.coefficient == -1j:
-            c.append_operation("S_DAG", t[:1])
+            c.append("S_DAG", t[:1], tag=tag)
         elif g.sub_gate.coefficient == 1:
             pass
         else:
@@ -386,13 +409,13 @@ def _stim_append_controlled_gate(c: stim.Circuit, g: cirq.ControlledGate, t: Lis
     raise TypeError(f"Don't know how to turn controlled gate {g!r} into Stim operations.")
 
 
-def _stim_append_random_gate_channel(c: stim.Circuit, g: cirq.RandomGateChannel, t: List[int]):
+def _stim_append_random_gate_channel(c: stim.Circuit, g: cirq.RandomGateChannel, t: List[int], tag: str):
     if g.sub_gate in [cirq.X, cirq.Y, cirq.Z]:
-        c.append_operation(f"{g.sub_gate}_ERROR", t, g.probability)
+        c.append(f"{g.sub_gate}_ERROR", t, g.probability, tag=tag)
     elif isinstance(g.sub_gate, cirq.DensePauliString):
         target_p = [None, stim.target_x, stim.target_y, stim.target_z]
         pauli_targets = [target_p[p](t) for t, p in zip(t, g.sub_gate.pauli_mask) if p]
-        c.append_operation(f"CORRELATED_ERROR", pauli_targets, g.probability)
+        c.append(f"CORRELATED_ERROR", pauli_targets, g.probability, tag=tag)
     else:
         raise NotImplementedError(
             f"Don't know how to turn probabilistic {g!r} into Stim operations."
@@ -400,33 +423,35 @@ def _stim_append_random_gate_channel(c: stim.Circuit, g: cirq.RandomGateChannel,
 
 
 class CirqToStimHelper:
-    def __init__(self):
+    def __init__(self, tag_func: Callable[[cirq.Operation], str]):
         self.key_out: List[Tuple[str, int]] = []
         self.out = stim.Circuit()
         self.q2i = {}
         self.have_seen_loop = False
         self.flatten = False
+        self.tag_func = tag_func
 
-    def process_circuit_operation_into_repeat_block(self, op: cirq.CircuitOperation) -> None:
+    def process_circuit_operation_into_repeat_block(self, op: cirq.CircuitOperation, tag: str) -> None:
         if self.flatten or op.repetitions == 1:
             moments = cirq.unroll_circuit_op(cirq.Circuit(op), deep=False, tags_to_check=None).moments
             self.process_moments(moments)
             self.out = self.out[:-1] # Remove a trailing TICK (to avoid double TICK)
             return
 
-        child = CirqToStimHelper()
+        child = CirqToStimHelper(tag_func=self.tag_func)
         child.key_out = self.key_out
         child.q2i = self.q2i
         child.have_seen_loop = True
         self.have_seen_loop = True
         child.process_moments(op.transform_qubits(lambda q: op.qubit_map.get(q, q)).circuit)
-        self.out += child.out * op.repetitions
+        self.out.append(stim.CircuitRepeatBlock(op.repetitions, child.out, tag=tag))
 
     def process_operations(self, operations: Iterable[cirq.Operation]) -> None:
         g2f = gate_to_stim_append_func()
         t2f = gate_type_to_stim_append_func()
         for op in operations:
             assert isinstance(op, cirq.Operation)
+            tag = self.tag_func(op)
             op = op.untagged
             gate = op.gate
             targets = [self.q2i[q] for q in op.qubits]
@@ -441,36 +466,37 @@ class CirqToStimHelper:
                     edit_measurement_key_lengths=self.key_out,
                     targets=targets,
                     have_seen_loop=self.have_seen_loop,
+                    tag=tag,
                 )
                 continue
 
             if isinstance(op, cirq.CircuitOperation):
-                self.process_circuit_operation_into_repeat_block(op)
+                self.process_circuit_operation_into_repeat_block(op, tag=tag)
                 continue
 
             # Special case measurement, because of its metadata.
             if isinstance(gate, cirq.PauliStringPhasorGate):
-                if _stim_append_spp_gate(self.out, gate, targets):
+                if _stim_append_spp_gate(self.out, gate, targets, tag=tag):
                     continue
             if isinstance(gate, cirq.PauliMeasurementGate):
                 self.key_out.append((gate.key, len(targets)))
-                _stim_append_pauli_measurement_gate(self.out, gate, targets)
+                _stim_append_pauli_measurement_gate(self.out, gate, targets, tag=tag)
                 continue
             if isinstance(gate, cirq.MeasurementGate):
                 self.key_out.append((gate.key, len(targets)))
-                _stim_append_measurement_gate(self.out, gate, targets)
+                _stim_append_measurement_gate(self.out, gate, targets, tag=tag)
                 continue
 
             # Look for recognized gate values like cirq.H.
             val_append_func = g2f.get(gate)
             if val_append_func is not None:
-                val_append_func(self.out, targets)
+                val_append_func(self.out, targets, tag=tag)
                 continue
 
             # Look for recognized gate types like cirq.DepolarizingChannel.
             type_append_func = t2f.get(type(gate))
             if type_append_func is not None:
-                type_append_func(self.out, gate, targets)
+                type_append_func(self.out, gate, targets, tag=tag)
                 continue
 
             # Ask unrecognized operations to decompose themselves into simpler operations.
@@ -489,7 +515,7 @@ class CirqToStimHelper:
 
         # Append a TICK, unless it was already handled by an internal REPEAT block.
         if length_before == len(self.out) or not isinstance(self.out[-1], stim.CircuitRepeatBlock):
-            self.out.append_operation("TICK", [])
+            self.out.append("TICK", [])
 
     def process_moments(self, moments: Iterable[cirq.Moment]):
         for moment in moments:

--- a/glue/cirq/stimcirq/_cx_swap_gate.py
+++ b/glue/cirq/stimcirq/_cx_swap_gate.py
@@ -35,8 +35,8 @@ class CXSwapGate(cirq.Gate):
             yield cirq.CNOT(a, b)
             yield cirq.SWAP(a, b)
 
-    def _stim_conversion_(self, edit_circuit: stim.Circuit, targets: List[int], **kwargs):
-        edit_circuit.append_operation('SWAPCX' if self.inverted else 'CXSWAP', targets)
+    def _stim_conversion_(self, edit_circuit: stim.Circuit, targets: List[int], tag: str, **kwargs):
+        edit_circuit.append('SWAPCX' if self.inverted else 'CXSWAP', targets, tag=tag)
 
     def __pow__(self, power: int) -> 'CXSwapGate':
         if power == +1:

--- a/glue/cirq/stimcirq/_cz_swap_gate.py
+++ b/glue/cirq/stimcirq/_cz_swap_gate.py
@@ -22,8 +22,8 @@ class CZSwapGate(cirq.Gate):
         yield cirq.SWAP(a, b)
         yield cirq.CZ(a, b)
 
-    def _stim_conversion_(self, edit_circuit: stim.Circuit, targets: List[int], **kwargs):
-        edit_circuit.append_operation('CZSWAP', targets)
+    def _stim_conversion_(self, edit_circuit: stim.Circuit, targets: List[int], tag: str, **kwargs):
+        edit_circuit.append('CZSWAP', targets, tag=tag)
 
     def __pow__(self, power: int) -> 'CZSwapGate':
         if power == +1:

--- a/glue/cirq/stimcirq/_det_annotation.py
+++ b/glue/cirq/stimcirq/_det_annotation.py
@@ -77,8 +77,10 @@ class DetAnnotation(cirq.Operation):
 
     def _stim_conversion_(
         self,
+        *,
         edit_circuit: stim.Circuit,
         edit_measurement_key_lengths: List[Tuple[str, int]],
+        tag: str,
         have_seen_loop: bool = False,
         **kwargs,
     ):
@@ -111,4 +113,4 @@ class DetAnnotation(cirq.Operation):
                 f" in an earlier moment (or earlier in the same moment's operation order)."
             )
 
-        edit_circuit.append_operation("DETECTOR", rec_targets, self.coordinate_metadata)
+        edit_circuit.append("DETECTOR", rec_targets, self.coordinate_metadata, tag=tag)

--- a/glue/cirq/stimcirq/_measure_and_or_reset_gate.py
+++ b/glue/cirq/stimcirq/_measure_and_or_reset_gate.py
@@ -91,15 +91,15 @@ class MeasureAndOrResetGate(cirq.Gate):
             result += self.basis
         return result
 
-    def _stim_conversion_(self, edit_circuit: stim.Circuit, targets: List[int], **kwargs):
+    def _stim_conversion_(self, *, edit_circuit: stim.Circuit, targets: List[int], tag: str, **kwargs):
         if self.invert_measure:
             targets[0] = stim.target_inv(targets[0])
         if self.measure_flip_probability:
             edit_circuit.append_operation(
-                self._stim_op_name(), targets, self.measure_flip_probability
+                self._stim_op_name(), targets, self.measure_flip_probability, tag=tag
             )
         else:
-            edit_circuit.append_operation(self._stim_op_name(), targets)
+            edit_circuit.append_operation(self._stim_op_name(), targets, tag=tag)
 
     def __str__(self) -> str:
         result = self._stim_op_name()

--- a/glue/cirq/stimcirq/_obs_annotation.py
+++ b/glue/cirq/stimcirq/_obs_annotation.py
@@ -75,9 +75,11 @@ class CumulativeObservableAnnotation(cirq.Operation):
 
     def _stim_conversion_(
         self,
+        *,
         edit_circuit: stim.Circuit,
         edit_measurement_key_lengths: List[Tuple[str, int]],
         have_seen_loop: bool = False,
+        tag: str,
         **kwargs,
     ):
         # Ideally these references would all be resolved ahead of time, to avoid the redundant
@@ -109,4 +111,4 @@ class CumulativeObservableAnnotation(cirq.Operation):
                 f" in an earlier moment (or earlier in the same moment's operation order)."
             )
 
-        edit_circuit.append_operation("OBSERVABLE_INCLUDE", rec_targets, self.observable_index)
+        edit_circuit.append("OBSERVABLE_INCLUDE", rec_targets, self.observable_index, tag=tag)

--- a/glue/cirq/stimcirq/_shift_coords_annotation.py
+++ b/glue/cirq/stimcirq/_shift_coords_annotation.py
@@ -49,5 +49,5 @@ class ShiftCoordsAnnotation(cirq.Operation):
     def _is_comment_(self) -> bool:
         return True
 
-    def _stim_conversion_(self, edit_circuit: stim.Circuit, **kwargs):
-        edit_circuit.append_operation("SHIFT_COORDS", [], self.shift)
+    def _stim_conversion_(self, *, edit_circuit: stim.Circuit, tag: str, **kwargs):
+        edit_circuit.append_operation("SHIFT_COORDS", [], self.shift, tag=tag)

--- a/glue/cirq/stimcirq/_stim_to_cirq.py
+++ b/glue/cirq/stimcirq/_stim_to_cirq.py
@@ -423,7 +423,7 @@ class CircuitTranslationTracker:
                             stim_sweep_bit_index=a.value,
                             cirq_sweep_symbol=f'sweep[{a.value}]',
                             pauli=self.pauli_gate,
-                        ).on(cirq.LineQubit(b.value).with_tags(*tags))
+                        ).on(cirq.LineQubit(b.value)).with_tags(*tags)
                     )
                 else:
                     if not a.is_qubit_target or not b.is_qubit_target:

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -303,6 +303,8 @@ class Circuit:
         name: str,
         targets: Union[int, stim.GateTarget, Iterable[Union[int, stim.GateTarget]]],
         arg: Union[float, Iterable[float]],
+        *,
+        tag: str = "",
     ) -> None:
         pass
     @overload
@@ -316,6 +318,8 @@ class Circuit:
         name: object,
         targets: object = (),
         arg: object = None,
+        *,
+        tag: str = '',
     ) -> None:
         """Appends an operation into the circuit.
 
@@ -366,6 +370,7 @@ class Circuit:
                 compatibility reasons, `cirq.append_operation` (but not
                 `cirq.append`) will default to a single 0.0 argument for gates that
                 take exactly one argument.
+            tag: A customizable string attached to the instruction.
         """
     def append_from_stim_program_text(
         self,
@@ -398,6 +403,8 @@ class Circuit:
         name: object,
         targets: object = (),
         arg: object = None,
+        *,
+        tag: str = '',
     ) -> None:
         """[DEPRECATED] use stim.Circuit.append instead
         """

--- a/src/stim/circuit/circuit.cc
+++ b/src/stim/circuit/circuit.cc
@@ -331,7 +331,7 @@ void Circuit::safe_append(CircuitInstruction operation, bool block_fusion) {
     }
 }
 
-void Circuit::safe_append_ua(std::string_view gate_name, const std::vector<uint32_t> &targets, double singleton_arg) {
+void Circuit::safe_append_ua(std::string_view gate_name, const std::vector<uint32_t> &targets, double singleton_arg, std::string_view tag) {
     const auto &gate = GATE_DATA.at(gate_name);
 
     std::vector<GateTarget> converted;
@@ -340,11 +340,11 @@ void Circuit::safe_append_ua(std::string_view gate_name, const std::vector<uint3
         converted.push_back({e});
     }
 
-    safe_append(CircuitInstruction(gate.id, &singleton_arg, converted, ""));
+    safe_append(CircuitInstruction(gate.id, &singleton_arg, converted, tag));
 }
 
 void Circuit::safe_append_u(
-    std::string_view gate_name, const std::vector<uint32_t> &targets, const std::vector<double> &args) {
+    std::string_view gate_name, const std::vector<uint32_t> &targets, const std::vector<double> &args, std::string_view tag) {
     const auto &gate = GATE_DATA.at(gate_name);
 
     std::vector<GateTarget> converted;
@@ -353,7 +353,7 @@ void Circuit::safe_append_u(
         converted.push_back({e});
     }
 
-    safe_append(CircuitInstruction(gate.id, args, converted, ""));
+    safe_append(CircuitInstruction(gate.id, args, converted, tag));
 }
 
 void Circuit::safe_insert(size_t index, const CircuitInstruction &instruction) {

--- a/src/stim/circuit/circuit.h
+++ b/src/stim/circuit/circuit.h
@@ -108,10 +108,10 @@ struct Circuit {
     /// Safely adds an operation at the end of the circuit, copying its data into the circuit's jagged data as needed.
     void safe_append(CircuitInstruction operation, bool block_fusion = false);
     /// Safely adds an operation at the end of the circuit, copying its data into the circuit's jagged data as needed.
-    void safe_append_ua(std::string_view gate_name, const std::vector<uint32_t> &targets, double singleton_arg);
+    void safe_append_ua(std::string_view gate_name, const std::vector<uint32_t> &targets, double singleton_arg, std::string_view tag = "");
     /// Safely adds an operation at the end of the circuit, copying its data into the circuit's jagged data as needed.
     void safe_append_u(
-        std::string_view gate_name, const std::vector<uint32_t> &targets, const std::vector<double> &args = {});
+        std::string_view gate_name, const std::vector<uint32_t> &targets, const std::vector<double> &args = {}, std::string_view tag = "");
     /// Safely copies a repeat block to the end of the circuit.
     void append_repeat_block(uint64_t repeat_count, const Circuit &body, std::string_view tag);
     /// Safely moves a repeat block to the end of the circuit.

--- a/src/stim/circuit/circuit_pybind_test.py
+++ b/src/stim/circuit/circuit_pybind_test.py
@@ -2306,3 +2306,17 @@ def test_tag_without_noise():
         M[test3] 0
         DETECTOR[test4] rec[-1]
     """)
+
+
+def test_append_tag():
+    c = stim.Circuit()
+    c.append("H", [2, 3], tag="test")
+    assert c == stim.Circuit("H[test] 2 3")
+
+    with pytest.raises(ValueError, match="tag"):
+        c.append(c[0], tag="newtag")
+
+    with pytest.raises(ValueError, match="tag"):
+        c.append(stim.CircuitRepeatBlock(10, stim.Circuit()), tag="newtag")
+
+    assert c == stim.Circuit("H[test] 2 3")

--- a/src/stim/util_top/export_crumble_url.test.cc
+++ b/src/stim/util_top/export_crumble_url.test.cc
@@ -127,8 +127,6 @@ TEST(export_crumble, graphlike_error) {
     auto error = ErrorMatcher::explain_errors_from_circuit(circuit, &filter, false);
 
     auto actual = export_crumble_url(circuit, true, {{0, error}});
-    std::cout << actual << "\n";
-    std::cout << actual << "\n";
     auto expected =
         "https://algassert.com/crumble#circuit="
         "R_0_1_2_3;"


### PR DESCRIPTION
- Add `tag: str = ""` to `stim.Circuit.append`
- Stim tags now become string tags on cirq circuit operations
- A string tag on a cirq operation will turn into a stim tag by default if there is exactly one such string tag
- Add optional  `tag_func` argument to `stimcirq.cirq_circuit_to_stim_circuit`

Some inspiration from https://github.com/quantumlib/Stim/pull/862