### PR TITLE
release: Enable Python 3.13 build for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@
 
 name: ci
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,9 @@
 
 name: ci
 on:
-  workflow_dispatch:
   push:
     branches:
       - main
-      - guenp-patch-1
     tags:
       - v*
   pull_request:
@@ -128,8 +126,6 @@ jobs:
           {os: windows-2025, dist: cp310-win_amd64},
           {os: windows-2025, dist: cp311-win_amd64},
           {os: windows-2025, dist: cp312-win_amd64},
-
-          # (April 2024) disabled because numpy fails to build. Unsure why it's not using a prebuilt wheel.
           {os: windows-2025, dist: cp313-win_amd64},
 
           {os: windows-2025, dist: cp36-win32},

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
           {os: windows-2025, dist: cp312-win_amd64},
 
           # (April 2024) disabled because numpy fails to build. Unsure why it's not using a prebuilt wheel.
-          # {os: windows-2025, dist: cp313-win_amd64},
+          {os: windows-2025, dist: cp313-win_amd64},
 
           {os: windows-2025, dist: cp36-win32},
           {os: windows-2025, dist: cp37-win32},

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ on:
   push:
     branches:
       - main
+      - guenp-patch-1
     tags:
       - v*
   pull_request:


### PR DESCRIPTION
Enable the Python 3.13 build, such that there is a wheel built for the next release on PyPI
This works now (as `numpy` wheels have been uploaded since April 2024). Tested here: https://github.com/guenp/Stim/actions/runs/17592185854