### PR TITLE
Fix typo in `stim.TableauSimulator.z_error`'s signature override

### DIFF
--- a/dev/util_gen_stub_file.py
+++ b/dev/util_gen_stub_file.py
@@ -150,6 +150,7 @@ def _handle_pybind_method(
     sig_handled = False
     has_setter = False
     doc_lines_left = []
+    term_name = full_name.split(".")[-1]
     for line in doc_lines:
         if was_args and line.strip().startswith('*') and ':' in line:
             new_args_name = line[line.index('*'):line.index(':')]
@@ -164,6 +165,8 @@ def _handle_pybind_method(
         elif '@signature ' in line:
             _, sig = line.split('@signature ')
             is_static = '(self' not in sig and inspect.isclass(parent)
+            if term_name not in sig:
+                raise ValueError(f"Expected name {term_name!r} to appear in signature override for {full_name!r}:\n    {line}")
             if is_static:
                 out_obj.lines.append("@staticmethod")
             out_obj.lines.extend(splay_signature(sig))
@@ -172,7 +175,6 @@ def _handle_pybind_method(
             doc_lines_left.append(line)
         was_args = 'Args:' in line
 
-    term_name = full_name.split(".")[-1]
     if is_property:
         if hasattr(obj, 'fget'):
             sig_name = term_name + obj.fget.__doc__.replace('arg0', 'self').strip()

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -15987,7 +15987,7 @@ def z(
 # stim.TableauSimulator.z_error
 
 # (in class stim.TableauSimulator)
-def y_error(
+def z_error(
     self,
     *targets: int,
     p: float,

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -12789,7 +12789,7 @@ class TableauSimulator:
             >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
             -X -Y +Z
         """
-    def y_error(
+    def z_error(
         self,
         *targets: int,
         p: float,

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -12789,7 +12789,7 @@ class TableauSimulator:
             >>> print(" ".join(str(s.peek_bloch(k)) for k in range(3)))
             -X -Y +Z
         """
-    def y_error(
+    def z_error(
         self,
         *targets: int,
         p: float,

--- a/src/stim/simulators/tableau_simulator.pybind.cc
+++ b/src/stim/simulators/tableau_simulator.pybind.cc
@@ -694,7 +694,7 @@ void stim_pybind::pybind_tableau_simulator_methods(
                 build_single_qubit_gate_instruction_ensure_size<MAX_BITWORD_WIDTH>(self, GateType::Z_ERROR, args, &p));
         },
         clean_doc_string(R"DOC(
-            @signature def y_error(self, *targets: int, p: float):
+            @signature def z_error(self, *targets: int, p: float):
             Probabilistically applies Z errors to targets.
 
             Args:


### PR DESCRIPTION
- Add a check to the signature override code that verifies the name isn't changed

Fixes https://github.com/quantumlib/Stim/issues/878