### PR TITLE
Add `stim.Flow(included_observables=...)` and fix X/Z inversion when sampling observables with free-floating Pauli terms

### DIFF
--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -223,6 +223,7 @@ API references for stable versions are kept on the [stim github wiki](https://gi
     - [`stim.Flow.__ne__`](#stim.Flow.__ne__)
     - [`stim.Flow.__repr__`](#stim.Flow.__repr__)
     - [`stim.Flow.__str__`](#stim.Flow.__str__)
+    - [`stim.Flow.included_observables_copy`](#stim.Flow.included_observables_copy)
     - [`stim.Flow.input_copy`](#stim.Flow.input_copy)
     - [`stim.Flow.measurements_copy`](#stim.Flow.measurements_copy)
     - [`stim.Flow.output_copy`](#stim.Flow.output_copy)
@@ -3110,34 +3111,50 @@ def solve_flow_measurements(
     self,
     flows: List[stim.Flow],
 ) -> List[Optional[List[int]]]:
-    """Finds measurements that explain the starts/ends of the given flows.
+    """Finds measurements to explain the starts/ends of the given flows, ignoring sign.
 
     CAUTION: it's not guaranteed that the solutions returned by this method are
     minimal. It may use 20 measurements when only 2 are needed. The method applies
     some simple heuristics that attempt to reduce the size, but these heuristics
-    aren't perfect.
+    aren't perfect and don't make any strong guarantees.
+
+    The recommended way to use this method is on small parts of a circuit, such as a
+    single surface code round. The ideal use case is when there is exactly one
+    solution for each flow, because then the method behaves predictably and
+    consistently. When there are multiple solutions, the method has no real way to
+    pick out a "good" solution rather than a "cataclysmic trash fire of a" solution.
+    For example, if you have a multi-round surface code circuit with open time
+    boundaries and solve the flow 1 -> Z1*Z2*Z3*Z4, then there's a good solution
+    (the Z1*Z2*Z3*Z4 measurement from the last round), various mediocre solutions
+    (a Z1*Z2*Z3*Z4 measurement from a different round), and lots of terrible
+    solutions (a combination of multiple Z1*Z2*Z3*Z4 measurements from an odd number
+    of rounds, times a random combination of unrelated detectors). The method is
+    permitted to return any of those solutions.
 
     Args:
         flows: A list of flows, each of which to be solved. Measurements and signs
-            are entirely ignored. The input/output of a flow can't both be identity
-            Paulis.
+            are entirely ignored.
+
+            An error is raised if one of the given flows has an identity pauli
+            string as its input and as its output, despite the fact that this case
+            has a vacuous solution (no measurements). This error is only present as
+            a safety check that catches some possible bugs in the calling code, such
+            as accidentally applying this method to detector flows. This error may
+            be removed in the future, so that the vacuous case succeeds vacuously.
 
     Returns:
         A list of solutions for each given flow.
 
-        If no solution exists for flows[k], then results[k] is None.
-        Otherwise, results[k] is the measurement indices for flows[k].
+        If no solution exists for flows[k], then solutions[k] is None.
+        Otherwise, solutions[k] is a list of measurement indices for flows[k].
 
-        When a solution exists, it's guaranteed that
+        When solutions[k] is not None, it's guaranteed that
 
-            stim.Flow(
+            circuit.has_flow(stim.Flow(
                 input=flows[k].input,
                 output=flows[k].output,
-                measurements=results[k],
-            )
-
-        is an unsigned flow of the circuit. The sign can be solved for separately
-        if needed.
+                measurements=solutions[k],
+            ), unsigned=True)
 
     Raises:
         ValueError:
@@ -9093,6 +9110,7 @@ def __init__(
     input: Optional[stim.PauliString] = None,
     output: Optional[stim.PauliString] = None,
     measurements: Optional[Iterable[Union[int, GateTarget]]] = None,
+    included_observables: Optional[Iterable[int]] = None,
 ) -> None:
     """Initializes a stim.Flow.
 
@@ -9109,11 +9127,18 @@ def __init__(
             specify the flow's input stabilizer.
         output: Defaults to None. Can be set to a stim.PauliString to directly
             specify the flow's output stabilizer.
-        measurements: Can be set to a list of integers or gate targets like
-            `stim.target_rec(-1)`, to specify the measurements that mediate the
-            flow. Negative and positive measurement indices are allowed. Indexes
-            follow the python convention where -1 is the last measurement in a
-            circuit and 0 is the first measurement in a circuit.
+        measurements: Defaults to None. Can be set to a list of integers or gate
+            targets like `stim.target_rec(-1)`, to specify the measurements that
+            mediate the flow. Negative and positive measurement indices are allowed.
+            Indexes follow the python convention where -1 is the last measurement in
+            a circuit and 0 is the first measurement in a circuit.
+        included_observables: Defaults to None. `OBSERVABLE_INCLUDE` instructions
+            that target an observable index from this list will be implicitly
+            included in the flow. This allows flows to refer to observables. For
+            example, the flow "X5 -> obs[3]" says "At the start of the circuit,
+            observable 3 should be an X term on qubit 5. By the end of the circuit
+            it will be measured. The `OBSERVABLE_INCLUDE(3)` instructions in the
+            circuit should explain how this happened.".
 
     Examples:
         >>> import stim
@@ -9130,6 +9155,13 @@ def __init__(
         ...     measurements=[],
         ... )
         stim.Flow("XX -> _X")
+
+        >>> # Identical terms cancel.
+        >>> stim.Flow("X2 -> Y2*Y2 xor rec[-2] xor rec[-2]")
+        stim.Flow("__X -> ___")
+
+        >>> stim.Flow("X -> Y xor obs[3] xor obs[3] xor obs[3]")
+        stim.Flow("X -> Y xor obs[3]")
     """
 ```
 
@@ -9167,6 +9199,37 @@ def __str__(
     self,
 ) -> str:
     """Returns a shorthand description of the flow.
+    """
+```
+
+<a name="stim.Flow.included_observables_copy"></a>
+```python
+# stim.Flow.included_observables_copy
+
+# (in class stim.Flow)
+def included_observables_copy(
+    self,
+) -> List[int]:
+    """Returns a copy of the flow's included observable indices.
+
+    When an observable is included in a flow, the flow implicitly includes all
+    measurements and pauli terms from `OBSERVABLE_INCLUDE` instructions targeting
+    that observable index.
+
+    Examples:
+        >>> import stim
+        >>> f = stim.Flow(included_observables=[3, 2])
+        >>> f.included_observables_copy()
+        [2, 3]
+
+        >>> f.included_observables_copy() is f.included_observables_copy()
+        False
+
+        >>> f = stim.Flow("X2 -> obs[3]")
+        >>> f.included_observables_copy()
+        [3]
+        >>> stim.Circuit("OBSERVABLE_INCLUDE(3) X2").has_flow(f)
+        True
     """
 ```
 

--- a/file_lists/source_files_no_main
+++ b/file_lists/source_files_no_main
@@ -94,6 +94,7 @@ src/stim/util_top/circuit_vs_amplitudes.cc
 src/stim/util_top/export_crumble_url.cc
 src/stim/util_top/export_qasm.cc
 src/stim/util_top/export_quirk_url.cc
+src/stim/util_top/has_flow.cc
 src/stim/util_top/reference_sample_tree.cc
 src/stim/util_top/simplified_circuit.cc
 src/stim/util_top/transform_without_feedback.cc

--- a/src/stim/mem/simd_bit_table.h
+++ b/src/stim/mem/simd_bit_table.h
@@ -99,7 +99,7 @@ struct simd_bit_table {
     /// As minor_index_low ranges from 0 to W-1, (*this)[major_index][minor_index] ranges over the
     /// bits of an aligned SIMD word. get_index_of_bitword returns the index in data.ptr_simd of
     /// the corresponding simd word.
-    inline const size_t get_index_of_bitword(
+    inline size_t get_index_of_bitword(
         size_t major_index_high, size_t major_index_low, size_t minor_index_high) const {
         size_t major_index = (major_index_high << bitword<W>::BIT_POW) + major_index_low;
         return major_index * num_simd_words_minor + minor_index_high;

--- a/src/stim/mem/span_ref.h
+++ b/src/stim/mem/span_ref.h
@@ -19,11 +19,8 @@
 
 #include <array>
 #include <cstdlib>
-#include <cstring>
-#include <iostream>
 #include <span>
 #include <sstream>
-#include <stdexcept>
 #include <vector>
 
 namespace stim {

--- a/src/stim/simulators/frame_simulator.inl
+++ b/src/stim/simulators/frame_simulator.inl
@@ -239,10 +239,10 @@ void FrameSimulator<W>::do_OBSERVABLE_INCLUDE(const CircuitInstruction &inst) {
                 r ^= m_record.lookback(lookback);
             } else if (t.is_pauli_target()) {
                 if (t.data & TARGET_PAULI_X_BIT) {
-                    r ^= x_table[t.qubit_value()];
+                    r ^= z_table[t.qubit_value()];
                 }
                 if (t.data & TARGET_PAULI_Z_BIT) {
-                    r ^= z_table[t.qubit_value()];
+                    r ^= x_table[t.qubit_value()];
                 }
             } else {
                 throw std::invalid_argument("Unexpected target for OBSERVABLE_INCLUDE: " + t.str());

--- a/src/stim/simulators/frame_simulator.test.cc
+++ b/src/stim/simulators/frame_simulator.test.cc
@@ -1681,3 +1681,63 @@ TEST_EACH_WORD_SIZE_W(FrameSimulator, heralded_pauli_channel_1_statistics_offset
     EXPECT_NEAR(bins[6] / (double)n, 0.25, 0.04);
     EXPECT_NEAR(bins[7] / (double)n, 0.15, 0.04);
 })
+
+TEST_EACH_WORD_SIZE_W(FrameSimulator, observable_include_paulis_rz, {
+    auto circuit = Circuit(R"CIRCUIT(
+        RZ 0
+        OBSERVABLE_INCLUDE(0) X0
+        OBSERVABLE_INCLUDE(1) Y0
+        OBSERVABLE_INCLUDE(2) Z0
+    )CIRCUIT");
+    FrameSimulator<W> sim(
+        circuit.compute_stats(), FrameSimulatorMode::STORE_DETECTIONS_TO_MEMORY, 1024, INDEPENDENT_TEST_RNG());
+    sim.reset_all();
+    sim.do_circuit(circuit);
+    auto x0 = sim.obs_record[0].popcnt();
+    auto y0 = sim.obs_record[1].popcnt();
+    auto z0 = sim.obs_record[2].popcnt();
+    ASSERT_EQ(x0, y0);
+    ASSERT_GT(x0, 300);
+    ASSERT_LT(x0, 700);
+    ASSERT_EQ(z0, 0);
+})
+
+TEST_EACH_WORD_SIZE_W(FrameSimulator, observable_include_paulis_ry, {
+    auto circuit = Circuit(R"CIRCUIT(
+        RY 0
+        OBSERVABLE_INCLUDE(0) X0
+        OBSERVABLE_INCLUDE(1) Y0
+        OBSERVABLE_INCLUDE(2) Z0
+    )CIRCUIT");
+    FrameSimulator<W> sim(
+        circuit.compute_stats(), FrameSimulatorMode::STORE_DETECTIONS_TO_MEMORY, 1024, INDEPENDENT_TEST_RNG());
+    sim.reset_all();
+    sim.do_circuit(circuit);
+    auto x0 = sim.obs_record[0].popcnt();
+    auto y0 = sim.obs_record[1].popcnt();
+    auto z0 = sim.obs_record[2].popcnt();
+    ASSERT_EQ(x0, z0);
+    ASSERT_GT(x0, 300);
+    ASSERT_LT(x0, 700);
+    ASSERT_EQ(y0, 0);
+})
+
+TEST_EACH_WORD_SIZE_W(FrameSimulator, observable_include_paulis_rx, {
+    auto circuit = Circuit(R"CIRCUIT(
+        RX 0
+        OBSERVABLE_INCLUDE(0) X0
+        OBSERVABLE_INCLUDE(1) Y0
+        OBSERVABLE_INCLUDE(2) Z0
+    )CIRCUIT");
+    FrameSimulator<W> sim(
+        circuit.compute_stats(), FrameSimulatorMode::STORE_DETECTIONS_TO_MEMORY, 1024, INDEPENDENT_TEST_RNG());
+    sim.reset_all();
+    sim.do_circuit(circuit);
+    auto x0 = sim.obs_record[0].popcnt();
+    auto y0 = sim.obs_record[1].popcnt();
+    auto z0 = sim.obs_record[2].popcnt();
+    ASSERT_EQ(y0, z0);
+    ASSERT_GT(y0, 300);
+    ASSERT_LT(y0, 700);
+    ASSERT_EQ(x0, 0);
+})

--- a/src/stim/simulators/sparse_rev_frame_tracker.cc
+++ b/src/stim/simulators/sparse_rev_frame_tracker.cc
@@ -839,7 +839,8 @@ void SparseUnsignedRevFrameTracker::undo_DETECTOR(const CircuitInstruction &dat)
 }
 
 void SparseUnsignedRevFrameTracker::undo_OBSERVABLE_INCLUDE(const CircuitInstruction &dat) {
-    auto obs = DemTarget::observable_id((int32_t)dat.args[0]);
+    uint64_t obs_id = (uint32_t)dat.args[0];
+    auto obs = DemTarget::observable_id(obs_id);
     for (auto t : dat.targets) {
         if (t.is_measurement_record_target()) {
             int64_t index = t.rec_offset() + (int64_t)num_measurements_in_past;

--- a/src/stim/stabilizers/flow.h
+++ b/src/stim/stabilizers/flow.h
@@ -17,19 +17,24 @@
 #ifndef _STIM_STABILIZERS_FLOW_H
 #define _STIM_STABILIZERS_FLOW_H
 
-#include <iostream>
-#include <span>
-
 #include "stim/stabilizers/pauli_string.h"
 
 namespace stim {
 
 template <size_t W>
 struct Flow {
+    /// The stabilizer at the beginning of the circuit.
     stim::PauliString<W> input;
+    /// The equivalent stabilizer at the end the circuit.
     stim::PauliString<W> output;
+    /// The measurements mediating the equivalence.
     /// Indexing follows python convention: -1 is the last element, 0 is the first element.
+    /// ENTRIES MUST BE SORTED AND UNIQUE.
     std::vector<int32_t> measurements;
+    /// Indices of observables included in the flow.
+    /// Determines which OBSERVABLE_INCLUDE instructions are included.
+    /// ENTRIES MUST BE SORTED AND UNIQUE.
+    std::vector<uint32_t> observables;
 
     static Flow<W> from_str(std::string_view text);
     bool operator<(const Flow<W> &other) const;

--- a/src/stim/stabilizers/flow.inl
+++ b/src/stim/stabilizers/flow.inl
@@ -1,16 +1,30 @@
 #include "stim/circuit/circuit.h"
-#include "stim/simulators/frame_simulator_util.h"
-#include "stim/simulators/sparse_rev_frame_tracker.h"
-#include "stim/simulators/tableau_simulator.h"
 #include "stim/stabilizers/flex_pauli_string.h"
 #include "stim/stabilizers/flow.h"
 #include "stim/util_bot/arg_parse.h"
+#include "stim/mem/span_ref.h"
 
 namespace stim {
 
+inline bool parse_obs_index(std::string_view obs, uint32_t *out) {
+    if (obs.size() < 6 || obs[0] != 'o' || obs[1] != 'b' || obs[2] != 's' || obs[3] != '[' || obs.back() != ']') {
+        throw std::invalid_argument("");  // Caught and given a message by caller.
+    }
+    int64_t i = 0;
+    if (!parse_int64(obs.substr(4, obs.size() - 5), &i)) {
+        return false;
+    }
+
+    if (i >= 0 && i <= UINT32_MAX) {
+        *out = (uint32_t)i;
+        return true;
+    }
+    return false;
+}
+
 inline bool parse_rec_allowing_non_negative(std::string_view rec, int32_t *out) {
     if (rec.size() < 6 || rec[0] != 'r' || rec[1] != 'e' || rec[2] != 'c' || rec[3] != '[' || rec.back() != ']') {
-        throw std::invalid_argument("");  // Caught and given a message below.
+        throw std::invalid_argument("");  // Caught and given a message by caller.
     }
     int64_t i = 0;
     if (!parse_int64(rec.substr(4, rec.size() - 5), &i)) {
@@ -75,19 +89,29 @@ Flow<W> Flow<W>::from_str(std::string_view text) {
         }
         PauliString<W> out(0);
         std::vector<int32_t> measurements;
+        std::vector<uint32_t> observables;
         bool flip_out = false;
         if (parts[k].starts_with('-')) {
             flip_out = true;
             parts[k] = parts[k].substr(1);
         }
-        if (!parts[k].empty() && parts[k][0] != 'r') {
+        if (!parts[k].empty() && parts[k][0] != 'r' && parts[k][0] != 'o') {
             out = parse_non_empty_pauli_string_allowing_i<W>(parts[k], &imag_out);
-        } else {
+        } else if (parts[k][0] == 'r') {
             int32_t rec;
             if (!parse_rec_allowing_non_negative(parts[k], &rec)) {
                 throw std::invalid_argument("");  // Caught and given a message below.
             }
             measurements.push_back(rec);
+        } else if (parts[k][0] == 'o') {
+            uint32_t rec;
+            if (!parse_obs_index(parts[k], &rec)) {
+                throw std::invalid_argument("");  // Caught and given a message below.
+            }
+            observables.push_back(rec);
+        } else {
+            throw std::invalid_argument("Parsing reached an expected-to-be-impossible state. "
+                                        "Failed to understand a Pauli term.");
         }
         out.sign ^= flip_out;
         k++;
@@ -95,17 +119,31 @@ Flow<W> Flow<W>::from_str(std::string_view text) {
             if (parts[k] != "xor" || k + 1 == parts.size()) {
                 throw std::invalid_argument("");  // Caught and given a message below.
             }
-            int32_t rec;
-            if (!parse_rec_allowing_non_negative(parts[k + 1], &rec)) {
+            if (parts[k + 1].starts_with("r")) {
+                int32_t rec;
+                if (!parse_rec_allowing_non_negative(parts[k + 1], &rec)) {
+                    throw std::invalid_argument("");  // Caught and given a message below.
+                }
+                measurements.push_back(rec);
+            } else if (parts[k + 1].starts_with("o")) {
+                uint32_t obs;
+                if (!parse_obs_index(parts[k + 1], &obs)) {
+                    throw std::invalid_argument("");  // Caught and given a message below.
+                }
+                observables.push_back(obs);
+            } else {
                 throw std::invalid_argument("");  // Caught and given a message below.
             }
-            measurements.push_back(rec);
             k += 2;
         }
         if (imag_inp != imag_out) {
             throw std::invalid_argument("Anti-Hermitian flows aren't allowed.");
         }
-        return Flow{inp, out, measurements};
+        size_t measurements_kept = inplace_xor_sort(SpanRef<int32_t>(measurements)).size();
+        size_t obs_kept = inplace_xor_sort(SpanRef<uint32_t>(observables)).size();
+        measurements.resize(measurements_kept);
+        observables.resize(obs_kept);
+        return Flow{inp, out, measurements, observables};
     } catch (const std::invalid_argument &ex) {
         if (*ex.what() != '\0') {
             throw;
@@ -116,7 +154,7 @@ Flow<W> Flow<W>::from_str(std::string_view text) {
 
 template <size_t W>
 bool Flow<W>::operator==(const Flow<W> &other) const {
-    return input == other.input && output == other.output && measurements == other.measurements;
+    return input == other.input && output == other.output && measurements == other.measurements && observables == other.observables;
 }
 
 template <size_t W>
@@ -129,6 +167,9 @@ bool Flow<W>::operator<(const Flow<W> &other) const {
     }
     if (measurements != other.measurements) {
         return SpanRef<const int32_t>(measurements) < SpanRef<const int32_t>(other.measurements);
+    }
+    if (observables != other.observables) {
+        return SpanRef<const uint32_t>(observables) < SpanRef<const uint32_t>(other.observables);
     }
     return false;
 }
@@ -203,6 +244,13 @@ std::ostream &operator<<(std::ostream &out, const Flow<W> &flow) {
         }
         has_out = true;
         out << "rec[" << t << "]";
+    }
+    for (const auto &t : flow.observables) {
+        if (has_out) {
+            out << " xor ";
+        }
+        has_out = true;
+        out << "obs[" << t << "]";
     }
     if (!has_out) {
         out << "1";

--- a/src/stim/stabilizers/flow.pybind.cc
+++ b/src/stim/stabilizers/flow.pybind.cc
@@ -71,7 +71,8 @@ static Flow<MAX_BITWORD_WIDTH> py_init_flow(
     const pybind11::object &arg,
     const pybind11::object &input,
     const pybind11::object &output,
-    const pybind11::object &measurements) {
+    const pybind11::object &measurements,
+    const pybind11::object &included_observables) {
     if (arg.is_none()) {
         Flow<MAX_BITWORD_WIDTH> result{PauliString<MAX_BITWORD_WIDTH>(0), PauliString<MAX_BITWORD_WIDTH>(0)};
         bool imag = false;
@@ -100,6 +101,13 @@ static Flow<MAX_BITWORD_WIDTH> py_init_flow(
                     result.measurements.push_back(pybind11::cast<int32_t>(h));
                 }
             }
+            inplace_xor_sort(SpanRef<int32_t>(result.measurements));
+        }
+        if (!included_observables.is_none()) {
+            for (const auto &h : included_observables) {
+                result.observables.push_back(pybind11::cast<uint32_t>(h));
+            }
+            inplace_xor_sort(SpanRef<uint32_t>(result.observables));
         }
         return result;
     }
@@ -112,6 +120,9 @@ static Flow<MAX_BITWORD_WIDTH> py_init_flow(
     }
     if (!measurements.is_none()) {
         throw std::invalid_argument("Can't specify both a positional argument and `measurements=`.");
+    }
+    if (!included_observables.is_none()) {
+        throw std::invalid_argument("Can't specify both a positional argument and `included_observables=`.");
     }
 
     if (pybind11::isinstance<Flow<MAX_BITWORD_WIDTH>>(arg)) {
@@ -134,8 +145,9 @@ void stim_pybind::pybind_flow_methods(pybind11::module &m, pybind11::class_<Flow
         pybind11::arg("input") = pybind11::none(),
         pybind11::arg("output") = pybind11::none(),
         pybind11::arg("measurements") = pybind11::none(),
+        pybind11::arg("included_observables") = pybind11::none(),
         clean_doc_string(R"DOC(
-            @signature def __init__(self, arg: Union[None, str, stim.Flow] = None, /, *, input: Optional[stim.PauliString] = None, output: Optional[stim.PauliString] = None, measurements: Optional[Iterable[Union[int, GateTarget]]] = None) -> None:
+            @signature def __init__(self, arg: Union[None, str, stim.Flow] = None, /, *, input: Optional[stim.PauliString] = None, output: Optional[stim.PauliString] = None, measurements: Optional[Iterable[Union[int, GateTarget]]] = None, included_observables: Optional[Iterable[int]] = None) -> None:
             Initializes a stim.Flow.
 
             When given a string, the string is parsed as flow shorthand. For example,
@@ -151,11 +163,18 @@ void stim_pybind::pybind_flow_methods(pybind11::module &m, pybind11::class_<Flow
                     specify the flow's input stabilizer.
                 output: Defaults to None. Can be set to a stim.PauliString to directly
                     specify the flow's output stabilizer.
-                measurements: Can be set to a list of integers or gate targets like
-                    `stim.target_rec(-1)`, to specify the measurements that mediate the
-                    flow. Negative and positive measurement indices are allowed. Indexes
-                    follow the python convention where -1 is the last measurement in a
-                    circuit and 0 is the first measurement in a circuit.
+                measurements: Defaults to None. Can be set to a list of integers or gate
+                    targets like `stim.target_rec(-1)`, to specify the measurements that
+                    mediate the flow. Negative and positive measurement indices are allowed.
+                    Indexes follow the python convention where -1 is the last measurement in
+                    a circuit and 0 is the first measurement in a circuit.
+                included_observables: Defaults to None. `OBSERVABLE_INCLUDE` instructions
+                    that target an observable index from this list will be implicitly
+                    included in the flow. This allows flows to refer to observables. For
+                    example, the flow "X5 -> obs[3]" says "At the start of the circuit,
+                    observable 3 should be an X term on qubit 5. By the end of the circuit
+                    it will be measured. The `OBSERVABLE_INCLUDE(3)` instructions in the
+                    circuit should explain how this happened.".
 
             Examples:
                 >>> import stim
@@ -172,6 +191,13 @@ void stim_pybind::pybind_flow_methods(pybind11::module &m, pybind11::class_<Flow
                 ...     measurements=[],
                 ... )
                 stim.Flow("XX -> _X")
+
+                >>> # Identical terms cancel.
+                >>> stim.Flow("X2 -> Y2*Y2 xor rec[-2] xor rec[-2]")
+                stim.Flow("__X -> ___")
+
+                >>> stim.Flow("X -> Y xor obs[3] xor obs[3] xor obs[3]")
+                stim.Flow("X -> Y xor obs[3]")
         )DOC")
             .data());
 
@@ -229,6 +255,35 @@ void stim_pybind::pybind_flow_methods(pybind11::module &m, pybind11::class_<Flow
 
                 >>> f.measurements_copy() is f.measurements_copy()
                 False
+        )DOC")
+            .data());
+
+    c.def(
+        "included_observables_copy",
+        [](const Flow<MAX_BITWORD_WIDTH> &self) -> std::vector<uint32_t> {
+            return self.observables;
+        },
+        clean_doc_string(R"DOC(
+            Returns a copy of the flow's included observable indices.
+
+            When an observable is included in a flow, the flow implicitly includes all
+            measurements and pauli terms from `OBSERVABLE_INCLUDE` instructions targeting
+            that observable index.
+
+            Examples:
+                >>> import stim
+                >>> f = stim.Flow(included_observables=[3, 2])
+                >>> f.included_observables_copy()
+                [2, 3]
+
+                >>> f.included_observables_copy() is f.included_observables_copy()
+                False
+
+                >>> f = stim.Flow("X2 -> obs[3]")
+                >>> f.included_observables_copy()
+                [3]
+                >>> stim.Circuit("OBSERVABLE_INCLUDE(3) X2").has_flow(f)
+                True
         )DOC")
             .data());
 

--- a/src/stim/stabilizers/flow.test.cc
+++ b/src/stim/stabilizers/flow.test.cc
@@ -7,6 +7,17 @@
 
 using namespace stim;
 
+TEST_EACH_WORD_SIZE_W(stabilizer_flow, from_str_dedupe, {
+    EXPECT_EQ(
+        Flow<W>::from_str("X -> Y xor rec[-1] xor rec[-1] xor rec[-1] xor rec[-2] xor rec[-2] xor rec[-3] xor obs[1] xor obs[1] xor obs[3] xor obs[3] xor obs[3]"),
+        (Flow<W>{
+            .input = PauliString<W>::from_str("X"),
+            .output = PauliString<W>::from_str("Y"),
+            .measurements = {-3, -1},
+            .observables = {3},
+        }));
+})
+
 TEST_EACH_WORD_SIZE_W(stabilizer_flow, from_str, {
     ASSERT_THROW({ Flow<W>::from_str(""); }, std::invalid_argument);
     ASSERT_THROW({ Flow<W>::from_str("X"); }, std::invalid_argument);
@@ -21,6 +32,11 @@ TEST_EACH_WORD_SIZE_W(stabilizer_flow, from_str, {
     ASSERT_THROW({ Flow<W>::from_str("X -> X rec[-1]"); }, std::invalid_argument);
     ASSERT_THROW({ Flow<W>::from_str("X -> X xor"); }, std::invalid_argument);
     ASSERT_THROW({ Flow<W>::from_str("X -> rec[-1] xor X"); }, std::invalid_argument);
+    ASSERT_THROW({ Flow<W>::from_str("X -> obs[-1]"); }, std::invalid_argument);
+    ASSERT_THROW({ Flow<W>::from_str("X -> obs[A]"); }, std::invalid_argument);
+    ASSERT_THROW({ Flow<W>::from_str("X -> obs[]"); }, std::invalid_argument);
+    ASSERT_THROW({ Flow<W>::from_str("X -> obs[ 5]"); }, std::invalid_argument);
+    ASSERT_THROW({ Flow<W>::from_str("X -> rec[]"); }, std::invalid_argument);
 
     ASSERT_EQ(
         Flow<W>::from_str("1 -> 1"),
@@ -28,6 +44,7 @@ TEST_EACH_WORD_SIZE_W(stabilizer_flow, from_str, {
             .input = PauliString<W>::from_str(""),
             .output = PauliString<W>::from_str(""),
             .measurements = {},
+            .observables = {},
         }));
     ASSERT_EQ(
         Flow<W>::from_str("1 -> -rec[0]"),
@@ -35,6 +52,7 @@ TEST_EACH_WORD_SIZE_W(stabilizer_flow, from_str, {
             .input = PauliString<W>::from_str(""),
             .output = PauliString<W>::from_str("-"),
             .measurements = {0},
+            .observables = {},
         }));
     ASSERT_EQ(
         Flow<W>::from_str("i -> -i"),
@@ -42,6 +60,7 @@ TEST_EACH_WORD_SIZE_W(stabilizer_flow, from_str, {
             .input = PauliString<W>::from_str(""),
             .output = PauliString<W>::from_str("-"),
             .measurements = {},
+            .observables = {},
         }));
     ASSERT_EQ(
         Flow<W>::from_str("iX -> -iY"),
@@ -49,6 +68,7 @@ TEST_EACH_WORD_SIZE_W(stabilizer_flow, from_str, {
             .input = PauliString<W>::from_str("X"),
             .output = PauliString<W>::from_str("-Y"),
             .measurements = {},
+            .observables = {},
         }));
     ASSERT_EQ(
         Flow<W>::from_str("X->-Y"),
@@ -56,6 +76,7 @@ TEST_EACH_WORD_SIZE_W(stabilizer_flow, from_str, {
             .input = PauliString<W>::from_str("X"),
             .output = PauliString<W>::from_str("-Y"),
             .measurements = {},
+            .observables = {},
         }));
     ASSERT_EQ(
         Flow<W>::from_str("X -> -Y"),
@@ -63,6 +84,7 @@ TEST_EACH_WORD_SIZE_W(stabilizer_flow, from_str, {
             .input = PauliString<W>::from_str("X"),
             .output = PauliString<W>::from_str("-Y"),
             .measurements = {},
+            .observables = {},
         }));
     ASSERT_EQ(
         Flow<W>::from_str("-X -> Y"),
@@ -70,6 +92,7 @@ TEST_EACH_WORD_SIZE_W(stabilizer_flow, from_str, {
             .input = PauliString<W>::from_str("-X"),
             .output = PauliString<W>::from_str("Y"),
             .measurements = {},
+            .observables = {},
         }));
     ASSERT_EQ(
         Flow<W>::from_str("XYZ -> -Z_Z"),
@@ -77,6 +100,7 @@ TEST_EACH_WORD_SIZE_W(stabilizer_flow, from_str, {
             .input = PauliString<W>::from_str("XYZ"),
             .output = PauliString<W>::from_str("-Z_Z"),
             .measurements = {},
+            .observables = {},
         }));
     ASSERT_EQ(
         Flow<W>::from_str("XYZ -> Z_Y xor rec[-1]"),
@@ -84,6 +108,7 @@ TEST_EACH_WORD_SIZE_W(stabilizer_flow, from_str, {
             .input = PauliString<W>::from_str("XYZ"),
             .output = PauliString<W>::from_str("Z_Y"),
             .measurements = {-1},
+            .observables = {},
         }));
     ASSERT_EQ(
         Flow<W>::from_str("XYZ -> Z_Y xor rec[5]"),
@@ -91,6 +116,7 @@ TEST_EACH_WORD_SIZE_W(stabilizer_flow, from_str, {
             .input = PauliString<W>::from_str("XYZ"),
             .output = PauliString<W>::from_str("Z_Y"),
             .measurements = {5},
+            .observables = {},
         }));
     ASSERT_EQ(
         Flow<W>::from_str("XYZ -> rec[-1]"),
@@ -98,27 +124,66 @@ TEST_EACH_WORD_SIZE_W(stabilizer_flow, from_str, {
             .input = PauliString<W>::from_str("XYZ"),
             .output = PauliString<W>::from_str(""),
             .measurements = {-1},
+            .observables = {},
         }));
     ASSERT_EQ(
         Flow<W>::from_str("XYZ -> Z_Y xor rec[-1] xor rec[-3]"),
         (Flow<W>{
             .input = PauliString<W>::from_str("XYZ"),
             .output = PauliString<W>::from_str("Z_Y"),
-            .measurements = {-1, -3},
+            .measurements = {-3, -1},
+            .observables = {},
         }));
     ASSERT_EQ(
         Flow<W>::from_str("XYZ -> ZIY xor rec[55] xor rec[-3]"),
         (Flow<W>{
             .input = PauliString<W>::from_str("XYZ"),
             .output = PauliString<W>::from_str("Z_Y"),
-            .measurements = {55, -3},
+            .measurements = {-3, 55},
+            .observables = {},
+        }));
+    ASSERT_EQ(
+        Flow<W>::from_str("XYZ -> ZIY xor rec[-3] xor rec[55]"),
+        (Flow<W>{
+            .input = PauliString<W>::from_str("XYZ"),
+            .output = PauliString<W>::from_str("Z_Y"),
+            .measurements = {-3, 55},
+            .observables = {},
         }));
     ASSERT_EQ(
         Flow<W>::from_str("X9 -> -Z5*Y3 xor rec[55] xor rec[-3]"),
         (Flow<W>{
             .input = PauliString<W>::from_str("_________X"),
             .output = PauliString<W>::from_str("-___Y_Z"),
-            .measurements = {55, -3},
+            .measurements = {-3, 55},
+            .observables = {},
+        }));
+})
+
+TEST_EACH_WORD_SIZE_W(stabilizer_flow, from_str_obs, {
+    EXPECT_EQ(
+        Flow<W>::from_str("X9 -> obs[5]"),
+        (Flow<W>{
+            .input = PauliString<W>::from_str("_________X"),
+            .output = PauliString<W>::from_str(""),
+            .measurements = {},
+            .observables = {5},
+        }));
+    EXPECT_EQ(
+        Flow<W>::from_str("X9 -> X xor obs[5] xor obs[3] xor rec[-1]"),
+        (Flow<W>{
+            .input = PauliString<W>::from_str("_________X"),
+            .output = PauliString<W>::from_str("X"),
+            .measurements = {-1},
+            .observables = {3, 5},
+        }));
+    EXPECT_EQ(
+        Flow<W>::from_str("X9 -> X xor obs[5] xor rec[-1] xor obs[3]"),
+        (Flow<W>{
+            .input = PauliString<W>::from_str("_________X"),
+            .output = PauliString<W>::from_str("X"),
+            .measurements = {-1},
+            .observables = {3, 5},
         }));
 })
 
@@ -141,7 +206,7 @@ TEST_EACH_WORD_SIZE_W(stabilizer_flow, str_and_from_str, {
 
     ASSERT_EQ(
         Flow<W>::from_str("-1 -> -X xor rec[-1] xor rec[-3]"),
-        (Flow<W>{PauliString<W>::from_str("-"), PauliString<W>::from_str("-X"), {-1, -3}}));
+        (Flow<W>{PauliString<W>::from_str("-"), PauliString<W>::from_str("-X"), {-3, -1}}));
 })
 
 TEST_EACH_WORD_SIZE_W(stabilizer_flow, ordering, {

--- a/src/stim/stabilizers/flow_pybind_test.py
+++ b/src/stim/stabilizers/flow_pybind_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import numpy as np
 import stim
 import pytest
 
@@ -104,3 +104,75 @@ def test_equality():
 def test_repr(value):
     assert eval(repr(value), {'stim': stim}) == value
     assert repr(eval(repr(value), {'stim': stim})) == repr(value)
+
+
+def test_obs_flows():
+    assert stim.Circuit("""
+        OBSERVABLE_INCLUDE(1) X2
+    """).has_flow(stim.Flow("X2 -> obs[1]"))
+    assert not stim.Circuit("""
+        OBSERVABLE_INCLUDE(1) !X2
+    """).has_flow(stim.Flow("X2 -> obs[1]"))
+    assert stim.Circuit("""
+        OBSERVABLE_INCLUDE(1) !X2
+    """).has_flow(stim.Flow("X2 -> obs[1]"), unsigned=True)
+    assert stim.Circuit("""
+        OBSERVABLE_INCLUDE(1) !X2
+    """).has_flow(stim.Flow("-X2 -> obs[1]"))
+    assert not stim.Circuit("""
+        OBSERVABLE_INCLUDE(1) X2
+    """).has_flow(stim.Flow("Y2 -> obs[1]"))
+    assert not stim.Circuit("""
+        OBSERVABLE_INCLUDE(1) X2
+    """).has_flow(stim.Flow("Y2 -> obs[1]"), unsigned=True)
+
+
+def test_obs_include_pauli_terms_sensitivity():
+    _, obs = stim.Circuit("""
+        OBSERVABLE_INCLUDE(0) X0
+        X_ERROR(0.5) 0
+        OBSERVABLE_INCLUDE(0) X0
+    """).compile_detector_sampler().sample(shots=1024, separate_observables=True)
+    assert np.count_nonzero(obs) == 0
+
+    _, obs = stim.Circuit("""
+        OBSERVABLE_INCLUDE(0) X0
+        OBSERVABLE_INCLUDE(1) Y0
+        OBSERVABLE_INCLUDE(2) Z0
+        X_ERROR(0.5) 0
+        OBSERVABLE_INCLUDE(0) X0
+        OBSERVABLE_INCLUDE(1) Y0
+        OBSERVABLE_INCLUDE(2) Z0
+    """).compile_detector_sampler().sample(shots=1024, separate_observables=True)
+    xs, ys, zs = np.count_nonzero(obs, axis=0)
+    assert xs == 0
+    assert 256 <= ys <= 768
+    assert zs == ys
+
+    _, obs = stim.Circuit("""
+        OBSERVABLE_INCLUDE(0) X0
+        OBSERVABLE_INCLUDE(1) Y0
+        OBSERVABLE_INCLUDE(2) Z0
+        Y_ERROR(0.5) 0
+        OBSERVABLE_INCLUDE(0) X0
+        OBSERVABLE_INCLUDE(1) Y0
+        OBSERVABLE_INCLUDE(2) Z0
+    """).compile_detector_sampler().sample(shots=1024, separate_observables=True)
+    xs, ys, zs = np.count_nonzero(obs, axis=0)
+    assert ys == 0
+    assert 256 <= xs <= 768
+    assert zs == xs
+
+    _, obs = stim.Circuit("""
+        OBSERVABLE_INCLUDE(0) X0
+        OBSERVABLE_INCLUDE(1) Y0
+        OBSERVABLE_INCLUDE(2) Z0
+        Z_ERROR(0.5) 0
+        OBSERVABLE_INCLUDE(0) X0
+        OBSERVABLE_INCLUDE(1) Y0
+        OBSERVABLE_INCLUDE(2) Z0
+    """).compile_detector_sampler().sample(shots=1024, separate_observables=True)
+    xs, ys, zs = np.count_nonzero(obs, axis=0)
+    assert zs == 0
+    assert 256 <= ys <= 768
+    assert xs == ys

--- a/src/stim/util_bot/probability_util.cc
+++ b/src/stim/util_bot/probability_util.cc
@@ -14,6 +14,8 @@
 
 #include "stim/util_bot/probability_util.h"
 
+#include <cstring>
+
 #include "stim/util_bot/arg_parse.h"
 
 using namespace stim;

--- a/src/stim/util_top/circuit_inverse_qec.h
+++ b/src/stim/util_top/circuit_inverse_qec.h
@@ -3,6 +3,7 @@
 
 #include "stim/circuit/circuit.h"
 #include "stim/stabilizers/flow.h"
+#include "stim/simulators/sparse_rev_frame_tracker.h"
 
 namespace stim {
 

--- a/src/stim/util_top/has_flow.cc
+++ b/src/stim/util_top/has_flow.cc
@@ -1,0 +1,65 @@
+#include "stim/util_top/has_flow.h"
+
+using namespace stim;
+
+Circuit stim::flow_test_block_for_circuit(const Circuit &circuit, GateTarget ancilla_qubit, const std::set<uint32_t> &obs_indices) {
+    Circuit result;
+
+    for (CircuitInstruction inst : circuit.operations) {
+        if (inst.gate_type == GateType::REPEAT) {
+            const Circuit &body = inst.repeat_block_body(circuit);
+            Circuit new_body = flow_test_block_for_circuit(body, ancilla_qubit, obs_indices);
+            result.append_repeat_block(inst.repeat_block_rep_count(), std::move(new_body), inst.tag);
+        } else if (inst.gate_type == GateType::OBSERVABLE_INCLUDE && obs_indices.contains((uint32_t)inst.args[0])) {
+            for (GateTarget t : inst.targets) {
+                if (t.is_inverted_result_target()) {
+                    result.safe_append(CircuitInstruction{
+                        GateType::X,
+                        {},
+                        &ancilla_qubit,
+                        inst.tag
+                    });
+                }
+                if (t.is_measurement_record_target()) {
+                    std::array<GateTarget, 2> targets{t, ancilla_qubit};
+                    result.safe_append(CircuitInstruction{
+                        GateType::CX,
+                        {},
+                        targets,
+                        inst.tag,
+                    });
+                } else if (t.is_x_target()) {
+                    std::array<GateTarget, 2> targets{GateTarget::qubit(t.qubit_value()), ancilla_qubit};
+                    result.safe_append(CircuitInstruction{
+                        GateType::XCX,
+                        {},
+                        targets,
+                        inst.tag,
+                    });
+                } else if (t.is_y_target()) {
+                    std::array<GateTarget, 2> targets{GateTarget::qubit(t.qubit_value()), ancilla_qubit};
+                    result.safe_append(CircuitInstruction{
+                        GateType::YCX,
+                        {},
+                        targets,
+                        inst.tag,
+                    });
+                } else if (t.is_z_target()) {
+                    std::array<GateTarget, 2> targets{GateTarget::qubit(t.qubit_value()), ancilla_qubit};
+                    result.safe_append(CircuitInstruction{
+                        GateType::CX,
+                        {},
+                        targets,
+                        inst.tag,
+                    });
+                } else {
+                    throw std::invalid_argument("Not handled: " + inst.str());
+                }
+            }
+        } else {
+            result.safe_append(inst);
+        }
+    }
+
+    return result;
+}

--- a/src/stim/util_top/has_flow.h
+++ b/src/stim/util_top/has_flow.h
@@ -48,6 +48,9 @@ std::vector<bool> check_if_circuit_has_unsigned_stabilizer_flows(
 template <size_t W>
 std::ostream &operator<<(std::ostream &out, const Flow<W> &flow);
 
+/// Internal helper method.
+Circuit flow_test_block_for_circuit(const Circuit &circuit, GateTarget ancilla_qubit, const std::set<uint32_t> &obs_indices);
+
 }  // namespace stim
 
 #include "stim/util_top/has_flow.inl"

--- a/src/stim/util_top/has_flow.test.cc
+++ b/src/stim/util_top/has_flow.test.cc
@@ -49,6 +49,153 @@ TEST_EACH_WORD_SIZE_W(stabilizer_flow, sample_if_circuit_has_stabilizer_flows, {
     ASSERT_EQ(results, (std::vector<bool>{1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 0}));
 })
 
+TEST_EACH_WORD_SIZE_W(stabilizer_flow, sample_if_circuit_has_stabilizer_flows_signed_checked, {
+    auto rng = INDEPENDENT_TEST_RNG();
+    auto results = sample_if_circuit_has_stabilizer_flows<W>(
+        256,
+        rng,
+        Circuit(R"CIRCUIT(
+            R 2 3
+            X 1 3
+        )CIRCUIT"),
+        std::vector<Flow<W>>{
+            Flow<W>::from_str("Z0 -> Z0"),
+            Flow<W>::from_str("Z1 -> -Z1"),
+            Flow<W>::from_str("1 -> Z2"),
+            Flow<W>::from_str("1 -> -Z3"),
+
+            Flow<W>::from_str("Z0 -> -Z0"),
+            Flow<W>::from_str("Z1 -> Z1"),
+            Flow<W>::from_str("1 -> -Z2"),
+            Flow<W>::from_str("1 -> Z3"),
+        });
+    ASSERT_EQ(results, (std::vector<bool>{1, 1, 1, 1, 0, 0, 0, 0}));
+})
+
+TEST_EACH_WORD_SIZE_W(stabilizer_flow, sample_if_circuit_has_stabilizer_flows_measurements_signed_checked, {
+    auto rng = INDEPENDENT_TEST_RNG();
+    auto results = sample_if_circuit_has_stabilizer_flows<W>(
+        256,
+        rng,
+        Circuit(R"CIRCUIT(
+            X 1
+            M 0 1 2
+            X 2
+        )CIRCUIT"),
+        std::vector<Flow<W>>{
+            Flow<W>::from_str("Z0 -> Z0"),
+            Flow<W>::from_str("Z1 -> -Z1"),
+            Flow<W>::from_str("Z2 -> -Z2"),
+            Flow<W>::from_str("Z0 -> rec[-3]"),
+            Flow<W>::from_str("-Z1 -> rec[-2]"),
+            Flow<W>::from_str("Z2 -> rec[-1]"),
+            Flow<W>::from_str("1 -> Z0 xor rec[-3]"),
+            Flow<W>::from_str("1 -> Z1 xor rec[-2]"),
+            Flow<W>::from_str("1 -> -Z2 xor rec[-1]"),
+
+            Flow<W>::from_str("Z0 -> -Z0"),
+            Flow<W>::from_str("Z1 -> Z1"),
+            Flow<W>::from_str("Z2 -> Z2"),
+            Flow<W>::from_str("-Z0 -> rec[-3]"),
+            Flow<W>::from_str("Z1 -> rec[-2]"),
+            Flow<W>::from_str("-Z2 -> rec[-1]"),
+            Flow<W>::from_str("1 -> -Z0 xor rec[-3]"),
+            Flow<W>::from_str("1 -> -Z1 xor rec[-2]"),
+            Flow<W>::from_str("1 -> Z2 xor rec[-1]"),
+        });
+    ASSERT_EQ(results, (std::vector<bool>{1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
+})
+
+TEST_EACH_WORD_SIZE_W(stabilizer_flow, sample_if_circuit_has_stabilizer_flows_signed_obs, {
+    auto rng = INDEPENDENT_TEST_RNG();
+    auto results = sample_if_circuit_has_stabilizer_flows<W>(
+        256,
+        rng,
+        Circuit(R"CIRCUIT(
+            X 1
+            M 0 1 2
+            X 2
+            OBSERVABLE_INCLUDE(0) rec[-3]
+            OBSERVABLE_INCLUDE(1) rec[-2]
+            OBSERVABLE_INCLUDE(2) rec[-1]
+        )CIRCUIT"),
+        std::vector<Flow<W>>{
+            Flow<W>::from_str("Z0 -> Z0"),
+            Flow<W>::from_str("Z1 -> -Z1"),
+            Flow<W>::from_str("Z2 -> -Z2"),
+            Flow<W>::from_str("Z0 -> obs[0]"),
+            Flow<W>::from_str("-Z1 -> obs[1]"),
+            Flow<W>::from_str("Z2 -> obs[2]"),
+            Flow<W>::from_str("1 -> Z0 xor obs[0]"),
+            Flow<W>::from_str("1 -> Z1 xor obs[1]"),
+            Flow<W>::from_str("1 -> -Z2 xor obs[2]"),
+
+            Flow<W>::from_str("Z0 -> -Z0"),
+            Flow<W>::from_str("Z1 -> Z1"),
+            Flow<W>::from_str("Z2 -> Z2"),
+            Flow<W>::from_str("-Z0 -> obs[0]"),
+            Flow<W>::from_str("Z1 -> obs[1]"),
+            Flow<W>::from_str("-Z2 -> obs[2]"),
+            Flow<W>::from_str("1 -> -Z0 xor obs[0]"),
+            Flow<W>::from_str("1 -> -Z1 xor obs[1]"),
+            Flow<W>::from_str("1 -> Z2 xor obs[2]"),
+        });
+    ASSERT_EQ(results, (std::vector<bool>{1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
+})
+
+TEST_EACH_WORD_SIZE_W(stabilizer_flow, sample_if_circuit_has_stabilizer_flows_obs, {
+    auto rng = INDEPENDENT_TEST_RNG();
+    auto results = sample_if_circuit_has_stabilizer_flows<W>(
+        256,
+        rng,
+        Circuit(R"CIRCUIT(
+            OBSERVABLE_INCLUDE(3) X0
+            OBSERVABLE_INCLUDE(2) Y0
+        )CIRCUIT"),
+        std::vector<Flow<W>>{
+            Flow<W>::from_str("X0 -> obs[3]"),
+            Flow<W>::from_str("Y0 -> obs[2]"),
+            Flow<W>::from_str("-X0 -> obs[3]"),
+            Flow<W>::from_str("X0 -> obs[2]"),
+            Flow<W>::from_str("Y0 -> obs[3]"),
+        });
+    ASSERT_EQ(results, (std::vector<bool>{1, 1, 0, 0, 0}));
+})
+
+TEST_EACH_WORD_SIZE_W(stabilizer_flow, sample_if_circuit_has_stabilizer_flows_inverted_obs_pauli, {
+    auto rng = INDEPENDENT_TEST_RNG();
+    auto results = sample_if_circuit_has_stabilizer_flows<W>(
+        256,
+        rng,
+        Circuit(R"CIRCUIT(
+            OBSERVABLE_INCLUDE(3) X0
+            OBSERVABLE_INCLUDE(2) !X0
+        )CIRCUIT"),
+        std::vector<Flow<W>>{
+            Flow<W>::from_str("X0 -> obs[3]"),
+            Flow<W>::from_str("-X0 -> obs[2]"),
+            Flow<W>::from_str("-X0 -> obs[3]"),
+            Flow<W>::from_str("X0 -> obs[2]"),
+        });
+    ASSERT_EQ(results, (std::vector<bool>{1, 1, 0, 0}));
+})
+
+TEST_EACH_WORD_SIZE_W(stabilizer_flow, sample_if_circuit_has_stabilizer_flows_inverted_obs_rec, {
+    auto rng = INDEPENDENT_TEST_RNG();
+    auto results = sample_if_circuit_has_stabilizer_flows<W>(
+        256,
+        rng,
+        Circuit(R"CIRCUIT(
+            M !0
+            OBSERVABLE_INCLUDE(3) rec[-1]
+        )CIRCUIT"),
+        std::vector<Flow<W>>{
+            Flow<W>::from_str("-Z0 -> obs[3]"),
+            Flow<W>::from_str("Z0 -> obs[3]"),
+        });
+    ASSERT_EQ(results, (std::vector<bool>{1, 0}));
+})
+
 TEST_EACH_WORD_SIZE_W(stabilizer_flow, check_if_circuit_has_unsigned_stabilizer_flows, {
     auto results = check_if_circuit_has_unsigned_stabilizer_flows<W>(
         Circuit(R"CIRCUIT(
@@ -100,4 +247,34 @@ TEST_EACH_WORD_SIZE_W(stabilizer_flow, check_if_circuit_has_unsigned_stabilizer_
             Flow<W>::from_str("Z0 -> Z0"),
         });
     ASSERT_EQ(results, (std::vector<bool>{1, 0, 1, 1, 1}));
+})
+
+TEST_EACH_WORD_SIZE_W(stabilizer_flow, has_flow_observable, {
+    auto results = check_if_circuit_has_unsigned_stabilizer_flows<W>(
+        Circuit(R"CIRCUIT(
+            MZZ 0 1
+            OBSERVABLE_INCLUDE(2) rec[-1]
+        )CIRCUIT"),
+        std::vector<Flow<W>>{
+            Flow<W>::from_str("Z0*Z1 -> obs[2]"),
+            Flow<W>::from_str("1 -> Z0*Z1 xor obs[2]"),
+            Flow<W>::from_str("X0*X1 -> X0*X1 xor obs[0]"),
+            Flow<W>::from_str("X0*X1 -> Y0*Y1 xor obs[2]"),
+            Flow<W>::from_str("X0*X1 -> Y0*Y1 xor obs[1]"),
+            Flow<W>::from_str("X0*X1 -> Y0*Y1 xor rec[-1]"),
+        });
+    ASSERT_EQ(results, (std::vector<bool>{1, 1, 1, 1, 0, 1}));
+
+    results = check_if_circuit_has_unsigned_stabilizer_flows<W>(
+        Circuit(R"CIRCUIT(
+            OBSERVABLE_INCLUDE(3) X0 Y1 Z2
+            OBSERVABLE_INCLUDE(2) Y0
+        )CIRCUIT"),
+        std::vector<Flow<W>>{
+            Flow<W>::from_str("X0*Y1*Z2 -> obs[3]"),
+            Flow<W>::from_str("-Y0 -> obs[2]"),
+            Flow<W>::from_str("Y0 -> obs[3]"),
+            Flow<W>::from_str("1 -> X0*Y1*Z2 xor obs[3]"),
+        });
+    ASSERT_EQ(results, (std::vector<bool>{1, 1, 0, 1}));
 })


### PR DESCRIPTION
- Fix pauli term `OBSERVABLE_INCLUDE` instructions having X/Z sensitivity inverted when sampling detection events
- Add field `stim.Flow.included_observables`
- Add argument `stim.Flow(..., included_observables=None)`
- Improve documentation of `stim.Circuit.solve_flow_measurements`
- `stim.Flow` now xor-sorts its measurements (and included_observables)

The 'included observables' of a flow say which `OBSERVABLE_INCLUDE` instructions to implicitly add into the flow. This allows flows to make statements about observables.

Fixes https://github.com/quantumlib/Stim/issues/940