### PR TITLE
Add `stim.{Circuit,DetectorErrorModel}.without_tags`

### DIFF
--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -62,6 +62,7 @@ API references for stable versions are kept on the [stim github wiki](https://gi
     - [`stim.Circuit.to_tableau`](#stim.Circuit.to_tableau)
     - [`stim.Circuit.with_inlined_feedback`](#stim.Circuit.with_inlined_feedback)
     - [`stim.Circuit.without_noise`](#stim.Circuit.without_noise)
+    - [`stim.Circuit.without_tags`](#stim.Circuit.without_tags)
 - [`stim.CircuitErrorLocation`](#stim.CircuitErrorLocation)
     - [`stim.CircuitErrorLocation.__init__`](#stim.CircuitErrorLocation.__init__)
     - [`stim.CircuitErrorLocation.flipped_measurement`](#stim.CircuitErrorLocation.flipped_measurement)
@@ -187,6 +188,7 @@ API references for stable versions are kept on the [stim github wiki](https://gi
     - [`stim.DetectorErrorModel.rounded`](#stim.DetectorErrorModel.rounded)
     - [`stim.DetectorErrorModel.shortest_graphlike_error`](#stim.DetectorErrorModel.shortest_graphlike_error)
     - [`stim.DetectorErrorModel.to_file`](#stim.DetectorErrorModel.to_file)
+    - [`stim.DetectorErrorModel.without_tags`](#stim.DetectorErrorModel.without_tags)
 - [`stim.ExplainedError`](#stim.ExplainedError)
     - [`stim.ExplainedError.__init__`](#stim.ExplainedError.__init__)
     - [`stim.ExplainedError.circuit_error_locations`](#stim.ExplainedError.circuit_error_locations)
@@ -3589,6 +3591,33 @@ def without_noise(
         stim.Circuit('''
             CX 0 1
             M 0
+        ''')
+    """
+```
+
+<a name="stim.Circuit.without_tags"></a>
+```python
+# stim.Circuit.without_tags
+
+# (in class stim.Circuit)
+def without_tags(
+    self,
+) -> stim.Circuit:
+    """Returns a copy of the circuit with all tags removed.
+
+    Returns:
+        A `stim.Circuit` with the same instructions except all tags have been
+        removed.
+
+    Examples:
+        >>> import stim
+        >>> stim.Circuit('''
+        ...     X[test-tag] 0
+        ...     M[test-tag-2](0.125) 0
+        ... ''').without_tags()
+        stim.Circuit('''
+            X 0
+            M(0.125) 0
         ''')
     """
 ```
@@ -7586,6 +7615,31 @@ def to_file(
         ...         contents = f.read()
         >>> contents
         'error(0.25) D2 D3\n'
+    """
+```
+
+<a name="stim.DetectorErrorModel.without_tags"></a>
+```python
+# stim.DetectorErrorModel.without_tags
+
+# (in class stim.DetectorErrorModel)
+def without_tags(
+    self,
+) -> stim.DetectorErrorModel:
+    """Returns a copy of the detector error model with all tags removed.
+
+    Returns:
+        A `stim.DetectorErrorModel` with the same instructions except all tags have
+        been removed.
+
+    Examples:
+        >>> import stim
+        >>> stim.DetectorErrorModel('''
+        ...     error[test-tag](0.25) D0
+        ... ''').without_tags()
+        stim.DetectorErrorModel('''
+            error(0.25) D0
+        ''')
     """
 ```
 

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -2792,6 +2792,26 @@ class Circuit:
                 M 0
             ''')
         """
+    def without_tags(
+        self,
+    ) -> stim.Circuit:
+        """Returns a copy of the circuit with all tags removed.
+
+        Returns:
+            A `stim.Circuit` with the same instructions except all tags have been
+            removed.
+
+        Examples:
+            >>> import stim
+            >>> stim.Circuit('''
+            ...     X[test-tag] 0
+            ...     M[test-tag-2](0.125) 0
+            ... ''').without_tags()
+            stim.Circuit('''
+                X 0
+                M(0.125) 0
+            ''')
+        """
 class CircuitErrorLocation:
     """Describes the location of an error mechanism from a stim circuit.
 
@@ -5968,6 +5988,24 @@ class DetectorErrorModel:
             ...         contents = f.read()
             >>> contents
             'error(0.25) D2 D3\n'
+        """
+    def without_tags(
+        self,
+    ) -> stim.DetectorErrorModel:
+        """Returns a copy of the detector error model with all tags removed.
+
+        Returns:
+            A `stim.DetectorErrorModel` with the same instructions except all tags have
+            been removed.
+
+        Examples:
+            >>> import stim
+            >>> stim.DetectorErrorModel('''
+            ...     error[test-tag](0.25) D0
+            ... ''').without_tags()
+            stim.DetectorErrorModel('''
+                error(0.25) D0
+            ''')
         """
 class ExplainedError:
     """Describes the location of an error mechanism from a stim circuit.

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -2792,6 +2792,26 @@ class Circuit:
                 M 0
             ''')
         """
+    def without_tags(
+        self,
+    ) -> stim.Circuit:
+        """Returns a copy of the circuit with all tags removed.
+
+        Returns:
+            A `stim.Circuit` with the same instructions except all tags have been
+            removed.
+
+        Examples:
+            >>> import stim
+            >>> stim.Circuit('''
+            ...     X[test-tag] 0
+            ...     M[test-tag-2](0.125) 0
+            ... ''').without_tags()
+            stim.Circuit('''
+                X 0
+                M(0.125) 0
+            ''')
+        """
 class CircuitErrorLocation:
     """Describes the location of an error mechanism from a stim circuit.
 
@@ -5968,6 +5988,24 @@ class DetectorErrorModel:
             ...         contents = f.read()
             >>> contents
             'error(0.25) D2 D3\n'
+        """
+    def without_tags(
+        self,
+    ) -> stim.DetectorErrorModel:
+        """Returns a copy of the detector error model with all tags removed.
+
+        Returns:
+            A `stim.DetectorErrorModel` with the same instructions except all tags have
+            been removed.
+
+        Examples:
+            >>> import stim
+            >>> stim.DetectorErrorModel('''
+            ...     error[test-tag](0.25) D0
+            ... ''').without_tags()
+            stim.DetectorErrorModel('''
+                error(0.25) D0
+            ''')
         """
 class ExplainedError:
     """Describes the location of an error mechanism from a stim circuit.

--- a/src/stim/circuit/circuit.cc
+++ b/src/stim/circuit/circuit.cc
@@ -802,6 +802,22 @@ const Circuit Circuit::aliased_noiseless_circuit() const {
     return result;
 }
 
+Circuit Circuit::without_tags() const {
+    Circuit result;
+    for (CircuitInstruction inst : operations) {
+        if (inst.gate_type == GateType::REPEAT) {
+            result.append_repeat_block(
+                inst.repeat_block_rep_count(),
+                inst.repeat_block_body(*this).without_tags(),
+                "");
+        } else {
+            inst.tag = "";
+            result.safe_append(inst);
+        }
+    }
+    return result;
+}
+
 Circuit Circuit::without_noise() const {
     Circuit result;
     for (const auto &op : operations) {

--- a/src/stim/circuit/circuit.h
+++ b/src/stim/circuit/circuit.h
@@ -147,6 +147,8 @@ struct Circuit {
 
     /// Returns a copy of the circuit with all noise processes removed.
     Circuit without_noise() const;
+    /// Returns a copy of the circuit with all tags removed.
+    Circuit without_tags() const;
 
     /// Returns an equivalent circuit without REPEAT or SHIFT_COORDS instructions.
     Circuit flattened() const;

--- a/src/stim/circuit/circuit.pybind.cc
+++ b/src/stim/circuit/circuit.pybind.cc
@@ -2237,6 +2237,29 @@ void stim_pybind::pybind_circuit_methods(pybind11::module &, pybind11::class_<Ci
             .data());
 
     c.def(
+        "without_tags",
+        &Circuit::without_tags,
+        clean_doc_string(R"DOC(
+            Returns a copy of the circuit with all tags removed.
+
+            Returns:
+                A `stim.Circuit` with the same instructions except all tags have been
+                removed.
+
+            Examples:
+                >>> import stim
+                >>> stim.Circuit('''
+                ...     X[test-tag] 0
+                ...     M[test-tag-2](0.125) 0
+                ... ''').without_tags()
+                stim.Circuit('''
+                    X 0
+                    M(0.125) 0
+                ''')
+        )DOC")
+            .data());
+
+    c.def(
         "flattened",
         &Circuit::flattened,
         clean_doc_string(R"DOC(

--- a/src/stim/circuit/circuit.test.cc
+++ b/src/stim/circuit/circuit.test.cc
@@ -1985,3 +1985,22 @@ TEST(circuit, insert_instruction) {
         X 1
     )CIRCUIT"));
 }
+
+TEST(circuit, without_tags) {
+    Circuit initial(R"CIRCUIT(
+        H[test-1] 0
+        REPEAT[test-2] 100 {
+            REPEAT[test-3] 100 {
+                M[test-4](0.125) 0
+            }
+        }
+    )CIRCUIT");
+    ASSERT_EQ(initial.without_tags(), Circuit(R"CIRCUIT(
+        H 0
+        REPEAT 100 {
+            REPEAT 100 {
+                M(0.125) 0
+            }
+        }
+    )CIRCUIT"));
+}

--- a/src/stim/circuit/circuit_pybind_test.py
+++ b/src/stim/circuit/circuit_pybind_test.py
@@ -2351,3 +2351,12 @@ def test_append_pauli_string():
         c.append("MPP", object())
     with pytest.raises(ValueError, match="Don't know how to target"):
         c.append("MPP", object())
+
+
+def test_without_tags():
+    circuit = stim.Circuit("""
+        H[tag] 5
+    """)
+    assert circuit.without_tags() == stim.Circuit("""
+        H 5
+    """)

--- a/src/stim/dem/detector_error_model.cc
+++ b/src/stim/dem/detector_error_model.cc
@@ -774,3 +774,19 @@ std::map<uint64_t, std::vector<double>> DetectorErrorModel::get_detector_coordin
 
     return out;
 }
+
+DetectorErrorModel DetectorErrorModel::without_tags() const {
+    DetectorErrorModel result;
+    for (DemInstruction inst : instructions) {
+        if (inst.type == DemInstructionType::DEM_REPEAT_BLOCK) {
+            result.append_repeat_block(
+                inst.repeat_block_rep_count(),
+                inst.repeat_block_body(*this).without_tags(),
+                "");
+        } else {
+            inst.tag = "";
+            result.append_dem_instruction(inst);
+        }
+    }
+    return result;
+}

--- a/src/stim/dem/detector_error_model.h
+++ b/src/stim/dem/detector_error_model.h
@@ -63,6 +63,8 @@ struct DetectorErrorModel {
     bool approx_equals(const DetectorErrorModel &other, double atol) const;
     std::string str() const;
 
+    DetectorErrorModel without_tags() const;
+
     uint64_t total_detector_shift() const;
     uint64_t count_detectors() const;
     uint64_t count_observables() const;

--- a/src/stim/dem/detector_error_model.pybind.cc
+++ b/src/stim/dem/detector_error_model.pybind.cc
@@ -1204,4 +1204,25 @@ void stim_pybind::pybind_detector_error_model_methods(
                 ...         print(diagram, file=f)
         )DOC")
             .data());
+
+    c.def(
+        "without_tags",
+        &DetectorErrorModel::without_tags,
+        clean_doc_string(R"DOC(
+            Returns a copy of the detector error model with all tags removed.
+
+            Returns:
+                A `stim.DetectorErrorModel` with the same instructions except all tags have
+                been removed.
+
+            Examples:
+                >>> import stim
+                >>> stim.DetectorErrorModel('''
+                ...     error[test-tag](0.25) D0
+                ... ''').without_tags()
+                stim.DetectorErrorModel('''
+                    error(0.25) D0
+                ''')
+        )DOC")
+            .data());
 }

--- a/src/stim/dem/detector_error_model_pybind_test.py
+++ b/src/stim/dem/detector_error_model_pybind_test.py
@@ -540,3 +540,12 @@ def test_shortest_graphlike_error_remnant():
 
 def test_init_parse():
     assert stim.DemInstruction("error(0.125) D0 D1") == stim.DemInstruction("error", [0.125], [stim.DemTarget("D0"), stim.DemTarget("D1")])
+
+
+def test_without_tags():
+    dem = stim.DetectorErrorModel("""
+        error[tag](0.25) D5
+    """)
+    assert dem.without_tags() == stim.Circuit("""
+        error(0.25) D5
+    """)

--- a/src/stim/dem/detector_error_model_pybind_test.py
+++ b/src/stim/dem/detector_error_model_pybind_test.py
@@ -546,6 +546,6 @@ def test_without_tags():
     dem = stim.DetectorErrorModel("""
         error[tag](0.25) D5
     """)
-    assert dem.without_tags() == stim.Circuit("""
+    assert dem.without_tags() == stim.DetectorErrorModel("""
         error(0.25) D5
     """)


### PR DESCRIPTION
- Add `stim.Circuit.without_tags`
- Add `stim.CircuitDetectorErrorModel.without_tags`

Fixes https://github.com/quantumlib/Stim/issues/884