### PR TITLE
Add CITATION.cff file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,70 @@
+cff-version: 1.2.0
+message: If you use Stim, please cite it using this metadata.
+
+preferred-citation:
+  type: article
+  authors:
+    - family-names: Gidney
+      given-names: Craig
+  title: 'Stim: a fast stabilizer circuit simulator'
+  journal: Quantum
+  year: 2021
+  month: 7
+  volume: 5
+  start: 497
+  issn: 2521-327X
+  url: https://doi.org/10.22331/q-2021-07-06-497
+  publisher:
+    name: >-
+      Verein zur Förderung des Open Access Publizierens in den
+      Quantenwissenschaften
+
+title: Stim
+abstract: >-
+  Stim is a tool for high performance simulation and analysis of quantum
+  stabilizer circuits, especially quantum error correction (QEC) circuits.
+authors:
+  - family-names: Gidney
+    given-names: Craig
+version: 1.14.0
+date-released: 2024-09-24
+url: https://github.com/quantumlib/stim
+repository-code: https://github.com/quantumlib/stim
+license: Apache-2.0
+type: software
+identifiers:
+  - description: The GitHub repository for Stim
+    value: https://quantumai.google/Stim
+    type: url
+  - description: PyPI project for Stim
+    value: https://pypi.org/project/Stim
+    type: url
+keywords:
+  - algorithms
+  - API
+  - application programming interface
+  - Clifford gates
+  - Clifford operations
+  - high performance
+  - open-source software
+  - physics
+  - Python
+  - QEC
+  - quantum
+  - quantum algorithms
+  - quantum circuits
+  - quantum computing
+  - quantum error correction
+  - quantum error decoder
+  - quantum gates
+  - quantum programming
+  - quantum simulation
+  - quantum state
+  - qubit
+  - science
+  - SDK
+  - simulation
+  - simulator
+  - software
+  - software development toolkit
+  - stabilizer circuits

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -43,6 +43,7 @@ keywords:
   - algorithms
   - API
   - application programming interface
+  - C++
   - Clifford gates
   - Clifford operations
   - high performance


### PR DESCRIPTION
A file in [CITATION File Format](https://citation-file-format.github.io/) (`CITATION.cff`) can be placed at the top level of a GitHub repo to [provide machine-readable citation information](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files) that helps users correctly cite software. When it detects a `CITATION.cff` file in a repository, GitHub adds a [button to the upper right sidebar](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files#:~:text=added%20to%20the%20repository%20landing%20page%20in%20the%20right%20sidebar%2C%20with%20the%20label%20%22Cite%20this%20repository.%22) that lets users copy a formatted citation.

I generated this particular `CITATION.cff` file mostly by hand, with a little initial help from [Citation.js](https://citation-js.github.io/cff-generator/). 

@Strilanc the abstract and the list of keywords could use a review. I gave it a good try but there may still be errors.