### PR TITLE
Fix overly strict bounds checking for negative indices in FlipSimulator

### DIFF
--- a/src/stim/simulators/frame_simulator.pybind.cc
+++ b/src/stim/simulators/frame_simulator.pybind.cc
@@ -16,7 +16,7 @@ std::optional<size_t> py_index_to_optional_size_t(
         return {};
     }
     int64_t i = pybind11::cast<int64_t>(index);
-    if (i < -(int64_t)length || (uint64_t)i >= length) {
+    if (i < -(int64_t)length || (i >= 0 && (uint64_t)i >= length)) {
         std::stringstream msg;
         msg << "not (";
         msg << "-" << len_name << " <= ";

--- a/src/stim/simulators/frame_simulator_pybind_test.py
+++ b/src/stim/simulators/frame_simulator_pybind_test.py
@@ -612,3 +612,15 @@ def test_generate_bernoulli_samples():
     assert np.all(v[0::2][:-1] == 0xFF)
     assert v[0::2][-1] == 0x7F
     assert np.all(v[1::2] == 0)
+
+
+def test_get_measurement_flips_negative_index():
+    sim = stim.FlipSimulator(batch_size=8, disable_stabilizer_randomization=True)
+    sim.do(stim.Circuit("""
+        X_ERROR(1) 1
+        M 0 1
+    """))
+    np.testing.assert_array_equal(sim.get_measurement_flips(record_index=-2), [False] * 8)
+    np.testing.assert_array_equal(sim.get_measurement_flips(record_index=-1), [True] * 8)
+    np.testing.assert_array_equal(sim.get_measurement_flips(record_index=0), [False] * 8)
+    np.testing.assert_array_equal(sim.get_measurement_flips(record_index=1), [True] * 8)


### PR DESCRIPTION
- Casting to unsigned before checking if non-negative resulted in negative values always looking too large

Fixes https://github.com/quantumlib/Stim/issues/926