### PR TITLE
ReferenceSampleTree Random Access

### DIFF
--- a/src/stim/util_top/reference_sample_tree.cc
+++ b/src/stim/util_top/reference_sample_tree.cc
@@ -186,6 +186,32 @@ bool ReferenceSampleTree::operator!=(const ReferenceSampleTree &other) const {
     return !(*this == other);
 }
 
+bool ReferenceSampleTree::operator[](size_t index) const {
+    size_t current_absolute_index = 0;
+    bool result;
+    bool value_found = try_get_bit_value(index, current_absolute_index, result);
+    assert(value_found);
+    return result;
+}
+
+bool ReferenceSampleTree::try_get_bit_value(
+    size_t desired_absolute_index, size_t &current_absolute_index, bool &bit_value) const {
+    for (uint64_t k = 0; k < repetitions; k++) {
+        const size_t relative_index = desired_absolute_index - current_absolute_index;
+        if (relative_index < prefix_bits.size()) {
+            bit_value = prefix_bits[relative_index];
+            return true;
+        }
+        current_absolute_index += prefix_bits.size();
+        for (const ReferenceSampleTree &child : suffix_children) {
+            if (child.try_get_bit_value(desired_absolute_index, current_absolute_index, bit_value)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 std::ostream &stim::operator<<(std::ostream &out, const ReferenceSampleTree &v) {
     out << v.repetitions << "*";
     out << "(";

--- a/src/stim/util_top/reference_sample_tree.h
+++ b/src/stim/util_top/reference_sample_tree.h
@@ -24,6 +24,8 @@ struct ReferenceSampleTree {
     bool operator==(const ReferenceSampleTree &other) const;
     /// Checks if two trees are not exactly the same, including structure (not just uncompressed contents).
     bool operator!=(const ReferenceSampleTree &other) const;
+    /// Returns the bit value for a given absolute index.
+    bool operator[](size_t index) const;
     /// Returns a simple description of the tree's structure, like "5*('101'+6*('11'))".
     std::string str() const;
 
@@ -45,6 +47,8 @@ struct ReferenceSampleTree {
    private:
     /// Helper method for `simplified`.
     void flatten_and_simplify_into(std::vector<ReferenceSampleTree> &out) const;
+    /// Helper method for `operator[]`.
+    bool try_get_bit_value(size_t desired_absolute_index, size_t & current_absolute_index, bool & bit_value) const;
 };
 std::ostream &operator<<(std::ostream &out, const ReferenceSampleTree &v);
 

--- a/src/stim/util_top/reference_sample_tree.test.cc
+++ b/src/stim/util_top/reference_sample_tree.test.cc
@@ -15,6 +15,9 @@ void expect_tree_matches_normal_reference_sample_of(const ReferenceSampleTree &t
     }
     auto expected = TableauSimulator<MAX_BITWORD_WIDTH>::reference_sample_circuit(circuit);
     EXPECT_EQ(actual, expected);
+    for (size_t index = 0; index < decompressed.size(); ++index) {
+        ASSERT_EQ(tree[index], decompressed[index]);
+    }
 }
 
 TEST(ReferenceSampleTree, equality) {
@@ -102,7 +105,7 @@ TEST(ReferenceSampleTree, simplified) {
 
 TEST(ReferenceSampleTree, decompress_into) {
     std::vector<bool> result;
-    ReferenceSampleTree{
+    ReferenceSampleTree tree_under_test{
         .prefix_bits = {1, 1, 0, 1},
         .suffix_children = {ReferenceSampleTree{
             .prefix_bits = {1},
@@ -110,12 +113,16 @@ TEST(ReferenceSampleTree, decompress_into) {
             .repetitions = 5,
         }},
         .repetitions = 2,
+    };
+    tree_under_test.decompress_into(result);
+    std::vector<bool> expected = std::vector<bool>{1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1};
+    ASSERT_EQ(result, expected);
+    for (size_t index = 0; index < expected.size(); ++index) {
+        ASSERT_EQ(tree_under_test[index], expected[index]);
     }
-        .decompress_into(result);
-    ASSERT_EQ(result, (std::vector<bool>{1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1}));
 
     result.clear();
-    ReferenceSampleTree{
+    tree_under_test = ReferenceSampleTree{
         .prefix_bits = {1, 1, 0, 1},
         .suffix_children =
             {
@@ -131,10 +138,14 @@ TEST(ReferenceSampleTree, decompress_into) {
                 },
             },
         .repetitions = 1,
+    };
+    tree_under_test.decompress_into(result);
+    expected =
+        std::vector<bool>{1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 0, 0};
+    ASSERT_EQ(result, expected);
+    for (size_t index = 0; index < expected.size(); ++index) {
+        ASSERT_EQ(tree_under_test[index], expected[index]);
     }
-        .decompress_into(result);
-    ASSERT_EQ(result, (std::vector<bool>{1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0,
-                                         1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 0, 0}));
 }
 
 TEST(ReferenceSampleTree, simple_circuit) {


### PR DESCRIPTION
* Adding `operator[]` to `ReferenceSampleTree`.
  * Allows quick access to any reference sample bit within the tree at a given absolute index.
* Updating `src/stim/util_top/reference_sample_tree.test.cc` to check bit positions, as applicable.