### PR TITLE
Add `stim.FlipSimulator.{to_numpy,generate_bernoulli_samples}`

### DIFF
--- a/dev/util_gen_stub_file.py
+++ b/dev/util_gen_stub_file.py
@@ -37,6 +37,7 @@ keep = {
 }
 skip = {
     "__firstlineno__",
+    "__replace__",
     "__builtins__",
     "__cached__",
     "__getstate__",

--- a/dev/util_gen_stub_file.py
+++ b/dev/util_gen_stub_file.py
@@ -36,6 +36,7 @@ keep = {
     "__next__",
 }
 skip = {
+    "__firstlineno__",
     "__builtins__",
     "__cached__",
     "__getstate__",

--- a/dev/util_gen_stub_file.py
+++ b/dev/util_gen_stub_file.py
@@ -102,6 +102,7 @@ def splay_signature(sig: str) -> List[str]:
     sig = sig.replace('dict[', 'Dict[')
     sig = sig.replace('tuple[', 'Tuple[')
     sig = sig.replace('set[', 'Set[')
+    sig = sig.replace('pathlib._local.Path', 'pathlib.Path')
 
     assert sig.startswith('def')
     out = []

--- a/dev/util_gen_stub_file.py
+++ b/dev/util_gen_stub_file.py
@@ -37,6 +37,7 @@ keep = {
 }
 skip = {
     "__firstlineno__",
+    "__static_attributes__",
     "__replace__",
     "__builtins__",
     "__cached__",

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -4520,6 +4520,16 @@ def __init__(
     targets_in_range: List[stim.GateTargetWithCoords],
 ) -> None:
     """Creates a stim.CircuitTargetsInsideInstruction.
+
+    Examples:
+        >>> import stim
+        >>> val = stim.CircuitTargetsInsideInstruction(
+        ...     gate='X_ERROR',
+        ...     args=[0.25],
+        ...     target_range_start=0,
+        ...     target_range_end=1,
+        ...     targets_in_range=[stim.GateTargetWithCoords(0, [])],
+        ... )
     """
 ```
 
@@ -4533,6 +4543,19 @@ def args(
     self,
 ) -> List[float]:
     """Returns parens arguments of the gate / instruction that was being executed.
+
+    Examples:
+        >>> import stim
+        >>> err = stim.Circuit('''
+        ...     R 0 1
+        ...     X_ERROR(0.25) 0 1
+        ...     M 0 1
+        ...     DETECTOR(2, 3) rec[-1] rec[-2]
+        ...     OBSERVABLE_INCLUDE(0) rec[-1]
+        ... ''').shortest_graphlike_error()
+        >>> loc: stim.CircuitErrorLocation = err[0].circuit_error_locations[0]
+        >>> loc.instruction_targets.args
+        [0.25]
     """
 ```
 
@@ -4546,6 +4569,19 @@ def gate(
     self,
 ) -> Optional[str]:
     """Returns the name of the gate / instruction that was being executed.
+
+    Examples:
+        >>> import stim
+        >>> err = stim.Circuit('''
+        ...     R 0 1
+        ...     X_ERROR(0.25) 0 1
+        ...     M 0 1
+        ...     DETECTOR(2, 3) rec[-1] rec[-2]
+        ...     OBSERVABLE_INCLUDE(0) rec[-1]
+        ... ''').shortest_graphlike_error()
+        >>> loc: stim.CircuitErrorLocation = err[0].circuit_error_locations[0]
+        >>> loc.instruction_targets.gate
+        'X_ERROR'
     """
 ```
 
@@ -4560,6 +4596,21 @@ def target_range_end(
 ) -> int:
     """Returns the exclusive end of the range of targets that were executing
     within the gate / instruction.
+
+    Examples:
+        >>> import stim
+        >>> err = stim.Circuit('''
+        ...     R 0 1
+        ...     X_ERROR(0.25) 0 1
+        ...     M 0 1
+        ...     DETECTOR(2, 3) rec[-1] rec[-2]
+        ...     OBSERVABLE_INCLUDE(0) rec[-1]
+        ... ''').shortest_graphlike_error()
+        >>> loc: stim.CircuitErrorLocation = err[0].circuit_error_locations[0]
+        >>> loc.instruction_targets.target_range_start
+        0
+        >>> loc.instruction_targets.target_range_end
+        1
     """
 ```
 
@@ -4574,6 +4625,21 @@ def target_range_start(
 ) -> int:
     """Returns the inclusive start of the range of targets that were executing
     within the gate / instruction.
+
+    Examples:
+        >>> import stim
+        >>> err = stim.Circuit('''
+        ...     R 0 1
+        ...     X_ERROR(0.25) 0 1
+        ...     M 0 1
+        ...     DETECTOR(2, 3) rec[-1] rec[-2]
+        ...     OBSERVABLE_INCLUDE(0) rec[-1]
+        ... ''').shortest_graphlike_error()
+        >>> loc: stim.CircuitErrorLocation = err[0].circuit_error_locations[0]
+        >>> loc.instruction_targets.target_range_start
+        0
+        >>> loc.instruction_targets.target_range_end
+        1
     """
 ```
 
@@ -4589,6 +4655,19 @@ def targets_in_range(
     """Returns the subset of targets of the gate/instruction that were being executed.
 
     Includes coordinate data with the targets.
+
+    Examples:
+        >>> import stim
+        >>> err = stim.Circuit('''
+        ...     R 0 1
+        ...     X_ERROR(0.25) 0 1
+        ...     M 0 1
+        ...     DETECTOR(2, 3) rec[-1] rec[-2]
+        ...     OBSERVABLE_INCLUDE(0) rec[-1]
+        ... ''').shortest_graphlike_error()
+        >>> loc: stim.CircuitErrorLocation = err[0].circuit_error_locations[0]
+        >>> loc.instruction_targets.targets_in_range
+        [stim.GateTargetWithCoords(0, [])]
     """
 ```
 
@@ -6222,6 +6301,14 @@ class DemTargetWithCoords:
     problem in a circuit, instead of having to constantly manually
     look up the coordinates of a detector index in order to understand
     what is happening.
+
+    Examples:
+        >>> import stim
+        >>> t = stim.DemTargetWithCoords(stim.DemTarget("D1"), [1.5, 2.0])
+        >>> t.dem_target
+        stim.DemTarget('D1')
+        >>> t.coords
+        [1.5, 2.0]
     """
 ```
 
@@ -6232,7 +6319,6 @@ class DemTargetWithCoords:
 # (in class stim.DemTargetWithCoords)
 def __init__(
     self,
-    *,
     dem_target: stim.DemTarget,
     coords: List[float],
 ) -> None:
@@ -7413,6 +7499,28 @@ def to_file(
 # (at top-level in the stim module)
 class ExplainedError:
     """Describes the location of an error mechanism from a stim circuit.
+
+    Examples:
+        >>> import stim
+        >>> err = stim.Circuit('''
+        ...     R 0
+        ...     TICK
+        ...     Y_ERROR(0.125) 0
+        ...     M 0
+        ...     OBSERVABLE_INCLUDE(0) rec[-1]
+        ... ''').shortest_graphlike_error()
+        >>> print(err[0])
+        ExplainedError {
+            dem_error_terms: L0
+            CircuitErrorLocation {
+                flipped_pauli_product: Y0
+                Circuit location stack trace:
+                    (after 1 TICKs)
+                    at instruction #3 (Y_ERROR) in the circuit
+                    at target #1 of the instruction
+                    resolving to Y_ERROR(0.125) 0
+            }
+        }
     """
 ```
 
@@ -7428,6 +7536,28 @@ def __init__(
     circuit_error_locations: List[stim.CircuitErrorLocation],
 ) -> None:
     """Creates a stim.ExplainedError.
+
+    Examples:
+        >>> import stim
+        >>> err = stim.Circuit('''
+        ...     R 0
+        ...     TICK
+        ...     Y_ERROR(0.125) 0
+        ...     M 0
+        ...     OBSERVABLE_INCLUDE(0) rec[-1]
+        ... ''').shortest_graphlike_error()
+        >>> print(err[0])
+        ExplainedError {
+            dem_error_terms: L0
+            CircuitErrorLocation {
+                flipped_pauli_product: Y0
+                Circuit location stack trace:
+                    (after 1 TICKs)
+                    at instruction #3 (Y_ERROR) in the circuit
+                    at target #1 of the instruction
+                    resolving to Y_ERROR(0.125) 0
+            }
+        }
     """
 ```
 
@@ -7449,6 +7579,25 @@ def circuit_error_locations(
     Note: if this list is empty, it may be because there was a DEM error decomposed
     into parts where one of the parts is impossible to make on its own from a single
     circuit error.
+
+    Examples:
+        >>> import stim
+        >>> err = stim.Circuit('''
+        ...     R 0
+        ...     TICK
+        ...     Y_ERROR(0.125) 0
+        ...     M 0
+        ...     OBSERVABLE_INCLUDE(0) rec[-1]
+        ... ''').shortest_graphlike_error()
+        >>> print(err[0].circuit_error_locations[0])
+        CircuitErrorLocation {
+            flipped_pauli_product: Y0
+            Circuit location stack trace:
+                (after 1 TICKs)
+                at instruction #3 (Y_ERROR) in the circuit
+                at target #1 of the instruction
+                resolving to Y_ERROR(0.125) 0
+        }
     """
 ```
 
@@ -8365,6 +8514,7 @@ def to_numpy(
 
     Examples:
         >>> import stim
+        >>> import numpy as np
         >>> sim = stim.FlipSimulator(batch_size=9)
         >>> sim.do(stim.Circuit('M(1) 0 1 2'))
 
@@ -8372,12 +8522,11 @@ def to_numpy(
         >>> xs, zs, ms, ds, os = sim.to_numpy(
         ...     transpose=True,
         ...     bit_packed=True,
-        ...     output_zs=True,
+        ...     output_xs=True,
         ...     output_measure_flips=ms_buf,
         ... )
         >>> assert ms is ms_buf
         >>> xs
-        >>> zs
         array([[0],
                [0],
                [0],
@@ -8387,6 +8536,7 @@ def to_numpy(
                [0],
                [0],
                [0]], dtype=uint8)
+        >>> zs
         >>> ms
         array([[7],
                [7],
@@ -8412,6 +8562,18 @@ class FlippedMeasurement:
 
     Gives the measurement's index in the measurement record, and also
     the observable of the measurement.
+
+    Examples:
+        >>> import stim
+        >>> err = stim.Circuit('''
+        ...     M(0.25) 1 10
+        ...     OBSERVABLE_INCLUDE(0) rec[-1]
+        ... ''').shortest_graphlike_error()
+        >>> err[0].circuit_error_locations[0].flipped_measurement
+        stim.FlippedMeasurement(
+            record_index=1,
+            observable=(stim.GateTargetWithCoords(stim.target_z(10), []),),
+        )
     """
 ```
 
@@ -8452,6 +8614,15 @@ def observable(
     """Returns the observable of the flipped measurement.
 
     For example, an `MX 5` measurement will have the observable X5.
+
+    Examples:
+        >>> import stim
+        >>> err = stim.Circuit('''
+        ...     M(0.25) 1 10
+        ...     OBSERVABLE_INCLUDE(0) rec[-1]
+        ... ''').shortest_graphlike_error()
+        >>> err[0].circuit_error_locations[0].flipped_measurement.observable
+        [stim.GateTargetWithCoords(stim.target_z(10), [])]
     """
 ```
 
@@ -8467,6 +8638,15 @@ def record_index(
     """The measurement record index of the flipped measurement.
     For example, the fifth measurement in a circuit has a measurement
     record index of 4.
+
+    Examples:
+        >>> import stim
+        >>> err = stim.Circuit('''
+        ...     M(0.25) 1 10
+        ...     OBSERVABLE_INCLUDE(0) rec[-1]
+        ... ''').shortest_graphlike_error()
+        >>> err[0].circuit_error_locations[0].flipped_measurement.record_index
+        1
     """
 ```
 
@@ -9561,7 +9741,21 @@ def __init__(
     """Initializes a `stim.GateTarget`.
 
     Args:
-        value: A target like `5` or `stim.target_rec(-1)`.
+        value: A value to convert into a gate target, like an integer
+            to interpret as a qubit target or a string to parse.
+
+    Examples:
+        >>> import stim
+        >>> stim.GateTarget(stim.GateTarget(5))
+        stim.GateTarget(5)
+        >>> stim.GateTarget("X7")
+        stim.target_x(7)
+        >>> stim.GateTarget("rec[-3]")
+        stim.target_rec(-3)
+        >>> stim.GateTarget("!Z7")
+        stim.target_z(7, invert=True)
+        >>> stim.GateTarget("*")
+        stim.GateTarget.combiner()
     """
 ```
 
@@ -9724,7 +9918,6 @@ def is_sweep_bit_target(
     self,
 ) -> bool:
     """Returns whether or not this is a sweep bit target like `sweep[4]`.
-
 
     Examples:
         >>> import stim
@@ -9946,6 +10139,14 @@ class GateTargetWithCoords:
     problem in a circuit, instead of having to constantly manually
     look up the coordinates of a qubit index in order to understand
     what is happening.
+
+    Examples:
+        >>> import stim
+        >>> t = stim.GateTargetWithCoords(0, [1.5, 2.0])
+        >>> t.gate_target
+        stim.GateTarget(0)
+        >>> t.coords
+        [1.5, 2.0]
     """
 ```
 
@@ -9960,6 +10161,14 @@ def __init__(
     coords: List[float],
 ) -> None:
     """Creates a stim.GateTargetWithCoords.
+
+    Examples:
+        >>> import stim
+        >>> t = stim.GateTargetWithCoords(0, [1.5, 2.0])
+        >>> t.gate_target
+        stim.GateTarget(0)
+        >>> t.coords
+        [1.5, 2.0]
     """
 ```
 
@@ -9975,6 +10184,12 @@ def coords(
     """Returns the associated coordinate information as a list of floats.
 
     If there is no coordinate information, returns an empty list.
+
+    Examples:
+        >>> import stim
+        >>> t = stim.GateTargetWithCoords(0, [1.5, 2.0])
+        >>> t.coords
+        [1.5, 2.0]
     """
 ```
 
@@ -9988,6 +10203,12 @@ def gate_target(
     self,
 ) -> stim.GateTarget:
     """Returns the actual gate target as a `stim.GateTarget`.
+
+    Examples:
+        >>> import stim
+        >>> t = stim.GateTargetWithCoords(0, [1.5, 2.0])
+        >>> t.gate_target
+        stim.GateTarget(0)
     """
 ```
 
@@ -13460,6 +13681,18 @@ def c_xyz(
 
     Args:
         *targets: The indices of the qubits to target with the gate.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        +X +Y +Z
+        >>> s.c_xyz(0, 1, 2)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        +Y +Z +X
     """
 ```
 
@@ -13476,6 +13709,18 @@ def c_zyx(
 
     Args:
         *targets: The indices of the qubits to target with the gate.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        +X +Y +Z
+        >>> s.c_zyx(0, 1, 2)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        +Z +X +Y
     """
 ```
 
@@ -13550,6 +13795,18 @@ def cnot(
         *targets: The indices of the qubits to target with the gate.
             Applies the gate to the first two targets, then the next two targets,
             and so forth. There must be an even number of targets.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0, 3)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +X +Y +Z +X
+        >>> s.cnot(0, 1, 2, 3)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +_ +_ +Z +X
     """
 ```
 
@@ -13722,6 +13979,18 @@ def cx(
         *targets: The indices of the qubits to target with the gate.
             Applies the gate to the first two targets, then the next two targets,
             and so forth. There must be an even number of targets.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0, 3)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +X +Y +Z +X
+        >>> s.cx(0, 1, 2, 3)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +_ +_ +Z +X
     """
 ```
 
@@ -13740,6 +14009,18 @@ def cy(
         *targets: The indices of the qubits to target with the gate.
             Applies the gate to the first two targets, then the next two targets,
             and so forth. There must be an even number of targets.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0, 3)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +X +Y +Z +X
+        >>> s.cy(0, 1, 2, 3)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +X +Y +Z +X
     """
 ```
 
@@ -13758,6 +14039,18 @@ def cz(
         *targets: The indices of the qubits to target with the gate.
             Applies the gate to the first two targets, then the next two targets,
             and so forth. There must be an even number of targets.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0, 3)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +X +Y +Z +X
+        >>> s.cz(0, 1, 2, 3)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +_ +_ +Z +X
     """
 ```
 
@@ -13777,6 +14070,11 @@ def depolarize1(
         *targets: The indices of the qubits to target with the noise.
         p: The chance of the error being applied,
             independently, to each qubit.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.depolarize1(0, 1, 2, p=0.01)
     """
 ```
 
@@ -13798,6 +14096,11 @@ def depolarize2(
             zip(targets[::1], targets[1::2]).
         p: The chance of the error being applied,
             independently, to each qubit pair.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.depolarize1(0, 1, 4, 5, p=0.01)
     """
 ```
 
@@ -13945,6 +14248,18 @@ def h(
 
     Args:
         *targets: The indices of the qubits to target with the gate.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        +X +Y +Z
+        >>> s.h(0, 1, 2)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        +Z -Y +X
     """
 ```
 
@@ -13961,6 +14276,18 @@ def h_xy(
 
     Args:
         *targets: The indices of the qubits to target with the gate.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        +X +Y +Z
+        >>> s.h_xy(0, 1, 2)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        +Y +X -Z
     """
 ```
 
@@ -13977,6 +14304,18 @@ def h_xz(
 
     Args:
         *targets: The indices of the qubits to target with the gate.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        +X +Y +Z
+        >>> s.h_xz(0, 1, 2)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        +Z -Y +X
     """
 ```
 
@@ -13993,6 +14332,18 @@ def h_yz(
 
     Args:
         *targets: The indices of the qubits to target with the gate.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        +X +Y +Z
+        >>> s.h_yz(0, 1, 2)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        -X +Z +Y
     """
 ```
 
@@ -14011,6 +14362,18 @@ def iswap(
         *targets: The indices of the qubits to target with the gate.
             Applies the gate to the first two targets, then the next two targets,
             and so forth. There must be an even number of targets.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0, 3)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +X +Y +Z +X
+        >>> s.iswap(0, 1, 2, 3)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +_ +_ +Y +Z
     """
 ```
 
@@ -14029,6 +14392,18 @@ def iswap_dag(
         *targets: The indices of the qubits to target with the gate.
             Applies the gate to the first two targets, then the next two targets,
             and so forth. There must be an even number of targets.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0, 3)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +X +Y +Z +X
+        >>> s.iswap_dag(0, 1, 2, 3)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +_ +_ -Y +Z
     """
 ```
 
@@ -14054,6 +14429,15 @@ def measure(
 
     Returns:
         The measurement result as a bool.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.x(1)
+        >>> s.measure(0)
+        False
+        >>> s.measure(1)
+        True
     """
 ```
 
@@ -14135,6 +14519,13 @@ def measure_many(
 
     Returns:
         The measurement results as a list of bools.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.x(1)
+        >>> s.measure_many(0, 1)
+        [False, True]
     """
 ```
 
@@ -14720,6 +15111,18 @@ def s(
 
     Args:
         *targets: The indices of the qubits to target with the gate.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        +X +Y +Z
+        >>> s.s(0, 1, 2)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        +Y -X +Z
     """
 ```
 
@@ -14736,6 +15139,18 @@ def s_dag(
 
     Args:
         *targets: The indices of the qubits to target with the gate.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        +X +Y +Z
+        >>> s.s_dag(0, 1, 2)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        -Y +X +Z
     """
 ```
 
@@ -14997,6 +15412,18 @@ def sqrt_x(
 
     Args:
         *targets: The indices of the qubits to target with the gate.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        +X +Y +Z
+        >>> s.sqrt_x(0, 1, 2)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        +X +Z -Y
     """
 ```
 
@@ -15013,6 +15440,18 @@ def sqrt_x_dag(
 
     Args:
         *targets: The indices of the qubits to target with the gate.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        +X +Y +Z
+        >>> s.sqrt_x_dag(0, 1, 2)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        +X -Z +Y
     """
 ```
 
@@ -15029,6 +15468,18 @@ def sqrt_y(
 
     Args:
         *targets: The indices of the qubits to target with the gate.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        +X +Y +Z
+        >>> s.sqrt_y(0, 1, 2)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        -Z +Y +X
     """
 ```
 
@@ -15045,6 +15496,18 @@ def sqrt_y_dag(
 
     Args:
         *targets: The indices of the qubits to target with the gate.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        +X +Y +Z
+        >>> s.sqrt_y_dag(0, 1, 2)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        +Z +Y -X
     """
 ```
 
@@ -15121,6 +15584,18 @@ def swap(
         *targets: The indices of the qubits to target with the gate.
             Applies the gate to the first two targets, then the next two targets,
             and so forth. There must be an even number of targets.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0, 3)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +X +Y +Z +X
+        >>> s.swap(0, 1, 2, 3)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +Y +X +X +Z
     """
 ```
 
@@ -15137,6 +15612,18 @@ def x(
 
     Args:
         *targets: The indices of the qubits to target with the gate.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        +X +Y +Z
+        >>> s.x(0, 1, 2)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        +X -Y -Z
     """
 ```
 
@@ -15156,6 +15643,11 @@ def x_error(
         *targets: The indices of the qubits to target with the noise.
         p: The chance of the X error being applied,
             independently, to each qubit.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.x_error(0, 1, 2, p=0.01)
     """
 ```
 
@@ -15174,6 +15666,18 @@ def xcx(
         *targets: The indices of the qubits to target with the gate.
             Applies the gate to the first two targets, then the next two targets,
             and so forth. There must be an even number of targets.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0, 3)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +X +Y +Z +X
+        >>> s.xcx(0, 1, 2, 3)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +X +Y +Z +X
     """
 ```
 
@@ -15192,6 +15696,18 @@ def xcy(
         *targets: The indices of the qubits to target with the gate.
             Applies the gate to the first two targets, then the next two targets,
             and so forth. There must be an even number of targets.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0, 3)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +X +Y +Z +X
+        >>> s.xcy(0, 1, 2, 3)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +X +Y +_ +_
     """
 ```
 
@@ -15210,6 +15726,18 @@ def xcz(
         *targets: The indices of the qubits to target with the gate.
             Applies the gate to the first two targets, then the next two targets,
             and so forth. There must be an even number of targets.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0, 3)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +X +Y +Z +X
+        >>> s.xcz(0, 1, 2, 3)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +X +Y +_ +_
     """
 ```
 
@@ -15226,6 +15754,18 @@ def y(
 
     Args:
         *targets: The indices of the qubits to target with the gate.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        +X +Y +Z
+        >>> s.y(0, 1, 2)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        -X +Y -Z
     """
 ```
 
@@ -15245,6 +15785,11 @@ def y_error(
         *targets: The indices of the qubits to target with the noise.
         p: The chance of the Y error being applied,
             independently, to each qubit.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.y_error(0, 1, 2, p=0.01)
     """
 ```
 
@@ -15263,6 +15808,18 @@ def ycx(
         *targets: The indices of the qubits to target with the gate.
             Applies the gate to the first two targets, then the next two targets,
             and so forth. There must be an even number of targets.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0, 3)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +X +Y +Z +X
+        >>> s.ycx(0, 1, 2, 3)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +_ +_ +Z +X
     """
 ```
 
@@ -15281,6 +15838,18 @@ def ycy(
         *targets: The indices of the qubits to target with the gate.
             Applies the gate to the first two targets, then the next two targets,
             and so forth. There must be an even number of targets.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0, 3)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +X +Y +Z +X
+        >>> s.ycy(0, 1, 2, 3)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +X +Y +_ +_
     """
 ```
 
@@ -15299,6 +15868,18 @@ def ycz(
         *targets: The indices of the qubits to target with the gate.
             Applies the gate to the first two targets, then the next two targets,
             and so forth. There must be an even number of targets.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0, 3)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +X +Y +Z +X
+        >>> s.ycz(0, 1, 2, 3)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +_ +_ +_ +_
     """
 ```
 
@@ -15315,6 +15896,18 @@ def z(
 
     Args:
         *targets: The indices of the qubits to target with the gate.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        +X +Y +Z
+        >>> s.z(0, 1, 2)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+        -X -Y +Z
     """
 ```
 
@@ -15334,6 +15927,11 @@ def y_error(
         *targets: The indices of the qubits to target with the noise.
         p: The chance of the Z error being applied,
             independently, to each qubit.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.z_error(0, 1, 2, p=0.01)
     """
 ```
 
@@ -15352,6 +15950,18 @@ def zcx(
         *targets: The indices of the qubits to target with the gate.
             Applies the gate to the first two targets, then the next two targets,
             and so forth. There must be an even number of targets.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0, 3)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +X +Y +Z +X
+        >>> s.zcx(0, 1, 2, 3)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +_ +_ +Z +X
     """
 ```
 
@@ -15370,6 +15980,18 @@ def zcy(
         *targets: The indices of the qubits to target with the gate.
             Applies the gate to the first two targets, then the next two targets,
             and so forth. There must be an even number of targets.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0, 3)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +X +Y +Z +X
+        >>> s.zcy(0, 1, 2, 3)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +X +Y +Z +X
     """
 ```
 
@@ -15388,6 +16010,18 @@ def zcz(
         *targets: The indices of the qubits to target with the gate.
             Applies the gate to the first two targets, then the next two targets,
             and so forth. There must be an even number of targets.
+
+    Examples:
+        >>> import stim
+        >>> s = stim.TableauSimulator()
+        >>> s.reset_x(0, 3)
+        >>> s.reset_y(1)
+
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +X +Y +Z +X
+        >>> s.zcz(0, 1, 2, 3)
+        >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+        +_ +_ +Z +X
     """
 ```
 

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -195,6 +195,7 @@ API references for stable versions are kept on the [stim github wiki](https://gi
     - [`stim.FlipSimulator.clear`](#stim.FlipSimulator.clear)
     - [`stim.FlipSimulator.copy`](#stim.FlipSimulator.copy)
     - [`stim.FlipSimulator.do`](#stim.FlipSimulator.do)
+    - [`stim.FlipSimulator.generate_bernoulli_samples`](#stim.FlipSimulator.generate_bernoulli_samples)
     - [`stim.FlipSimulator.get_detector_flips`](#stim.FlipSimulator.get_detector_flips)
     - [`stim.FlipSimulator.get_measurement_flips`](#stim.FlipSimulator.get_measurement_flips)
     - [`stim.FlipSimulator.get_observable_flips`](#stim.FlipSimulator.get_observable_flips)
@@ -7965,6 +7966,76 @@ def do(
     """
 ```
 
+<a name="stim.FlipSimulator.generate_bernoulli_samples"></a>
+```python
+# stim.FlipSimulator.generate_bernoulli_samples
+
+# (in class stim.FlipSimulator)
+def generate_bernoulli_samples(
+    self,
+    num_samples: int,
+    *,
+    p: float,
+    bit_packed: bool = False,
+    out: Optional[np.ndarray] = None,
+) -> np.ndarray:
+    """Uses the simulator's random number generator to produce biased coin flips.
+
+    This method has best performance when specifying `bit_packed=True` and
+    when specifying an `out=` parameter pointing to a numpy array that has
+    contiguous data aligned to a 64 bit boundary. (If `out` isn't specified,
+    the returned numpy array will have this property.)
+
+    Args:
+        num_samples: The number of samples to produce.
+        p: The probability of each sample being True instead of False.
+        bit_packed: Defaults to False (no bit packing). When True, the result
+            has type np.uint8 instead of np.bool_ and 8 samples are packed into
+            each byte as if by np.packbits(bitorder='little'). (The bit order
+            is relevant when producing a number of samples that isn't a multiple
+            of 8.)
+        out: Defaults to None (allocate new). A numpy array to write the samples
+            into. Must have the correct size and dtype.
+
+    Returns:
+        A numpy array containing the samples. The shape and dtype depends on
+        the bit_packed argument:
+
+            if not bit_packed:
+                shape = (num_samples,)
+                dtype = np.bool_
+            elif not transpose and bit_packed:
+                shape = (math.ceil(num_samples / 8),)
+                dtype = np.uint8
+
+    Raises:
+        ValueError:
+            The given `out` argument had a shape or dtype inconsistent with the
+            requested data.
+
+    Examples:
+        >>> import stim
+        >>> sim = stim.FlipSimulator(batch_size=256)
+        >>> r = sim.generate_bernoulli_samples(1001, p=0.25)
+        >>> r.dtype
+        dtype('bool')
+        >>> r.shape
+        (1001,)
+
+        >>> r = sim.generate_bernoulli_samples(53, p=0.1, bit_packed=True)
+        >>> r.dtype
+        dtype('uint8')
+        >>> r.shape
+        (7,)
+        >>> r[6] & 0b1110_0000  # zero'd padding bits
+        0
+
+        >>> r2 = sim.generate_bernoulli_samples(53, p=0.2, bit_packed=True, out=r)
+        >>> r is r2  # Check request to reuse r worked.
+        True
+    """
+```
+
 <a name="stim.FlipSimulator.get_detector_flips"></a>
 ```python
 # stim.FlipSimulator.get_detector_flips
@@ -8403,11 +8474,11 @@ def to_numpy(
     *,
     bit_packed: bool = False,
     transpose: bool = False,
-    output_xs: bool | np.ndarray = False,
-    output_zs: bool | np.ndarray = False,
-    output_measure_flips: bool | np.ndarray = False,
-    output_detector_flips: bool | np.ndarray = False,
-    output_observable_flips: bool | np.ndarray = False,
+    output_xs: Union[bool, np.ndarray] = False,
+    output_zs: Union[bool, np.ndarray] = False,
+    output_measure_flips: Union[bool, np.ndarray] = False,
+    output_detector_flips: Union[bool, np.ndarray] = False,
+    output_observable_flips: Union[bool, np.ndarray] = False,
 ) -> Optional[Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]]:
     """Writes the simulator state into numpy arrays.
 

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -8259,7 +8259,7 @@ def to_numpy(
     output_measure_flips: bool | np.ndarray = False,
     output_detector_flips: bool | np.ndarray = False,
     output_observable_flips: bool | np.ndarray = False,
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> Optional[Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]]:
     """Writes the simulator state into numpy arrays.
 
     Args:
@@ -8366,16 +8366,18 @@ def to_numpy(
     Examples:
         >>> import stim
         >>> sim = stim.FlipSimulator(batch_size=9)
-        >>> sim.do(stim.Circuit('M 0 1 2'))
+        >>> sim.do(stim.Circuit('M(1) 0 1 2'))
 
+        >>> ms_buf = np.empty(shape=(9, 1), dtype=np.uint8)
         >>> xs, zs, ms, ds, os = sim.to_numpy(
         ...     transpose=True,
         ...     bit_packed=True,
-        ...     output_measure_flips=True,
+        ...     output_zs=True,
+        ...     output_measure_flips=ms_buf,
         ... )
+        >>> assert ms is ms_buf
         >>> xs
         >>> zs
-        >>> ms
         array([[0],
                [0],
                [0],
@@ -8385,6 +8387,16 @@ def to_numpy(
                [0],
                [0],
                [0]], dtype=uint8)
+        >>> ms
+        array([[7],
+               [7],
+               [7],
+               [7],
+               [7],
+               [7],
+               [7],
+               [7],
+               [7]], dtype=uint8)
         >>> ds
         >>> os
     """

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -8028,7 +8028,7 @@ def generate_bernoulli_samples(
         >>> r.shape
         (7,)
         >>> r[6] & 0b1110_0000  # zero'd padding bits
-        0
+        np.uint8(0)
 
         >>> r2 = sim.generate_bernoulli_samples(53, p=0.2, bit_packed=True, out=r)
         >>> r is r2  # Check request to reuse r worked.

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -6293,6 +6293,69 @@ class FlipSimulator:
             >>> sim.peek_pauli_flips()
             [stim.PauliString("+YX__")]
         """
+    def generate_bernoulli_samples(
+        self,
+        num_samples: int,
+        *,
+        p: float,
+        bit_packed: bool = False,
+        out: Optional[np.ndarray] = None,
+    ) -> np.ndarray:
+        """Uses the simulator's random number generator to produce biased coin flips.
+
+        This method has best performance when specifying `bit_packed=True` and
+        when specifying an `out=` parameter pointing to a numpy array that has
+        contiguous data aligned to a 64 bit boundary. (If `out` isn't specified,
+        the returned numpy array will have this property.)
+
+        Args:
+            num_samples: The number of samples to produce.
+            p: The probability of each sample being True instead of False.
+            bit_packed: Defaults to False (no bit packing). When True, the result
+                has type np.uint8 instead of np.bool_ and 8 samples are packed into
+                each byte as if by np.packbits(bitorder='little'). (The bit order
+                is relevant when producing a number of samples that isn't a multiple
+                of 8.)
+            out: Defaults to None (allocate new). A numpy array to write the samples
+                into. Must have the correct size and dtype.
+
+        Returns:
+            A numpy array containing the samples. The shape and dtype depends on
+            the bit_packed argument:
+
+                if not bit_packed:
+                    shape = (num_samples,)
+                    dtype = np.bool_
+                elif not transpose and bit_packed:
+                    shape = (math.ceil(num_samples / 8),)
+                    dtype = np.uint8
+
+        Raises:
+            ValueError:
+                The given `out` argument had a shape or dtype inconsistent with the
+                requested data.
+
+        Examples:
+            >>> import stim
+            >>> sim = stim.FlipSimulator(batch_size=256)
+            >>> r = sim.generate_bernoulli_samples(1001, p=0.25)
+            >>> r.dtype
+            dtype('bool')
+            >>> r.shape
+            (1001,)
+
+            >>> r = sim.generate_bernoulli_samples(53, p=0.1, bit_packed=True)
+            >>> r.dtype
+            dtype('uint8')
+            >>> r.shape
+            (7,)
+            >>> r[6] & 0b1110_0000  # zero'd padding bits
+            0
+
+            >>> r2 = sim.generate_bernoulli_samples(53, p=0.2, bit_packed=True, out=r)
+            >>> r is r2  # Check request to reuse r worked.
+            True
+        """
     def get_detector_flips(
         self,
         *,
@@ -6663,11 +6726,11 @@ class FlipSimulator:
         *,
         bit_packed: bool = False,
         transpose: bool = False,
-        output_xs: bool | np.ndarray = False,
-        output_zs: bool | np.ndarray = False,
-        output_measure_flips: bool | np.ndarray = False,
-        output_detector_flips: bool | np.ndarray = False,
-        output_observable_flips: bool | np.ndarray = False,
+        output_xs: Union[bool, np.ndarray] = False,
+        output_zs: Union[bool, np.ndarray] = False,
+        output_measure_flips: Union[bool, np.ndarray] = False,
+        output_detector_flips: Union[bool, np.ndarray] = False,
+        output_observable_flips: Union[bool, np.ndarray] = False,
     ) -> Optional[Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]]:
         """Writes the simulator state into numpy arrays.
 

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -3332,6 +3332,17 @@ class CircuitRepeatBlock:
             repeat_count: The number of times to repeat the block.
             body: The body of the block, as a circuit.
             tag: Defaults to empty. A custom string attached to the REPEAT instruction.
+
+        Examples:
+            >>> import stim
+            >>> c = stim.Circuit()
+            >>> c.append(stim.CircuitRepeatBlock(100, stim.Circuit("M 0")))
+            >>> c
+            stim.Circuit('''
+                REPEAT 100 {
+                    M 0
+                }
+            ''')
         """
     def __ne__(
         self,
@@ -6497,6 +6508,145 @@ class FlipSimulator:
             >>> sim.set_pauli_flip('X', qubit_index=2, instance_index=1)
             >>> sim.peek_pauli_flips()
             [stim.PauliString("+___"), stim.PauliString("+__X")]
+        """
+    def to_numpy(
+        self,
+        *,
+        bit_packed: bool = False,
+        transpose: bool = False,
+        output_xs: bool | np.ndarray = False,
+        output_zs: bool | np.ndarray = False,
+        output_measure_flips: bool | np.ndarray = False,
+        output_detector_flips: bool | np.ndarray = False,
+        output_observable_flips: bool | np.ndarray = False,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Writes the simulator state into numpy arrays.
+
+        Args:
+            bit_packed: Whether or not the result is bit packed, storing 8 bits per
+                byte instead of 1 bit per byte. Bit packing always applies to
+                the second index of the result. Bits are packed in little endian
+                order (as if by `np.packbits(X, axis=1, order='little')`).
+            transpose: Defaults to False. When set to False, the second index of the
+                returned array (the index affected by bit packing) is the shot index
+                (meaning the first index is the qubit index or measurement index or
+                etc). When set to True, results are transposed so that the first
+                index is the shot index.
+            output_xs: Defaults to False. When set to False, the X flip data is not
+                generated and the corresponding array in the result tuple is set to
+                None. When set to True, a new array is allocated to hold the X flip
+                data and this array is returned via the result tuple. When set to
+                a numpy array, the results are written into that array (the shape and
+                dtype of the array must be exactly correct).
+            output_zs: Defaults to False. When set to False, the Z flip data is not
+                generated and the corresponding array in the result tuple is set to
+                None. When set to True, a new array is allocated to hold the Z flip
+                data and this array is returned via the result tuple. When set to
+                a numpy array, the results are written into that array (the shape and
+                dtype of the array must be exactly correct).
+            output_measure_flips: Defaults to False. When set to False, the measure
+                flip data is not generated and the corresponding array in the result
+                tuple is set to None. When set to True, a new array is allocated to
+                hold the measure flip data and this array is returned via the result
+                tuple. When set to a numpy array, the results are written into that
+                array (the shape and dtype of the array must be exactly correct).
+            output_detector_flips: Defaults to False. When set to False, the detector
+                flip data is not generated and the corresponding array in the result
+                tuple is set to None. When set to True, a new array is allocated to
+                hold the detector flip data and this array is returned via the result
+                tuple. When set to a numpy array, the results are written into that
+                array (the shape and dtype of the array must be exactly correct).
+            output_observable_flips: Defaults to False. When set to False, the obs
+                flip data is not generated and the corresponding array in the result
+                tuple is set to None. When set to True, a new array is allocated to
+                hold the obs flip data and this array is returned via the result
+                tuple. When set to a numpy array, the results are written into that
+                array (the shape and dtype of the array must be exactly correct).
+
+        Returns:
+            A tuple (xs, zs, ms, ds, os) of numpy arrays. The xs and zs arrays are
+            the pauli flip data specified using XZ encoding (00=I, 10=X, 11=Y, 01=Z).
+            The ms array is the measure flip data, the ds array is the detector flip
+            data, and the os array is the obs flip data. The arrays default to
+            `None` when the corresponding `output_*` argument was left False.
+
+            The shape and dtype of the data depends on arguments given to the function.
+            The following specifies each array's shape and dtype for each case:
+
+                if not transpose and not bit_packed:
+                    xs.shape = (sim.batch_size, sim.num_qubits)
+                    zs.shape = (sim.batch_size, sim.num_qubits)
+                    ms.shape = (sim.batch_size, sim.num_measurements)
+                    ds.shape = (sim.batch_size, sim.num_detectors)
+                    os.shape = (sim.batch_size, sim.num_observables)
+                    xs.dtype = np.bool_
+                    zs.dtype = np.bool_
+                    ms.dtype = np.bool_
+                    ds.dtype = np.bool_
+                    os.dtype = np.bool_
+                elif not transpose and bit_packed:
+                    xs.shape = (sim.batch_size, math.ceil(sim.num_qubits / 8))
+                    zs.shape = (sim.batch_size, math.ceil(sim.num_qubits / 8))
+                    ms.shape = (sim.batch_size, math.ceil(sim.num_measurements / 8))
+                    ds.shape = (sim.batch_size, math.ceil(sim.num_detectors / 8))
+                    os.shape = (sim.batch_size, math.ceil(sim.num_observables / 8))
+                    xs.dtype = np.uint8
+                    zs.dtype = np.uint8
+                    ms.dtype = np.uint8
+                    ds.dtype = np.uint8
+                    os.dtype = np.uint8
+                elif transpose and not bit_packed:
+                    xs.shape = (sim.num_qubits, sim.batch_size)
+                    zs.shape = (sim.num_qubits, sim.batch_size)
+                    ms.shape = (sim.num_measurements, sim.batch_size)
+                    ds.shape = (sim.num_detectors, sim.batch_size)
+                    os.shape = (sim.num_observables, sim.batch_size)
+                    xs.dtype = np.bool_
+                    zs.dtype = np.bool_
+                    ms.dtype = np.bool_
+                    ds.dtype = np.bool_
+                    os.dtype = np.bool_
+                elif transpose and bit_packed:
+                    xs.shape = (sim.num_qubits, math.ceil(sim.batch_size / 8))
+                    zs.shape = (sim.num_qubits, math.ceil(sim.batch_size / 8))
+                    ms.shape = (sim.num_measurements, math.ceil(sim.batch_size / 8))
+                    ds.shape = (sim.num_detectors, math.ceil(sim.batch_size / 8))
+                    os.shape = (sim.num_observables, math.ceil(sim.batch_size / 8))
+                    xs.dtype = np.uint8
+                    zs.dtype = np.uint8
+                    ms.dtype = np.uint8
+                    ds.dtype = np.uint8
+                    os.dtype = np.uint8
+
+        Raises:
+            ValueError:
+                All the `output_*` arguments were False, or an `output_*` argument
+                had a shape or dtype inconsistent with the requested data.
+
+        Examples:
+            >>> import stim
+            >>> sim = stim.FlipSimulator(batch_size=9)
+            >>> sim.do(stim.Circuit('M 0 1 2'))
+
+            >>> xs, zs, ms, ds, os = sim.to_numpy(
+            ...     transpose=True,
+            ...     bit_packed=True,
+            ...     output_measure_flips=True,
+            ... )
+            >>> xs
+            >>> zs
+            >>> ms
+            array([[0],
+                   [0],
+                   [0],
+                   [0],
+                   [0],
+                   [0],
+                   [0],
+                   [0],
+                   [0]], dtype=uint8)
+            >>> ds
+            >>> os
         """
 class FlippedMeasurement:
     """Describes a measurement that was flipped.

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -6350,7 +6350,7 @@ class FlipSimulator:
             >>> r.shape
             (7,)
             >>> r[6] & 0b1110_0000  # zero'd padding bits
-            0
+            np.uint8(0)
 
             >>> r2 = sim.generate_bernoulli_samples(53, p=0.2, bit_packed=True, out=r)
             >>> r is r2  # Check request to reuse r worked.

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -6519,7 +6519,7 @@ class FlipSimulator:
         output_measure_flips: bool | np.ndarray = False,
         output_detector_flips: bool | np.ndarray = False,
         output_observable_flips: bool | np.ndarray = False,
-    ) -> Tuple[np.ndarray, np.ndarray]:
+    ) -> Optional[Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]]:
         """Writes the simulator state into numpy arrays.
 
         Args:
@@ -6626,16 +6626,18 @@ class FlipSimulator:
         Examples:
             >>> import stim
             >>> sim = stim.FlipSimulator(batch_size=9)
-            >>> sim.do(stim.Circuit('M 0 1 2'))
+            >>> sim.do(stim.Circuit('M(1) 0 1 2'))
 
+            >>> ms_buf = np.empty(shape=(9, 1), dtype=np.uint8)
             >>> xs, zs, ms, ds, os = sim.to_numpy(
             ...     transpose=True,
             ...     bit_packed=True,
-            ...     output_measure_flips=True,
+            ...     output_zs=True,
+            ...     output_measure_flips=ms_buf,
             ... )
+            >>> assert ms is ms_buf
             >>> xs
             >>> zs
-            >>> ms
             array([[0],
                    [0],
                    [0],
@@ -6645,6 +6647,16 @@ class FlipSimulator:
                    [0],
                    [0],
                    [0]], dtype=uint8)
+            >>> ms
+            array([[7],
+                   [7],
+                   [7],
+                   [7],
+                   [7],
+                   [7],
+                   [7],
+                   [7],
+                   [7]], dtype=uint8)
             >>> ds
             >>> os
         """

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -3473,18 +3473,54 @@ class CircuitTargetsInsideInstruction:
         targets_in_range: List[stim.GateTargetWithCoords],
     ) -> None:
         """Creates a stim.CircuitTargetsInsideInstruction.
+
+        Examples:
+            >>> import stim
+            >>> val = stim.CircuitTargetsInsideInstruction(
+            ...     gate='X_ERROR',
+            ...     args=[0.25],
+            ...     target_range_start=0,
+            ...     target_range_end=1,
+            ...     targets_in_range=[stim.GateTargetWithCoords(0, [])],
+            ... )
         """
     @property
     def args(
         self,
     ) -> List[float]:
         """Returns parens arguments of the gate / instruction that was being executed.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.Circuit('''
+            ...     R 0 1
+            ...     X_ERROR(0.25) 0 1
+            ...     M 0 1
+            ...     DETECTOR(2, 3) rec[-1] rec[-2]
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ... ''').shortest_graphlike_error()
+            >>> loc: stim.CircuitErrorLocation = err[0].circuit_error_locations[0]
+            >>> loc.instruction_targets.args
+            [0.25]
         """
     @property
     def gate(
         self,
     ) -> Optional[str]:
         """Returns the name of the gate / instruction that was being executed.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.Circuit('''
+            ...     R 0 1
+            ...     X_ERROR(0.25) 0 1
+            ...     M 0 1
+            ...     DETECTOR(2, 3) rec[-1] rec[-2]
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ... ''').shortest_graphlike_error()
+            >>> loc: stim.CircuitErrorLocation = err[0].circuit_error_locations[0]
+            >>> loc.instruction_targets.gate
+            'X_ERROR'
         """
     @property
     def target_range_end(
@@ -3492,6 +3528,21 @@ class CircuitTargetsInsideInstruction:
     ) -> int:
         """Returns the exclusive end of the range of targets that were executing
         within the gate / instruction.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.Circuit('''
+            ...     R 0 1
+            ...     X_ERROR(0.25) 0 1
+            ...     M 0 1
+            ...     DETECTOR(2, 3) rec[-1] rec[-2]
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ... ''').shortest_graphlike_error()
+            >>> loc: stim.CircuitErrorLocation = err[0].circuit_error_locations[0]
+            >>> loc.instruction_targets.target_range_start
+            0
+            >>> loc.instruction_targets.target_range_end
+            1
         """
     @property
     def target_range_start(
@@ -3499,6 +3550,21 @@ class CircuitTargetsInsideInstruction:
     ) -> int:
         """Returns the inclusive start of the range of targets that were executing
         within the gate / instruction.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.Circuit('''
+            ...     R 0 1
+            ...     X_ERROR(0.25) 0 1
+            ...     M 0 1
+            ...     DETECTOR(2, 3) rec[-1] rec[-2]
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ... ''').shortest_graphlike_error()
+            >>> loc: stim.CircuitErrorLocation = err[0].circuit_error_locations[0]
+            >>> loc.instruction_targets.target_range_start
+            0
+            >>> loc.instruction_targets.target_range_end
+            1
         """
     @property
     def targets_in_range(
@@ -3507,6 +3573,19 @@ class CircuitTargetsInsideInstruction:
         """Returns the subset of targets of the gate/instruction that were being executed.
 
         Includes coordinate data with the targets.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.Circuit('''
+            ...     R 0 1
+            ...     X_ERROR(0.25) 0 1
+            ...     M 0 1
+            ...     DETECTOR(2, 3) rec[-1] rec[-2]
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ... ''').shortest_graphlike_error()
+            >>> loc: stim.CircuitErrorLocation = err[0].circuit_error_locations[0]
+            >>> loc.instruction_targets.targets_in_range
+            [stim.GateTargetWithCoords(0, [])]
         """
 class CompiledDemSampler:
     """A helper class for efficiently sampler from a detector error model.
@@ -4846,10 +4925,17 @@ class DemTargetWithCoords:
     problem in a circuit, instead of having to constantly manually
     look up the coordinates of a detector index in order to understand
     what is happening.
+
+    Examples:
+        >>> import stim
+        >>> t = stim.DemTargetWithCoords(stim.DemTarget("D1"), [1.5, 2.0])
+        >>> t.dem_target
+        stim.DemTarget('D1')
+        >>> t.coords
+        [1.5, 2.0]
     """
     def __init__(
         self,
-        *,
         dem_target: stim.DemTarget,
         coords: List[float],
     ) -> None:
@@ -5813,6 +5899,28 @@ class DetectorErrorModel:
         """
 class ExplainedError:
     """Describes the location of an error mechanism from a stim circuit.
+
+    Examples:
+        >>> import stim
+        >>> err = stim.Circuit('''
+        ...     R 0
+        ...     TICK
+        ...     Y_ERROR(0.125) 0
+        ...     M 0
+        ...     OBSERVABLE_INCLUDE(0) rec[-1]
+        ... ''').shortest_graphlike_error()
+        >>> print(err[0])
+        ExplainedError {
+            dem_error_terms: L0
+            CircuitErrorLocation {
+                flipped_pauli_product: Y0
+                Circuit location stack trace:
+                    (after 1 TICKs)
+                    at instruction #3 (Y_ERROR) in the circuit
+                    at target #1 of the instruction
+                    resolving to Y_ERROR(0.125) 0
+            }
+        }
     """
     def __init__(
         self,
@@ -5821,6 +5929,28 @@ class ExplainedError:
         circuit_error_locations: List[stim.CircuitErrorLocation],
     ) -> None:
         """Creates a stim.ExplainedError.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.Circuit('''
+            ...     R 0
+            ...     TICK
+            ...     Y_ERROR(0.125) 0
+            ...     M 0
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ... ''').shortest_graphlike_error()
+            >>> print(err[0])
+            ExplainedError {
+                dem_error_terms: L0
+                CircuitErrorLocation {
+                    flipped_pauli_product: Y0
+                    Circuit location stack trace:
+                        (after 1 TICKs)
+                        at instruction #3 (Y_ERROR) in the circuit
+                        at target #1 of the instruction
+                        resolving to Y_ERROR(0.125) 0
+                }
+            }
         """
     @property
     def circuit_error_locations(
@@ -5835,6 +5965,25 @@ class ExplainedError:
         Note: if this list is empty, it may be because there was a DEM error decomposed
         into parts where one of the parts is impossible to make on its own from a single
         circuit error.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.Circuit('''
+            ...     R 0
+            ...     TICK
+            ...     Y_ERROR(0.125) 0
+            ...     M 0
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ... ''').shortest_graphlike_error()
+            >>> print(err[0].circuit_error_locations[0])
+            CircuitErrorLocation {
+                flipped_pauli_product: Y0
+                Circuit location stack trace:
+                    (after 1 TICKs)
+                    at instruction #3 (Y_ERROR) in the circuit
+                    at target #1 of the instruction
+                    resolving to Y_ERROR(0.125) 0
+            }
         """
     @property
     def dem_error_terms(
@@ -6625,6 +6774,7 @@ class FlipSimulator:
 
         Examples:
             >>> import stim
+            >>> import numpy as np
             >>> sim = stim.FlipSimulator(batch_size=9)
             >>> sim.do(stim.Circuit('M(1) 0 1 2'))
 
@@ -6632,12 +6782,11 @@ class FlipSimulator:
             >>> xs, zs, ms, ds, os = sim.to_numpy(
             ...     transpose=True,
             ...     bit_packed=True,
-            ...     output_zs=True,
+            ...     output_xs=True,
             ...     output_measure_flips=ms_buf,
             ... )
             >>> assert ms is ms_buf
             >>> xs
-            >>> zs
             array([[0],
                    [0],
                    [0],
@@ -6647,6 +6796,7 @@ class FlipSimulator:
                    [0],
                    [0],
                    [0]], dtype=uint8)
+            >>> zs
             >>> ms
             array([[7],
                    [7],
@@ -6665,6 +6815,18 @@ class FlippedMeasurement:
 
     Gives the measurement's index in the measurement record, and also
     the observable of the measurement.
+
+    Examples:
+        >>> import stim
+        >>> err = stim.Circuit('''
+        ...     M(0.25) 1 10
+        ...     OBSERVABLE_INCLUDE(0) rec[-1]
+        ... ''').shortest_graphlike_error()
+        >>> err[0].circuit_error_locations[0].flipped_measurement
+        stim.FlippedMeasurement(
+            record_index=1,
+            observable=(stim.GateTargetWithCoords(stim.target_z(10), []),),
+        )
     """
     def __init__(
         self,
@@ -6691,6 +6853,15 @@ class FlippedMeasurement:
         """Returns the observable of the flipped measurement.
 
         For example, an `MX 5` measurement will have the observable X5.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.Circuit('''
+            ...     M(0.25) 1 10
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ... ''').shortest_graphlike_error()
+            >>> err[0].circuit_error_locations[0].flipped_measurement.observable
+            [stim.GateTargetWithCoords(stim.target_z(10), [])]
         """
     @property
     def record_index(
@@ -6699,6 +6870,15 @@ class FlippedMeasurement:
         """The measurement record index of the flipped measurement.
         For example, the fifth measurement in a circuit has a measurement
         record index of 4.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.Circuit('''
+            ...     M(0.25) 1 10
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ... ''').shortest_graphlike_error()
+            >>> err[0].circuit_error_locations[0].flipped_measurement.record_index
+            1
         """
 class Flow:
     """A stabilizer flow (e.g. "XI -> XX xor rec[-1]").
@@ -7541,7 +7721,21 @@ class GateTarget:
         """Initializes a `stim.GateTarget`.
 
         Args:
-            value: A target like `5` or `stim.target_rec(-1)`.
+            value: A value to convert into a gate target, like an integer
+                to interpret as a qubit target or a string to parse.
+
+        Examples:
+            >>> import stim
+            >>> stim.GateTarget(stim.GateTarget(5))
+            stim.GateTarget(5)
+            >>> stim.GateTarget("X7")
+            stim.target_x(7)
+            >>> stim.GateTarget("rec[-3]")
+            stim.target_rec(-3)
+            >>> stim.GateTarget("!Z7")
+            stim.target_z(7, invert=True)
+            >>> stim.GateTarget("*")
+            stim.GateTarget.combiner()
         """
     def __ne__(
         self,
@@ -7655,7 +7849,6 @@ class GateTarget:
         self,
     ) -> bool:
         """Returns whether or not this is a sweep bit target like `sweep[4]`.
-
 
         Examples:
             >>> import stim
@@ -7828,6 +8021,14 @@ class GateTargetWithCoords:
     problem in a circuit, instead of having to constantly manually
     look up the coordinates of a qubit index in order to understand
     what is happening.
+
+    Examples:
+        >>> import stim
+        >>> t = stim.GateTargetWithCoords(0, [1.5, 2.0])
+        >>> t.gate_target
+        stim.GateTarget(0)
+        >>> t.coords
+        [1.5, 2.0]
     """
     def __init__(
         self,
@@ -7835,6 +8036,14 @@ class GateTargetWithCoords:
         coords: List[float],
     ) -> None:
         """Creates a stim.GateTargetWithCoords.
+
+        Examples:
+            >>> import stim
+            >>> t = stim.GateTargetWithCoords(0, [1.5, 2.0])
+            >>> t.gate_target
+            stim.GateTarget(0)
+            >>> t.coords
+            [1.5, 2.0]
         """
     @property
     def coords(
@@ -7843,12 +8052,24 @@ class GateTargetWithCoords:
         """Returns the associated coordinate information as a list of floats.
 
         If there is no coordinate information, returns an empty list.
+
+        Examples:
+            >>> import stim
+            >>> t = stim.GateTargetWithCoords(0, [1.5, 2.0])
+            >>> t.coords
+            [1.5, 2.0]
         """
     @property
     def gate_target(
         self,
     ) -> stim.GateTarget:
         """Returns the actual gate target as a `stim.GateTarget`.
+
+        Examples:
+            >>> import stim
+            >>> t = stim.GateTargetWithCoords(0, [1.5, 2.0])
+            >>> t.gate_target
+            stim.GateTarget(0)
         """
 class PauliString:
     """A signed Pauli tensor product (e.g. "+X \u2297 X \u2297 X" or "-Y \u2297 Z".
@@ -10711,6 +10932,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.c_xyz(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +Y +Z +X
         """
     def c_zyx(
         self,
@@ -10720,6 +10953,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.c_zyx(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +Z +X +Y
         """
     def canonical_stabilizers(
         self,
@@ -10780,6 +11025,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.cnot(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +_ +_ +Z +X
         """
     def copy(
         self,
@@ -10924,6 +11181,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.cx(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +_ +_ +Z +X
         """
     def cy(
         self,
@@ -10935,6 +11204,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.cy(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
         """
     def cz(
         self,
@@ -10946,6 +11227,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.cz(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +_ +_ +Z +X
         """
     def depolarize1(
         self,
@@ -10958,6 +11251,11 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the noise.
             p: The chance of the error being applied,
                 independently, to each qubit.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.depolarize1(0, 1, 2, p=0.01)
         """
     def depolarize2(
         self,
@@ -10972,6 +11270,11 @@ class TableauSimulator:
                 zip(targets[::1], targets[1::2]).
             p: The chance of the error being applied,
                 independently, to each qubit pair.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.depolarize1(0, 1, 4, 5, p=0.01)
         """
     def do(
         self,
@@ -11084,6 +11387,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.h(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +Z -Y +X
         """
     def h_xy(
         self,
@@ -11093,6 +11408,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.h_xy(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +Y +X -Z
         """
     def h_xz(
         self,
@@ -11102,6 +11429,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.h_xz(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +Z -Y +X
         """
     def h_yz(
         self,
@@ -11111,6 +11450,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.h_yz(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            -X +Z +Y
         """
     def iswap(
         self,
@@ -11122,6 +11473,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.iswap(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +_ +_ +Y +Z
         """
     def iswap_dag(
         self,
@@ -11133,6 +11496,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.iswap_dag(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +_ +_ -Y +Z
         """
     def measure(
         self,
@@ -11151,6 +11526,15 @@ class TableauSimulator:
 
         Returns:
             The measurement result as a bool.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.x(1)
+            >>> s.measure(0)
+            False
+            >>> s.measure(1)
+            True
         """
     def measure_kickback(
         self,
@@ -11218,6 +11602,13 @@ class TableauSimulator:
 
         Returns:
             The measurement results as a list of bools.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.x(1)
+            >>> s.measure_many(0, 1)
+            [False, True]
         """
     def measure_observable(
         self,
@@ -11691,6 +12082,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.s(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +Y -X +Z
         """
     def s_dag(
         self,
@@ -11700,6 +12103,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.s_dag(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            -Y +X +Z
         """
     def set_inverse_tableau(
         self,
@@ -11926,6 +12341,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.sqrt_x(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Z -Y
         """
     def sqrt_x_dag(
         self,
@@ -11935,6 +12362,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.sqrt_x_dag(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X -Z +Y
         """
     def sqrt_y(
         self,
@@ -11944,6 +12383,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.sqrt_y(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            -Z +Y +X
         """
     def sqrt_y_dag(
         self,
@@ -11953,6 +12404,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.sqrt_y_dag(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +Z +Y -X
         """
     def state_vector(
         self,
@@ -12015,6 +12478,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.swap(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +Y +X +X +Z
         """
     def x(
         self,
@@ -12024,6 +12499,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.x(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X -Y -Z
         """
     def x_error(
         self,
@@ -12036,6 +12523,11 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the noise.
             p: The chance of the X error being applied,
                 independently, to each qubit.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.x_error(0, 1, 2, p=0.01)
         """
     def xcx(
         self,
@@ -12047,6 +12539,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.xcx(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
         """
     def xcy(
         self,
@@ -12058,6 +12562,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.xcy(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +_ +_
         """
     def xcz(
         self,
@@ -12069,6 +12585,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.xcz(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +_ +_
         """
     def y(
         self,
@@ -12078,6 +12606,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.y(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            -X +Y -Z
         """
     def y_error(
         self,
@@ -12090,6 +12630,11 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the noise.
             p: The chance of the Y error being applied,
                 independently, to each qubit.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.y_error(0, 1, 2, p=0.01)
         """
     def ycx(
         self,
@@ -12101,6 +12646,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.ycx(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +_ +_ +Z +X
         """
     def ycy(
         self,
@@ -12112,6 +12669,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.ycy(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +_ +_
         """
     def ycz(
         self,
@@ -12123,6 +12692,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.ycz(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +_ +_ +_ +_
         """
     def z(
         self,
@@ -12132,6 +12713,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.z(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            -X -Y +Z
         """
     def y_error(
         self,
@@ -12144,6 +12737,11 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the noise.
             p: The chance of the Z error being applied,
                 independently, to each qubit.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.z_error(0, 1, 2, p=0.01)
         """
     def zcx(
         self,
@@ -12155,6 +12753,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.zcx(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +_ +_ +Z +X
         """
     def zcy(
         self,
@@ -12166,6 +12776,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.zcy(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
         """
     def zcz(
         self,
@@ -12177,6 +12799,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.zcz(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +_ +_ +Z +X
         """
 @overload
 def gate_data(

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -6293,6 +6293,69 @@ class FlipSimulator:
             >>> sim.peek_pauli_flips()
             [stim.PauliString("+YX__")]
         """
+    def generate_bernoulli_samples(
+        self,
+        num_samples: int,
+        *,
+        p: float,
+        bit_packed: bool = False,
+        out: Optional[np.ndarray] = None,
+    ) -> np.ndarray:
+        """Uses the simulator's random number generator to produce biased coin flips.
+
+        This method has best performance when specifying `bit_packed=True` and
+        when specifying an `out=` parameter pointing to a numpy array that has
+        contiguous data aligned to a 64 bit boundary. (If `out` isn't specified,
+        the returned numpy array will have this property.)
+
+        Args:
+            num_samples: The number of samples to produce.
+            p: The probability of each sample being True instead of False.
+            bit_packed: Defaults to False (no bit packing). When True, the result
+                has type np.uint8 instead of np.bool_ and 8 samples are packed into
+                each byte as if by np.packbits(bitorder='little'). (The bit order
+                is relevant when producing a number of samples that isn't a multiple
+                of 8.)
+            out: Defaults to None (allocate new). A numpy array to write the samples
+                into. Must have the correct size and dtype.
+
+        Returns:
+            A numpy array containing the samples. The shape and dtype depends on
+            the bit_packed argument:
+
+                if not bit_packed:
+                    shape = (num_samples,)
+                    dtype = np.bool_
+                elif not transpose and bit_packed:
+                    shape = (math.ceil(num_samples / 8),)
+                    dtype = np.uint8
+
+        Raises:
+            ValueError:
+                The given `out` argument had a shape or dtype inconsistent with the
+                requested data.
+
+        Examples:
+            >>> import stim
+            >>> sim = stim.FlipSimulator(batch_size=256)
+            >>> r = sim.generate_bernoulli_samples(1001, p=0.25)
+            >>> r.dtype
+            dtype('bool')
+            >>> r.shape
+            (1001,)
+
+            >>> r = sim.generate_bernoulli_samples(53, p=0.1, bit_packed=True)
+            >>> r.dtype
+            dtype('uint8')
+            >>> r.shape
+            (7,)
+            >>> r[6] & 0b1110_0000  # zero'd padding bits
+            0
+
+            >>> r2 = sim.generate_bernoulli_samples(53, p=0.2, bit_packed=True, out=r)
+            >>> r is r2  # Check request to reuse r worked.
+            True
+        """
     def get_detector_flips(
         self,
         *,
@@ -6663,11 +6726,11 @@ class FlipSimulator:
         *,
         bit_packed: bool = False,
         transpose: bool = False,
-        output_xs: bool | np.ndarray = False,
-        output_zs: bool | np.ndarray = False,
-        output_measure_flips: bool | np.ndarray = False,
-        output_detector_flips: bool | np.ndarray = False,
-        output_observable_flips: bool | np.ndarray = False,
+        output_xs: Union[bool, np.ndarray] = False,
+        output_zs: Union[bool, np.ndarray] = False,
+        output_measure_flips: Union[bool, np.ndarray] = False,
+        output_detector_flips: Union[bool, np.ndarray] = False,
+        output_observable_flips: Union[bool, np.ndarray] = False,
     ) -> Optional[Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]]:
         """Writes the simulator state into numpy arrays.
 

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -3332,6 +3332,17 @@ class CircuitRepeatBlock:
             repeat_count: The number of times to repeat the block.
             body: The body of the block, as a circuit.
             tag: Defaults to empty. A custom string attached to the REPEAT instruction.
+
+        Examples:
+            >>> import stim
+            >>> c = stim.Circuit()
+            >>> c.append(stim.CircuitRepeatBlock(100, stim.Circuit("M 0")))
+            >>> c
+            stim.Circuit('''
+                REPEAT 100 {
+                    M 0
+                }
+            ''')
         """
     def __ne__(
         self,
@@ -6497,6 +6508,145 @@ class FlipSimulator:
             >>> sim.set_pauli_flip('X', qubit_index=2, instance_index=1)
             >>> sim.peek_pauli_flips()
             [stim.PauliString("+___"), stim.PauliString("+__X")]
+        """
+    def to_numpy(
+        self,
+        *,
+        bit_packed: bool = False,
+        transpose: bool = False,
+        output_xs: bool | np.ndarray = False,
+        output_zs: bool | np.ndarray = False,
+        output_measure_flips: bool | np.ndarray = False,
+        output_detector_flips: bool | np.ndarray = False,
+        output_observable_flips: bool | np.ndarray = False,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Writes the simulator state into numpy arrays.
+
+        Args:
+            bit_packed: Whether or not the result is bit packed, storing 8 bits per
+                byte instead of 1 bit per byte. Bit packing always applies to
+                the second index of the result. Bits are packed in little endian
+                order (as if by `np.packbits(X, axis=1, order='little')`).
+            transpose: Defaults to False. When set to False, the second index of the
+                returned array (the index affected by bit packing) is the shot index
+                (meaning the first index is the qubit index or measurement index or
+                etc). When set to True, results are transposed so that the first
+                index is the shot index.
+            output_xs: Defaults to False. When set to False, the X flip data is not
+                generated and the corresponding array in the result tuple is set to
+                None. When set to True, a new array is allocated to hold the X flip
+                data and this array is returned via the result tuple. When set to
+                a numpy array, the results are written into that array (the shape and
+                dtype of the array must be exactly correct).
+            output_zs: Defaults to False. When set to False, the Z flip data is not
+                generated and the corresponding array in the result tuple is set to
+                None. When set to True, a new array is allocated to hold the Z flip
+                data and this array is returned via the result tuple. When set to
+                a numpy array, the results are written into that array (the shape and
+                dtype of the array must be exactly correct).
+            output_measure_flips: Defaults to False. When set to False, the measure
+                flip data is not generated and the corresponding array in the result
+                tuple is set to None. When set to True, a new array is allocated to
+                hold the measure flip data and this array is returned via the result
+                tuple. When set to a numpy array, the results are written into that
+                array (the shape and dtype of the array must be exactly correct).
+            output_detector_flips: Defaults to False. When set to False, the detector
+                flip data is not generated and the corresponding array in the result
+                tuple is set to None. When set to True, a new array is allocated to
+                hold the detector flip data and this array is returned via the result
+                tuple. When set to a numpy array, the results are written into that
+                array (the shape and dtype of the array must be exactly correct).
+            output_observable_flips: Defaults to False. When set to False, the obs
+                flip data is not generated and the corresponding array in the result
+                tuple is set to None. When set to True, a new array is allocated to
+                hold the obs flip data and this array is returned via the result
+                tuple. When set to a numpy array, the results are written into that
+                array (the shape and dtype of the array must be exactly correct).
+
+        Returns:
+            A tuple (xs, zs, ms, ds, os) of numpy arrays. The xs and zs arrays are
+            the pauli flip data specified using XZ encoding (00=I, 10=X, 11=Y, 01=Z).
+            The ms array is the measure flip data, the ds array is the detector flip
+            data, and the os array is the obs flip data. The arrays default to
+            `None` when the corresponding `output_*` argument was left False.
+
+            The shape and dtype of the data depends on arguments given to the function.
+            The following specifies each array's shape and dtype for each case:
+
+                if not transpose and not bit_packed:
+                    xs.shape = (sim.batch_size, sim.num_qubits)
+                    zs.shape = (sim.batch_size, sim.num_qubits)
+                    ms.shape = (sim.batch_size, sim.num_measurements)
+                    ds.shape = (sim.batch_size, sim.num_detectors)
+                    os.shape = (sim.batch_size, sim.num_observables)
+                    xs.dtype = np.bool_
+                    zs.dtype = np.bool_
+                    ms.dtype = np.bool_
+                    ds.dtype = np.bool_
+                    os.dtype = np.bool_
+                elif not transpose and bit_packed:
+                    xs.shape = (sim.batch_size, math.ceil(sim.num_qubits / 8))
+                    zs.shape = (sim.batch_size, math.ceil(sim.num_qubits / 8))
+                    ms.shape = (sim.batch_size, math.ceil(sim.num_measurements / 8))
+                    ds.shape = (sim.batch_size, math.ceil(sim.num_detectors / 8))
+                    os.shape = (sim.batch_size, math.ceil(sim.num_observables / 8))
+                    xs.dtype = np.uint8
+                    zs.dtype = np.uint8
+                    ms.dtype = np.uint8
+                    ds.dtype = np.uint8
+                    os.dtype = np.uint8
+                elif transpose and not bit_packed:
+                    xs.shape = (sim.num_qubits, sim.batch_size)
+                    zs.shape = (sim.num_qubits, sim.batch_size)
+                    ms.shape = (sim.num_measurements, sim.batch_size)
+                    ds.shape = (sim.num_detectors, sim.batch_size)
+                    os.shape = (sim.num_observables, sim.batch_size)
+                    xs.dtype = np.bool_
+                    zs.dtype = np.bool_
+                    ms.dtype = np.bool_
+                    ds.dtype = np.bool_
+                    os.dtype = np.bool_
+                elif transpose and bit_packed:
+                    xs.shape = (sim.num_qubits, math.ceil(sim.batch_size / 8))
+                    zs.shape = (sim.num_qubits, math.ceil(sim.batch_size / 8))
+                    ms.shape = (sim.num_measurements, math.ceil(sim.batch_size / 8))
+                    ds.shape = (sim.num_detectors, math.ceil(sim.batch_size / 8))
+                    os.shape = (sim.num_observables, math.ceil(sim.batch_size / 8))
+                    xs.dtype = np.uint8
+                    zs.dtype = np.uint8
+                    ms.dtype = np.uint8
+                    ds.dtype = np.uint8
+                    os.dtype = np.uint8
+
+        Raises:
+            ValueError:
+                All the `output_*` arguments were False, or an `output_*` argument
+                had a shape or dtype inconsistent with the requested data.
+
+        Examples:
+            >>> import stim
+            >>> sim = stim.FlipSimulator(batch_size=9)
+            >>> sim.do(stim.Circuit('M 0 1 2'))
+
+            >>> xs, zs, ms, ds, os = sim.to_numpy(
+            ...     transpose=True,
+            ...     bit_packed=True,
+            ...     output_measure_flips=True,
+            ... )
+            >>> xs
+            >>> zs
+            >>> ms
+            array([[0],
+                   [0],
+                   [0],
+                   [0],
+                   [0],
+                   [0],
+                   [0],
+                   [0],
+                   [0]], dtype=uint8)
+            >>> ds
+            >>> os
         """
 class FlippedMeasurement:
     """Describes a measurement that was flipped.

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -6350,7 +6350,7 @@ class FlipSimulator:
             >>> r.shape
             (7,)
             >>> r[6] & 0b1110_0000  # zero'd padding bits
-            0
+            np.uint8(0)
 
             >>> r2 = sim.generate_bernoulli_samples(53, p=0.2, bit_packed=True, out=r)
             >>> r is r2  # Check request to reuse r worked.

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -6519,7 +6519,7 @@ class FlipSimulator:
         output_measure_flips: bool | np.ndarray = False,
         output_detector_flips: bool | np.ndarray = False,
         output_observable_flips: bool | np.ndarray = False,
-    ) -> Tuple[np.ndarray, np.ndarray]:
+    ) -> Optional[Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]]:
         """Writes the simulator state into numpy arrays.
 
         Args:
@@ -6626,16 +6626,18 @@ class FlipSimulator:
         Examples:
             >>> import stim
             >>> sim = stim.FlipSimulator(batch_size=9)
-            >>> sim.do(stim.Circuit('M 0 1 2'))
+            >>> sim.do(stim.Circuit('M(1) 0 1 2'))
 
+            >>> ms_buf = np.empty(shape=(9, 1), dtype=np.uint8)
             >>> xs, zs, ms, ds, os = sim.to_numpy(
             ...     transpose=True,
             ...     bit_packed=True,
-            ...     output_measure_flips=True,
+            ...     output_zs=True,
+            ...     output_measure_flips=ms_buf,
             ... )
+            >>> assert ms is ms_buf
             >>> xs
             >>> zs
-            >>> ms
             array([[0],
                    [0],
                    [0],
@@ -6645,6 +6647,16 @@ class FlipSimulator:
                    [0],
                    [0],
                    [0]], dtype=uint8)
+            >>> ms
+            array([[7],
+                   [7],
+                   [7],
+                   [7],
+                   [7],
+                   [7],
+                   [7],
+                   [7],
+                   [7]], dtype=uint8)
             >>> ds
             >>> os
         """

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -3473,18 +3473,54 @@ class CircuitTargetsInsideInstruction:
         targets_in_range: List[stim.GateTargetWithCoords],
     ) -> None:
         """Creates a stim.CircuitTargetsInsideInstruction.
+
+        Examples:
+            >>> import stim
+            >>> val = stim.CircuitTargetsInsideInstruction(
+            ...     gate='X_ERROR',
+            ...     args=[0.25],
+            ...     target_range_start=0,
+            ...     target_range_end=1,
+            ...     targets_in_range=[stim.GateTargetWithCoords(0, [])],
+            ... )
         """
     @property
     def args(
         self,
     ) -> List[float]:
         """Returns parens arguments of the gate / instruction that was being executed.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.Circuit('''
+            ...     R 0 1
+            ...     X_ERROR(0.25) 0 1
+            ...     M 0 1
+            ...     DETECTOR(2, 3) rec[-1] rec[-2]
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ... ''').shortest_graphlike_error()
+            >>> loc: stim.CircuitErrorLocation = err[0].circuit_error_locations[0]
+            >>> loc.instruction_targets.args
+            [0.25]
         """
     @property
     def gate(
         self,
     ) -> Optional[str]:
         """Returns the name of the gate / instruction that was being executed.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.Circuit('''
+            ...     R 0 1
+            ...     X_ERROR(0.25) 0 1
+            ...     M 0 1
+            ...     DETECTOR(2, 3) rec[-1] rec[-2]
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ... ''').shortest_graphlike_error()
+            >>> loc: stim.CircuitErrorLocation = err[0].circuit_error_locations[0]
+            >>> loc.instruction_targets.gate
+            'X_ERROR'
         """
     @property
     def target_range_end(
@@ -3492,6 +3528,21 @@ class CircuitTargetsInsideInstruction:
     ) -> int:
         """Returns the exclusive end of the range of targets that were executing
         within the gate / instruction.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.Circuit('''
+            ...     R 0 1
+            ...     X_ERROR(0.25) 0 1
+            ...     M 0 1
+            ...     DETECTOR(2, 3) rec[-1] rec[-2]
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ... ''').shortest_graphlike_error()
+            >>> loc: stim.CircuitErrorLocation = err[0].circuit_error_locations[0]
+            >>> loc.instruction_targets.target_range_start
+            0
+            >>> loc.instruction_targets.target_range_end
+            1
         """
     @property
     def target_range_start(
@@ -3499,6 +3550,21 @@ class CircuitTargetsInsideInstruction:
     ) -> int:
         """Returns the inclusive start of the range of targets that were executing
         within the gate / instruction.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.Circuit('''
+            ...     R 0 1
+            ...     X_ERROR(0.25) 0 1
+            ...     M 0 1
+            ...     DETECTOR(2, 3) rec[-1] rec[-2]
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ... ''').shortest_graphlike_error()
+            >>> loc: stim.CircuitErrorLocation = err[0].circuit_error_locations[0]
+            >>> loc.instruction_targets.target_range_start
+            0
+            >>> loc.instruction_targets.target_range_end
+            1
         """
     @property
     def targets_in_range(
@@ -3507,6 +3573,19 @@ class CircuitTargetsInsideInstruction:
         """Returns the subset of targets of the gate/instruction that were being executed.
 
         Includes coordinate data with the targets.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.Circuit('''
+            ...     R 0 1
+            ...     X_ERROR(0.25) 0 1
+            ...     M 0 1
+            ...     DETECTOR(2, 3) rec[-1] rec[-2]
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ... ''').shortest_graphlike_error()
+            >>> loc: stim.CircuitErrorLocation = err[0].circuit_error_locations[0]
+            >>> loc.instruction_targets.targets_in_range
+            [stim.GateTargetWithCoords(0, [])]
         """
 class CompiledDemSampler:
     """A helper class for efficiently sampler from a detector error model.
@@ -4846,10 +4925,17 @@ class DemTargetWithCoords:
     problem in a circuit, instead of having to constantly manually
     look up the coordinates of a detector index in order to understand
     what is happening.
+
+    Examples:
+        >>> import stim
+        >>> t = stim.DemTargetWithCoords(stim.DemTarget("D1"), [1.5, 2.0])
+        >>> t.dem_target
+        stim.DemTarget('D1')
+        >>> t.coords
+        [1.5, 2.0]
     """
     def __init__(
         self,
-        *,
         dem_target: stim.DemTarget,
         coords: List[float],
     ) -> None:
@@ -5813,6 +5899,28 @@ class DetectorErrorModel:
         """
 class ExplainedError:
     """Describes the location of an error mechanism from a stim circuit.
+
+    Examples:
+        >>> import stim
+        >>> err = stim.Circuit('''
+        ...     R 0
+        ...     TICK
+        ...     Y_ERROR(0.125) 0
+        ...     M 0
+        ...     OBSERVABLE_INCLUDE(0) rec[-1]
+        ... ''').shortest_graphlike_error()
+        >>> print(err[0])
+        ExplainedError {
+            dem_error_terms: L0
+            CircuitErrorLocation {
+                flipped_pauli_product: Y0
+                Circuit location stack trace:
+                    (after 1 TICKs)
+                    at instruction #3 (Y_ERROR) in the circuit
+                    at target #1 of the instruction
+                    resolving to Y_ERROR(0.125) 0
+            }
+        }
     """
     def __init__(
         self,
@@ -5821,6 +5929,28 @@ class ExplainedError:
         circuit_error_locations: List[stim.CircuitErrorLocation],
     ) -> None:
         """Creates a stim.ExplainedError.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.Circuit('''
+            ...     R 0
+            ...     TICK
+            ...     Y_ERROR(0.125) 0
+            ...     M 0
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ... ''').shortest_graphlike_error()
+            >>> print(err[0])
+            ExplainedError {
+                dem_error_terms: L0
+                CircuitErrorLocation {
+                    flipped_pauli_product: Y0
+                    Circuit location stack trace:
+                        (after 1 TICKs)
+                        at instruction #3 (Y_ERROR) in the circuit
+                        at target #1 of the instruction
+                        resolving to Y_ERROR(0.125) 0
+                }
+            }
         """
     @property
     def circuit_error_locations(
@@ -5835,6 +5965,25 @@ class ExplainedError:
         Note: if this list is empty, it may be because there was a DEM error decomposed
         into parts where one of the parts is impossible to make on its own from a single
         circuit error.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.Circuit('''
+            ...     R 0
+            ...     TICK
+            ...     Y_ERROR(0.125) 0
+            ...     M 0
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ... ''').shortest_graphlike_error()
+            >>> print(err[0].circuit_error_locations[0])
+            CircuitErrorLocation {
+                flipped_pauli_product: Y0
+                Circuit location stack trace:
+                    (after 1 TICKs)
+                    at instruction #3 (Y_ERROR) in the circuit
+                    at target #1 of the instruction
+                    resolving to Y_ERROR(0.125) 0
+            }
         """
     @property
     def dem_error_terms(
@@ -6625,6 +6774,7 @@ class FlipSimulator:
 
         Examples:
             >>> import stim
+            >>> import numpy as np
             >>> sim = stim.FlipSimulator(batch_size=9)
             >>> sim.do(stim.Circuit('M(1) 0 1 2'))
 
@@ -6632,12 +6782,11 @@ class FlipSimulator:
             >>> xs, zs, ms, ds, os = sim.to_numpy(
             ...     transpose=True,
             ...     bit_packed=True,
-            ...     output_zs=True,
+            ...     output_xs=True,
             ...     output_measure_flips=ms_buf,
             ... )
             >>> assert ms is ms_buf
             >>> xs
-            >>> zs
             array([[0],
                    [0],
                    [0],
@@ -6647,6 +6796,7 @@ class FlipSimulator:
                    [0],
                    [0],
                    [0]], dtype=uint8)
+            >>> zs
             >>> ms
             array([[7],
                    [7],
@@ -6665,6 +6815,18 @@ class FlippedMeasurement:
 
     Gives the measurement's index in the measurement record, and also
     the observable of the measurement.
+
+    Examples:
+        >>> import stim
+        >>> err = stim.Circuit('''
+        ...     M(0.25) 1 10
+        ...     OBSERVABLE_INCLUDE(0) rec[-1]
+        ... ''').shortest_graphlike_error()
+        >>> err[0].circuit_error_locations[0].flipped_measurement
+        stim.FlippedMeasurement(
+            record_index=1,
+            observable=(stim.GateTargetWithCoords(stim.target_z(10), []),),
+        )
     """
     def __init__(
         self,
@@ -6691,6 +6853,15 @@ class FlippedMeasurement:
         """Returns the observable of the flipped measurement.
 
         For example, an `MX 5` measurement will have the observable X5.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.Circuit('''
+            ...     M(0.25) 1 10
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ... ''').shortest_graphlike_error()
+            >>> err[0].circuit_error_locations[0].flipped_measurement.observable
+            [stim.GateTargetWithCoords(stim.target_z(10), [])]
         """
     @property
     def record_index(
@@ -6699,6 +6870,15 @@ class FlippedMeasurement:
         """The measurement record index of the flipped measurement.
         For example, the fifth measurement in a circuit has a measurement
         record index of 4.
+
+        Examples:
+            >>> import stim
+            >>> err = stim.Circuit('''
+            ...     M(0.25) 1 10
+            ...     OBSERVABLE_INCLUDE(0) rec[-1]
+            ... ''').shortest_graphlike_error()
+            >>> err[0].circuit_error_locations[0].flipped_measurement.record_index
+            1
         """
 class Flow:
     """A stabilizer flow (e.g. "XI -> XX xor rec[-1]").
@@ -7541,7 +7721,21 @@ class GateTarget:
         """Initializes a `stim.GateTarget`.
 
         Args:
-            value: A target like `5` or `stim.target_rec(-1)`.
+            value: A value to convert into a gate target, like an integer
+                to interpret as a qubit target or a string to parse.
+
+        Examples:
+            >>> import stim
+            >>> stim.GateTarget(stim.GateTarget(5))
+            stim.GateTarget(5)
+            >>> stim.GateTarget("X7")
+            stim.target_x(7)
+            >>> stim.GateTarget("rec[-3]")
+            stim.target_rec(-3)
+            >>> stim.GateTarget("!Z7")
+            stim.target_z(7, invert=True)
+            >>> stim.GateTarget("*")
+            stim.GateTarget.combiner()
         """
     def __ne__(
         self,
@@ -7655,7 +7849,6 @@ class GateTarget:
         self,
     ) -> bool:
         """Returns whether or not this is a sweep bit target like `sweep[4]`.
-
 
         Examples:
             >>> import stim
@@ -7828,6 +8021,14 @@ class GateTargetWithCoords:
     problem in a circuit, instead of having to constantly manually
     look up the coordinates of a qubit index in order to understand
     what is happening.
+
+    Examples:
+        >>> import stim
+        >>> t = stim.GateTargetWithCoords(0, [1.5, 2.0])
+        >>> t.gate_target
+        stim.GateTarget(0)
+        >>> t.coords
+        [1.5, 2.0]
     """
     def __init__(
         self,
@@ -7835,6 +8036,14 @@ class GateTargetWithCoords:
         coords: List[float],
     ) -> None:
         """Creates a stim.GateTargetWithCoords.
+
+        Examples:
+            >>> import stim
+            >>> t = stim.GateTargetWithCoords(0, [1.5, 2.0])
+            >>> t.gate_target
+            stim.GateTarget(0)
+            >>> t.coords
+            [1.5, 2.0]
         """
     @property
     def coords(
@@ -7843,12 +8052,24 @@ class GateTargetWithCoords:
         """Returns the associated coordinate information as a list of floats.
 
         If there is no coordinate information, returns an empty list.
+
+        Examples:
+            >>> import stim
+            >>> t = stim.GateTargetWithCoords(0, [1.5, 2.0])
+            >>> t.coords
+            [1.5, 2.0]
         """
     @property
     def gate_target(
         self,
     ) -> stim.GateTarget:
         """Returns the actual gate target as a `stim.GateTarget`.
+
+        Examples:
+            >>> import stim
+            >>> t = stim.GateTargetWithCoords(0, [1.5, 2.0])
+            >>> t.gate_target
+            stim.GateTarget(0)
         """
 class PauliString:
     """A signed Pauli tensor product (e.g. "+X \u2297 X \u2297 X" or "-Y \u2297 Z".
@@ -10711,6 +10932,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.c_xyz(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +Y +Z +X
         """
     def c_zyx(
         self,
@@ -10720,6 +10953,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.c_zyx(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +Z +X +Y
         """
     def canonical_stabilizers(
         self,
@@ -10780,6 +11025,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.cnot(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +_ +_ +Z +X
         """
     def copy(
         self,
@@ -10924,6 +11181,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.cx(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +_ +_ +Z +X
         """
     def cy(
         self,
@@ -10935,6 +11204,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.cy(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
         """
     def cz(
         self,
@@ -10946,6 +11227,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.cz(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +_ +_ +Z +X
         """
     def depolarize1(
         self,
@@ -10958,6 +11251,11 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the noise.
             p: The chance of the error being applied,
                 independently, to each qubit.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.depolarize1(0, 1, 2, p=0.01)
         """
     def depolarize2(
         self,
@@ -10972,6 +11270,11 @@ class TableauSimulator:
                 zip(targets[::1], targets[1::2]).
             p: The chance of the error being applied,
                 independently, to each qubit pair.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.depolarize1(0, 1, 4, 5, p=0.01)
         """
     def do(
         self,
@@ -11084,6 +11387,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.h(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +Z -Y +X
         """
     def h_xy(
         self,
@@ -11093,6 +11408,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.h_xy(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +Y +X -Z
         """
     def h_xz(
         self,
@@ -11102,6 +11429,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.h_xz(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +Z -Y +X
         """
     def h_yz(
         self,
@@ -11111,6 +11450,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.h_yz(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            -X +Z +Y
         """
     def iswap(
         self,
@@ -11122,6 +11473,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.iswap(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +_ +_ +Y +Z
         """
     def iswap_dag(
         self,
@@ -11133,6 +11496,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.iswap_dag(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +_ +_ -Y +Z
         """
     def measure(
         self,
@@ -11151,6 +11526,15 @@ class TableauSimulator:
 
         Returns:
             The measurement result as a bool.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.x(1)
+            >>> s.measure(0)
+            False
+            >>> s.measure(1)
+            True
         """
     def measure_kickback(
         self,
@@ -11218,6 +11602,13 @@ class TableauSimulator:
 
         Returns:
             The measurement results as a list of bools.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.x(1)
+            >>> s.measure_many(0, 1)
+            [False, True]
         """
     def measure_observable(
         self,
@@ -11691,6 +12082,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.s(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +Y -X +Z
         """
     def s_dag(
         self,
@@ -11700,6 +12103,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.s_dag(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            -Y +X +Z
         """
     def set_inverse_tableau(
         self,
@@ -11926,6 +12341,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.sqrt_x(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Z -Y
         """
     def sqrt_x_dag(
         self,
@@ -11935,6 +12362,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.sqrt_x_dag(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X -Z +Y
         """
     def sqrt_y(
         self,
@@ -11944,6 +12383,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.sqrt_y(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            -Z +Y +X
         """
     def sqrt_y_dag(
         self,
@@ -11953,6 +12404,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.sqrt_y_dag(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +Z +Y -X
         """
     def state_vector(
         self,
@@ -12015,6 +12478,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.swap(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +Y +X +X +Z
         """
     def x(
         self,
@@ -12024,6 +12499,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.x(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X -Y -Z
         """
     def x_error(
         self,
@@ -12036,6 +12523,11 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the noise.
             p: The chance of the X error being applied,
                 independently, to each qubit.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.x_error(0, 1, 2, p=0.01)
         """
     def xcx(
         self,
@@ -12047,6 +12539,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.xcx(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
         """
     def xcy(
         self,
@@ -12058,6 +12562,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.xcy(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +_ +_
         """
     def xcz(
         self,
@@ -12069,6 +12585,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.xcz(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +_ +_
         """
     def y(
         self,
@@ -12078,6 +12606,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.y(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            -X +Y -Z
         """
     def y_error(
         self,
@@ -12090,6 +12630,11 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the noise.
             p: The chance of the Y error being applied,
                 independently, to each qubit.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.y_error(0, 1, 2, p=0.01)
         """
     def ycx(
         self,
@@ -12101,6 +12646,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.ycx(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +_ +_ +Z +X
         """
     def ycy(
         self,
@@ -12112,6 +12669,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.ycy(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +_ +_
         """
     def ycz(
         self,
@@ -12123,6 +12692,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.ycz(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +_ +_ +_ +_
         """
     def z(
         self,
@@ -12132,6 +12713,18 @@ class TableauSimulator:
 
         Args:
             *targets: The indices of the qubits to target with the gate.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            +X +Y +Z
+            >>> s.z(0, 1, 2)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+            -X -Y +Z
         """
     def y_error(
         self,
@@ -12144,6 +12737,11 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the noise.
             p: The chance of the Z error being applied,
                 independently, to each qubit.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.z_error(0, 1, 2, p=0.01)
         """
     def zcx(
         self,
@@ -12155,6 +12753,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.zcx(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +_ +_ +Z +X
         """
     def zcy(
         self,
@@ -12166,6 +12776,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.zcy(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
         """
     def zcz(
         self,
@@ -12177,6 +12799,18 @@ class TableauSimulator:
             *targets: The indices of the qubits to target with the gate.
                 Applies the gate to the first two targets, then the next two targets,
                 and so forth. There must be an even number of targets.
+
+        Examples:
+            >>> import stim
+            >>> s = stim.TableauSimulator()
+            >>> s.reset_x(0, 3)
+            >>> s.reset_y(1)
+
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +X +Y +Z +X
+            >>> s.zcz(0, 1, 2, 3)
+            >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+            +_ +_ +Z +X
         """
 @overload
 def gate_data(

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -169,12 +169,12 @@ std::vector<ExplainedError> py_find_undetectable_logical_error(
     return ErrorMatcher::explain_errors_from_circuit(self, &filter, reduce_to_representative);
 }
 
-std::string py_shortest_error_sat_problem(const Circuit &self, std::string format) {
+std::string py_shortest_error_sat_problem(const Circuit &self, std::string_view format) {
     DetectorErrorModel dem = ErrorAnalyzer::circuit_to_detector_error_model(self, false, true, false, 1, false, false);
     return stim::shortest_error_sat_problem(dem, format);
 }
 
-std::string py_likeliest_error_sat_problem(const Circuit &self, int quantization, std::string format) {
+std::string py_likeliest_error_sat_problem(const Circuit &self, int quantization, std::string_view format) {
     DetectorErrorModel dem = ErrorAnalyzer::circuit_to_detector_error_model(self, false, true, false, 1, false, false);
     return stim::likeliest_error_sat_problem(dem, quantization, format);
 }
@@ -255,7 +255,7 @@ void circuit_append(
     std::vector<uint32_t> raw_targets;
     try {
         raw_targets.push_back(obj_to_gate_target(targets).data);
-    } catch (const std::invalid_argument &ex) {
+    } catch (const std::invalid_argument &) {
         for (const auto &t : targets) {
             raw_targets.push_back(handle_to_gate_target(t).data);
         }
@@ -279,13 +279,13 @@ void circuit_append(
             auto d = pybind11::cast<double>(used_arg);
             self.safe_append_ua(gate_name, raw_targets, d, tag);
             return;
-        } catch (const pybind11::cast_error &ex) {
+        } catch (const pybind11::cast_error &) {
         }
         try {
             auto args = pybind11::cast<std::vector<double>>(used_arg);
             self.safe_append_u(gate_name, raw_targets, args, tag);
             return;
-        } catch (const pybind11::cast_error &ex) {
+        } catch (const pybind11::cast_error &) {
         }
         throw std::invalid_argument("Arg must be a double or sequence of doubles.");
     } else if (pybind11::isinstance<PyCircuitInstruction>(obj)) {
@@ -1329,8 +1329,8 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
            double before_measure_flip_probability,
            double after_reset_flip_probability) {
             auto r = type.find(':');
-            std::string code;
-            std::string task;
+            std::string_view code;
+            std::string_view task;
             if (r == std::string::npos) {
                 code = "";
                 task = type;
@@ -1339,7 +1339,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
                 task = type.substr(r + 1);
             }
 
-            CircuitGenParameters params(rounds, distance, task);
+            CircuitGenParameters params(rounds, distance, std::string(task));
             params.after_clifford_depolarization = after_clifford_depolarization;
             params.after_reset_flip_probability = after_reset_flip_probability;
             params.before_measure_flip_probability = before_measure_flip_probability;
@@ -1920,7 +1920,7 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
         [](const Circuit &self, const pybind11::object &obj, double atol) -> bool {
             try {
                 return self.approx_equals(pybind11::cast<Circuit>(obj), atol);
-            } catch (const pybind11::cast_error &ex) {
+            } catch (const pybind11::cast_error &) {
                 return false;
             }
         },

--- a/src/stim/circuit/circuit_repeat_block.pybind.cc
+++ b/src/stim/circuit/circuit_repeat_block.pybind.cc
@@ -85,6 +85,17 @@ void stim_pybind::pybind_circuit_repeat_block_methods(pybind11::module &m, pybin
                 repeat_count: The number of times to repeat the block.
                 body: The body of the block, as a circuit.
                 tag: Defaults to empty. A custom string attached to the REPEAT instruction.
+
+            Examples:
+                >>> import stim
+                >>> c = stim.Circuit()
+                >>> c.append(stim.CircuitRepeatBlock(100, stim.Circuit("M 0")))
+                >>> c
+                stim.Circuit('''
+                    REPEAT 100 {
+                        M 0
+                    }
+                ''')
         )DOC")
             .data());
 

--- a/src/stim/circuit/gate_target.pybind.cc
+++ b/src/stim/circuit/gate_target.pybind.cc
@@ -22,6 +22,11 @@ using namespace stim_pybind;
 
 GateTarget handle_to_gate_target(const pybind11::handle &obj) {
     try {
+        std::string_view text = pybind11::cast<std::string_view>(obj);
+        return GateTarget::from_target_str(text);
+    } catch (const pybind11::cast_error &ex) {
+    }
+    try {
         return pybind11::cast<GateTarget>(obj);
     } catch (const pybind11::cast_error &ex) {
     }
@@ -65,7 +70,21 @@ void stim_pybind::pybind_circuit_gate_target_methods(pybind11::module &m, pybind
             Initializes a `stim.GateTarget`.
 
             Args:
-                value: A target like `5` or `stim.target_rec(-1)`.
+                value: A value to convert into a gate target, like an integer
+                    to interpret as a qubit target or a string to parse.
+
+            Examples:
+                >>> import stim
+                >>> stim.GateTarget(stim.GateTarget(5))
+                stim.GateTarget(5)
+                >>> stim.GateTarget("X7")
+                stim.target_x(7)
+                >>> stim.GateTarget("rec[-3]")
+                stim.target_rec(-3)
+                >>> stim.GateTarget("!Z7")
+                stim.target_z(7, invert=True)
+                >>> stim.GateTarget("*")
+                stim.GateTarget.combiner()
         )DOC")
             .data());
 
@@ -339,7 +358,6 @@ void stim_pybind::pybind_circuit_gate_target_methods(pybind11::module &m, pybind
         &GateTarget::is_sweep_bit_target,
         clean_doc_string(R"DOC(
             Returns whether or not this is a sweep bit target like `sweep[4]`.
-
 
             Examples:
                 >>> import stim

--- a/src/stim/search/sat/wcnf.cc
+++ b/src/stim/search/sat/wcnf.cc
@@ -260,14 +260,14 @@ std::string sat_problem_as_wcnf_string(const DetectorErrorModel& model, bool wei
 }
 
 // Should ignore weights entirely and minimize the cardinality.
-std::string stim::shortest_error_sat_problem(const DetectorErrorModel& model, std::string format) {
+std::string stim::shortest_error_sat_problem(const DetectorErrorModel& model, std::string_view format) {
     if (format != "WDIMACS") {
         throw std::invalid_argument("Unsupported format.");
     }
     return sat_problem_as_wcnf_string(model, /*weighted=*/false, /*quantization=*/0);
 }
 
-std::string stim::likeliest_error_sat_problem(const DetectorErrorModel& model, int quantization, std::string format) {
+std::string stim::likeliest_error_sat_problem(const DetectorErrorModel& model, int quantization, std::string_view format) {
     if (format != "WDIMACS") {
         throw std::invalid_argument("Unsupported format.");
     }

--- a/src/stim/search/sat/wcnf.h
+++ b/src/stim/search/sat/wcnf.h
@@ -1,8 +1,6 @@
 #ifndef _STIM_SEARCH_SAT_WCNF_H
 #define _STIM_SEARCH_SAT_WCNF_H
 
-#include <cstdint>
-
 #include "stim/dem/detector_error_model.h"
 
 namespace stim {
@@ -33,13 +31,11 @@ namespace stim {
 ///     users must separately manage the process of selecting and running the solver. This approach is designed to
 ///     sidestep the need for direct integration with any particular solver and allow
 ///     for experimentation with different solvers to achieve the best performance.
-// std::string shortest_error_problem_as_wcnf_file(
-//   const DetectorErrorModel &model, bool weighted=false, size_t weight_scale_factor=0);
 
-std::string shortest_error_sat_problem(const DetectorErrorModel& model, std::string format = "WDIMACS");
+std::string shortest_error_sat_problem(const DetectorErrorModel& model, std::string_view format = "WDIMACS");
 
 std::string likeliest_error_sat_problem(
-    const DetectorErrorModel& model, int quantization = 10, std::string format = "WDIMACS");
+    const DetectorErrorModel& model, int quantization = 10, std::string_view format = "WDIMACS");
 
 }  // namespace stim
 

--- a/src/stim/simulators/frame_simulator.pybind.cc
+++ b/src/stim/simulators/frame_simulator.pybind.cc
@@ -951,7 +951,7 @@ void stim_pybind::pybind_frame_simulator_methods(
                 >>> r.shape
                 (7,)
                 >>> r[6] & 0b1110_0000  # zero'd padding bits
-                np.uint8(0)
+                0
 
                 >>> r2 = sim.generate_bernoulli_samples(53, p=0.2, bit_packed=True, out=r)
                 >>> r is r2  # Check request to reuse r worked.

--- a/src/stim/simulators/frame_simulator.pybind.cc
+++ b/src/stim/simulators/frame_simulator.pybind.cc
@@ -951,7 +951,7 @@ void stim_pybind::pybind_frame_simulator_methods(
                 >>> r.shape
                 (7,)
                 >>> r[6] & 0b1110_0000  # zero'd padding bits
-                0
+                np.uint8(0)
 
                 >>> r2 = sim.generate_bernoulli_samples(53, p=0.2, bit_packed=True, out=r)
                 >>> r is r2  # Check request to reuse r worked.

--- a/src/stim/simulators/frame_simulator.pybind.cc
+++ b/src/stim/simulators/frame_simulator.pybind.cc
@@ -613,7 +613,7 @@ void stim_pybind::pybind_frame_simulator_methods(
         pybind11::arg("output_detector_flips") = false,
         pybind11::arg("output_observable_flips") = false,
         clean_doc_string(R"DOC(
-            @signature def to_numpy(self, *, bit_packed: bool = False, transpose: bool = False, output_xs: bool | np.ndarray = False, output_zs: bool | np.ndarray = False, output_measure_flips: bool | np.ndarray = False, output_detector_flips: bool | np.ndarray = False, output_observable_flips: bool | np.ndarray = False) -> tuple[np.ndarray, np.ndarray]:
+            @signature def to_numpy(self, *, bit_packed: bool = False, transpose: bool = False, output_xs: bool | np.ndarray = False, output_zs: bool | np.ndarray = False, output_measure_flips: bool | np.ndarray = False, output_detector_flips: bool | np.ndarray = False, output_observable_flips: bool | np.ndarray = False) -> Optional[Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]]:
             Writes the simulator state into numpy arrays.
 
             Args:
@@ -719,17 +719,19 @@ void stim_pybind::pybind_frame_simulator_methods(
 
             Examples:
                 >>> import stim
+                >>> import numpy as np
                 >>> sim = stim.FlipSimulator(batch_size=9)
-                >>> sim.do(stim.Circuit('M 0 1 2'))
+                >>> sim.do(stim.Circuit('M(1) 0 1 2'))
 
+                >>> ms_buf = np.empty(shape=(9, 1), dtype=np.uint8)
                 >>> xs, zs, ms, ds, os = sim.to_numpy(
                 ...     transpose=True,
                 ...     bit_packed=True,
-                ...     output_measure_flips=True,
+                ...     output_xs=True,
+                ...     output_measure_flips=ms_buf,
                 ... )
+                >>> assert ms is ms_buf
                 >>> xs
-                >>> zs
-                >>> ms
                 array([[0],
                        [0],
                        [0],
@@ -739,6 +741,17 @@ void stim_pybind::pybind_frame_simulator_methods(
                        [0],
                        [0],
                        [0]], dtype=uint8)
+                >>> zs
+                >>> ms
+                array([[7],
+                       [7],
+                       [7],
+                       [7],
+                       [7],
+                       [7],
+                       [7],
+                       [7],
+                       [7]], dtype=uint8)
                 >>> ds
                 >>> os
         )DOC")

--- a/src/stim/simulators/frame_simulator.pybind.cc
+++ b/src/stim/simulators/frame_simulator.pybind.cc
@@ -95,6 +95,99 @@ pybind11::object peek_pauli_flips(const FrameSimulator<W> &self, const pybind11:
     return pybind11::cast(std::move(result));
 }
 
+pybind11::object pick_output_numpy_array(pybind11::object output_vs, bool bit_packed, bool transpose, size_t shape1, size_t shape2, const char *name) {
+    auto numpy = pybind11::module::import("numpy");
+    auto dtype = bit_packed ? numpy.attr("uint8") : numpy.attr("bool_");
+    auto py_bool = pybind11::module::import("builtins").attr("bool");
+    if (transpose) {
+        std::swap(shape1, shape2);
+    }
+    if (bit_packed) {
+        shape2 = (shape2 + 7) >> 3;
+    }
+    auto shape = pybind11::make_tuple(shape1, shape2);
+    if (pybind11::isinstance<pybind11::bool_>(output_vs) && pybind11::bool_(false).equal(output_vs)) {
+        return pybind11::none();
+    } else if (pybind11::isinstance<pybind11::bool_>(output_vs) && pybind11::bool_(true).equal(output_vs)) {
+        return numpy.attr("empty")(shape, dtype);
+    } else if (bit_packed && pybind11::isinstance<pybind11::array_t<uint8_t>>(output_vs) && shape.equal(output_vs.attr("shape"))) {
+        return output_vs;
+    } else if (!bit_packed && pybind11::isinstance<pybind11::array_t<bool>>(output_vs) && shape.equal(output_vs.attr("shape"))) {
+        return output_vs;
+    } else {
+        std::stringstream ss;
+        ss << name << " wasn't set to False, True, or a numpy array with dtype=" << pybind11::str(dtype) << " and shape=" << shape;
+        throw std::invalid_argument(ss.str());
+    }
+}
+
+template <size_t W>
+pybind11::object to_numpy(
+    const FrameSimulator<W> &self,
+    bool bit_packed,
+    bool transpose,
+    pybind11::object output_xs,
+    pybind11::object output_zs,
+    pybind11::object output_measure_flips,
+    pybind11::object output_detector_flips,
+    pybind11::object output_observable_flips) {
+    output_xs = pick_output_numpy_array(output_xs, bit_packed, transpose, self.num_qubits, self.batch_size, "output_xs");
+    output_zs = pick_output_numpy_array(output_zs, bit_packed, transpose, self.num_qubits, self.batch_size, "output_zs");
+    output_measure_flips = pick_output_numpy_array(output_measure_flips, bit_packed, transpose, self.m_record.stored, self.batch_size, "output_measure_flips");
+    output_detector_flips = pick_output_numpy_array(output_detector_flips, bit_packed, transpose, self.det_record.stored, self.batch_size, "output_detector_flips");
+    output_observable_flips = pick_output_numpy_array(output_observable_flips, bit_packed, transpose, self.num_observables, self.batch_size, "output_observable_flips");
+
+    if (!output_xs.is_none()) {
+        simd_bit_table_to_numpy(
+            self.x_table,
+            self.num_qubits,
+            self.batch_size,
+            bit_packed,
+            transpose,
+            output_xs);
+    }
+    if (!output_zs.is_none()) {
+        simd_bit_table_to_numpy(
+            self.z_table,
+            self.num_qubits,
+            self.batch_size,
+            bit_packed,
+            transpose,
+            output_zs);
+    }
+    if (!output_measure_flips.is_none()) {
+        simd_bit_table_to_numpy(
+            self.m_record.storage,
+            self.m_record.stored,
+            self.batch_size,
+            bit_packed,
+            transpose,
+            output_measure_flips);
+    }
+    if (!output_detector_flips.is_none()) {
+        simd_bit_table_to_numpy(
+            self.det_record.storage,
+            self.det_record.stored,
+            self.batch_size,
+            bit_packed,
+            transpose,
+            output_detector_flips);
+    }
+    if (!output_observable_flips.is_none()) {
+        simd_bit_table_to_numpy(
+            self.obs_record,
+            self.num_observables,
+            self.batch_size,
+            bit_packed,
+            transpose,
+            output_observable_flips);
+    }
+    if (output_xs.is_none() + output_zs.is_none() + output_measure_flips.is_none() + output_detector_flips.is_none() + output_observable_flips.is_none() == 5) {
+        throw std::invalid_argument("No outputs requested! Specify at least one output_*= argument.");
+    }
+    return pybind11::make_tuple(output_xs, output_zs, output_measure_flips, output_detector_flips, output_observable_flips);
+}
+
 template <size_t W>
 FrameSimulator<W> create_frame_simulator(
     size_t batch_size, bool disable_heisenberg_uncertainty, uint32_t num_qubits, const pybind11::object &seed) {
@@ -505,6 +598,149 @@ void stim_pybind::pybind_frame_simulator_methods(
                 >>> sorted(set(str(flips)))  # Should have Zs from stabilizer randomization
                 ['+', 'Z', '_']
 
+        )DOC")
+            .data());
+
+    c.def(
+        "to_numpy",
+        &to_numpy<MAX_BITWORD_WIDTH>,
+        pybind11::kw_only(),
+        pybind11::arg("bit_packed") = false,
+        pybind11::arg("transpose") = false,
+        pybind11::arg("output_xs") = false,
+        pybind11::arg("output_zs") = false,
+        pybind11::arg("output_measure_flips") = false,
+        pybind11::arg("output_detector_flips") = false,
+        pybind11::arg("output_observable_flips") = false,
+        clean_doc_string(R"DOC(
+            @signature def to_numpy(self, *, bit_packed: bool = False, transpose: bool = False, output_xs: bool | np.ndarray = False, output_zs: bool | np.ndarray = False, output_measure_flips: bool | np.ndarray = False, output_detector_flips: bool | np.ndarray = False, output_observable_flips: bool | np.ndarray = False) -> tuple[np.ndarray, np.ndarray]:
+            Writes the simulator state into numpy arrays.
+
+            Args:
+                bit_packed: Whether or not the result is bit packed, storing 8 bits per
+                    byte instead of 1 bit per byte. Bit packing always applies to
+                    the second index of the result. Bits are packed in little endian
+                    order (as if by `np.packbits(X, axis=1, order='little')`).
+                transpose: Defaults to False. When set to False, the second index of the
+                    returned array (the index affected by bit packing) is the shot index
+                    (meaning the first index is the qubit index or measurement index or
+                    etc). When set to True, results are transposed so that the first
+                    index is the shot index.
+                output_xs: Defaults to False. When set to False, the X flip data is not
+                    generated and the corresponding array in the result tuple is set to
+                    None. When set to True, a new array is allocated to hold the X flip
+                    data and this array is returned via the result tuple. When set to
+                    a numpy array, the results are written into that array (the shape and
+                    dtype of the array must be exactly correct).
+                output_zs: Defaults to False. When set to False, the Z flip data is not
+                    generated and the corresponding array in the result tuple is set to
+                    None. When set to True, a new array is allocated to hold the Z flip
+                    data and this array is returned via the result tuple. When set to
+                    a numpy array, the results are written into that array (the shape and
+                    dtype of the array must be exactly correct).
+                output_measure_flips: Defaults to False. When set to False, the measure
+                    flip data is not generated and the corresponding array in the result
+                    tuple is set to None. When set to True, a new array is allocated to
+                    hold the measure flip data and this array is returned via the result
+                    tuple. When set to a numpy array, the results are written into that
+                    array (the shape and dtype of the array must be exactly correct).
+                output_detector_flips: Defaults to False. When set to False, the detector
+                    flip data is not generated and the corresponding array in the result
+                    tuple is set to None. When set to True, a new array is allocated to
+                    hold the detector flip data and this array is returned via the result
+                    tuple. When set to a numpy array, the results are written into that
+                    array (the shape and dtype of the array must be exactly correct).
+                output_observable_flips: Defaults to False. When set to False, the obs
+                    flip data is not generated and the corresponding array in the result
+                    tuple is set to None. When set to True, a new array is allocated to
+                    hold the obs flip data and this array is returned via the result
+                    tuple. When set to a numpy array, the results are written into that
+                    array (the shape and dtype of the array must be exactly correct).
+
+            Returns:
+                A tuple (xs, zs, ms, ds, os) of numpy arrays. The xs and zs arrays are
+                the pauli flip data specified using XZ encoding (00=I, 10=X, 11=Y, 01=Z).
+                The ms array is the measure flip data, the ds array is the detector flip
+                data, and the os array is the obs flip data. The arrays default to
+                `None` when the corresponding `output_*` argument was left False.
+
+                The shape and dtype of the data depends on arguments given to the function.
+                The following specifies each array's shape and dtype for each case:
+
+                    if not transpose and not bit_packed:
+                        xs.shape = (sim.batch_size, sim.num_qubits)
+                        zs.shape = (sim.batch_size, sim.num_qubits)
+                        ms.shape = (sim.batch_size, sim.num_measurements)
+                        ds.shape = (sim.batch_size, sim.num_detectors)
+                        os.shape = (sim.batch_size, sim.num_observables)
+                        xs.dtype = np.bool_
+                        zs.dtype = np.bool_
+                        ms.dtype = np.bool_
+                        ds.dtype = np.bool_
+                        os.dtype = np.bool_
+                    elif not transpose and bit_packed:
+                        xs.shape = (sim.batch_size, math.ceil(sim.num_qubits / 8))
+                        zs.shape = (sim.batch_size, math.ceil(sim.num_qubits / 8))
+                        ms.shape = (sim.batch_size, math.ceil(sim.num_measurements / 8))
+                        ds.shape = (sim.batch_size, math.ceil(sim.num_detectors / 8))
+                        os.shape = (sim.batch_size, math.ceil(sim.num_observables / 8))
+                        xs.dtype = np.uint8
+                        zs.dtype = np.uint8
+                        ms.dtype = np.uint8
+                        ds.dtype = np.uint8
+                        os.dtype = np.uint8
+                    elif transpose and not bit_packed:
+                        xs.shape = (sim.num_qubits, sim.batch_size)
+                        zs.shape = (sim.num_qubits, sim.batch_size)
+                        ms.shape = (sim.num_measurements, sim.batch_size)
+                        ds.shape = (sim.num_detectors, sim.batch_size)
+                        os.shape = (sim.num_observables, sim.batch_size)
+                        xs.dtype = np.bool_
+                        zs.dtype = np.bool_
+                        ms.dtype = np.bool_
+                        ds.dtype = np.bool_
+                        os.dtype = np.bool_
+                    elif transpose and bit_packed:
+                        xs.shape = (sim.num_qubits, math.ceil(sim.batch_size / 8))
+                        zs.shape = (sim.num_qubits, math.ceil(sim.batch_size / 8))
+                        ms.shape = (sim.num_measurements, math.ceil(sim.batch_size / 8))
+                        ds.shape = (sim.num_detectors, math.ceil(sim.batch_size / 8))
+                        os.shape = (sim.num_observables, math.ceil(sim.batch_size / 8))
+                        xs.dtype = np.uint8
+                        zs.dtype = np.uint8
+                        ms.dtype = np.uint8
+                        ds.dtype = np.uint8
+                        os.dtype = np.uint8
+
+            Raises:
+                ValueError:
+                    All the `output_*` arguments were False, or an `output_*` argument
+                    had a shape or dtype inconsistent with the requested data.
+
+            Examples:
+                >>> import stim
+                >>> sim = stim.FlipSimulator(batch_size=9)
+                >>> sim.do(stim.Circuit('M 0 1 2'))
+
+                >>> xs, zs, ms, ds, os = sim.to_numpy(
+                ...     transpose=True,
+                ...     bit_packed=True,
+                ...     output_measure_flips=True,
+                ... )
+                >>> xs
+                >>> zs
+                >>> ms
+                array([[0],
+                       [0],
+                       [0],
+                       [0],
+                       [0],
+                       [0],
+                       [0],
+                       [0],
+                       [0]], dtype=uint8)
+                >>> ds
+                >>> os
         )DOC")
             .data());
 

--- a/src/stim/simulators/frame_simulator_pybind_test.py
+++ b/src/stim/simulators/frame_simulator_pybind_test.py
@@ -583,6 +583,17 @@ def test_generate_bernoulli_samples():
     assert np.sum(np.unpackbits(v, count=1001, bitorder='little')) == 1001
     assert np.sum(np.unpackbits(v, count=1008, bitorder='little')) == 1001
 
+    v = sim.generate_bernoulli_samples(256, p=0, bit_packed=True)
+    assert np.all(v == 0)
+
+    sim.generate_bernoulli_samples(256 - 101, p=1, bit_packed=True, out=v[1:-11])
+    for k in v:
+        print(k)
+    assert np.all(v[1:-12] == 0xFF)
+    assert v[-12] == 7
+    assert np.all(v[-11:] == 0)
+    assert np.all(v[:1] == 0)
+
     v = sim.generate_bernoulli_samples(2**16, p=0.25, bit_packed=True)
     assert abs(np.sum(np.unpackbits(v, count=2**16)) - 2**16*0.25) < 2**12
 
@@ -590,7 +601,6 @@ def test_generate_bernoulli_samples():
     sim.generate_bernoulli_samples(2**16 - 1, p=1, bit_packed=True, out=v)
     assert np.all(v[:-1] == 0xFF)
     assert v[-1] == 0x7F
-
 
     v[:] = 0
     sim.generate_bernoulli_samples(2**15, p=1, bit_packed=True, out=v[::2])

--- a/src/stim/simulators/frame_simulator_pybind_test.py
+++ b/src/stim/simulators/frame_simulator_pybind_test.py
@@ -413,3 +413,141 @@ def test_repro_heralded_pauli_channel_1_bug():
     result = circuit.compile_sampler().sample(1024)
     assert np.sum(result[:, 0]) > 0
     assert np.sum(result[:, 1]) == 0
+
+
+def test_to_numpy():
+    sim = stim.FlipSimulator(batch_size=50)
+    sim.do(stim.Circuit.generated(
+        "surface_code:rotated_memory_x",
+        distance=5,
+        rounds=3,
+        after_clifford_depolarization=0.1,
+    ))
+
+    xs0, zs0, ms0, ds0, os0 = sim.to_numpy(
+        output_xs=True,
+        output_zs=True,
+        output_measure_flips=True,
+        output_detector_flips=True,
+        output_observable_flips=True,
+    )
+    for k in range(50):
+        np.testing.assert_array_equal(xs0[:, k], sim.peek_pauli_flips()[k].to_numpy()[0])
+        np.testing.assert_array_equal(zs0[:, k], sim.peek_pauli_flips()[k].to_numpy()[1])
+        np.testing.assert_array_equal(ms0[:, k], sim.get_measurement_flips(instance_index=k))
+        np.testing.assert_array_equal(ds0[:, k], sim.get_detector_flips(instance_index=k))
+        np.testing.assert_array_equal(os0[:, k], sim.get_observable_flips(instance_index=k))
+
+    xs, zs, ms, ds, os = sim.to_numpy(output_xs=True)
+    np.testing.assert_array_equal(xs, xs0)
+    assert zs is None
+    assert ms is None
+    assert ds is None
+    assert os is None
+
+    xs, zs, ms, ds, os = sim.to_numpy(output_zs=True)
+    assert xs is None
+    np.testing.assert_array_equal(zs, zs0)
+    assert ms is None
+    assert ds is None
+    assert os is None
+
+    xs, zs, ms, ds, os = sim.to_numpy(output_measure_flips=True)
+    assert xs is None
+    assert zs is None
+    np.testing.assert_array_equal(ms, ms0)
+    assert ds is None
+    assert os is None
+
+    xs, zs, ms, ds, os = sim.to_numpy(output_detector_flips=True)
+    assert xs is None
+    assert zs is None
+    assert ms is None
+    np.testing.assert_array_equal(ds, ds0)
+    assert os is None
+
+    xs, zs, ms, ds, os = sim.to_numpy(output_observable_flips=True)
+    assert xs is None
+    assert zs is None
+    assert ms is None
+    assert ds is None
+    np.testing.assert_array_equal(os, os0)
+
+    xs1 = np.empty_like(xs0)
+    zs1 = np.empty_like(zs0)
+    ms1 = np.empty_like(ms0)
+    ds1 = np.empty_like(ds0)
+    os1 = np.empty_like(os0)
+    xs2, zs2, ms2, ds2, os2 = sim.to_numpy(
+        output_xs=xs1,
+        output_zs=zs1,
+        output_measure_flips=ms1,
+        output_detector_flips=ds1,
+        output_observable_flips=os1,
+    )
+    assert xs1 is xs2
+    assert zs1 is zs2
+    assert ms1 is ms2
+    assert ds1 is ds2
+    assert os1 is os2
+    np.testing.assert_array_equal(xs1, xs0)
+    np.testing.assert_array_equal(zs1, zs0)
+    np.testing.assert_array_equal(ms1, ms0)
+    np.testing.assert_array_equal(ds1, ds0)
+    np.testing.assert_array_equal(os1, os0)
+
+    xs2, zs2, ms2, ds2, os2 = sim.to_numpy(
+        transpose=True,
+        output_xs=True,
+        output_zs=True,
+        output_measure_flips=True,
+        output_detector_flips=True,
+        output_observable_flips=True,
+    )
+    np.testing.assert_array_equal(xs2, np.transpose(xs0))
+    np.testing.assert_array_equal(zs2, np.transpose(zs0))
+    np.testing.assert_array_equal(ms2, np.transpose(ms0))
+    np.testing.assert_array_equal(ds2, np.transpose(ds0))
+    np.testing.assert_array_equal(os2, np.transpose(os0))
+
+    xs2, zs2, ms2, ds2, os2 = sim.to_numpy(
+        bit_packed=True,
+        output_xs=True,
+        output_zs=True,
+        output_measure_flips=True,
+        output_detector_flips=True,
+        output_observable_flips=True,
+    )
+    np.testing.assert_array_equal(xs2, np.packbits(xs0, axis=1, bitorder='little'))
+    np.testing.assert_array_equal(zs2, np.packbits(zs0, axis=1, bitorder='little'))
+    np.testing.assert_array_equal(ms2, np.packbits(ms0, axis=1, bitorder='little'))
+    np.testing.assert_array_equal(ds2, np.packbits(ds0, axis=1, bitorder='little'))
+    np.testing.assert_array_equal(os2, np.packbits(os0, axis=1, bitorder='little'))
+
+    xs2, zs2, ms2, ds2, os2 = sim.to_numpy(
+        transpose=True,
+        bit_packed=True,
+        output_xs=True,
+        output_zs=True,
+        output_measure_flips=True,
+        output_detector_flips=True,
+        output_observable_flips=True,
+    )
+    np.testing.assert_array_equal(xs2, np.packbits(np.transpose(xs0), axis=1, bitorder='little'))
+    np.testing.assert_array_equal(zs2, np.packbits(np.transpose(zs0), axis=1, bitorder='little'))
+    np.testing.assert_array_equal(ms2, np.packbits(np.transpose(ms0), axis=1, bitorder='little'))
+    np.testing.assert_array_equal(ds2, np.packbits(np.transpose(ds0), axis=1, bitorder='little'))
+    np.testing.assert_array_equal(os2, np.packbits(np.transpose(os0), axis=1, bitorder='little'))
+
+    with pytest.raises(ValueError, match="at least one output"):
+        sim.to_numpy()
+    with pytest.raises(ValueError, match="shape="):
+        sim.to_numpy(output_xs=np.empty(shape=(0, 0), dtype=np.uint64))
+    with pytest.raises(ValueError, match="shape="):
+        sim.to_numpy(output_zs=np.empty(shape=(0, 0), dtype=np.uint64))
+    with pytest.raises(ValueError, match="shape="):
+        sim.to_numpy(output_measure_flips=np.empty(shape=(0, 0), dtype=np.uint64))
+    with pytest.raises(ValueError, match="shape="):
+        sim.to_numpy(output_detector_flips=np.empty(shape=(0, 0), dtype=np.uint64))
+    with pytest.raises(ValueError, match="shape="):
+        sim.to_numpy(output_observable_flips=np.empty(shape=(0, 0), dtype=np.uint64))

--- a/src/stim/simulators/matched_error.pybind.cc
+++ b/src/stim/simulators/matched_error.pybind.cc
@@ -310,6 +310,14 @@ pybind11::class_<GateTargetWithCoords> stim_pybind::pybind_gate_target_with_coor
             problem in a circuit, instead of having to constantly manually
             look up the coordinates of a qubit index in order to understand
             what is happening.
+
+            Examples:
+                >>> import stim
+                >>> t = stim.GateTargetWithCoords(0, [1.5, 2.0])
+                >>> t.gate_target
+                stim.GateTarget(0)
+                >>> t.coords
+                [1.5, 2.0]
         )DOC")
             .data());
 }
@@ -321,6 +329,12 @@ void stim_pybind::pybind_gate_target_with_coords_methods(
         &GateTargetWithCoords::gate_target,
         clean_doc_string(R"DOC(
             Returns the actual gate target as a `stim.GateTarget`.
+
+            Examples:
+                >>> import stim
+                >>> t = stim.GateTargetWithCoords(0, [1.5, 2.0])
+                >>> t.gate_target
+                stim.GateTarget(0)
         )DOC")
             .data());
 
@@ -331,6 +345,12 @@ void stim_pybind::pybind_gate_target_with_coords_methods(
             Returns the associated coordinate information as a list of floats.
 
             If there is no coordinate information, returns an empty list.
+
+            Examples:
+                >>> import stim
+                >>> t = stim.GateTargetWithCoords(0, [1.5, 2.0])
+                >>> t.coords
+                [1.5, 2.0]
         )DOC")
             .data());
 
@@ -349,6 +369,14 @@ void stim_pybind::pybind_gate_target_with_coords_methods(
         pybind11::arg("coords"),
         clean_doc_string(R"DOC(
             Creates a stim.GateTargetWithCoords.
+
+            Examples:
+                >>> import stim
+                >>> t = stim.GateTargetWithCoords(0, [1.5, 2.0])
+                >>> t.gate_target
+                stim.GateTarget(0)
+                >>> t.coords
+                [1.5, 2.0]
         )DOC")
             .data());
     c.def("__repr__", &GateTargetWithCoords_repr);
@@ -373,6 +401,14 @@ pybind11::class_<DemTargetWithCoords> stim_pybind::pybind_dem_target_with_coords
             problem in a circuit, instead of having to constantly manually
             look up the coordinates of a detector index in order to understand
             what is happening.
+
+            Examples:
+                >>> import stim
+                >>> t = stim.DemTargetWithCoords(stim.DemTarget("D1"), [1.5, 2.0])
+                >>> t.dem_target
+                stim.DemTarget('D1')
+                >>> t.coords
+                [1.5, 2.0]
         )DOC")
             .data());
 }
@@ -435,7 +471,6 @@ void stim_pybind::pybind_dem_target_with_coords_methods(
             [](const ExposedDemTarget &dem_target, const std::vector<double> &coords) -> DemTargetWithCoords {
                 return DemTargetWithCoords{dem_target, coords};
             }),
-        pybind11::kw_only(),
         pybind11::arg("dem_target"),
         pybind11::arg("coords"),
         clean_doc_string(R"DOC(
@@ -466,6 +501,18 @@ pybind11::class_<FlippedMeasurement> stim_pybind::pybind_flipped_measurement(pyb
 
             Gives the measurement's index in the measurement record, and also
             the observable of the measurement.
+
+            Examples:
+                >>> import stim
+                >>> err = stim.Circuit('''
+                ...     M(0.25) 1 10
+                ...     OBSERVABLE_INCLUDE(0) rec[-1]
+                ... ''').shortest_graphlike_error()
+                >>> err[0].circuit_error_locations[0].flipped_measurement
+                stim.FlippedMeasurement(
+                    record_index=1,
+                    observable=(stim.GateTargetWithCoords(stim.target_z(10), []),),
+                )
         )DOC")
             .data());
 }
@@ -478,6 +525,15 @@ void stim_pybind::pybind_flipped_measurement_methods(
             The measurement record index of the flipped measurement.
             For example, the fifth measurement in a circuit has a measurement
             record index of 4.
+
+            Examples:
+                >>> import stim
+                >>> err = stim.Circuit('''
+                ...     M(0.25) 1 10
+                ...     OBSERVABLE_INCLUDE(0) rec[-1]
+                ... ''').shortest_graphlike_error()
+                >>> err[0].circuit_error_locations[0].flipped_measurement.record_index
+                1
         )DOC")
             .data());
 
@@ -488,6 +544,15 @@ void stim_pybind::pybind_flipped_measurement_methods(
             Returns the observable of the flipped measurement.
 
             For example, an `MX 5` measurement will have the observable X5.
+
+            Examples:
+                >>> import stim
+                >>> err = stim.Circuit('''
+                ...     M(0.25) 1 10
+                ...     OBSERVABLE_INCLUDE(0) rec[-1]
+                ... ''').shortest_graphlike_error()
+                >>> err[0].circuit_error_locations[0].flipped_measurement.observable
+                [stim.GateTargetWithCoords(stim.target_z(10), [])]
         )DOC")
             .data());
 
@@ -561,6 +626,19 @@ void stim_pybind::pybind_circuit_targets_inside_instruction_methods(
         clean_doc_string(R"DOC(
             Returns the name of the gate / instruction that was being executed.
             @signature def gate(self) -> Optional[str]:
+
+            Examples:
+                >>> import stim
+                >>> err = stim.Circuit('''
+                ...     R 0 1
+                ...     X_ERROR(0.25) 0 1
+                ...     M 0 1
+                ...     DETECTOR(2, 3) rec[-1] rec[-2]
+                ...     OBSERVABLE_INCLUDE(0) rec[-1]
+                ... ''').shortest_graphlike_error()
+                >>> loc: stim.CircuitErrorLocation = err[0].circuit_error_locations[0]
+                >>> loc.instruction_targets.gate
+                'X_ERROR'
         )DOC")
             .data());
 
@@ -570,6 +648,21 @@ void stim_pybind::pybind_circuit_targets_inside_instruction_methods(
         clean_doc_string(R"DOC(
             Returns the inclusive start of the range of targets that were executing
             within the gate / instruction.
+
+            Examples:
+                >>> import stim
+                >>> err = stim.Circuit('''
+                ...     R 0 1
+                ...     X_ERROR(0.25) 0 1
+                ...     M 0 1
+                ...     DETECTOR(2, 3) rec[-1] rec[-2]
+                ...     OBSERVABLE_INCLUDE(0) rec[-1]
+                ... ''').shortest_graphlike_error()
+                >>> loc: stim.CircuitErrorLocation = err[0].circuit_error_locations[0]
+                >>> loc.instruction_targets.target_range_start
+                0
+                >>> loc.instruction_targets.target_range_end
+                1
         )DOC")
             .data());
 
@@ -579,6 +672,21 @@ void stim_pybind::pybind_circuit_targets_inside_instruction_methods(
         clean_doc_string(R"DOC(
             Returns the exclusive end of the range of targets that were executing
             within the gate / instruction.
+
+            Examples:
+                >>> import stim
+                >>> err = stim.Circuit('''
+                ...     R 0 1
+                ...     X_ERROR(0.25) 0 1
+                ...     M 0 1
+                ...     DETECTOR(2, 3) rec[-1] rec[-2]
+                ...     OBSERVABLE_INCLUDE(0) rec[-1]
+                ... ''').shortest_graphlike_error()
+                >>> loc: stim.CircuitErrorLocation = err[0].circuit_error_locations[0]
+                >>> loc.instruction_targets.target_range_start
+                0
+                >>> loc.instruction_targets.target_range_end
+                1
         )DOC")
             .data());
 
@@ -587,6 +695,19 @@ void stim_pybind::pybind_circuit_targets_inside_instruction_methods(
         &CircuitTargetsInsideInstruction::args,
         clean_doc_string(R"DOC(
             Returns parens arguments of the gate / instruction that was being executed.
+
+            Examples:
+                >>> import stim
+                >>> err = stim.Circuit('''
+                ...     R 0 1
+                ...     X_ERROR(0.25) 0 1
+                ...     M 0 1
+                ...     DETECTOR(2, 3) rec[-1] rec[-2]
+                ...     OBSERVABLE_INCLUDE(0) rec[-1]
+                ... ''').shortest_graphlike_error()
+                >>> loc: stim.CircuitErrorLocation = err[0].circuit_error_locations[0]
+                >>> loc.instruction_targets.args
+                [0.25]
         )DOC")
             .data());
 
@@ -597,6 +718,19 @@ void stim_pybind::pybind_circuit_targets_inside_instruction_methods(
             Returns the subset of targets of the gate/instruction that were being executed.
 
             Includes coordinate data with the targets.
+
+            Examples:
+                >>> import stim
+                >>> err = stim.Circuit('''
+                ...     R 0 1
+                ...     X_ERROR(0.25) 0 1
+                ...     M 0 1
+                ...     DETECTOR(2, 3) rec[-1] rec[-2]
+                ...     OBSERVABLE_INCLUDE(0) rec[-1]
+                ... ''').shortest_graphlike_error()
+                >>> loc: stim.CircuitErrorLocation = err[0].circuit_error_locations[0]
+                >>> loc.instruction_targets.targets_in_range
+                [stim.GateTargetWithCoords(0, [])]
         )DOC")
             .data());
 
@@ -622,6 +756,16 @@ void stim_pybind::pybind_circuit_targets_inside_instruction_methods(
         pybind11::arg("targets_in_range"),
         clean_doc_string(R"DOC(
             Creates a stim.CircuitTargetsInsideInstruction.
+
+            Examples:
+                >>> import stim
+                >>> val = stim.CircuitTargetsInsideInstruction(
+                ...     gate='X_ERROR',
+                ...     args=[0.25],
+                ...     target_range_start=0,
+                ...     target_range_end=1,
+                ...     targets_in_range=[stim.GateTargetWithCoords(0, [])],
+                ... )
         )DOC")
             .data());
     c.def("__repr__", &CircuitTargetsInsideInstruction_repr);
@@ -878,6 +1022,28 @@ pybind11::class_<ExplainedError> stim_pybind::pybind_explained_error(pybind11::m
         "ExplainedError",
         clean_doc_string(R"DOC(
             Describes the location of an error mechanism from a stim circuit.
+
+            Examples:
+                >>> import stim
+                >>> err = stim.Circuit('''
+                ...     R 0
+                ...     TICK
+                ...     Y_ERROR(0.125) 0
+                ...     M 0
+                ...     OBSERVABLE_INCLUDE(0) rec[-1]
+                ... ''').shortest_graphlike_error()
+                >>> print(err[0])
+                ExplainedError {
+                    dem_error_terms: L0
+                    CircuitErrorLocation {
+                        flipped_pauli_product: Y0
+                        Circuit location stack trace:
+                            (after 1 TICKs)
+                            at instruction #3 (Y_ERROR) in the circuit
+                            at target #1 of the instruction
+                            resolving to Y_ERROR(0.125) 0
+                    }
+                }
         )DOC")
             .data());
 }
@@ -903,6 +1069,25 @@ void stim_pybind::pybind_explained_error_methods(pybind11::module &m, pybind11::
             Note: if this list is empty, it may be because there was a DEM error decomposed
             into parts where one of the parts is impossible to make on its own from a single
             circuit error.
+
+            Examples:
+                >>> import stim
+                >>> err = stim.Circuit('''
+                ...     R 0
+                ...     TICK
+                ...     Y_ERROR(0.125) 0
+                ...     M 0
+                ...     OBSERVABLE_INCLUDE(0) rec[-1]
+                ... ''').shortest_graphlike_error()
+                >>> print(err[0].circuit_error_locations[0])
+                CircuitErrorLocation {
+                    flipped_pauli_product: Y0
+                    Circuit location stack trace:
+                        (after 1 TICKs)
+                        at instruction #3 (Y_ERROR) in the circuit
+                        at target #1 of the instruction
+                        resolving to Y_ERROR(0.125) 0
+                }
         )DOC")
             .data());
 
@@ -928,6 +1113,28 @@ void stim_pybind::pybind_explained_error_methods(pybind11::module &m, pybind11::
         pybind11::arg("circuit_error_locations"),
         clean_doc_string(R"DOC(
             Creates a stim.ExplainedError.
+
+            Examples:
+                >>> import stim
+                >>> err = stim.Circuit('''
+                ...     R 0
+                ...     TICK
+                ...     Y_ERROR(0.125) 0
+                ...     M 0
+                ...     OBSERVABLE_INCLUDE(0) rec[-1]
+                ... ''').shortest_graphlike_error()
+                >>> print(err[0])
+                ExplainedError {
+                    dem_error_terms: L0
+                    CircuitErrorLocation {
+                        flipped_pauli_product: Y0
+                        Circuit location stack trace:
+                            (after 1 TICKs)
+                            at instruction #3 (Y_ERROR) in the circuit
+                            at target #1 of the instruction
+                            resolving to Y_ERROR(0.125) 0
+                    }
+                }
         )DOC")
             .data());
     c.def("__repr__", &MatchedError_repr);

--- a/src/stim/simulators/tableau_simulator.pybind.cc
+++ b/src/stim/simulators/tableau_simulator.pybind.cc
@@ -711,6 +711,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
 
             Args:
                 *targets: The indices of the qubits to target with the gate.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                +X +Y +Z
+                >>> s.c_xyz(0, 1, 2)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                +Y +Z +X
         )DOC")
             .data());
 
@@ -725,6 +737,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
 
             Args:
                 *targets: The indices of the qubits to target with the gate.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                +X +Y +Z
+                >>> s.c_zyx(0, 1, 2)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                +Z +X +Y
         )DOC")
             .data());
 
@@ -739,6 +763,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
 
             Args:
                 *targets: The indices of the qubits to target with the gate.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                +X +Y +Z
+                >>> s.h_xy(0, 1, 2)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                +Y +X -Z
         )DOC")
             .data());
 
@@ -753,6 +789,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
 
             Args:
                 *targets: The indices of the qubits to target with the gate.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                +X +Y +Z
+                >>> s.h_yz(0, 1, 2)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                -X +Z +Y
         )DOC")
             .data());
 
@@ -766,6 +814,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
 
             Args:
                 *targets: The indices of the qubits to target with the gate.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                +X +Y +Z
+                >>> s.x(0, 1, 2)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                +X -Y -Z
         )DOC")
             .data());
 
@@ -779,6 +839,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
 
             Args:
                 *targets: The indices of the qubits to target with the gate.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                +X +Y +Z
+                >>> s.y(0, 1, 2)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                -X +Y -Z
         )DOC")
             .data());
 
@@ -792,6 +864,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
 
             Args:
                 *targets: The indices of the qubits to target with the gate.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                +X +Y +Z
+                >>> s.z(0, 1, 2)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                -X -Y +Z
         )DOC")
             .data());
 
@@ -805,6 +889,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
 
             Args:
                 *targets: The indices of the qubits to target with the gate.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                +X +Y +Z
+                >>> s.s(0, 1, 2)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                +Y -X +Z
         )DOC")
             .data());
 
@@ -819,6 +915,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
 
             Args:
                 *targets: The indices of the qubits to target with the gate.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                +X +Y +Z
+                >>> s.s_dag(0, 1, 2)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                -Y +X +Z
         )DOC")
             .data());
 
@@ -833,6 +941,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
 
             Args:
                 *targets: The indices of the qubits to target with the gate.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                +X +Y +Z
+                >>> s.sqrt_x(0, 1, 2)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                +X +Z -Y
         )DOC")
             .data());
 
@@ -847,6 +967,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
 
             Args:
                 *targets: The indices of the qubits to target with the gate.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                +X +Y +Z
+                >>> s.sqrt_x_dag(0, 1, 2)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                +X -Z +Y
         )DOC")
             .data());
 
@@ -861,6 +993,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
 
             Args:
                 *targets: The indices of the qubits to target with the gate.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                +X +Y +Z
+                >>> s.sqrt_y(0, 1, 2)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                -Z +Y +X
         )DOC")
             .data());
 
@@ -875,6 +1019,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
 
             Args:
                 *targets: The indices of the qubits to target with the gate.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                +X +Y +Z
+                >>> s.sqrt_y_dag(0, 1, 2)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                +Z +Y -X
         )DOC")
             .data());
 
@@ -890,6 +1046,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
                 *targets: The indices of the qubits to target with the gate.
                     Applies the gate to the first two targets, then the next two targets,
                     and so forth. There must be an even number of targets.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0, 3)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +X +Y +Z +X
+                >>> s.swap(0, 1, 2, 3)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +Y +X +X +Z
         )DOC")
             .data());
 
@@ -905,6 +1073,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
                 *targets: The indices of the qubits to target with the gate.
                     Applies the gate to the first two targets, then the next two targets,
                     and so forth. There must be an even number of targets.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0, 3)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +X +Y +Z +X
+                >>> s.iswap(0, 1, 2, 3)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +_ +_ +Y +Z
         )DOC")
             .data());
 
@@ -921,6 +1101,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
                 *targets: The indices of the qubits to target with the gate.
                     Applies the gate to the first two targets, then the next two targets,
                     and so forth. There must be an even number of targets.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0, 3)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +X +Y +Z +X
+                >>> s.iswap_dag(0, 1, 2, 3)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +_ +_ -Y +Z
         )DOC")
             .data());
 
@@ -936,6 +1128,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
                 *targets: The indices of the qubits to target with the gate.
                     Applies the gate to the first two targets, then the next two targets,
                     and so forth. There must be an even number of targets.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0, 3)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +X +Y +Z +X
+                >>> s.cnot(0, 1, 2, 3)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +_ +_ +Z +X
         )DOC")
             .data());
 
@@ -951,6 +1155,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
                 *targets: The indices of the qubits to target with the gate.
                     Applies the gate to the first two targets, then the next two targets,
                     and so forth. There must be an even number of targets.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0, 3)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +X +Y +Z +X
+                >>> s.zcx(0, 1, 2, 3)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +_ +_ +Z +X
         )DOC")
             .data());
 
@@ -966,6 +1182,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
                 *targets: The indices of the qubits to target with the gate.
                     Applies the gate to the first two targets, then the next two targets,
                     and so forth. There must be an even number of targets.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0, 3)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +X +Y +Z +X
+                >>> s.cx(0, 1, 2, 3)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +_ +_ +Z +X
         )DOC")
             .data());
 
@@ -981,6 +1209,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
                 *targets: The indices of the qubits to target with the gate.
                     Applies the gate to the first two targets, then the next two targets,
                     and so forth. There must be an even number of targets.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0, 3)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +X +Y +Z +X
+                >>> s.cz(0, 1, 2, 3)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +_ +_ +Z +X
         )DOC")
             .data());
 
@@ -996,6 +1236,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
                 *targets: The indices of the qubits to target with the gate.
                     Applies the gate to the first two targets, then the next two targets,
                     and so forth. There must be an even number of targets.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0, 3)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +X +Y +Z +X
+                >>> s.zcz(0, 1, 2, 3)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +_ +_ +Z +X
         )DOC")
             .data());
 
@@ -1011,6 +1263,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
                 *targets: The indices of the qubits to target with the gate.
                     Applies the gate to the first two targets, then the next two targets,
                     and so forth. There must be an even number of targets.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0, 3)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +X +Y +Z +X
+                >>> s.cy(0, 1, 2, 3)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +X +Y +Z +X
         )DOC")
             .data());
 
@@ -1026,6 +1290,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
                 *targets: The indices of the qubits to target with the gate.
                     Applies the gate to the first two targets, then the next two targets,
                     and so forth. There must be an even number of targets.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0, 3)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +X +Y +Z +X
+                >>> s.zcy(0, 1, 2, 3)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +X +Y +Z +X
         )DOC")
             .data());
 
@@ -1041,6 +1317,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
                 *targets: The indices of the qubits to target with the gate.
                     Applies the gate to the first two targets, then the next two targets,
                     and so forth. There must be an even number of targets.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0, 3)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +X +Y +Z +X
+                >>> s.xcx(0, 1, 2, 3)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +X +Y +Z +X
         )DOC")
             .data());
 
@@ -1056,6 +1344,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
                 *targets: The indices of the qubits to target with the gate.
                     Applies the gate to the first two targets, then the next two targets,
                     and so forth. There must be an even number of targets.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0, 3)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +X +Y +Z +X
+                >>> s.xcy(0, 1, 2, 3)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +X +Y +_ +_
         )DOC")
             .data());
 
@@ -1071,6 +1371,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
                 *targets: The indices of the qubits to target with the gate.
                     Applies the gate to the first two targets, then the next two targets,
                     and so forth. There must be an even number of targets.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0, 3)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +X +Y +Z +X
+                >>> s.xcz(0, 1, 2, 3)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +X +Y +_ +_
         )DOC")
             .data());
 
@@ -1086,6 +1398,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
                 *targets: The indices of the qubits to target with the gate.
                     Applies the gate to the first two targets, then the next two targets,
                     and so forth. There must be an even number of targets.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0, 3)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +X +Y +Z +X
+                >>> s.ycx(0, 1, 2, 3)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +_ +_ +Z +X
         )DOC")
             .data());
 
@@ -1101,6 +1425,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
                 *targets: The indices of the qubits to target with the gate.
                     Applies the gate to the first two targets, then the next two targets,
                     and so forth. There must be an even number of targets.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0, 3)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +X +Y +Z +X
+                >>> s.ycy(0, 1, 2, 3)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +X +Y +_ +_
         )DOC")
             .data());
 
@@ -1116,6 +1452,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
                 *targets: The indices of the qubits to target with the gate.
                     Applies the gate to the first two targets, then the next two targets,
                     and so forth. There must be an even number of targets.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0, 3)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +X +Y +Z +X
+                >>> s.ycz(0, 1, 2, 3)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(4)))
+                +_ +_ +_ +_
         )DOC")
             .data());
 

--- a/src/stim/simulators/tableau_simulator.pybind.cc
+++ b/src/stim/simulators/tableau_simulator.pybind.cc
@@ -1,17 +1,3 @@
-// Copyright 2021 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 #include "stim/simulators/tableau_simulator.pybind.h"
 
 #include "stim/circuit/circuit_instruction.pybind.h"
@@ -20,7 +6,6 @@
 #include "stim/simulators/tableau_simulator.h"
 #include "stim/stabilizers/pauli_string.pybind.h"
 #include "stim/stabilizers/tableau.h"
-#include "stim/util_bot/probability_util.h"
 #include "stim/util_bot/str_util.h"
 #include "stim/util_top/circuit_vs_amplitudes.h"
 #include "stim/util_top/stabilizers_to_tableau.h"
@@ -575,6 +560,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
 
             Args:
                 *targets: The indices of the qubits to target with the gate.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                +X +Y +Z
+                >>> s.h(0, 1, 2)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                +Z -Y +X
         )DOC")
             .data());
 
@@ -597,6 +594,11 @@ void stim_pybind::pybind_tableau_simulator_methods(
                 *targets: The indices of the qubits to target with the noise.
                 p: The chance of the error being applied,
                     independently, to each qubit.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.depolarize1(0, 1, 2, p=0.01)
         )DOC")
             .data());
 
@@ -620,6 +622,11 @@ void stim_pybind::pybind_tableau_simulator_methods(
                     zip(targets[::1], targets[1::2]).
                 p: The chance of the error being applied,
                     independently, to each qubit pair.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.depolarize1(0, 1, 4, 5, p=0.01)
         )DOC")
             .data());
 
@@ -642,6 +649,11 @@ void stim_pybind::pybind_tableau_simulator_methods(
                 *targets: The indices of the qubits to target with the noise.
                 p: The chance of the X error being applied,
                     independently, to each qubit.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.x_error(0, 1, 2, p=0.01)
         )DOC")
             .data());
 
@@ -663,6 +675,11 @@ void stim_pybind::pybind_tableau_simulator_methods(
                 *targets: The indices of the qubits to target with the noise.
                 p: The chance of the Y error being applied,
                     independently, to each qubit.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.y_error(0, 1, 2, p=0.01)
         )DOC")
             .data());
 
@@ -684,6 +701,11 @@ void stim_pybind::pybind_tableau_simulator_methods(
                 *targets: The indices of the qubits to target with the noise.
                 p: The chance of the Z error being applied,
                     independently, to each qubit.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.z_error(0, 1, 2, p=0.01)
         )DOC")
             .data());
 
@@ -697,6 +719,18 @@ void stim_pybind::pybind_tableau_simulator_methods(
 
             Args:
                 *targets: The indices of the qubits to target with the gate.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.reset_x(0)
+                >>> s.reset_y(1)
+
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                +X +Y +Z
+                >>> s.h_xz(0, 1, 2)
+                >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
+                +Z -Y +X
         )DOC")
             .data());
 
@@ -1886,6 +1920,15 @@ void stim_pybind::pybind_tableau_simulator_methods(
 
             Returns:
                 The measurement result as a bool.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.x(1)
+                >>> s.measure(0)
+                False
+                >>> s.measure(1)
+                True
         )DOC")
             .data());
 
@@ -1906,6 +1949,13 @@ void stim_pybind::pybind_tableau_simulator_methods(
 
             Returns:
                 The measurement results as a list of bools.
+
+            Examples:
+                >>> import stim
+                >>> s = stim.TableauSimulator()
+                >>> s.x(1)
+                >>> s.measure_many(0, 1)
+                [False, True]
         )DOC")
             .data());
 


### PR DESCRIPTION
- Add `stim.FlipSimulator.generate_bernoulli_samples`
- Add `stim.FlipSimulator.to_numpy`
- Fix bit packed numpy outputs not masking off bits beyond a non-multiple-of-8 result count
- Fix remaining "doc doesn't include example" warnings from regen_docs script

Fixes https://github.com/quantumlib/Stim/issues/875

Fixes https://github.com/quantumlib/Stim/issues/877