### PR TITLE
Make `sinter.Decoder.decode_via_files` fallback to `sinter.Decoder.compile_decoder_for_dem`

### DIFF
--- a/doc/sinter_api.md
+++ b/doc/sinter_api.md
@@ -335,7 +335,7 @@ def sample(
 # sinter.Decoder
 
 # (at top-level in the sinter module)
-class Decoder(metaclass=abc.ABCMeta):
+class Decoder:
     """Abstract base class for custom decoders.
 
     Custom decoders can be explained to sinter by inheriting from this class and
@@ -343,6 +343,10 @@ class Decoder(metaclass=abc.ABCMeta):
 
     Decoder classes MUST be serializable (e.g. via pickling), so that they can
     be given to worker processes when using python multiprocessing.
+
+    Child classes should implement `compile_decoder_for_dem`, but (for legacy
+    reasons) can alternatively implement `decode_via_files`. At least one of
+    the two methods must be implemented.
     """
 ```
 
@@ -386,7 +390,6 @@ def compile_decoder_for_dem(
 # sinter.Decoder.decode_via_files
 
 # (in class sinter.Decoder)
-@abc.abstractmethod
 def decode_via_files(
     self,
     *,

--- a/glue/sample/src/sinter/_decoding/_stim_then_decode_sampler.py
+++ b/glue/sample/src/sinter/_decoding/_stim_then_decode_sampler.py
@@ -140,7 +140,7 @@ def _compile_decoder_with_disk_fallback(
 ) -> CompiledDecoder:
     try:
         return decoder.compile_decoder_for_dem(dem=task.detector_error_model)
-    except (NotImplementedError, ValueError):
+    except NotImplementedError:
         pass
     if tmp_dir is None:
         raise ValueError(f"Decoder {task.decoder=} didn't implement `compile_decoder_for_dem`, but no temporary directory was provided for falling back to `decode_via_files`.")


### PR DESCRIPTION
- The class `sinter.Decoder` now implements `decode_via_files` by calling `compile_decoder_for_dem`
- Child classes now must implement at least one of `decode_via_files` or `compile_decoder_for_dem`
- Sinter's internal fallback to `sinter.Decoder.decode_via_files` now only occurs if `sinter.Decoder.compile_decoder_for_dem` raises a `NotImplementedError` (it no longer happens if a `ValueError` was raised).
- Also, make one of the multiprocessing unit tests less flaky by waiting up to a second for messages to arrive

Fixes https://github.com/quantumlib/Stim/issues/923