### PR TITLE
Revert "Temporary workaround for issue #920"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,12 +483,7 @@ jobs:
       - run: bazel build :stim_dev_wheel
       - run: pip install bazel-bin/stim-0.0.dev0-py3-none-any.whl
       - run: pip install -e glue/sample
-      # TODO: remove the echo & export lines below after PyMatching is updated
-      # to use a more recent pybind11. C.f. issue #920.
-      - run: |
-          echo 'cmake<4.0.0' > constraint.txt
-          export PIP_CONSTRAINT=constraint.txt
-          pip install pytest pymatching fusion-blossom~=0.1.4 mwpf~=0.1.5
+      - run: pip install pytest pymatching fusion-blossom~=0.1.4 mwpf~=0.1.5
       - run: pytest glue/sample
       - run: dev/doctest_proper.py --module sinter
       - run: sinter help


### PR DESCRIPTION
Reverts quantumlib/Stim#921 because the recent updates to PyMatching and the Stim doctest code made things work again without needing the constraint on cmake's version.