### PR TITLE
Fix `stim.Circuit.detecting_regions` not failing on anticommutations at start of circuit

### DIFF
--- a/src/stim/diagram/detector_slice/detector_slice_set.test.cc
+++ b/src/stim/diagram/detector_slice/detector_slice_set.test.cc
@@ -56,7 +56,7 @@ TEST(detector_slice_set, from_circuit) {
         2,
         1,
         {&empty_filter});
-    ASSERT_EQ(slice_set.coordinates, (std::map<uint64_t, std::vector<double>>{{0, {}}, {1, {3, 5}}}));
+    ASSERT_EQ(slice_set.coordinates, (std::map<uint64_t, std::vector<double>>{{0, {}}, {1, {3, 5}}, {2, {}}}));
     ASSERT_EQ(
         slice_set.slices,
         (std::map<std::pair<uint64_t, stim::DemTarget>, std::vector<stim::GateTarget>>{
@@ -417,7 +417,7 @@ TEST(detector_slice_set, from_circuit_with_errors) {
     ASSERT_EQ(
         slice_set.anticommutations,
         (std::map<std::pair<uint64_t, stim::DemTarget>, std::vector<stim::GateTarget>>{
-            {{2, DemTarget::relative_detector_id(0)}, {GateTarget::x(0)}},
+            {{3, DemTarget::relative_detector_id(0)}, {GateTarget::x(0)}},
         }));
     ASSERT_EQ(
         slice_set.slices,

--- a/src/stim/simulators/sparse_rev_frame_tracker.cc
+++ b/src/stim/simulators/sparse_rev_frame_tracker.cc
@@ -405,6 +405,25 @@ void SparseUnsignedRevFrameTracker::undo_RZ(const CircuitInstruction &dat) {
     clear_qubits(dat);
 }
 
+void SparseUnsignedRevFrameTracker::undo_implicit_RZs_at_start_of_circuit() {
+    for (size_t q = 0; q < xs.size(); q++) {
+        for (const auto &d : xs[q]) {
+            anticommutations.insert({d, GateTarget::qubit(q)});
+        }
+    }
+    if (!anticommutations.empty() && fail_on_anticommute) {
+        std::stringstream ss;
+        ss << "While running backwards through the circuit,\n";
+        ss << "during reverse-execution of the implicit resets at the beginning of the circuit,\n";
+        ss << "the following detecting region vs dissipation anticommutations occurred\n";
+        for (auto &[d, g] : anticommutations) {
+            ss << "    " << d << " vs " << g << "\n";
+        }
+        ss << "Therefore invalid detectors/observables are present in the circuit.\n";
+        throw std::invalid_argument(ss.str());
+    }
+}
+
 void SparseUnsignedRevFrameTracker::undo_MPAD(const CircuitInstruction &dat) {
     for (size_t k = dat.targets.size(); k-- > 0;) {
         num_measurements_in_past--;

--- a/src/stim/simulators/sparse_rev_frame_tracker.h
+++ b/src/stim/simulators/sparse_rev_frame_tracker.h
@@ -81,6 +81,7 @@ struct SparseUnsignedRevFrameTracker {
     void handle_y_gauges(const CircuitInstruction &inst);
     void handle_z_gauges(const CircuitInstruction &inst);
 
+    void undo_implicit_RZs_at_start_of_circuit();
     void undo_DETECTOR(const CircuitInstruction &inst);
     void undo_OBSERVABLE_INCLUDE(const CircuitInstruction &inst);
     void undo_RX(const CircuitInstruction &inst);

--- a/src/stim/util_top/circuit_to_detecting_regions.cc
+++ b/src/stim/util_top/circuit_to_detecting_regions.cc
@@ -42,5 +42,6 @@ std::map<DemTarget, std::map<uint64_t, FlexPauliString>> stim::circuit_to_detect
         }
         tracker.undo_gate(inst);
     });
+    tracker.undo_implicit_RZs_at_start_of_circuit();
     return result;
 }

--- a/src/stim/util_top/circuit_to_detecting_regions_test.py
+++ b/src/stim/util_top/circuit_to_detecting_regions_test.py
@@ -1,0 +1,33 @@
+import pytest
+import stim
+
+
+def test_detecting_regions_fails_on_anticommutations_at_start_of_circuit():
+    c = stim.Circuit("""
+        TICK
+        R 0
+        TICK
+        MX 0
+        DETECTOR rec[-1]
+    """)
+    assert 'magenta' in str(c.diagram('detslice-with-ops-svg'))
+    with pytest.raises(ValueError, match="anticommutation"):
+        c.detecting_regions()
+
+    c = stim.Circuit("""
+        R 0
+        TICK
+        MX 0
+        DETECTOR rec[-1]
+    """)
+    assert 'magenta' in str(c.diagram('detslice-with-ops-svg'))
+    with pytest.raises(ValueError, match="anticommutation"):
+        c.detecting_regions()
+
+    c = stim.Circuit("""
+        MX 0
+        DETECTOR rec[-1]
+    """)
+    assert 'magenta' in str(c.diagram('detslice-with-ops-svg'))
+    with pytest.raises(ValueError, match="anticommutation"):
+        c.detecting_regions()


### PR DESCRIPTION
- Also fix detslice diagrams not drawing these anticommutations

Fixes https://github.com/quantumlib/Stim/issues/922