### PR TITLE
Fix `stim.Tableau.iter_all(0)` segfaulting

### DIFF
--- a/src/stim/stabilizers/tableau_iter.inl
+++ b/src/stim/stabilizers/tableau_iter.inl
@@ -200,6 +200,14 @@ TableauIterator<W>::constraints_for_pauli_iterator(size_t k) const {
 
 template <size_t W>
 bool TableauIterator<W>::iter_next() {
+    if (result.num_qubits == 0) {
+        if (cur_k == 0) {
+            cur_k = 1;
+            return true;
+        }
+        return false;
+    }
+
     if (result.xs.signs.u64[0] > 0) {
         result.xs.signs.u64[0]--;
         return true;

--- a/src/stim/stabilizers/tableau_pybind_test.py
+++ b/src/stim/stabilizers/tableau_pybind_test.py
@@ -713,6 +713,11 @@ def test_to_pauli_string():
         cnot.to_pauli_string()
 
 
+def test_iter_0q():
+    assert list(stim.Tableau.iter_all(0, unsigned=True)) == [stim.Tableau(0)]
+    assert list(stim.Tableau.iter_all(0, unsigned=False)) == [stim.Tableau(0)]
+
+
 def test_iter_1q():
     r = stim.Tableau.iter_all(1, unsigned=True)
     assert len(set(repr(e) for e in r)) == 6


### PR DESCRIPTION
- It now returns an iterator that yields the empty tableau then stops

Fixes https://github.com/quantumlib/Stim/issues/859