### PR TITLE
Add MBQC decompositions to the gates documentation

### DIFF
--- a/doc/gates.md
+++ b/doc/gates.md
@@ -154,6 +154,14 @@ Decomposition (into H, S, CX, M, R):
     # The following circuit is equivalent (up to global phase) to `I 0`
     # (no operations)
     
+    # (The decomposition is empty because this gate has no effect.)
+    
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `I 0` (but affects the measurement record and an ancilla qubit)
+                
+    # (The decomposition is empty because this gate has no effect.)
+    
 
 <a name="X"></a>
 ### The 'X' Gate
@@ -206,6 +214,13 @@ Decomposition (into H, S, CX, M, R):
     S 0
     S 0
     H 0
+    
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `X 0` (but affects the measurement record and an ancilla qubit)
+    X 0
+                
+    # (The decomposition is trivial because this gate is in the target gate set.)
     
 
 <a name="Y"></a>
@@ -261,6 +276,13 @@ Decomposition (into H, S, CX, M, R):
     S 0
     H 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `Y 0` (but affects the measurement record and an ancilla qubit)
+    Y 0
+                
+    # (The decomposition is trivial because this gate is in the target gate set.)
+    
 
 <a name="Z"></a>
 ### The 'Z' Gate
@@ -311,6 +333,13 @@ Decomposition (into H, S, CX, M, R):
     # The following circuit is equivalent (up to global phase) to `Z 0`
     S 0
     S 0
+    
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `Z 0` (but affects the measurement record and an ancilla qubit)
+    Z 0
+                
+    # (The decomposition is trivial because this gate is in the target gate set.)
     
 
 ## Single Qubit Clifford Gates
@@ -368,6 +397,19 @@ Decomposition (into H, S, CX, M, R):
     S 0
     S 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `C_NXYZ 0` (but affects the measurement record and an ancilla qubit)
+    MZ 1
+    MXX 0 1
+    MY 1
+    MZZ 0 1
+    MX 1
+    Z 0
+    CX rec[-3] 0
+    CY rec[-5] 0 rec[-4] 0
+    CZ rec[-2] 0 rec[-1] 0
+                
 
 <a name="C_NZYX"></a>
 ### The 'C_NZYX' Gate
@@ -422,6 +464,19 @@ Decomposition (into H, S, CX, M, R):
     S 0
     S 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `C_NZYX 0` (but affects the measurement record and an ancilla qubit)
+    MX 1
+    MZZ 0 1
+    MY 1
+    MXX 0 1
+    MZ 1
+    X 0
+    CX rec[-2] 0 rec[-1] 0
+    CY rec[-5] 0 rec[-4] 0
+    CZ rec[-3] 0
+                
 
 <a name="C_XNYZ"></a>
 ### The 'C_XNYZ' Gate
@@ -472,6 +527,19 @@ Decomposition (into H, S, CX, M, R):
     S 0
     H 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `C_XNYZ 0` (but affects the measurement record and an ancilla qubit)
+    MZ 1
+    MXX 0 1
+    MY 1
+    MZZ 0 1
+    MX 1
+    X 0
+    CX rec[-3] 0
+    CY rec[-5] 0 rec[-4] 0
+    CZ rec[-2] 0 rec[-1] 0
+                
 
 <a name="C_XYNZ"></a>
 ### The 'C_XYNZ' Gate
@@ -524,6 +592,19 @@ Decomposition (into H, S, CX, M, R):
     S 0
     S 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `C_XYNZ 0` (but affects the measurement record and an ancilla qubit)
+    MZ 1
+    MXX 0 1
+    MY 1
+    MZZ 0 1
+    MX 1
+    Y 0
+    CX rec[-3] 0
+    CY rec[-5] 0 rec[-4] 0
+    CZ rec[-2] 0 rec[-1] 0
+                
 
 <a name="C_XYZ"></a>
 ### The 'C_XYZ' Gate
@@ -576,6 +657,18 @@ Decomposition (into H, S, CX, M, R):
     S 0
     H 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `C_XYZ 0` (but affects the measurement record and an ancilla qubit)
+    MZ 1
+    MXX 0 1
+    MY 1
+    MZZ 0 1
+    MX 1
+    CX rec[-3] 0
+    CY rec[-5] 0 rec[-4] 0
+    CZ rec[-2] 0 rec[-1] 0
+                
 
 <a name="C_ZNYX"></a>
 ### The 'C_ZNYX' Gate
@@ -628,6 +721,19 @@ Decomposition (into H, S, CX, M, R):
     S 0
     S 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `C_ZNYX 0` (but affects the measurement record and an ancilla qubit)
+    MX 1
+    MZZ 0 1
+    MY 1
+    MXX 0 1
+    MZ 1
+    Z 0
+    CX rec[-2] 0 rec[-1] 0
+    CY rec[-5] 0 rec[-4] 0
+    CZ rec[-3] 0
+                
 
 <a name="C_ZYNX"></a>
 ### The 'C_ZYNX' Gate
@@ -680,6 +786,19 @@ Decomposition (into H, S, CX, M, R):
     H 0
     S 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `C_ZYNX 0` (but affects the measurement record and an ancilla qubit)
+    MX 1
+    MZZ 0 1
+    MY 1
+    MXX 0 1
+    MZ 1
+    Y 0
+    CX rec[-2] 0 rec[-1] 0
+    CY rec[-5] 0 rec[-4] 0
+    CZ rec[-3] 0
+                
 
 <a name="C_ZYX"></a>
 ### The 'C_ZYX' Gate
@@ -730,6 +849,18 @@ Decomposition (into H, S, CX, M, R):
     H 0
     S 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `C_ZYX 0` (but affects the measurement record and an ancilla qubit)
+    MX 1
+    MZZ 0 1
+    MY 1
+    MXX 0 1
+    MZ 1
+    CX rec[-2] 0 rec[-1] 0
+    CY rec[-5] 0 rec[-4] 0
+    CZ rec[-3] 0
+                
 
 <a name="H"></a>
 ### The 'H' Gate
@@ -784,6 +915,21 @@ Decomposition (into H, S, CX, M, R):
     
     # (The decomposition is trivial because this gate is in the target gate set.)
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `H 0` (but affects the measurement record and an ancilla qubit)
+    MX 1
+    MZZ 0 1
+    MY 1
+    MXX 0 1
+    MZ 1
+    MX 1
+    MZZ 0 1
+    MY 1
+    CX rec[-8] 0 rec[-7] 0
+    CY rec[-5] 0 rec[-4] 0
+    CZ rec[-6] 0 rec[-3] 0 rec[-2] 0 rec[-1] 0
+                
 
 <a name="H_NXY"></a>
 ### The 'H_NXY' Gate
@@ -837,6 +983,15 @@ Decomposition (into H, S, CX, M, R):
     S 0
     H 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `H_NXY 0` (but affects the measurement record and an ancilla qubit)
+    MX 1
+    MZZ 0 1
+    MY 1
+    Y 0
+    CZ rec[-3] 0 rec[-2] 0 rec[-1] 0
+                
 
 <a name="H_NXZ"></a>
 ### The 'H_NXZ' Gate
@@ -890,6 +1045,22 @@ Decomposition (into H, S, CX, M, R):
     S 0
     S 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `H_NXZ 0` (but affects the measurement record and an ancilla qubit)
+    MX 1
+    MZZ 0 1
+    MY 1
+    MXX 0 1
+    MZ 1
+    MX 1
+    MZZ 0 1
+    MY 1
+    Y 0
+    CX rec[-8] 0 rec[-7] 0
+    CY rec[-5] 0 rec[-4] 0
+    CZ rec[-6] 0 rec[-3] 0 rec[-2] 0 rec[-1] 0
+                
 
 <a name="H_NYZ"></a>
 ### The 'H_NYZ' Gate
@@ -943,6 +1114,15 @@ Decomposition (into H, S, CX, M, R):
     S 0
     H 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `H_NYZ 0` (but affects the measurement record and an ancilla qubit)
+    MZ 1
+    MXX 0 1
+    MY 1
+    Y 0
+    CX rec[-3] 0 rec[-2] 0 rec[-1] 0
+                
 
 <a name="H_XY"></a>
 ### The 'H_XY' Gate
@@ -996,6 +1176,15 @@ Decomposition (into H, S, CX, M, R):
     H 0
     S 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `H_XY 0` (but affects the measurement record and an ancilla qubit)
+    MX 1
+    MZZ 0 1
+    MY 1
+    X 0
+    CZ rec[-3] 0 rec[-2] 0 rec[-1] 0
+                
 
 <a name="H_YZ"></a>
 ### The 'H_YZ' Gate
@@ -1049,6 +1238,15 @@ Decomposition (into H, S, CX, M, R):
     S 0
     S 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `H_YZ 0` (but affects the measurement record and an ancilla qubit)
+    MZ 1
+    MXX 0 1
+    MY 1
+    Z 0
+    CX rec[-3] 0 rec[-2] 0 rec[-1] 0
+                
 
 <a name="S"></a>
 ### The 'S' Gate
@@ -1103,6 +1301,14 @@ Decomposition (into H, S, CX, M, R):
     
     # (The decomposition is trivial because this gate is in the target gate set.)
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `S 0` (but affects the measurement record and an ancilla qubit)
+    MY 1
+    MZZ 0 1
+    MX 1
+    CZ rec[-3] 0 rec[-2] 0 rec[-1] 0
+                
 
 <a name="SQRT_X"></a>
 ### The 'SQRT_X' Gate
@@ -1155,6 +1361,14 @@ Decomposition (into H, S, CX, M, R):
     S 0
     H 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `SQRT_X 0` (but affects the measurement record and an ancilla qubit)
+    MZ 1
+    MXX 0 1
+    MY 1
+    CX rec[-3] 0 rec[-2] 0 rec[-1] 0
+                
 
 <a name="SQRT_X_DAG"></a>
 ### The 'SQRT_X_DAG' Gate
@@ -1207,6 +1421,14 @@ Decomposition (into H, S, CX, M, R):
     H 0
     S 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `SQRT_X_DAG 0` (but affects the measurement record and an ancilla qubit)
+    MY 1
+    MXX 0 1
+    MZ 1
+    CX rec[-3] 0 rec[-2] 0 rec[-1] 0
+                
 
 <a name="SQRT_Y"></a>
 ### The 'SQRT_Y' Gate
@@ -1259,6 +1481,22 @@ Decomposition (into H, S, CX, M, R):
     S 0
     H 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `SQRT_Y 0` (but affects the measurement record and an ancilla qubit)
+    MX 1
+    MZZ 0 1
+    MY 1
+    MXX 0 1
+    MZ 1
+    MX 1
+    MZZ 0 1
+    MY 1
+    X 0
+    CX rec[-8] 0 rec[-7] 0
+    CY rec[-5] 0 rec[-4] 0
+    CZ rec[-6] 0 rec[-3] 0 rec[-2] 0 rec[-1] 0
+                
 
 <a name="SQRT_Y_DAG"></a>
 ### The 'SQRT_Y_DAG' Gate
@@ -1311,6 +1549,22 @@ Decomposition (into H, S, CX, M, R):
     S 0
     S 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `SQRT_Y_DAG 0` (but affects the measurement record and an ancilla qubit)
+    MX 1
+    MZZ 0 1
+    MY 1
+    MXX 0 1
+    MZ 1
+    MX 1
+    MZZ 0 1
+    MY 1
+    Z 0
+    CX rec[-8] 0 rec[-7] 0
+    CY rec[-5] 0 rec[-4] 0
+    CZ rec[-6] 0 rec[-3] 0 rec[-2] 0 rec[-1] 0
+                
 
 <a name="S_DAG"></a>
 ### The 'S_DAG' Gate
@@ -1365,6 +1619,14 @@ Decomposition (into H, S, CX, M, R):
     S 0
     S 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `S_DAG 0` (but affects the measurement record and an ancilla qubit)
+    MX 1
+    MZZ 0 1
+    MY 1
+    CZ rec[-3] 0 rec[-2] 0 rec[-1] 0
+                
 
 ## Two Qubit Clifford Gates
 
@@ -1428,6 +1690,16 @@ Decomposition (into H, S, CX, M, R):
     
     # (The decomposition is trivial because this gate is in the target gate set.)
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `CX 0 1` (but affects the measurement record and an ancilla qubit)
+    MX 2
+    MZZ 0 2
+    MXX 1 2
+    MZ 2
+    CX rec[-3] 1 rec[-1] 1
+    CZ rec[-4] 0 rec[-2] 0
+                
 
 <a name="CXSWAP"></a>
 ### The 'CXSWAP' Gate
@@ -1469,6 +1741,19 @@ Decomposition (into H, S, CX, M, R):
     CNOT 1 0
     CNOT 0 1
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `CXSWAP 0 1` (but affects the measurement record and an ancilla qubit)
+    MZ 2
+    MXX 0 2
+    MZZ 1 2
+    MX 2
+    MZZ 0 2
+    MXX 1 2
+    MZ 2
+    CX rec[-7] 0 rec[-7] 1 rec[-5] 0 rec[-5] 1 rec[-3] 1 rec[-1] 1
+    CZ rec[-6] 0 rec[-6] 1 rec[-2] 0 rec[-4] 1
+                
 
 <a name="CY"></a>
 ### The 'CY' Gate
@@ -1530,6 +1815,22 @@ Decomposition (into H, S, CX, M, R):
     CNOT 0 1
     S 1
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `CY 0 1` (but affects the measurement record and an ancilla qubit)
+    MY 2
+    MZZ 1 2
+    MX 2
+    MZZ 0 2
+    MXX 1 2
+    MZ 2
+    MX 2
+    MZZ 1 2
+    MY 2
+    Z 0
+    CY rec[-6] 1 rec[-4] 1
+    CZ rec[-9] 0 rec[-9] 1 rec[-8] 0 rec[-8] 1 rec[-5] 0 rec[-7] 1 rec[-3] 1 rec[-2] 1 rec[-1] 1
+                
 
 <a name="CZ"></a>
 ### The 'CZ' Gate
@@ -1592,6 +1893,26 @@ Decomposition (into H, S, CX, M, R):
     CNOT 0 1
     H 1
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `CZ 0 1` (but affects the measurement record and an ancilla qubit)
+    MZ 2
+    MXX 0 2
+    MY 2
+    MZZ 0 2
+    MX 2
+    MZZ 1 2
+    MXX 0 2
+    MZ 2
+    MX 2
+    MZZ 0 2
+    MY 2
+    MXX 0 2
+    MZ 2
+    CX rec[-13] 0 rec[-12] 0 rec[-2] 0 rec[-1] 0
+    CY rec[-10] 0 rec[-9] 0 rec[-5] 0 rec[-4] 0
+    CZ rec[-11] 0 rec[-10] 1 rec[-8] 0 rec[-6] 0 rec[-3] 0 rec[-13] 1 rec[-12] 1 rec[-7] 1
+                
 
 <a name="CZSWAP"></a>
 ### The 'CZSWAP' Gate
@@ -1637,6 +1958,28 @@ Decomposition (into H, S, CX, M, R):
     CX 1 0
     H 1
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `CZSWAP 0 1` (but affects the measurement record and an ancilla qubit)
+    MZ 2
+    MXX 0 2
+    MY 2
+    MZZ 0 2
+    MX 2
+    MZZ 0 2
+    MXX 1 2
+    MZ 2
+    MXX 0 2
+    MZZ 1 2
+    MX 2
+    MZZ 1 2
+    MY 2
+    MXX 1 2
+    MZ 2
+    CX rec[-10] 0 rec[-6] 0 rec[-15] 1 rec[-14] 1 rec[-2] 1 rec[-1] 1
+    CY rec[-12] 1 rec[-9] 1 rec[-7] 1 rec[-4] 1
+    CZ rec[-15] 0 rec[-14] 0 rec[-12] 0 rec[-9] 0 rec[-13] 1 rec[-10] 1 rec[-8] 1 rec[-3] 1
+                
 
 <a name="II"></a>
 ### The 'II' Gate
@@ -1679,6 +2022,13 @@ Unitary Matrix (little endian):
 Decomposition (into H, S, CX, M, R):
 
     # The following circuit is equivalent (up to global phase) to `II 0 1`
+    
+    # (The decomposition is empty because this gate has no effect.)
+    
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `II 0 1` (but affects the measurement record and an ancilla qubit)
+    # (The decomposition is empty because this gate has no effect.)
     
 
 <a name="ISWAP"></a>
@@ -1725,6 +2075,34 @@ Decomposition (into H, S, CX, M, R):
     S 1
     S 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `ISWAP 0 1` (but affects the measurement record and an ancilla qubit)
+    MX 2
+    MZZ 0 2
+    MY 2
+    MZZ 1 2
+    MX 2
+    MZ 2
+    MXX 0 2
+    MY 2
+    MZZ 0 2
+    MX 2
+    MZZ 0 2
+    MXX 1 2
+    MZ 2
+    MXX 0 2
+    MZZ 1 2
+    MX 2
+    MZZ 1 2
+    MY 2
+    MXX 1 2
+    MZ 2
+    Z 1
+    CX rec[-10] 0 rec[-6] 0 rec[-15] 1 rec[-14] 1 rec[-2] 1 rec[-1] 1
+    CY rec[-12] 1 rec[-9] 1 rec[-7] 1 rec[-4] 1
+    CZ rec[-18] 0 rec[-18] 1 rec[-17] 0 rec[-16] 0 rec[-15] 0 rec[-14] 0 rec[-12] 0 rec[-9] 0 rec[-20] 1 rec[-19] 1 rec[-13] 1 rec[-10] 1 rec[-8] 1 rec[-3] 1
+                
 
 <a name="ISWAP_DAG"></a>
 ### The 'ISWAP_DAG' Gate
@@ -1774,6 +2152,34 @@ Decomposition (into H, S, CX, M, R):
     CNOT 0 1
     H 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `ISWAP_DAG 0 1` (but affects the measurement record and an ancilla qubit)
+    MX 2
+    MZZ 0 2
+    MY 2
+    MZZ 1 2
+    MX 2
+    MZ 2
+    MXX 0 2
+    MY 2
+    MZZ 0 2
+    MX 2
+    MZZ 0 2
+    MXX 1 2
+    MZ 2
+    MXX 0 2
+    MZZ 1 2
+    MX 2
+    MZZ 1 2
+    MY 2
+    MXX 1 2
+    MZ 2
+    Z 0
+    CX rec[-10] 0 rec[-6] 0 rec[-15] 1 rec[-14] 1 rec[-2] 1 rec[-1] 1
+    CY rec[-12] 1 rec[-9] 1 rec[-7] 1 rec[-4] 1
+    CZ rec[-18] 0 rec[-18] 1 rec[-17] 0 rec[-16] 0 rec[-15] 0 rec[-14] 0 rec[-12] 0 rec[-9] 0 rec[-20] 1 rec[-19] 1 rec[-13] 1 rec[-10] 1 rec[-8] 1 rec[-3] 1
+                
 
 <a name="SQRT_XX"></a>
 ### The 'SQRT_XX' Gate
@@ -1819,6 +2225,32 @@ Decomposition (into H, S, CX, M, R):
     H 0
     H 1
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `SQRT_XX 0 1` (but affects the measurement record and an ancilla qubit)
+    MX 2
+    MZZ 0 2
+    MY 2
+    MXX 0 2
+    MZ 2
+    MXX 1 2
+    MZZ 0 2
+    MX 2
+    MY 2
+    MXX 1 2
+    MZ 2
+    MXX 0 2
+    MY 2
+    MZZ 0 2
+    MX 2
+    MZ 2
+    MXX 0 2
+    MY 2
+    X 1
+    CX rec[-18] 1 rec[-17] 1 rec[-16] 0 rec[-13] 0 rec[-11] 0 rec[-6] 0 rec[-3] 0 rec[-2] 0 rec[-1] 0 rec[-15] 1 rec[-12] 1 rec[-10] 1 rec[-9] 1 rec[-8] 1
+    CY rec[-18] 0 rec[-17] 0 rec[-5] 0 rec[-4] 0
+    CZ rec[-15] 0 rec[-14] 0 rec[-8] 0 rec[-7] 0
+                
 
 <a name="SQRT_XX_DAG"></a>
 ### The 'SQRT_XX_DAG' Gate
@@ -1868,6 +2300,32 @@ Decomposition (into H, S, CX, M, R):
     H 0
     H 1
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `SQRT_XX_DAG 0 1` (but affects the measurement record and an ancilla qubit)
+    MX 2
+    MZZ 0 2
+    MY 2
+    MXX 0 2
+    MZ 2
+    MXX 1 2
+    MZZ 0 2
+    MX 2
+    MY 2
+    MXX 1 2
+    MZ 2
+    MXX 0 2
+    MY 2
+    MZZ 0 2
+    MX 2
+    MZ 2
+    MXX 0 2
+    MY 2
+    X 0
+    CX rec[-18] 1 rec[-17] 1 rec[-16] 0 rec[-13] 0 rec[-11] 0 rec[-6] 0 rec[-3] 0 rec[-2] 0 rec[-1] 0 rec[-15] 1 rec[-12] 1 rec[-10] 1 rec[-9] 1 rec[-8] 1
+    CY rec[-18] 0 rec[-17] 0 rec[-5] 0 rec[-4] 0
+    CZ rec[-15] 0 rec[-14] 0 rec[-8] 0 rec[-7] 0
+                
 
 <a name="SQRT_YY"></a>
 ### The 'SQRT_YY' Gate
@@ -1921,6 +2379,31 @@ Decomposition (into H, S, CX, M, R):
     S 0
     S 1
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `SQRT_YY 0 1` (but affects the measurement record and an ancilla qubit)
+    MX 2
+    MZZ 1 2
+    MY 2
+    MXX 0 2
+    MZ 2
+    MXX 1 2
+    MZZ 0 2
+    MX 2
+    MZZ 0 2
+    MY 2
+    MXX 0 2
+    MZ 2
+    MXX 1 2
+    MY 2
+    MZZ 1 2
+    MX 2
+    X 0
+    Y 1
+    CX rec[-16] 1 rec[-15] 1 rec[-14] 0 rec[-6] 0 rec[-5] 0 rec[-3] 1
+    CY rec[-16] 0 rec[-15] 0 rec[-11] 0 rec[-8] 0 rec[-5] 1 rec[-13] 1 rec[-10] 1 rec[-4] 1
+    CZ rec[-13] 0 rec[-12] 0 rec[-7] 0 rec[-14] 1 rec[-2] 1 rec[-1] 1
+                
 
 <a name="SQRT_YY_DAG"></a>
 ### The 'SQRT_YY_DAG' Gate
@@ -1974,6 +2457,30 @@ Decomposition (into H, S, CX, M, R):
     S 1
     S 1
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `SQRT_YY_DAG 0 1` (but affects the measurement record and an ancilla qubit)
+    MX 2
+    MZZ 1 2
+    MY 2
+    MXX 0 2
+    MZ 2
+    MXX 1 2
+    MZZ 0 2
+    MX 2
+    MZZ 0 2
+    MY 2
+    MXX 0 2
+    MZ 2
+    MXX 1 2
+    MY 2
+    MZZ 1 2
+    MX 2
+    Z 0
+    CX rec[-16] 1 rec[-15] 1 rec[-14] 0 rec[-6] 0 rec[-5] 0 rec[-3] 1
+    CY rec[-16] 0 rec[-15] 0 rec[-11] 0 rec[-8] 0 rec[-5] 1 rec[-13] 1 rec[-10] 1 rec[-4] 1
+    CZ rec[-13] 0 rec[-12] 0 rec[-7] 0 rec[-14] 1 rec[-2] 1 rec[-1] 1
+                
 
 <a name="SQRT_ZZ"></a>
 ### The 'SQRT_ZZ' Gate
@@ -2017,6 +2524,32 @@ Decomposition (into H, S, CX, M, R):
     S 0
     S 1
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `SQRT_ZZ 0 1` (but affects the measurement record and an ancilla qubit)
+    MZ 2
+    MXX 0 2
+    MY 2
+    MZZ 0 2
+    MX 2
+    MZZ 1 2
+    MXX 0 2
+    MZ 2
+    MY 2
+    MZZ 1 2
+    MX 2
+    MZZ 0 2
+    MY 2
+    MXX 0 2
+    MZ 2
+    MX 2
+    MZZ 0 2
+    MY 2
+    Z 0
+    CX rec[-15] 0 rec[-14] 0 rec[-8] 0 rec[-7] 0
+    CY rec[-18] 0 rec[-17] 0 rec[-5] 0 rec[-4] 0
+    CZ rec[-18] 1 rec[-17] 1 rec[-16] 0 rec[-13] 0 rec[-11] 0 rec[-6] 0 rec[-3] 0 rec[-2] 0 rec[-1] 0 rec[-15] 1 rec[-12] 1 rec[-10] 1 rec[-9] 1 rec[-8] 1
+                
 
 <a name="SQRT_ZZ_DAG"></a>
 ### The 'SQRT_ZZ_DAG' Gate
@@ -2064,6 +2597,32 @@ Decomposition (into H, S, CX, M, R):
     S 1
     S 1
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `SQRT_ZZ_DAG 0 1` (but affects the measurement record and an ancilla qubit)
+    MZ 2
+    MXX 0 2
+    MY 2
+    MZZ 0 2
+    MX 2
+    MZZ 1 2
+    MXX 0 2
+    MZ 2
+    MY 2
+    MZZ 1 2
+    MX 2
+    MZZ 0 2
+    MY 2
+    MXX 0 2
+    MZ 2
+    MX 2
+    MZZ 0 2
+    MY 2
+    Z 1
+    CX rec[-15] 0 rec[-14] 0 rec[-8] 0 rec[-7] 0
+    CY rec[-18] 0 rec[-17] 0 rec[-5] 0 rec[-4] 0
+    CZ rec[-18] 1 rec[-17] 1 rec[-16] 0 rec[-13] 0 rec[-11] 0 rec[-6] 0 rec[-3] 0 rec[-2] 0 rec[-1] 0 rec[-15] 1 rec[-12] 1 rec[-10] 1 rec[-9] 1 rec[-8] 1
+                
 
 <a name="SWAP"></a>
 ### The 'SWAP' Gate
@@ -2105,6 +2664,22 @@ Decomposition (into H, S, CX, M, R):
     CNOT 1 0
     CNOT 0 1
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `SWAP 0 1` (but affects the measurement record and an ancilla qubit)
+    MZ 2
+    MXX 0 2
+    MZZ 1 2
+    MX 2
+    MZZ 0 2
+    MXX 1 2
+    MZ 2
+    MXX 0 2
+    MZZ 1 2
+    MX 2
+    CX rec[-6] 0 rec[-6] 1 rec[-2] 0 rec[-10] 1 rec[-8] 1 rec[-4] 1
+    CZ rec[-9] 0 rec[-5] 0 rec[-5] 1 rec[-7] 1 rec[-3] 1 rec[-1] 1
+                
 
 <a name="SWAPCX"></a>
 ### The 'SWAPCX' Gate
@@ -2146,6 +2721,19 @@ Decomposition (into H, S, CX, M, R):
     CNOT 0 1
     CNOT 1 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `SWAPCX 0 1` (but affects the measurement record and an ancilla qubit)
+    MX 2
+    MZZ 0 2
+    MXX 1 2
+    MZ 2
+    MXX 0 2
+    MZZ 1 2
+    MX 2
+    CX rec[-6] 0 rec[-6] 1 rec[-2] 0 rec[-4] 1
+    CZ rec[-7] 0 rec[-7] 1 rec[-5] 0 rec[-5] 1 rec[-3] 1 rec[-1] 1
+                
 
 <a name="XCX"></a>
 ### The 'XCX' Gate
@@ -2192,6 +2780,26 @@ Decomposition (into H, S, CX, M, R):
     CNOT 0 1
     H 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `XCX 0 1` (but affects the measurement record and an ancilla qubit)
+    MX 2
+    MZZ 0 2
+    MY 2
+    MXX 0 2
+    MZ 2
+    MXX 1 2
+    MZZ 0 2
+    MX 2
+    MZ 2
+    MXX 0 2
+    MY 2
+    MZZ 0 2
+    MX 2
+    CX rec[-11] 0 rec[-10] 1 rec[-8] 0 rec[-6] 0 rec[-3] 0 rec[-13] 1 rec[-12] 1 rec[-7] 1
+    CY rec[-10] 0 rec[-9] 0 rec[-5] 0 rec[-4] 0
+    CZ rec[-13] 0 rec[-12] 0 rec[-2] 0 rec[-1] 0
+                
 
 <a name="XCY"></a>
 ### The 'XCY' Gate
@@ -2242,6 +2850,22 @@ Decomposition (into H, S, CX, M, R):
     H 0
     S 1
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `XCY 0 1` (but affects the measurement record and an ancilla qubit)
+    MY 2
+    MXX 1 2
+    MZ 2
+    MXX 0 2
+    MZZ 1 2
+    MX 2
+    MZ 2
+    MXX 1 2
+    MY 2
+    X 0
+    CX rec[-9] 0 rec[-9] 1 rec[-8] 0 rec[-8] 1 rec[-5] 0 rec[-7] 1 rec[-3] 1 rec[-2] 1 rec[-1] 1
+    CY rec[-6] 1 rec[-4] 1
+                
 
 <a name="XCZ"></a>
 ### The 'XCZ' Gate
@@ -2298,6 +2922,16 @@ Decomposition (into H, S, CX, M, R):
     # The following circuit is equivalent (up to global phase) to `XCZ 0 1`
     CNOT 1 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `XCZ 0 1` (but affects the measurement record and an ancilla qubit)
+    MZ 2
+    MXX 0 2
+    MZZ 1 2
+    MX 2
+    CX rec[-4] 0 rec[-2] 0
+    CZ rec[-3] 1 rec[-1] 1
+                
 
 <a name="YCX"></a>
 ### The 'YCX' Gate
@@ -2348,6 +2982,22 @@ Decomposition (into H, S, CX, M, R):
     S 0
     H 1
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `YCX 0 1` (but affects the measurement record and an ancilla qubit)
+    MY 2
+    MXX 0 2
+    MZ 2
+    MXX 1 2
+    MZZ 0 2
+    MX 2
+    MZ 2
+    MXX 0 2
+    MY 2
+    X 1
+    CX rec[-9] 0 rec[-9] 1 rec[-8] 0 rec[-8] 1 rec[-7] 0 rec[-3] 0 rec[-2] 0 rec[-1] 0 rec[-5] 1
+    CY rec[-6] 0 rec[-4] 0
+                
 
 <a name="YCY"></a>
 ### The 'YCY' Gate
@@ -2402,6 +3052,27 @@ Decomposition (into H, S, CX, M, R):
     S 0
     S 1
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `YCY 0 1` (but affects the measurement record and an ancilla qubit)
+    MX 2
+    MZZ 1 2
+    MY 2
+    MXX 0 2
+    MZ 2
+    MXX 1 2
+    MZZ 0 2
+    MX 2
+    MZ 2
+    MXX 0 2
+    MY 2
+    MZZ 1 2
+    MX 2
+    Y 1
+    CX rec[-10] 0 rec[-9] 0 rec[-5] 0 rec[-4] 0 rec[-3] 0 rec[-11] 1
+    CY rec[-13] 0 rec[-12] 0 rec[-10] 1 rec[-8] 0 rec[-6] 0 rec[-7] 1
+    CZ rec[-13] 1 rec[-12] 1 rec[-11] 0 rec[-3] 1 rec[-2] 1 rec[-1] 1
+                
 
 <a name="YCZ"></a>
 ### The 'YCZ' Gate
@@ -2462,6 +3133,22 @@ Decomposition (into H, S, CX, M, R):
     CNOT 1 0
     S 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `YCZ 0 1` (but affects the measurement record and an ancilla qubit)
+    MX 2
+    MZZ 0 2
+    MY 2
+    MZ 2
+    MXX 0 2
+    MZZ 1 2
+    MX 2
+    MZZ 0 2
+    MY 2
+    Z 0
+    CY rec[-6] 0 rec[-4] 0
+    CZ rec[-9] 0 rec[-9] 1 rec[-8] 0 rec[-8] 1 rec[-7] 0 rec[-7] 1 rec[-3] 0 rec[-3] 1 rec[-2] 0 rec[-1] 0 rec[-5] 1
+                
 
 ## Noise Channels
 
@@ -3040,6 +3727,13 @@ Decomposition (into H, S, CX, M, R):
     
     # (The decomposition is trivial because this gate is in the target gate set.)
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `M 0` (but affects the measurement record and an ancilla qubit)
+    MZ 0
+                
+    # (The decomposition is trivial because this gate is in the target gate set.)
+    
 
 <a name="MR"></a>
 ### The 'MR' Instruction
@@ -3091,6 +3785,12 @@ Decomposition (into H, S, CX, M, R):
     M 0
     R 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `MR 0` (but affects the measurement record and an ancilla qubit)
+    MZ 0
+    CX rec[-1] 0
+                
 
 <a name="MRX"></a>
 ### The 'MRX' Instruction
@@ -3139,6 +3839,12 @@ Decomposition (into H, S, CX, M, R):
     R 0
     H 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `MRX 0` (but affects the measurement record and an ancilla qubit)
+    MX 0
+    CZ rec[-1] 0
+                
 
 <a name="MRY"></a>
 ### The 'MRY' Instruction
@@ -3191,6 +3897,12 @@ Decomposition (into H, S, CX, M, R):
     H 0
     S 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `MRY 0` (but affects the measurement record and an ancilla qubit)
+    MY 0
+    CX rec[-1] 0
+                
 
 <a name="MX"></a>
 ### The 'MX' Instruction
@@ -3236,6 +3948,13 @@ Decomposition (into H, S, CX, M, R):
     H 0
     M 0
     H 0
+    
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `MX 0` (but affects the measurement record and an ancilla qubit)
+    MX 0
+                
+    # (The decomposition is trivial because this gate is in the target gate set.)
     
 
 <a name="MY"></a>
@@ -3287,6 +4006,13 @@ Decomposition (into H, S, CX, M, R):
     H 0
     S 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `MY 0` (but affects the measurement record and an ancilla qubit)
+    MY 0
+                
+    # (The decomposition is trivial because this gate is in the target gate set.)
+    
 
 <a name="R"></a>
 ### The 'R' Instruction
@@ -3325,6 +4051,12 @@ Decomposition (into H, S, CX, M, R):
     
     # (The decomposition is trivial because this gate is in the target gate set.)
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `R 0` (but affects the measurement record and an ancilla qubit)
+    MZ 0
+    CX rec[-1] 0
+                
 
 <a name="RX"></a>
 ### The 'RX' Instruction
@@ -3357,6 +4089,12 @@ Decomposition (into H, S, CX, M, R):
     R 0
     H 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `RX 0` (but affects the measurement record and an ancilla qubit)
+    MX 0
+    CZ rec[-1] 0
+                
 
 <a name="RY"></a>
 ### The 'RY' Instruction
@@ -3390,6 +4128,12 @@ Decomposition (into H, S, CX, M, R):
     H 0
     S 0
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `RY 0` (but affects the measurement record and an ancilla qubit)
+    MY 0
+    CX rec[-1] 0
+                
 
 ## Pair Measurement Gates
 
@@ -3452,6 +4196,13 @@ Decomposition (into H, S, CX, M, R):
     M 0
     H 0
     CX 0 1
+    
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `MXX 0 1` (but affects the measurement record and an ancilla qubit)
+    MXX 0 1
+                
+    # (The decomposition is trivial because this gate is in the target gate set.)
     
 
 <a name="MYY"></a>
@@ -3517,6 +4268,25 @@ Decomposition (into H, S, CX, M, R):
     CX 0 1
     S 0 1
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `MYY 0 1` (but affects the measurement record and an ancilla qubit)
+    MX 2
+    MZZ 0 2
+    MY 2
+    MX 2
+    MZZ 1 2
+    MY 2
+    MXX 0 1
+    MX 2
+    MZZ 0 2
+    MY 2
+    MX 2
+    MZZ 1 2
+    MY 2
+    Z 0 1
+    CZ rec[-13] 0 rec[-12] 0 rec[-11] 0 rec[-6] 0 rec[-5] 0 rec[-4] 0 rec[-10] 1 rec[-9] 1 rec[-8] 1 rec[-3] 1 rec[-2] 1 rec[-1] 1
+                
 
 <a name="MZZ"></a>
 ### The 'MZZ' Instruction
@@ -3575,6 +4345,13 @@ Decomposition (into H, S, CX, M, R):
     CX 0 1
     M 1
     CX 0 1
+    
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `MZZ 0 1` (but affects the measurement record and an ancilla qubit)
+    MZZ 0 1
+                
+    # (The decomposition is trivial because this gate is in the target gate set.)
     
 
 ## Generalized Pauli Product Gates
@@ -3644,6 +4421,43 @@ Decomposition (into H, S, CX, M, R):
     H 0 1 3 4
     S 1
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `MPP X0*Y1*Z2 X3*X4` (but affects the measurement record and an ancilla qubit)
+    MY 5
+    MZZ 1 5
+    MX 5
+    MZZ 0 5
+    MXX 1 5
+    MZ 5
+    MX 5
+    MZZ 1 5
+    MY 5
+    MZ 5
+    MXX 2 5
+    MY 5
+    MZZ 2 5
+    MX 5
+    MXX 0 2
+    MXX 3 4
+    MX 5
+    MZZ 2 5
+    MY 5
+    MXX 2 5
+    MZ 5
+    MY 5
+    MZZ 1 5
+    MX 5
+    MZZ 0 5
+    MXX 1 5
+    MZ 5
+    MX 5
+    MZZ 1 5
+    MY 5
+    CX rec[-21] 2 rec[-20] 2 rec[-11] 2 rec[-10] 2
+    CY rec[-27] 1 rec[-25] 1 rec[-6] 1 rec[-4] 1 rec[-18] 2 rec[-13] 2
+    CZ rec[-28] 0 rec[-28] 1 rec[-26] 0 rec[-24] 0 rec[-24] 1 rec[-23] 0 rec[-23] 1 rec[-22] 0 rec[-22] 1 rec[-9] 0 rec[-9] 1 rec[-8] 0 rec[-8] 1 rec[-5] 0 rec[-30] 1 rec[-29] 1 rec[-7] 1 rec[-3] 1 rec[-2] 1 rec[-1] 1 rec[-19] 2 rec[-12] 2
+                
 
 <a name="SPP"></a>
 ### The 'SPP' Gate
@@ -3710,6 +4524,62 @@ Decomposition (into H, S, CX, M, R):
     CX 1 0
     CX 2 1
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `SPP X0*Y1*Z2` (but affects the measurement record and an ancilla qubit)
+    MY 3
+    MZZ 1 3
+    MX 3
+    MZZ 0 3
+    MXX 1 3
+    MZ 3
+    MX 3
+    MZZ 1 3
+    MY 3
+    MZ 3
+    MXX 0 3
+    MY 3
+    MZZ 0 3
+    MX 3
+    MZZ 2 3
+    MXX 0 3
+    MZ 3
+    MX 3
+    MZZ 0 3
+    MY 3
+    MXX 0 3
+    MZ 3
+    MXX 0 3
+    MY 3
+    MZ 3
+    MXX 0 3
+    MY 3
+    MZZ 0 3
+    MX 3
+    MZZ 2 3
+    MXX 0 3
+    MZ 3
+    MX 3
+    MZZ 0 3
+    MY 3
+    MXX 0 3
+    MZ 3
+    MY 3
+    MZZ 1 3
+    MX 3
+    MZZ 0 3
+    MXX 1 3
+    MZ 3
+    MX 3
+    MZZ 1 3
+    MY 3
+    X 0
+    Y 1
+    Z 2
+    CX rec[-46] 0 rec[-46] 1 rec[-45] 0 rec[-45] 1 rec[-37] 0 rec[-36] 0 rec[-26] 0 rec[-24] 0 rec[-23] 0 rec[-22] 0 rec[-21] 0 rec[-11] 0 rec[-10] 0
+    CY rec[-42] 0 rec[-42] 1 rec[-37] 1 rec[-36] 1 rec[-35] 0 rec[-35] 1 rec[-32] 0 rec[-32] 1 rec[-30] 0 rec[-30] 1 rec[-27] 0 rec[-27] 1 rec[-26] 1 rec[-24] 1 rec[-23] 1 rec[-22] 1 rec[-21] 1 rec[-19] 0 rec[-19] 1 rec[-18] 0 rec[-18] 1 rec[-14] 0 rec[-14] 1 rec[-13] 0 rec[-13] 1 rec[-11] 1 rec[-10] 1 rec[-43] 1 rec[-41] 1 rec[-6] 1 rec[-4] 1
+    CZ rec[-44] 0 rec[-44] 1 rec[-42] 2 rec[-40] 0 rec[-40] 1 rec[-39] 0 rec[-39] 1 rec[-38] 0 rec[-38] 1 rec[-35] 2 rec[-34] 0 rec[-34] 2 rec[-33] 0 rec[-32] 2 rec[-30] 2 rec[-29] 0 rec[-28] 0 rec[-27] 2 rec[-20] 0 rec[-19] 2 rec[-17] 0 rec[-15] 0 rec[-12] 0 rec[-9] 0 rec[-9] 1 rec[-8] 0 rec[-8] 1 rec[-5] 0 rec[-26] 2 rec[-24] 2 rec[-23] 2 rec[-22] 2 rec[-21] 2 rec[-7] 1 rec[-3] 1 rec[-2] 1 rec[-1] 1 rec[-46] 2 rec[-45] 2 rec[-31] 2 rec[-16] 2
+                
 
 <a name="SPP_DAG"></a>
 ### The 'SPP_DAG' Gate
@@ -3776,6 +4646,59 @@ Decomposition (into H, S, CX, M, R):
     CX 1 0
     CX 2 1
     
+MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):
+
+    # The following circuit performs `SPP_DAG X0*Y1*Z2` (but affects the measurement record and an ancilla qubit)
+    MY 3
+    MZZ 1 3
+    MX 3
+    MZZ 0 3
+    MXX 1 3
+    MZ 3
+    MX 3
+    MZZ 1 3
+    MY 3
+    MZ 3
+    MXX 0 3
+    MY 3
+    MZZ 0 3
+    MX 3
+    MZZ 2 3
+    MXX 0 3
+    MZ 3
+    MX 3
+    MZZ 0 3
+    MY 3
+    MXX 0 3
+    MZ 3
+    MXX 0 3
+    MY 3
+    MZ 3
+    MXX 0 3
+    MY 3
+    MZZ 0 3
+    MX 3
+    MZZ 2 3
+    MXX 0 3
+    MZ 3
+    MX 3
+    MZZ 0 3
+    MY 3
+    MXX 0 3
+    MZ 3
+    MY 3
+    MZZ 1 3
+    MX 3
+    MZZ 0 3
+    MXX 1 3
+    MZ 3
+    MX 3
+    MZZ 1 3
+    MY 3
+    CX rec[-46] 0 rec[-46] 1 rec[-45] 0 rec[-45] 1 rec[-37] 0 rec[-36] 0 rec[-26] 0 rec[-24] 0 rec[-23] 0 rec[-22] 0 rec[-21] 0 rec[-11] 0 rec[-10] 0
+    CY rec[-42] 0 rec[-42] 1 rec[-37] 1 rec[-36] 1 rec[-35] 0 rec[-35] 1 rec[-32] 0 rec[-32] 1 rec[-30] 0 rec[-30] 1 rec[-27] 0 rec[-27] 1 rec[-26] 1 rec[-24] 1 rec[-23] 1 rec[-22] 1 rec[-21] 1 rec[-19] 0 rec[-19] 1 rec[-18] 0 rec[-18] 1 rec[-14] 0 rec[-14] 1 rec[-13] 0 rec[-13] 1 rec[-11] 1 rec[-10] 1 rec[-43] 1 rec[-41] 1 rec[-6] 1 rec[-4] 1
+    CZ rec[-44] 0 rec[-44] 1 rec[-42] 2 rec[-40] 0 rec[-40] 1 rec[-39] 0 rec[-39] 1 rec[-38] 0 rec[-38] 1 rec[-35] 2 rec[-34] 0 rec[-34] 2 rec[-33] 0 rec[-32] 2 rec[-30] 2 rec[-29] 0 rec[-28] 0 rec[-27] 2 rec[-20] 0 rec[-19] 2 rec[-17] 0 rec[-15] 0 rec[-12] 0 rec[-9] 0 rec[-9] 1 rec[-8] 0 rec[-8] 1 rec[-5] 0 rec[-26] 2 rec[-24] 2 rec[-23] 2 rec[-22] 2 rec[-21] 2 rec[-7] 1 rec[-3] 1 rec[-2] 1 rec[-1] 1 rec[-46] 2 rec[-45] 2 rec[-31] 2 rec[-16] 2
+                
 
 ## Control Flow
 

--- a/doc/python_api_reference_vDev.md
+++ b/doc/python_api_reference_vDev.md
@@ -220,6 +220,7 @@ API references for stable versions are kept on the [stim github wiki](https://gi
 - [`stim.Flow`](#stim.Flow)
     - [`stim.Flow.__eq__`](#stim.Flow.__eq__)
     - [`stim.Flow.__init__`](#stim.Flow.__init__)
+    - [`stim.Flow.__mul__`](#stim.Flow.__mul__)
     - [`stim.Flow.__ne__`](#stim.Flow.__ne__)
     - [`stim.Flow.__repr__`](#stim.Flow.__repr__)
     - [`stim.Flow.__str__`](#stim.Flow.__str__)
@@ -9162,6 +9163,40 @@ def __init__(
 
         >>> stim.Flow("X -> Y xor obs[3] xor obs[3] xor obs[3]")
         stim.Flow("X -> Y xor obs[3]")
+    """
+```
+
+<a name="stim.Flow.__mul__"></a>
+```python
+# stim.Flow.__mul__
+
+# (in class stim.Flow)
+def __mul__(
+    self,
+    rhs: stim.Flow,
+) -> stim.Flow:
+    """Computes the product of two flows.
+
+    Args:
+        rhs: The right hand side of the multiplication.
+
+    Returns:
+        The product of the two flows.
+
+    Raises:
+        ValueError: The inputs anti-commute (their product would be anti-Hermitian).
+            For example, 1 -> X times 1 -> Y fails because it would give 1 -> iZ.
+
+    Examples:
+        >>> import stim
+        >>> stim.Flow("X -> X") * stim.Flow("Z -> Z")
+        stim.Flow("Y -> Y")
+
+        >>> stim.Flow("1 -> XX") * stim.Flow("1 -> ZZ")
+        stim.Flow("1 -> -YY")
+
+        >>> stim.Flow("X -> rec[-1]") * stim.Flow("X -> rec[-2]")
+        stim.Flow("_ -> rec[-2] xor rec[-1]")
     """
 ```
 

--- a/doc/sinter_api.md
+++ b/doc/sinter_api.md
@@ -335,7 +335,7 @@ def sample(
 # sinter.Decoder
 
 # (at top-level in the sinter module)
-class Decoder:
+class Decoder(metaclass=abc.ABCMeta):
     """Abstract base class for custom decoders.
 
     Custom decoders can be explained to sinter by inheriting from this class and
@@ -343,10 +343,6 @@ class Decoder:
 
     Decoder classes MUST be serializable (e.g. via pickling), so that they can
     be given to worker processes when using python multiprocessing.
-
-    Child classes should implement `compile_decoder_for_dem`, but (for legacy
-    reasons) can alternatively implement `decode_via_files`. At least one of
-    the two methods must be implemented.
     """
 ```
 
@@ -390,6 +386,7 @@ def compile_decoder_for_dem(
 # sinter.Decoder.decode_via_files
 
 # (in class sinter.Decoder)
+@abc.abstractmethod
 def decode_via_files(
     self,
     *,
@@ -1411,7 +1408,7 @@ def log_binomial(
     Examples:
         >>> import sinter
         >>> sinter.log_binomial(p=0.5, n=100, hits=50)
-        array(-2.5308762, dtype=float32)
+        array(-2.5308785, dtype=float32)
         >>> sinter.log_binomial(p=0.2, n=1_000_000, hits=1_000)
         array(-216626.97, dtype=float32)
         >>> sinter.log_binomial(p=0.1, n=1_000_000, hits=1_000)

--- a/doc/sinter_api.md
+++ b/doc/sinter_api.md
@@ -335,7 +335,7 @@ def sample(
 # sinter.Decoder
 
 # (at top-level in the sinter module)
-class Decoder(metaclass=abc.ABCMeta):
+class Decoder:
     """Abstract base class for custom decoders.
 
     Custom decoders can be explained to sinter by inheriting from this class and
@@ -343,6 +343,10 @@ class Decoder(metaclass=abc.ABCMeta):
 
     Decoder classes MUST be serializable (e.g. via pickling), so that they can
     be given to worker processes when using python multiprocessing.
+
+    Child classes should implement `compile_decoder_for_dem`, but (for legacy
+    reasons) can alternatively implement `decode_via_files`. At least one of
+    the two methods must be implemented.
     """
 ```
 
@@ -386,7 +390,6 @@ def compile_decoder_for_dem(
 # sinter.Decoder.decode_via_files
 
 # (in class sinter.Decoder)
-@abc.abstractmethod
 def decode_via_files(
     self,
     *,
@@ -1408,7 +1411,7 @@ def log_binomial(
     Examples:
         >>> import sinter
         >>> sinter.log_binomial(p=0.5, n=100, hits=50)
-        array(-2.5308785, dtype=float32)
+        array(-2.5308762, dtype=float32)
         >>> sinter.log_binomial(p=0.2, n=1_000_000, hits=1_000)
         array(-216626.97, dtype=float32)
         >>> sinter.log_binomial(p=0.1, n=1_000_000, hits=1_000)

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -7309,6 +7309,33 @@ class Flow:
             >>> stim.Flow("X -> Y xor obs[3] xor obs[3] xor obs[3]")
             stim.Flow("X -> Y xor obs[3]")
         """
+    def __mul__(
+        self,
+        rhs: stim.Flow,
+    ) -> stim.Flow:
+        """Computes the product of two flows.
+
+        Args:
+            rhs: The right hand side of the multiplication.
+
+        Returns:
+            The product of the two flows.
+
+        Raises:
+            ValueError: The inputs anti-commute (their product would be anti-Hermitian).
+                For example, 1 -> X times 1 -> Y fails because it would give 1 -> iZ.
+
+        Examples:
+            >>> import stim
+            >>> stim.Flow("X -> X") * stim.Flow("Z -> Z")
+            stim.Flow("Y -> Y")
+
+            >>> stim.Flow("1 -> XX") * stim.Flow("1 -> ZZ")
+            stim.Flow("1 -> -YY")
+
+            >>> stim.Flow("X -> rec[-1]") * stim.Flow("X -> rec[-2]")
+            stim.Flow("_ -> rec[-2] xor rec[-1]")
+        """
     def __ne__(
         self,
         arg0: stim.Flow,

--- a/file_lists/source_files_no_main
+++ b/file_lists/source_files_no_main
@@ -95,6 +95,7 @@ src/stim/util_top/export_crumble_url.cc
 src/stim/util_top/export_qasm.cc
 src/stim/util_top/export_quirk_url.cc
 src/stim/util_top/has_flow.cc
+src/stim/util_top/mbqc_decomposition.cc
 src/stim/util_top/reference_sample_tree.cc
 src/stim/util_top/simplified_circuit.cc
 src/stim/util_top/transform_without_feedback.cc

--- a/file_lists/test_files
+++ b/file_lists/test_files
@@ -92,6 +92,7 @@ src/stim/util_top/export_crumble_url.test.cc
 src/stim/util_top/export_qasm.test.cc
 src/stim/util_top/export_quirk_url.test.cc
 src/stim/util_top/has_flow.test.cc
+src/stim/util_top/mbqc_decomposition.test.cc
 src/stim/util_top/reference_sample_tree.test.cc
 src/stim/util_top/simplified_circuit.test.cc
 src/stim/util_top/stabilizers_to_tableau.test.cc

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -7309,6 +7309,33 @@ class Flow:
             >>> stim.Flow("X -> Y xor obs[3] xor obs[3] xor obs[3]")
             stim.Flow("X -> Y xor obs[3]")
         """
+    def __mul__(
+        self,
+        rhs: stim.Flow,
+    ) -> stim.Flow:
+        """Computes the product of two flows.
+
+        Args:
+            rhs: The right hand side of the multiplication.
+
+        Returns:
+            The product of the two flows.
+
+        Raises:
+            ValueError: The inputs anti-commute (their product would be anti-Hermitian).
+                For example, 1 -> X times 1 -> Y fails because it would give 1 -> iZ.
+
+        Examples:
+            >>> import stim
+            >>> stim.Flow("X -> X") * stim.Flow("Z -> Z")
+            stim.Flow("Y -> Y")
+
+            >>> stim.Flow("1 -> XX") * stim.Flow("1 -> ZZ")
+            stim.Flow("1 -> -YY")
+
+            >>> stim.Flow("X -> rec[-1]") * stim.Flow("X -> rec[-2]")
+            stim.Flow("_ -> rec[-2] xor rec[-1]")
+        """
     def __ne__(
         self,
         arg0: stim.Flow,

--- a/src/stim.h
+++ b/src/stim.h
@@ -117,6 +117,7 @@
 #include "stim/util_top/export_qasm.h"
 #include "stim/util_top/export_quirk_url.h"
 #include "stim/util_top/has_flow.h"
+#include "stim/util_top/mbqc_decomposition.h"
 #include "stim/util_top/reference_sample_tree.h"
 #include "stim/util_top/simplified_circuit.h"
 #include "stim/util_top/stabilizers_to_tableau.h"

--- a/src/stim/cmd/command_help.cc
+++ b/src/stim/cmd/command_help.cc
@@ -19,23 +19,24 @@
 #include <iostream>
 #include <map>
 #include <set>
-#include <stim/circuit/circuit.h>
 
-#include "command_convert.h"
-#include "command_detect.h"
-#include "command_diagram.h"
-#include "command_explain_errors.h"
-#include "command_gen.h"
-#include "command_m2d.h"
-#include "command_repl.h"
-#include "command_sample.h"
-#include "command_sample_dem.h"
+#include "stim/circuit/circuit.h"
+#include "stim/cmd/command_convert.h"
+#include "stim/cmd/command_detect.h"
+#include "stim/cmd/command_diagram.h"
+#include "stim/cmd/command_explain_errors.h"
+#include "stim/cmd/command_gen.h"
+#include "stim/cmd/command_m2d.h"
+#include "stim/cmd/command_repl.h"
+#include "stim/cmd/command_sample.h"
+#include "stim/cmd/command_sample_dem.h"
 #include "stim/cmd/command_analyze_errors.h"
 #include "stim/gates/gates.h"
 #include "stim/io/stim_data_formats.h"
 #include "stim/stabilizers/flow.h"
 #include "stim/stabilizers/tableau.h"
 #include "stim/util_bot/arg_parse.h"
+#include "stim/util_top/mbqc_decomposition.h"
 
 using namespace stim;
 
@@ -255,9 +256,35 @@ void print_decomposition(Acc &out, const Gate &gate) {
         out << "# The following circuit is equivalent (up to global phase) to `";
         out << undecomposed.str() << "`";
         out << decomposition;
-        if (Circuit(decomposition) == Circuit(undecomposed.str())) {
+        Circuit c(decomposition);
+        if (c == Circuit(undecomposed.str())) {
             out << "\n# (The decomposition is trivial because this gate is in the target gate set.)\n";
+        } else if (c.operations.empty()) {
+            out << "\n# (The decomposition is empty because this gate has no effect.)\n";
         }
+        out.change_indent(-4);
+    }
+}
+
+void print_mbqc_decomposition(Acc &out, const Gate &gate) {
+    const char *decomposition = mbqc_decomposition(gate.id);
+    if (decomposition != nullptr) {
+        std::stringstream undecomposed;
+        auto decomp_targets = gate_decomposition_help_targets_for_gate_type(gate.id);
+        undecomposed << CircuitInstruction{gate.id, {}, decomp_targets, ""};
+
+        out << "MBQC Decomposition (into MX, MY, MZ, MXX, MZZ, and Pauli feedback):\n";
+        out.change_indent(+4);
+        out << "# The following circuit performs `";
+        out << undecomposed.str() << "` (but affects the measurement record and an ancilla qubit)";
+        out << decomposition;
+        Circuit c(decomposition);
+        if (c == Circuit(undecomposed.str())) {
+            out << "\n# (The decomposition is trivial because this gate is in the target gate set.)\n";
+        } else if (c.operations.empty()) {
+            out << "\n# (The decomposition is empty because this gate has no effect.)\n";
+        }
+
         out.change_indent(-4);
     }
 }
@@ -425,6 +452,7 @@ std::string generate_per_gate_help_markdown(const Gate &alt_gate, int indent, bo
     print_bloch_vector(out, gate);
     print_unitary_matrix(out, gate);
     print_decomposition(out, gate);
+    print_mbqc_decomposition(out, gate);
     out.flush();
     return out.settled;
 }

--- a/src/stim/stabilizers/flow.h
+++ b/src/stim/stabilizers/flow.h
@@ -36,7 +36,11 @@ struct Flow {
     /// ENTRIES MUST BE SORTED AND UNIQUE.
     std::vector<uint32_t> observables;
 
+    /// Fixes non-unique non-sorted measurements and observables.
+    void canonicalize();
+
     static Flow<W> from_str(std::string_view text);
+    Flow<W> operator*(const Flow<W> &rhs) const;
     bool operator<(const Flow<W> &other) const;
     bool operator==(const Flow<W> &other) const;
     bool operator!=(const Flow<W> &other) const;

--- a/src/stim/stabilizers/pauli_string_ref.inl
+++ b/src/stim/stabilizers/pauli_string_ref.inl
@@ -114,14 +114,14 @@ PauliStringRef<W> &PauliStringRef<W>::operator*=(const PauliStringRef<W> &rhs) {
 
 template <size_t W>
 uint8_t PauliStringRef<W>::inplace_right_mul_returning_log_i_scalar(const PauliStringRef<W> &rhs) noexcept {
-    assert(num_qubits == rhs.num_qubits);
+    assert(num_qubits >= rhs.num_qubits);
 
     // Accumulator registers for counting mod 4 in parallel across each bit position.
     simd_word<W> cnt1{};
     simd_word<W> cnt2{};
 
-    xs.for_each_word(
-        zs, rhs.xs, rhs.zs, [&cnt1, &cnt2](simd_word<W> &x1, simd_word<W> &z1, simd_word<W> &x2, simd_word<W> &z2) {
+    rhs.xs.for_each_word(
+        rhs.zs, xs, zs, [&cnt1, &cnt2](simd_word<W> &x2, simd_word<W> &z2, simd_word<W> &x1, simd_word<W> &z1) {
             // Update the left hand side Paulis.
             auto old_x1 = x1;
             auto old_z1 = z1;

--- a/src/stim/util_top/mbqc_decomposition.cc
+++ b/src/stim/util_top/mbqc_decomposition.cc
@@ -1,0 +1,871 @@
+#include "stim/util_top/mbqc_decomposition.h"
+
+using namespace stim;
+
+const char *stim::mbqc_decomposition(GateType gate) {
+    switch (gate) {
+        case GateType::NOT_A_GATE:
+        case GateType::DETECTOR:
+        case GateType::OBSERVABLE_INCLUDE:
+        case GateType::TICK:
+        case GateType::QUBIT_COORDS:
+        case GateType::SHIFT_COORDS:
+        case GateType::REPEAT:
+        case GateType::MPAD:
+        case GateType::DEPOLARIZE1:
+        case GateType::DEPOLARIZE2:
+        case GateType::X_ERROR:
+        case GateType::Y_ERROR:
+        case GateType::Z_ERROR:
+        case GateType::I_ERROR:
+        case GateType::II_ERROR:
+        case GateType::PAULI_CHANNEL_1:
+        case GateType::PAULI_CHANNEL_2:
+        case GateType::E:
+        case GateType::ELSE_CORRELATED_ERROR:
+        case GateType::HERALDED_ERASE:
+        case GateType::HERALDED_PAULI_CHANNEL_1:
+            return nullptr;
+        case GateType::MX:
+            return R"CIRCUIT(
+MX 0
+            )CIRCUIT";
+        case GateType::MY:
+            return R"CIRCUIT(
+MY 0
+            )CIRCUIT";
+        case GateType::M:
+            return R"CIRCUIT(
+MZ 0
+            )CIRCUIT";
+        case GateType::MRX:
+            return R"CIRCUIT(
+MX 0
+CZ rec[-1] 0
+            )CIRCUIT";
+        case GateType::MRY:
+            return R"CIRCUIT(
+MY 0
+CX rec[-1] 0
+            )CIRCUIT";
+        case GateType::MR:
+            return R"CIRCUIT(
+MZ 0
+CX rec[-1] 0
+            )CIRCUIT";
+        case GateType::RX:
+            return R"CIRCUIT(
+MX 0
+CZ rec[-1] 0
+            )CIRCUIT";
+        case GateType::RY:
+            return R"CIRCUIT(
+MY 0
+CX rec[-1] 0
+            )CIRCUIT";
+        case GateType::R:
+            return R"CIRCUIT(
+MZ 0
+CX rec[-1] 0
+            )CIRCUIT";
+        case GateType::XCX:
+            return R"CIRCUIT(
+MX 2
+MZZ 0 2
+MY 2
+MXX 0 2
+MZ 2
+MXX 1 2
+MZZ 0 2
+MX 2
+MZ 2
+MXX 0 2
+MY 2
+MZZ 0 2
+MX 2
+CX rec[-11] 0 rec[-10] 1 rec[-8] 0 rec[-6] 0 rec[-3] 0 rec[-13] 1 rec[-12] 1 rec[-7] 1
+CY rec[-10] 0 rec[-9] 0 rec[-5] 0 rec[-4] 0
+CZ rec[-13] 0 rec[-12] 0 rec[-2] 0 rec[-1] 0
+            )CIRCUIT";
+        case GateType::XCY:
+            return R"CIRCUIT(
+MY 2
+MXX 1 2
+MZ 2
+MXX 0 2
+MZZ 1 2
+MX 2
+MZ 2
+MXX 1 2
+MY 2
+X 0
+CX rec[-9] 0 rec[-9] 1 rec[-8] 0 rec[-8] 1 rec[-5] 0 rec[-7] 1 rec[-3] 1 rec[-2] 1 rec[-1] 1
+CY rec[-6] 1 rec[-4] 1
+            )CIRCUIT";
+        case GateType::XCZ:
+            return R"CIRCUIT(
+MZ 2
+MXX 0 2
+MZZ 1 2
+MX 2
+CX rec[-4] 0 rec[-2] 0
+CZ rec[-3] 1 rec[-1] 1
+            )CIRCUIT";
+        case GateType::YCX:
+            return R"CIRCUIT(
+MY 2
+MXX 0 2
+MZ 2
+MXX 1 2
+MZZ 0 2
+MX 2
+MZ 2
+MXX 0 2
+MY 2
+X 1
+CX rec[-9] 0 rec[-9] 1 rec[-8] 0 rec[-8] 1 rec[-7] 0 rec[-3] 0 rec[-2] 0 rec[-1] 0 rec[-5] 1
+CY rec[-6] 0 rec[-4] 0
+            )CIRCUIT";
+        case GateType::YCY:
+            return R"CIRCUIT(
+MX 2
+MZZ 1 2
+MY 2
+MXX 0 2
+MZ 2
+MXX 1 2
+MZZ 0 2
+MX 2
+MZ 2
+MXX 0 2
+MY 2
+MZZ 1 2
+MX 2
+Y 1
+CX rec[-10] 0 rec[-9] 0 rec[-5] 0 rec[-4] 0 rec[-3] 0 rec[-11] 1
+CY rec[-13] 0 rec[-12] 0 rec[-10] 1 rec[-8] 0 rec[-6] 0 rec[-7] 1
+CZ rec[-13] 1 rec[-12] 1 rec[-11] 0 rec[-3] 1 rec[-2] 1 rec[-1] 1
+            )CIRCUIT";
+        case GateType::YCZ:
+            return R"CIRCUIT(
+MX 2
+MZZ 0 2
+MY 2
+MZ 2
+MXX 0 2
+MZZ 1 2
+MX 2
+MZZ 0 2
+MY 2
+Z 0
+CY rec[-6] 0 rec[-4] 0
+CZ rec[-9] 0 rec[-9] 1 rec[-8] 0 rec[-8] 1 rec[-7] 0 rec[-7] 1 rec[-3] 0 rec[-3] 1 rec[-2] 0 rec[-1] 0 rec[-5] 1
+            )CIRCUIT";
+        case GateType::CX:
+            return R"CIRCUIT(
+MX 2
+MZZ 0 2
+MXX 1 2
+MZ 2
+CX rec[-3] 1 rec[-1] 1
+CZ rec[-4] 0 rec[-2] 0
+            )CIRCUIT";
+        case GateType::CY:
+            return R"CIRCUIT(
+MY 2
+MZZ 1 2
+MX 2
+MZZ 0 2
+MXX 1 2
+MZ 2
+MX 2
+MZZ 1 2
+MY 2
+Z 0
+CY rec[-6] 1 rec[-4] 1
+CZ rec[-9] 0 rec[-9] 1 rec[-8] 0 rec[-8] 1 rec[-5] 0 rec[-7] 1 rec[-3] 1 rec[-2] 1 rec[-1] 1
+            )CIRCUIT";
+        case GateType::CZ:
+            return R"CIRCUIT(
+MZ 2
+MXX 0 2
+MY 2
+MZZ 0 2
+MX 2
+MZZ 1 2
+MXX 0 2
+MZ 2
+MX 2
+MZZ 0 2
+MY 2
+MXX 0 2
+MZ 2
+CX rec[-13] 0 rec[-12] 0 rec[-2] 0 rec[-1] 0
+CY rec[-10] 0 rec[-9] 0 rec[-5] 0 rec[-4] 0
+CZ rec[-11] 0 rec[-10] 1 rec[-8] 0 rec[-6] 0 rec[-3] 0 rec[-13] 1 rec[-12] 1 rec[-7] 1
+            )CIRCUIT";
+        case GateType::H:
+            return R"CIRCUIT(
+MX 1
+MZZ 0 1
+MY 1
+MXX 0 1
+MZ 1
+MX 1
+MZZ 0 1
+MY 1
+CX rec[-8] 0 rec[-7] 0
+CY rec[-5] 0 rec[-4] 0
+CZ rec[-6] 0 rec[-3] 0 rec[-2] 0 rec[-1] 0
+            )CIRCUIT";
+        case GateType::H_XY:
+            return R"CIRCUIT(
+MX 1
+MZZ 0 1
+MY 1
+X 0
+CZ rec[-3] 0 rec[-2] 0 rec[-1] 0
+            )CIRCUIT";
+        case GateType::H_YZ:
+            return R"CIRCUIT(
+MZ 1
+MXX 0 1
+MY 1
+Z 0
+CX rec[-3] 0 rec[-2] 0 rec[-1] 0
+            )CIRCUIT";
+        case GateType::H_NXY:
+            return R"CIRCUIT(
+MX 1
+MZZ 0 1
+MY 1
+Y 0
+CZ rec[-3] 0 rec[-2] 0 rec[-1] 0
+            )CIRCUIT";
+        case GateType::H_NXZ:
+            return R"CIRCUIT(
+MX 1
+MZZ 0 1
+MY 1
+MXX 0 1
+MZ 1
+MX 1
+MZZ 0 1
+MY 1
+Y 0
+CX rec[-8] 0 rec[-7] 0
+CY rec[-5] 0 rec[-4] 0
+CZ rec[-6] 0 rec[-3] 0 rec[-2] 0 rec[-1] 0
+            )CIRCUIT";
+        case GateType::H_NYZ:
+            return R"CIRCUIT(
+MZ 1
+MXX 0 1
+MY 1
+Y 0
+CX rec[-3] 0 rec[-2] 0 rec[-1] 0
+            )CIRCUIT";
+        case GateType::I:
+            return R"CIRCUIT(
+            )CIRCUIT";
+        case GateType::X:
+            return R"CIRCUIT(
+X 0
+            )CIRCUIT";
+        case GateType::Y:
+            return R"CIRCUIT(
+Y 0
+            )CIRCUIT";
+        case GateType::Z:
+            return R"CIRCUIT(
+Z 0
+            )CIRCUIT";
+        case GateType::C_XYZ:
+            return R"CIRCUIT(
+MZ 1
+MXX 0 1
+MY 1
+MZZ 0 1
+MX 1
+CX rec[-3] 0
+CY rec[-5] 0 rec[-4] 0
+CZ rec[-2] 0 rec[-1] 0
+            )CIRCUIT";
+        case GateType::C_ZYX:
+            return R"CIRCUIT(
+MX 1
+MZZ 0 1
+MY 1
+MXX 0 1
+MZ 1
+CX rec[-2] 0 rec[-1] 0
+CY rec[-5] 0 rec[-4] 0
+CZ rec[-3] 0
+            )CIRCUIT";
+        case GateType::C_NXYZ:
+            return R"CIRCUIT(
+MZ 1
+MXX 0 1
+MY 1
+MZZ 0 1
+MX 1
+Z 0
+CX rec[-3] 0
+CY rec[-5] 0 rec[-4] 0
+CZ rec[-2] 0 rec[-1] 0
+            )CIRCUIT";
+        case GateType::C_XNYZ:
+            return R"CIRCUIT(
+MZ 1
+MXX 0 1
+MY 1
+MZZ 0 1
+MX 1
+X 0
+CX rec[-3] 0
+CY rec[-5] 0 rec[-4] 0
+CZ rec[-2] 0 rec[-1] 0
+            )CIRCUIT";
+        case GateType::C_XYNZ:
+            return R"CIRCUIT(
+MZ 1
+MXX 0 1
+MY 1
+MZZ 0 1
+MX 1
+Y 0
+CX rec[-3] 0
+CY rec[-5] 0 rec[-4] 0
+CZ rec[-2] 0 rec[-1] 0
+            )CIRCUIT";
+        case GateType::C_NZYX:
+            return R"CIRCUIT(
+MX 1
+MZZ 0 1
+MY 1
+MXX 0 1
+MZ 1
+X 0
+CX rec[-2] 0 rec[-1] 0
+CY rec[-5] 0 rec[-4] 0
+CZ rec[-3] 0
+            )CIRCUIT";
+        case GateType::C_ZNYX:
+            return R"CIRCUIT(
+MX 1
+MZZ 0 1
+MY 1
+MXX 0 1
+MZ 1
+Z 0
+CX rec[-2] 0 rec[-1] 0
+CY rec[-5] 0 rec[-4] 0
+CZ rec[-3] 0
+            )CIRCUIT";
+        case GateType::C_ZYNX:
+            return R"CIRCUIT(
+MX 1
+MZZ 0 1
+MY 1
+MXX 0 1
+MZ 1
+Y 0
+CX rec[-2] 0 rec[-1] 0
+CY rec[-5] 0 rec[-4] 0
+CZ rec[-3] 0
+            )CIRCUIT";
+        case GateType::SQRT_X:
+            return R"CIRCUIT(
+MZ 1
+MXX 0 1
+MY 1
+CX rec[-3] 0 rec[-2] 0 rec[-1] 0
+            )CIRCUIT";
+        case GateType::SQRT_X_DAG:
+            return R"CIRCUIT(
+MY 1
+MXX 0 1
+MZ 1
+CX rec[-3] 0 rec[-2] 0 rec[-1] 0
+            )CIRCUIT";
+        case GateType::SQRT_Y:
+            return R"CIRCUIT(
+MX 1
+MZZ 0 1
+MY 1
+MXX 0 1
+MZ 1
+MX 1
+MZZ 0 1
+MY 1
+X 0
+CX rec[-8] 0 rec[-7] 0
+CY rec[-5] 0 rec[-4] 0
+CZ rec[-6] 0 rec[-3] 0 rec[-2] 0 rec[-1] 0
+            )CIRCUIT";
+        case GateType::SQRT_Y_DAG:
+            return R"CIRCUIT(
+MX 1
+MZZ 0 1
+MY 1
+MXX 0 1
+MZ 1
+MX 1
+MZZ 0 1
+MY 1
+Z 0
+CX rec[-8] 0 rec[-7] 0
+CY rec[-5] 0 rec[-4] 0
+CZ rec[-6] 0 rec[-3] 0 rec[-2] 0 rec[-1] 0
+            )CIRCUIT";
+        case GateType::S:
+            return R"CIRCUIT(
+MY 1
+MZZ 0 1
+MX 1
+CZ rec[-3] 0 rec[-2] 0 rec[-1] 0
+            )CIRCUIT";
+        case GateType::S_DAG:
+            return R"CIRCUIT(
+MX 1
+MZZ 0 1
+MY 1
+CZ rec[-3] 0 rec[-2] 0 rec[-1] 0
+            )CIRCUIT";
+        case GateType::II:
+            return "";
+        case GateType::SQRT_XX:
+            return R"CIRCUIT(
+MX 2
+MZZ 0 2
+MY 2
+MXX 0 2
+MZ 2
+MXX 1 2
+MZZ 0 2
+MX 2
+MY 2
+MXX 1 2
+MZ 2
+MXX 0 2
+MY 2
+MZZ 0 2
+MX 2
+MZ 2
+MXX 0 2
+MY 2
+X 1
+CX rec[-18] 1 rec[-17] 1 rec[-16] 0 rec[-13] 0 rec[-11] 0 rec[-6] 0 rec[-3] 0 rec[-2] 0 rec[-1] 0 rec[-15] 1 rec[-12] 1 rec[-10] 1 rec[-9] 1 rec[-8] 1
+CY rec[-18] 0 rec[-17] 0 rec[-5] 0 rec[-4] 0
+CZ rec[-15] 0 rec[-14] 0 rec[-8] 0 rec[-7] 0
+            )CIRCUIT";
+        case GateType::SQRT_XX_DAG:
+            return R"CIRCUIT(
+MX 2
+MZZ 0 2
+MY 2
+MXX 0 2
+MZ 2
+MXX 1 2
+MZZ 0 2
+MX 2
+MY 2
+MXX 1 2
+MZ 2
+MXX 0 2
+MY 2
+MZZ 0 2
+MX 2
+MZ 2
+MXX 0 2
+MY 2
+X 0
+CX rec[-18] 1 rec[-17] 1 rec[-16] 0 rec[-13] 0 rec[-11] 0 rec[-6] 0 rec[-3] 0 rec[-2] 0 rec[-1] 0 rec[-15] 1 rec[-12] 1 rec[-10] 1 rec[-9] 1 rec[-8] 1
+CY rec[-18] 0 rec[-17] 0 rec[-5] 0 rec[-4] 0
+CZ rec[-15] 0 rec[-14] 0 rec[-8] 0 rec[-7] 0
+            )CIRCUIT";
+        case GateType::SQRT_YY:
+            return R"CIRCUIT(
+MX 2
+MZZ 1 2
+MY 2
+MXX 0 2
+MZ 2
+MXX 1 2
+MZZ 0 2
+MX 2
+MZZ 0 2
+MY 2
+MXX 0 2
+MZ 2
+MXX 1 2
+MY 2
+MZZ 1 2
+MX 2
+X 0
+Y 1
+CX rec[-16] 1 rec[-15] 1 rec[-14] 0 rec[-6] 0 rec[-5] 0 rec[-3] 1
+CY rec[-16] 0 rec[-15] 0 rec[-11] 0 rec[-8] 0 rec[-5] 1 rec[-13] 1 rec[-10] 1 rec[-4] 1
+CZ rec[-13] 0 rec[-12] 0 rec[-7] 0 rec[-14] 1 rec[-2] 1 rec[-1] 1
+            )CIRCUIT";
+        case GateType::SQRT_YY_DAG:
+            return R"CIRCUIT(
+MX 2
+MZZ 1 2
+MY 2
+MXX 0 2
+MZ 2
+MXX 1 2
+MZZ 0 2
+MX 2
+MZZ 0 2
+MY 2
+MXX 0 2
+MZ 2
+MXX 1 2
+MY 2
+MZZ 1 2
+MX 2
+Z 0
+CX rec[-16] 1 rec[-15] 1 rec[-14] 0 rec[-6] 0 rec[-5] 0 rec[-3] 1
+CY rec[-16] 0 rec[-15] 0 rec[-11] 0 rec[-8] 0 rec[-5] 1 rec[-13] 1 rec[-10] 1 rec[-4] 1
+CZ rec[-13] 0 rec[-12] 0 rec[-7] 0 rec[-14] 1 rec[-2] 1 rec[-1] 1
+            )CIRCUIT";
+        case GateType::SQRT_ZZ:
+            return R"CIRCUIT(
+MZ 2
+MXX 0 2
+MY 2
+MZZ 0 2
+MX 2
+MZZ 1 2
+MXX 0 2
+MZ 2
+MY 2
+MZZ 1 2
+MX 2
+MZZ 0 2
+MY 2
+MXX 0 2
+MZ 2
+MX 2
+MZZ 0 2
+MY 2
+Z 0
+CX rec[-15] 0 rec[-14] 0 rec[-8] 0 rec[-7] 0
+CY rec[-18] 0 rec[-17] 0 rec[-5] 0 rec[-4] 0
+CZ rec[-18] 1 rec[-17] 1 rec[-16] 0 rec[-13] 0 rec[-11] 0 rec[-6] 0 rec[-3] 0 rec[-2] 0 rec[-1] 0 rec[-15] 1 rec[-12] 1 rec[-10] 1 rec[-9] 1 rec[-8] 1
+            )CIRCUIT";
+        case GateType::SQRT_ZZ_DAG:
+            return R"CIRCUIT(
+MZ 2
+MXX 0 2
+MY 2
+MZZ 0 2
+MX 2
+MZZ 1 2
+MXX 0 2
+MZ 2
+MY 2
+MZZ 1 2
+MX 2
+MZZ 0 2
+MY 2
+MXX 0 2
+MZ 2
+MX 2
+MZZ 0 2
+MY 2
+Z 1
+CX rec[-15] 0 rec[-14] 0 rec[-8] 0 rec[-7] 0
+CY rec[-18] 0 rec[-17] 0 rec[-5] 0 rec[-4] 0
+CZ rec[-18] 1 rec[-17] 1 rec[-16] 0 rec[-13] 0 rec[-11] 0 rec[-6] 0 rec[-3] 0 rec[-2] 0 rec[-1] 0 rec[-15] 1 rec[-12] 1 rec[-10] 1 rec[-9] 1 rec[-8] 1
+            )CIRCUIT";
+        case GateType::SWAP:
+            return R"CIRCUIT(
+MZ 2
+MXX 0 2
+MZZ 1 2
+MX 2
+MZZ 0 2
+MXX 1 2
+MZ 2
+MXX 0 2
+MZZ 1 2
+MX 2
+CX rec[-6] 0 rec[-6] 1 rec[-2] 0 rec[-10] 1 rec[-8] 1 rec[-4] 1
+CZ rec[-9] 0 rec[-5] 0 rec[-5] 1 rec[-7] 1 rec[-3] 1 rec[-1] 1
+            )CIRCUIT";
+        case GateType::ISWAP:
+            return R"CIRCUIT(
+MX 2
+MZZ 0 2
+MY 2
+MZZ 1 2
+MX 2
+MZ 2
+MXX 0 2
+MY 2
+MZZ 0 2
+MX 2
+MZZ 0 2
+MXX 1 2
+MZ 2
+MXX 0 2
+MZZ 1 2
+MX 2
+MZZ 1 2
+MY 2
+MXX 1 2
+MZ 2
+Z 1
+CX rec[-10] 0 rec[-6] 0 rec[-15] 1 rec[-14] 1 rec[-2] 1 rec[-1] 1
+CY rec[-12] 1 rec[-9] 1 rec[-7] 1 rec[-4] 1
+CZ rec[-18] 0 rec[-18] 1 rec[-17] 0 rec[-16] 0 rec[-15] 0 rec[-14] 0 rec[-12] 0 rec[-9] 0 rec[-20] 1 rec[-19] 1 rec[-13] 1 rec[-10] 1 rec[-8] 1 rec[-3] 1
+            )CIRCUIT";
+        case GateType::CXSWAP:
+            return R"CIRCUIT(
+MZ 2
+MXX 0 2
+MZZ 1 2
+MX 2
+MZZ 0 2
+MXX 1 2
+MZ 2
+CX rec[-7] 0 rec[-7] 1 rec[-5] 0 rec[-5] 1 rec[-3] 1 rec[-1] 1
+CZ rec[-6] 0 rec[-6] 1 rec[-2] 0 rec[-4] 1
+            )CIRCUIT";
+        case GateType::SWAPCX:
+            return R"CIRCUIT(
+MX 2
+MZZ 0 2
+MXX 1 2
+MZ 2
+MXX 0 2
+MZZ 1 2
+MX 2
+CX rec[-6] 0 rec[-6] 1 rec[-2] 0 rec[-4] 1
+CZ rec[-7] 0 rec[-7] 1 rec[-5] 0 rec[-5] 1 rec[-3] 1 rec[-1] 1
+            )CIRCUIT";
+        case GateType::CZSWAP:
+            return R"CIRCUIT(
+MZ 2
+MXX 0 2
+MY 2
+MZZ 0 2
+MX 2
+MZZ 0 2
+MXX 1 2
+MZ 2
+MXX 0 2
+MZZ 1 2
+MX 2
+MZZ 1 2
+MY 2
+MXX 1 2
+MZ 2
+CX rec[-10] 0 rec[-6] 0 rec[-15] 1 rec[-14] 1 rec[-2] 1 rec[-1] 1
+CY rec[-12] 1 rec[-9] 1 rec[-7] 1 rec[-4] 1
+CZ rec[-15] 0 rec[-14] 0 rec[-12] 0 rec[-9] 0 rec[-13] 1 rec[-10] 1 rec[-8] 1 rec[-3] 1
+            )CIRCUIT";
+        case GateType::ISWAP_DAG:
+            return R"CIRCUIT(
+MX 2
+MZZ 0 2
+MY 2
+MZZ 1 2
+MX 2
+MZ 2
+MXX 0 2
+MY 2
+MZZ 0 2
+MX 2
+MZZ 0 2
+MXX 1 2
+MZ 2
+MXX 0 2
+MZZ 1 2
+MX 2
+MZZ 1 2
+MY 2
+MXX 1 2
+MZ 2
+Z 0
+CX rec[-10] 0 rec[-6] 0 rec[-15] 1 rec[-14] 1 rec[-2] 1 rec[-1] 1
+CY rec[-12] 1 rec[-9] 1 rec[-7] 1 rec[-4] 1
+CZ rec[-18] 0 rec[-18] 1 rec[-17] 0 rec[-16] 0 rec[-15] 0 rec[-14] 0 rec[-12] 0 rec[-9] 0 rec[-20] 1 rec[-19] 1 rec[-13] 1 rec[-10] 1 rec[-8] 1 rec[-3] 1
+            )CIRCUIT";
+        case GateType::MXX:
+            return R"CIRCUIT(
+MXX 0 1
+            )CIRCUIT";
+        case GateType::MYY:
+            return R"CIRCUIT(
+MX 2
+MZZ 0 2
+MY 2
+MX 2
+MZZ 1 2
+MY 2
+MXX 0 1
+MX 2
+MZZ 0 2
+MY 2
+MX 2
+MZZ 1 2
+MY 2
+Z 0 1
+CZ rec[-13] 0 rec[-12] 0 rec[-11] 0 rec[-6] 0 rec[-5] 0 rec[-4] 0 rec[-10] 1 rec[-9] 1 rec[-8] 1 rec[-3] 1 rec[-2] 1 rec[-1] 1
+            )CIRCUIT";
+        case GateType::MZZ:
+            return R"CIRCUIT(
+MZZ 0 1
+            )CIRCUIT";
+
+        case GateType::SPP:
+            return R"CIRCUIT(
+MY 3
+MZZ 1 3
+MX 3
+MZZ 0 3
+MXX 1 3
+MZ 3
+MX 3
+MZZ 1 3
+MY 3
+MZ 3
+MXX 0 3
+MY 3
+MZZ 0 3
+MX 3
+MZZ 2 3
+MXX 0 3
+MZ 3
+MX 3
+MZZ 0 3
+MY 3
+MXX 0 3
+MZ 3
+MXX 0 3
+MY 3
+MZ 3
+MXX 0 3
+MY 3
+MZZ 0 3
+MX 3
+MZZ 2 3
+MXX 0 3
+MZ 3
+MX 3
+MZZ 0 3
+MY 3
+MXX 0 3
+MZ 3
+MY 3
+MZZ 1 3
+MX 3
+MZZ 0 3
+MXX 1 3
+MZ 3
+MX 3
+MZZ 1 3
+MY 3
+X 0
+Y 1
+Z 2
+CX rec[-46] 0 rec[-46] 1 rec[-45] 0 rec[-45] 1 rec[-37] 0 rec[-36] 0 rec[-26] 0 rec[-24] 0 rec[-23] 0 rec[-22] 0 rec[-21] 0 rec[-11] 0 rec[-10] 0
+CY rec[-42] 0 rec[-42] 1 rec[-37] 1 rec[-36] 1 rec[-35] 0 rec[-35] 1 rec[-32] 0 rec[-32] 1 rec[-30] 0 rec[-30] 1 rec[-27] 0 rec[-27] 1 rec[-26] 1 rec[-24] 1 rec[-23] 1 rec[-22] 1 rec[-21] 1 rec[-19] 0 rec[-19] 1 rec[-18] 0 rec[-18] 1 rec[-14] 0 rec[-14] 1 rec[-13] 0 rec[-13] 1 rec[-11] 1 rec[-10] 1 rec[-43] 1 rec[-41] 1 rec[-6] 1 rec[-4] 1
+CZ rec[-44] 0 rec[-44] 1 rec[-42] 2 rec[-40] 0 rec[-40] 1 rec[-39] 0 rec[-39] 1 rec[-38] 0 rec[-38] 1 rec[-35] 2 rec[-34] 0 rec[-34] 2 rec[-33] 0 rec[-32] 2 rec[-30] 2 rec[-29] 0 rec[-28] 0 rec[-27] 2 rec[-20] 0 rec[-19] 2 rec[-17] 0 rec[-15] 0 rec[-12] 0 rec[-9] 0 rec[-9] 1 rec[-8] 0 rec[-8] 1 rec[-5] 0 rec[-26] 2 rec[-24] 2 rec[-23] 2 rec[-22] 2 rec[-21] 2 rec[-7] 1 rec[-3] 1 rec[-2] 1 rec[-1] 1 rec[-46] 2 rec[-45] 2 rec[-31] 2 rec[-16] 2
+            )CIRCUIT";
+        case GateType::SPP_DAG:
+            return R"CIRCUIT(
+MY 3
+MZZ 1 3
+MX 3
+MZZ 0 3
+MXX 1 3
+MZ 3
+MX 3
+MZZ 1 3
+MY 3
+MZ 3
+MXX 0 3
+MY 3
+MZZ 0 3
+MX 3
+MZZ 2 3
+MXX 0 3
+MZ 3
+MX 3
+MZZ 0 3
+MY 3
+MXX 0 3
+MZ 3
+MXX 0 3
+MY 3
+MZ 3
+MXX 0 3
+MY 3
+MZZ 0 3
+MX 3
+MZZ 2 3
+MXX 0 3
+MZ 3
+MX 3
+MZZ 0 3
+MY 3
+MXX 0 3
+MZ 3
+MY 3
+MZZ 1 3
+MX 3
+MZZ 0 3
+MXX 1 3
+MZ 3
+MX 3
+MZZ 1 3
+MY 3
+CX rec[-46] 0 rec[-46] 1 rec[-45] 0 rec[-45] 1 rec[-37] 0 rec[-36] 0 rec[-26] 0 rec[-24] 0 rec[-23] 0 rec[-22] 0 rec[-21] 0 rec[-11] 0 rec[-10] 0
+CY rec[-42] 0 rec[-42] 1 rec[-37] 1 rec[-36] 1 rec[-35] 0 rec[-35] 1 rec[-32] 0 rec[-32] 1 rec[-30] 0 rec[-30] 1 rec[-27] 0 rec[-27] 1 rec[-26] 1 rec[-24] 1 rec[-23] 1 rec[-22] 1 rec[-21] 1 rec[-19] 0 rec[-19] 1 rec[-18] 0 rec[-18] 1 rec[-14] 0 rec[-14] 1 rec[-13] 0 rec[-13] 1 rec[-11] 1 rec[-10] 1 rec[-43] 1 rec[-41] 1 rec[-6] 1 rec[-4] 1
+CZ rec[-44] 0 rec[-44] 1 rec[-42] 2 rec[-40] 0 rec[-40] 1 rec[-39] 0 rec[-39] 1 rec[-38] 0 rec[-38] 1 rec[-35] 2 rec[-34] 0 rec[-34] 2 rec[-33] 0 rec[-32] 2 rec[-30] 2 rec[-29] 0 rec[-28] 0 rec[-27] 2 rec[-20] 0 rec[-19] 2 rec[-17] 0 rec[-15] 0 rec[-12] 0 rec[-9] 0 rec[-9] 1 rec[-8] 0 rec[-8] 1 rec[-5] 0 rec[-26] 2 rec[-24] 2 rec[-23] 2 rec[-22] 2 rec[-21] 2 rec[-7] 1 rec[-3] 1 rec[-2] 1 rec[-1] 1 rec[-46] 2 rec[-45] 2 rec[-31] 2 rec[-16] 2
+            )CIRCUIT";
+        case GateType::MPP:
+            return R"CIRCUIT(
+MY 5
+MZZ 1 5
+MX 5
+MZZ 0 5
+MXX 1 5
+MZ 5
+MX 5
+MZZ 1 5
+MY 5
+MZ 5
+MXX 2 5
+MY 5
+MZZ 2 5
+MX 5
+MXX 0 2
+MXX 3 4
+MX 5
+MZZ 2 5
+MY 5
+MXX 2 5
+MZ 5
+MY 5
+MZZ 1 5
+MX 5
+MZZ 0 5
+MXX 1 5
+MZ 5
+MX 5
+MZZ 1 5
+MY 5
+CX rec[-21] 2 rec[-20] 2 rec[-11] 2 rec[-10] 2
+CY rec[-27] 1 rec[-25] 1 rec[-6] 1 rec[-4] 1 rec[-18] 2 rec[-13] 2
+CZ rec[-28] 0 rec[-28] 1 rec[-26] 0 rec[-24] 0 rec[-24] 1 rec[-23] 0 rec[-23] 1 rec[-22] 0 rec[-22] 1 rec[-9] 0 rec[-9] 1 rec[-8] 0 rec[-8] 1 rec[-5] 0 rec[-30] 1 rec[-29] 1 rec[-7] 1 rec[-3] 1 rec[-2] 1 rec[-1] 1 rec[-19] 2 rec[-12] 2
+            )CIRCUIT";
+        default:
+            throw std::invalid_argument("Unhandled gate type " + std::string(GATE_DATA[gate].name));
+    }
+}

--- a/src/stim/util_top/mbqc_decomposition.h
+++ b/src/stim/util_top/mbqc_decomposition.h
@@ -1,0 +1,12 @@
+#ifndef _STIM_UTIL_TOP_MBQC_DECOMPOSITION_H
+#define _STIM_UTIL_TOP_MBQC_DECOMPOSITION_H
+
+#include "stim/gates/gates.h"
+
+namespace stim {
+
+const char *mbqc_decomposition(GateType gate);
+
+}  // namespace stim
+
+#endif

--- a/src/stim/util_top/mbqc_decomposition.test.cc
+++ b/src/stim/util_top/mbqc_decomposition.test.cc
@@ -1,0 +1,42 @@
+#include "stim/util_top/mbqc_decomposition.h"
+
+#include <stim/util_bot/test_util.test.h>
+
+#include "gtest/gtest.h"
+
+#include "stim/circuit/circuit.h"
+#include "stim/util_top/has_flow.h"
+
+using namespace stim;
+
+TEST(mbqc_decomposition, all_gates) {
+    auto rng = INDEPENDENT_TEST_RNG();
+
+    for (const auto &g : GATE_DATA.items) {
+        const char *decomp = mbqc_decomposition(g.id);
+        if (decomp == nullptr) {
+            EXPECT_TRUE(g.flow_data.empty()) << g.name;
+            continue;
+        } else {
+            EXPECT_FALSE(g.flow_data.empty()) << g.name;
+        }
+
+        Circuit circuit(decomp);
+        std::vector<Flow<64>> verified_flows;
+        for (auto &flow : g.flows<64>()) {
+            if (flow.input.ref().weight() && flow.output.ref().weight()) {
+                verified_flows.push_back(std::move(flow));
+            }
+        }
+        std::vector<bool> result = sample_if_circuit_has_stabilizer_flows<64>(
+            256,
+            rng,
+            circuit,
+            verified_flows);
+        bool correct = true;
+        for (auto b : result) {
+            correct &= b;
+        }
+        EXPECT_TRUE(correct) << g.name;
+    }
+}


### PR DESCRIPTION
- Fix `stim.Flow.__init__` not xor-sorting measurements/observables
- Add `stim.Flow.__mul__`