### PR TITLE
Crumble: fix PropagatedPauliFrameLayer.toString when crossings contain objects [one liner]

### DIFF
--- a/glue/crumble/circuit/propagated_pauli_frames.js
+++ b/glue/crumble/circuit/propagated_pauli_frames.js
@@ -55,7 +55,7 @@ class PropagatedPauliFrameLayer {
         for (let q of this.errors) {
             num_qubits = Math.max(num_qubits, q + 1);
         }
-        for (let [q1, q2] of this.crossings) {
+        for (const {q1, q2} of this.crossings) {
             num_qubits = Math.max(num_qubits, q1 + 1);
             num_qubits = Math.max(num_qubits, q2 + 1);
         }

--- a/glue/crumble/circuit/propagated_pauli_frames.tostring.test.js
+++ b/glue/crumble/circuit/propagated_pauli_frames.tostring.test.js
@@ -1,0 +1,12 @@
+import {test, assertThat} from "../test/test_util.js";
+import {PropagatedPauliFrameLayer} from "./propagated_pauli_frames.js";
+
+test("propagated_pauli_frame_layer.toString_handles_object_crossings", () => {
+    const layer = new PropagatedPauliFrameLayer(
+        new Map([[0, 'X']]),
+        new Set(),
+        [{q1: 0, q2: 1, color: 'X'}],
+    );
+    assertThat(() => String(layer)).runsWithoutThrowingAnException();
+});
+


### PR DESCRIPTION
- What: Iterate crossings via {q1, q2} instead of [q1, q2] in PropagatedPauliFrameLayer.toString.
- Why: crossings entries are objects {q1, q2, color}. Array destructuring throws TypeError: .for is not
iterable when calling String(layer) or String(pf).
- Reproducing from dev console in browser (which requires an un-minified version of crumble such as the one you get just by cloning stim and hosting locally):

```
const {Circuit} = await import('./circuit/circuit.js');
const {PropagatedPauliFrames} = await import('./circuit/propagated_pauli_frames.js');
const c = Circuit.fromStimCircuit(`
QUBIT_COORDS(0,0) 0
QUBIT_COORDS(1,0) 1
MARKX(0) 0
TICK
CX 0 1
`);
const pf = PropagatedPauliFrames.fromCircuit(c, 0);
String(pf); // throws in toString() today
```

[This bug was found with the help of AI tools]