### PR TITLE
Add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/ossf-scorecard.yaml
+++ b/.github/workflows/ossf-scorecard.yaml
@@ -1,0 +1,60 @@
+# Summary: workflow for OSSF Scorecard (https://github.com/ossf/scorecard).
+#
+# Scorecard is an automated tool that assesses a number of important heuristics
+# associated with software security and assigns each check a score of 0-10. The
+# use of Scorecard is suggested in Google's internal GitHub guidance
+# (go/github-docs).
+#
+# Scorecard creates a report page at the following URL (for a repo ORG/REPO):
+# https://scorecard.dev/viewer/?uri=github.com/ORG/REPO
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+name: Scorecard code scan
+run-name: Run Scorecard code scan
+
+on:
+  schedule:
+    - cron: '19 20 * * 6'
+
+  # Allow manual invocation.
+  workflow_dispatch:
+
+# Declare default permissions as read only.
+permissions: read-all
+
+# Cancel any previously-started but still active runs on the same branch.
+concurrency:
+  cancel-in-progress: true
+  group: ${{github.workflow}}-${{github.event.pull_request.number||github.ref}}
+
+jobs:
+  scorecard:
+    name: Perform Scorecard analysis
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    permissions:
+      # Needed to upload the results to the code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+    steps:
+      - name: Check out a copy of the git repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
+        with:
+          # Save the results
+          results_file: results.sarif
+          results_format: sarif
+
+          # Publish results to OpenSSF REST API.
+          # See https://github.com/ossf/scorecard-action#publishing-results.
+          publish_results: true
+
+      - name: Upload results to code-scanning dashboard
+        uses: github/codeql-action/upload-sarif@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d # v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
This PR adds a nightly workflow to run [OpenSSF Scorecard](https://openssf.org/projects/scorecard/), a code-scanning system recommended by Google's GitHub OSS team. Once it starts running, Scorecard will create and update a report page at the following URL: <https://scorecard.dev/viewer/?uri=github.com/quantumlib/Stim>

As an example, here's the page for Cirq: <https://scorecard.dev/viewer/?uri=github.com/quantumlib/Cirq>