### PR TITLE
Add some circuit and flip sim utility methods

### DIFF
--- a/doc/file_format_stim_circuit.md
+++ b/doc/file_format_stim_circuit.md
@@ -25,7 +25,8 @@ and annotations for tasks such as detection event sampling and drawing the circu
 ## Encoding
 
 Stim circuit files are always encoded using UTF-8.
-Furthermore, the only place in the file where non-ASCII characters are permitted is inside of comments.
+
+(Also, the only place in the file where non-ASCII characters can validly appear is inside of comments and tags.)
 
 ## Syntax
 

--- a/doc/gates.md
+++ b/doc/gates.md
@@ -1784,7 +1784,7 @@ Example:
     # Apply Y to qubit 5 controlled by qubit 2.
     CY 2 5
 
-    # Perform CY 2 5 then CX 4 2.
+    # Perform CY 2 5 then CY 4 2.
     CY 2 5 4 2
 
     # Apply Y to qubit 6 if the most recent measurement result was TRUE.

--- a/doc/stim.pyi
+++ b/doc/stim.pyi
@@ -664,6 +664,8 @@ class Circuit:
         """
     def count_determined_measurements(
         self,
+        *,
+        unknown_input: bool = False,
     ) -> int:
         """Counts the number of predictable measurements in the circuit.
 
@@ -695,6 +697,13 @@ class Circuit:
         the Z basis. Typically this relationship is not declared as a detector, because
         it's not local, or as an observable, because it doesn't store a qubit.
 
+        Args:
+            unknown_input: Defaults to False (inputs assumed to be in the |0> state).
+                When set to True, the inputs are instead treated as being in unknown
+                random states. For example, this means that Z-basis measurements at
+                the very beginning of the circuit will be considered random rather
+                than determined.
+
         Returns:
             The number of measurements that were predictable.
 
@@ -713,6 +722,24 @@ class Circuit:
             ...     M 0
             ... ''').count_determined_measurements()
             0
+
+            >>> stim.Circuit('''
+            ...     M 0
+            ... ''').count_determined_measurements()
+            1
+
+            >>> stim.Circuit('''
+            ...     M 0
+            ... ''').count_determined_measurements(unknown_input=True)
+            0
+
+            >>> stim.Circuit('''
+            ...     M 0
+            ...     M 0 1
+            ...     M 0 1 2
+            ...     M 0 1 2 3
+            ... ''').count_determined_measurements(unknown_input=True)
+            6
 
             >>> stim.Circuit('''
             ...     R 0 1
@@ -1867,6 +1894,65 @@ class Circuit:
             1000 -2 0
             4001 -1 0
             4001 2 0
+        """
+    def missing_detectors(
+        self,
+        *,
+        unknown_input: bool = False,
+    ) -> int:
+        """Finds deterministic measurements independent of declared detectors/observables.
+
+        This method is useful for debugging missing detectors in a circuit, because it
+        identifies generators for uncovered degrees of freedom.
+
+        It's not recommended to use this method to solve for the detectors of a circuit.
+        The returned detectors are not guaranteed to be stable across versions, and
+        aren't optimized to be "good" (e.g. form a low weight basis or be matchable
+        if possible). It will also identify things that are technically determined
+        but that the user may not want to use as a detector, such as the fact that
+        in the first round after transversal Z basis initialization of a toric code
+        the product of all X stabilizer measurements is deterministic even though the
+        individual measurements are all random.
+
+        Args:
+            unknown_input: Defaults to False (inputs assumed to be in the |0> state).
+                When set to True, the inputs are instead treated as being in unknown
+                random states. For example, this means that Z-basis measurements at
+                the very beginning of the circuit will be considered random rather
+                than determined.
+
+        Returns:
+            A circuit containing DETECTOR instructions that specify the uncovered
+            degrees of freedom in the deterministic measurement sets of the input
+            circuit. The returned circuit can be appended to the input circuit to
+            get a circuit with no missing detectors.
+
+        Examples:
+            >>> import stim
+
+            >>> stim.Circuit('''
+            ...     R 0
+            ...     M 0
+            ... ''').missing_detectors()
+            stim.Circuit('''
+                DETECTOR rec[-1]
+            ''')
+
+            >>> stim.Circuit('''
+            ...     MZZ 0 1
+            ...     MYY 0 1
+            ...     MXX 0 1
+            ...     DEPOLARIZE1(0.1) 0 1
+            ...     MZZ 0 1
+            ...     MYY 0 1
+            ...     MXX 0 1
+            ...     DETECTOR rec[-1] rec[-4]
+            ...     DETECTOR rec[-2] rec[-5]
+            ...     DETECTOR rec[-3] rec[-6]
+            ... ''').missing_detectors(unknown_input=True)
+            stim.Circuit('''
+                DETECTOR rec[-3] rec[-2] rec[-1]
+            ''')
         """
     @property
     def num_detectors(
@@ -6353,6 +6439,79 @@ class FlipSimulator:
         Examples:
             >>> import stim
             >>> sim = stim.FlipSimulator(batch_size=256)
+        """
+    def append_measurement_flips(
+        self,
+        measurement_flip_data: np.ndarray,
+    ) -> None:
+        """Appends measurement flip data to the simulator's measurement record.
+
+        Args:
+            measurement_flip_data: The flip data to append. The following shape/dtype
+                combinations are supported.
+
+                Single measurement without bit packing:
+                    shape=(self.batch_size,)
+                    dtype=np.bool_
+
+                Single measurement with bit packing:
+                    shape=(math.ceil(self.batch_size / 8),)
+                    dtype=np.uint8
+
+                Multiple measurements without bit packing:
+                    shape=(num_measurements, self.batch_size)
+                    dtype=np.bool_
+
+                Multiple measurements with bit packing:
+                    shape=(num_measurements, math.ceil(self.batch_size / 8))
+                    dtype=np.uint8
+
+        Examples:
+            >>> import stim
+            >>> import numpy as np
+            >>> sim = stim.FlipSimulator(batch_size=9)
+            >>> sim.append_measurement_flips(np.array(
+            ...     [0, 1, 0, 0, 1, 0, 0, 1, 1],
+            ...     dtype=np.bool_,
+            ... ))
+
+            >>> sim.get_measurement_flips()
+            array([[False,  True, False, False,  True, False, False,  True,  True]])
+
+            >>> sim.append_measurement_flips(np.array(
+            ...     [0b11001001, 0],
+            ...     dtype=np.uint8,
+            ... ))
+
+            >>> sim.get_measurement_flips()
+            array([[False,  True, False, False,  True, False, False,  True,  True],
+                   [ True, False, False,  True, False, False,  True,  True, False]])
+
+            >>> sim.append_measurement_flips(np.array(
+            ...     [[0b11111111, 0b1], [0b00000000, 0b0], [0b11111111, 0b1]],
+            ...     dtype=np.uint8,
+            ... ))
+
+            >>> sim.get_measurement_flips()
+            array([[False,  True, False, False,  True, False, False,  True,  True],
+                   [ True, False, False,  True, False, False,  True,  True, False],
+                   [ True,  True,  True,  True,  True,  True,  True,  True,  True],
+                   [False, False, False, False, False, False, False, False, False],
+                   [ True,  True,  True,  True,  True,  True,  True,  True,  True]])
+
+            >>> sim.append_measurement_flips(np.array(
+            ...     [[1, 0, 1, 0, 1, 0, 1, 0, 1], [0, 1, 0, 1, 0, 1, 0, 1, 0]],
+            ...     dtype=np.bool_,
+            ... ))
+
+            >>> sim.get_measurement_flips()
+            array([[False,  True, False, False,  True, False, False,  True,  True],
+                   [ True, False, False,  True, False, False,  True,  True, False],
+                   [ True,  True,  True,  True,  True,  True,  True,  True,  True],
+                   [False, False, False, False, False, False, False, False, False],
+                   [ True,  True,  True,  True,  True,  True,  True,  True,  True],
+                   [ True, False,  True, False,  True, False,  True, False,  True],
+                   [False,  True, False,  True, False,  True, False,  True, False]])
         """
     @property
     def batch_size(

--- a/file_lists/source_files_no_main
+++ b/file_lists/source_files_no_main
@@ -96,6 +96,7 @@ src/stim/util_top/export_qasm.cc
 src/stim/util_top/export_quirk_url.cc
 src/stim/util_top/has_flow.cc
 src/stim/util_top/mbqc_decomposition.cc
+src/stim/util_top/missing_detectors.cc
 src/stim/util_top/reference_sample_tree.cc
 src/stim/util_top/simplified_circuit.cc
 src/stim/util_top/transform_without_feedback.cc

--- a/file_lists/test_files
+++ b/file_lists/test_files
@@ -93,6 +93,7 @@ src/stim/util_top/export_qasm.test.cc
 src/stim/util_top/export_quirk_url.test.cc
 src/stim/util_top/has_flow.test.cc
 src/stim/util_top/mbqc_decomposition.test.cc
+src/stim/util_top/missing_detectors.test.cc
 src/stim/util_top/reference_sample_tree.test.cc
 src/stim/util_top/simplified_circuit.test.cc
 src/stim/util_top/stabilizers_to_tableau.test.cc

--- a/glue/python/src/stim/__init__.pyi
+++ b/glue/python/src/stim/__init__.pyi
@@ -664,6 +664,8 @@ class Circuit:
         """
     def count_determined_measurements(
         self,
+        *,
+        unknown_input: bool = False,
     ) -> int:
         """Counts the number of predictable measurements in the circuit.
 
@@ -695,6 +697,13 @@ class Circuit:
         the Z basis. Typically this relationship is not declared as a detector, because
         it's not local, or as an observable, because it doesn't store a qubit.
 
+        Args:
+            unknown_input: Defaults to False (inputs assumed to be in the |0> state).
+                When set to True, the inputs are instead treated as being in unknown
+                random states. For example, this means that Z-basis measurements at
+                the very beginning of the circuit will be considered random rather
+                than determined.
+
         Returns:
             The number of measurements that were predictable.
 
@@ -713,6 +722,24 @@ class Circuit:
             ...     M 0
             ... ''').count_determined_measurements()
             0
+
+            >>> stim.Circuit('''
+            ...     M 0
+            ... ''').count_determined_measurements()
+            1
+
+            >>> stim.Circuit('''
+            ...     M 0
+            ... ''').count_determined_measurements(unknown_input=True)
+            0
+
+            >>> stim.Circuit('''
+            ...     M 0
+            ...     M 0 1
+            ...     M 0 1 2
+            ...     M 0 1 2 3
+            ... ''').count_determined_measurements(unknown_input=True)
+            6
 
             >>> stim.Circuit('''
             ...     R 0 1
@@ -1867,6 +1894,65 @@ class Circuit:
             1000 -2 0
             4001 -1 0
             4001 2 0
+        """
+    def missing_detectors(
+        self,
+        *,
+        unknown_input: bool = False,
+    ) -> int:
+        """Finds deterministic measurements independent of declared detectors/observables.
+
+        This method is useful for debugging missing detectors in a circuit, because it
+        identifies generators for uncovered degrees of freedom.
+
+        It's not recommended to use this method to solve for the detectors of a circuit.
+        The returned detectors are not guaranteed to be stable across versions, and
+        aren't optimized to be "good" (e.g. form a low weight basis or be matchable
+        if possible). It will also identify things that are technically determined
+        but that the user may not want to use as a detector, such as the fact that
+        in the first round after transversal Z basis initialization of a toric code
+        the product of all X stabilizer measurements is deterministic even though the
+        individual measurements are all random.
+
+        Args:
+            unknown_input: Defaults to False (inputs assumed to be in the |0> state).
+                When set to True, the inputs are instead treated as being in unknown
+                random states. For example, this means that Z-basis measurements at
+                the very beginning of the circuit will be considered random rather
+                than determined.
+
+        Returns:
+            A circuit containing DETECTOR instructions that specify the uncovered
+            degrees of freedom in the deterministic measurement sets of the input
+            circuit. The returned circuit can be appended to the input circuit to
+            get a circuit with no missing detectors.
+
+        Examples:
+            >>> import stim
+
+            >>> stim.Circuit('''
+            ...     R 0
+            ...     M 0
+            ... ''').missing_detectors()
+            stim.Circuit('''
+                DETECTOR rec[-1]
+            ''')
+
+            >>> stim.Circuit('''
+            ...     MZZ 0 1
+            ...     MYY 0 1
+            ...     MXX 0 1
+            ...     DEPOLARIZE1(0.1) 0 1
+            ...     MZZ 0 1
+            ...     MYY 0 1
+            ...     MXX 0 1
+            ...     DETECTOR rec[-1] rec[-4]
+            ...     DETECTOR rec[-2] rec[-5]
+            ...     DETECTOR rec[-3] rec[-6]
+            ... ''').missing_detectors(unknown_input=True)
+            stim.Circuit('''
+                DETECTOR rec[-3] rec[-2] rec[-1]
+            ''')
         """
     @property
     def num_detectors(
@@ -6353,6 +6439,79 @@ class FlipSimulator:
         Examples:
             >>> import stim
             >>> sim = stim.FlipSimulator(batch_size=256)
+        """
+    def append_measurement_flips(
+        self,
+        measurement_flip_data: np.ndarray,
+    ) -> None:
+        """Appends measurement flip data to the simulator's measurement record.
+
+        Args:
+            measurement_flip_data: The flip data to append. The following shape/dtype
+                combinations are supported.
+
+                Single measurement without bit packing:
+                    shape=(self.batch_size,)
+                    dtype=np.bool_
+
+                Single measurement with bit packing:
+                    shape=(math.ceil(self.batch_size / 8),)
+                    dtype=np.uint8
+
+                Multiple measurements without bit packing:
+                    shape=(num_measurements, self.batch_size)
+                    dtype=np.bool_
+
+                Multiple measurements with bit packing:
+                    shape=(num_measurements, math.ceil(self.batch_size / 8))
+                    dtype=np.uint8
+
+        Examples:
+            >>> import stim
+            >>> import numpy as np
+            >>> sim = stim.FlipSimulator(batch_size=9)
+            >>> sim.append_measurement_flips(np.array(
+            ...     [0, 1, 0, 0, 1, 0, 0, 1, 1],
+            ...     dtype=np.bool_,
+            ... ))
+
+            >>> sim.get_measurement_flips()
+            array([[False,  True, False, False,  True, False, False,  True,  True]])
+
+            >>> sim.append_measurement_flips(np.array(
+            ...     [0b11001001, 0],
+            ...     dtype=np.uint8,
+            ... ))
+
+            >>> sim.get_measurement_flips()
+            array([[False,  True, False, False,  True, False, False,  True,  True],
+                   [ True, False, False,  True, False, False,  True,  True, False]])
+
+            >>> sim.append_measurement_flips(np.array(
+            ...     [[0b11111111, 0b1], [0b00000000, 0b0], [0b11111111, 0b1]],
+            ...     dtype=np.uint8,
+            ... ))
+
+            >>> sim.get_measurement_flips()
+            array([[False,  True, False, False,  True, False, False,  True,  True],
+                   [ True, False, False,  True, False, False,  True,  True, False],
+                   [ True,  True,  True,  True,  True,  True,  True,  True,  True],
+                   [False, False, False, False, False, False, False, False, False],
+                   [ True,  True,  True,  True,  True,  True,  True,  True,  True]])
+
+            >>> sim.append_measurement_flips(np.array(
+            ...     [[1, 0, 1, 0, 1, 0, 1, 0, 1], [0, 1, 0, 1, 0, 1, 0, 1, 0]],
+            ...     dtype=np.bool_,
+            ... ))
+
+            >>> sim.get_measurement_flips()
+            array([[False,  True, False, False,  True, False, False,  True,  True],
+                   [ True, False, False,  True, False, False,  True,  True, False],
+                   [ True,  True,  True,  True,  True,  True,  True,  True,  True],
+                   [False, False, False, False, False, False, False, False, False],
+                   [ True,  True,  True,  True,  True,  True,  True,  True,  True],
+                   [ True, False,  True, False,  True, False,  True, False,  True],
+                   [False,  True, False,  True, False,  True, False,  True, False]])
         """
     @property
     def batch_size(

--- a/src/stim.h
+++ b/src/stim.h
@@ -118,6 +118,7 @@
 #include "stim/util_top/export_quirk_url.h"
 #include "stim/util_top/has_flow.h"
 #include "stim/util_top/mbqc_decomposition.h"
+#include "stim/util_top/missing_detectors.h"
 #include "stim/util_top/reference_sample_tree.h"
 #include "stim/util_top/simplified_circuit.h"
 #include "stim/util_top/stabilizers_to_tableau.h"

--- a/src/stim/gates/gate_data_controlled.cc
+++ b/src/stim/gates/gate_data_controlled.cc
@@ -380,7 +380,7 @@ Example:
     # Apply Y to qubit 5 controlled by qubit 2.
     CY 2 5
 
-    # Perform CY 2 5 then CX 4 2.
+    # Perform CY 2 5 then CY 4 2.
     CY 2 5 4 2
 
     # Apply Y to qubit 6 if the most recent measurement result was TRUE.

--- a/src/stim/mem/simd_bits.h
+++ b/src/stim/mem/simd_bits.h
@@ -128,6 +128,8 @@ struct simd_bits {
 
     /// Returns whether or not the two ranges have set bits in common.
     bool intersects(const simd_bits_range_ref<W> other) const;
+    /// Returns whether or not all bits that are set in `other` are also set in this range.
+    bool is_subset_of_or_equal_to(const simd_bits_range_ref<W> other) const;
 
     /// Writes bits from another location.
     /// Bits not part of the write are unchanged.
@@ -158,6 +160,19 @@ struct simd_bits {
     }
 
     uint64_t as_u64() const;
+
+    template <typename CALLBACK>
+    void for_each_set_bit(CALLBACK callback) const {
+        size_t n = num_u64_padded();
+        for (size_t w = 0; w < n; w++) {
+            uint64_t v = u64[w];
+            while (v) {
+                size_t q = w * 64 + std::countr_zero(v);
+                v &= v - 1;
+                callback(q);
+            }
+        }
+    }
 };
 
 template <size_t W>

--- a/src/stim/mem/simd_bits.inl
+++ b/src/stim/mem/simd_bits.inl
@@ -285,6 +285,11 @@ bool simd_bits<W>::intersects(const simd_bits_range_ref<W> other) const {
 }
 
 template <size_t W>
+bool simd_bits<W>::is_subset_of_or_equal_to(const simd_bits_range_ref<W> other) const {
+    return simd_bits_range_ref<W>(*this).is_subset_of_or_equal_to(other);
+}
+
+template <size_t W>
 std::string simd_bits<W>::str() const {
     return simd_bits_range_ref<W>(*this).str();
 }

--- a/src/stim/mem/simd_bits_range_ref.h
+++ b/src/stim/mem/simd_bits_range_ref.h
@@ -118,6 +118,8 @@ struct simd_bits_range_ref {
     size_t countr_zero() const;
     /// Returns whether or not the two ranges have set bits in common.
     bool intersects(const simd_bits_range_ref other) const;
+    /// Returns whether or not all bits that are set in `other` are also set in this range.
+    bool is_subset_of_or_equal_to(const simd_bits_range_ref<W> other) const;
 
     /// Writes bits from another location.
     /// Bits not part of the write are unchanged.

--- a/src/stim/mem/simd_bits_range_ref.inl
+++ b/src/stim/mem/simd_bits_range_ref.inl
@@ -248,6 +248,19 @@ bool simd_bits_range_ref<W>::intersects(const simd_bits_range_ref<W> other) cons
 }
 
 template <size_t W>
+bool simd_bits_range_ref<W>::is_subset_of_or_equal_to(const simd_bits_range_ref<W> other) const {
+    size_t n = std::min(num_u64_padded(), other.num_u64_padded());
+    uint64_t v = 0;
+    for (size_t k = 0; k < n; k++) {
+        v |= u64[k] & ~other.u64[k];
+    }
+    for (size_t k = other.num_u64_padded(); k < num_u64_padded(); k++) {
+        v |= u64[k];
+    }
+    return v == 0;
+}
+
+template <size_t W>
 uint64_t simd_bits_range_ref<W>::as_u64() const {
     size_t n64 = num_u64_padded();
     for (size_t k = 1; k < n64; k++) {

--- a/src/stim/mem/simd_bits_range_ref.test.cc
+++ b/src/stim/mem/simd_bits_range_ref.test.cc
@@ -391,6 +391,27 @@ TEST_EACH_WORD_SIZE_W(simd_bits_range_ref, intersects, {
     ASSERT_EQ(ref.intersects(other), true);
 })
 
+TEST_EACH_WORD_SIZE_W(simd_bits_range_ref, is_subset_of_or_equal_to, {
+    simd_bits<W> data(1024);
+    simd_bits<W> other(512);
+    simd_bits_range_ref<W> ref(data);
+    ASSERT_EQ(data.is_subset_of_or_equal_to(other), true);
+    ASSERT_EQ(ref.is_subset_of_or_equal_to(other), true);
+    other[511] = true;
+    ASSERT_EQ(data.is_subset_of_or_equal_to(other), true);
+    ASSERT_EQ(ref.is_subset_of_or_equal_to(other), true);
+    data[511] = true;
+    ASSERT_EQ(data.is_subset_of_or_equal_to(other), true);
+    ASSERT_EQ(ref.is_subset_of_or_equal_to(other), true);
+    other[511] = false;
+    ASSERT_EQ(data.is_subset_of_or_equal_to(other), false);
+    ASSERT_EQ(ref.is_subset_of_or_equal_to(other), false);
+    other[511] = true;
+    data[513] = true;
+    ASSERT_EQ(data.is_subset_of_or_equal_to(other), false);
+    ASSERT_EQ(ref.is_subset_of_or_equal_to(other), false);
+})
+
 TEST_EACH_WORD_SIZE_W(simd_bits_range_ref, prefix_ref, {
     simd_bits<W> data(1024);
     simd_bits_range_ref<W> ref(data);

--- a/src/stim/util_top/count_determined_measurements.test.cc
+++ b/src/stim/util_top/count_determined_measurements.test.cc
@@ -22,6 +22,43 @@
 
 using namespace stim;
 
+TEST_EACH_WORD_SIZE_W(count_determined_measurements, unknown_input, {
+    ASSERT_EQ(
+        count_determined_measurements<W>(Circuit(R"CIRCUIT(
+            MZZ 0 1
+        )CIRCUIT")),
+        1);
+    ASSERT_EQ(
+        count_determined_measurements<W>(Circuit(R"CIRCUIT(
+            MZZ 0 1
+        )CIRCUIT"), true),
+        0);
+    ASSERT_EQ(
+        count_determined_measurements<W>(Circuit(R"CIRCUIT(
+            MPP Z0*Z1 X2*X3
+        )CIRCUIT")),
+        1);
+    ASSERT_EQ(
+        count_determined_measurements<W>(Circuit(R"CIRCUIT(
+            MPP Z0*Z1 X2*X3
+        )CIRCUIT"), true),
+        0);
+    ASSERT_EQ(
+        count_determined_measurements<W>(Circuit(R"CIRCUIT(
+            MPP Z0*Z1 X2*X3
+            TICK
+            MPP Z0*Z1 X2*X3
+        )CIRCUIT"), true),
+        2);
+    ASSERT_EQ(
+        count_determined_measurements<W>(Circuit(R"CIRCUIT(
+            MPP Z0*Z1 X2*X3
+            TICK
+            MPP Z0*Z1 X2*X3
+        )CIRCUIT")),
+        3);
+})
+
 TEST_EACH_WORD_SIZE_W(count_determined_measurements, single_qubit_measurements_baseline, {
     ASSERT_EQ(
         count_determined_measurements<W>(Circuit(R"CIRCUIT(

--- a/src/stim/util_top/missing_detectors.cc
+++ b/src/stim/util_top/missing_detectors.cc
@@ -1,0 +1,136 @@
+#include "stim/util_top/missing_detectors.h"
+#include "stim/util_top/circuit_flow_generators.h"
+
+using namespace stim;
+
+static Circuit missing_detectors_impl(const Circuit& circuit) {
+    size_t num_measurements = circuit.count_measurements();
+    std::vector<std::pair<simd_bits<64>, bool>> rows;
+    std::vector<simd_bits<64>> logical_operators;
+    std::set<size_t> ignored_logical_operators;
+
+    // Turn existing detectors and observables into rows in the table.
+    uint64_t measurement_offset = 0;
+    circuit.for_each_operation([&](CircuitInstruction inst) {
+        measurement_offset += inst.count_measurement_results();
+
+        if (inst.gate_type == GateType::DETECTOR || inst.gate_type == GateType::OBSERVABLE_INCLUDE) {
+            if (inst.gate_type == GateType::DETECTOR) {
+                rows.push_back({simd_bits<64>(num_measurements), false});
+            } else {
+                while (logical_operators.size() <= (size_t)inst.args[0]) {
+                    logical_operators.push_back(simd_bits<64>(num_measurements));
+                }
+            }
+            simd_bits_range_ref<64> row = inst.gate_type == GateType::DETECTOR ? rows.back().first : logical_operators[(size_t)inst.args[0]];
+            for (auto e : inst.targets) {
+                if (e.is_measurement_record_target()) {
+                    row[e.rec_offset() + measurement_offset] ^= true;
+                } else if (e.is_pauli_target() && inst.gate_type == GateType::OBSERVABLE_INCLUDE) {
+                    ignored_logical_operators.insert((size_t)inst.args[0]);
+                }
+            }
+        }
+    });
+    for (size_t k = 0; k < logical_operators.size(); k++) {
+        if (!ignored_logical_operators.contains(k)) {
+            rows.push_back({std::move(logical_operators[k]), false});
+        }
+    }
+    std::vector<simd_bits<64>> original_detector_rows_for_cleanup;
+    for (const auto &row : rows) {
+        original_detector_rows_for_cleanup.push_back(row.first);
+    }
+
+    // Turn measurement invariants into rows in the table.
+    for (const auto &generator : circuit_flow_generators<64>(circuit)) {
+        if (generator.input.ref().has_no_pauli_terms() && generator.output.ref().has_no_pauli_terms() && generator.observables.empty()) {
+            rows.push_back({simd_bits<64>(num_measurements), true});
+            for (int32_t e : generator.measurements) {
+                if (e < 0) {
+                    rows.back().first[e + num_measurements] ^= true;
+                } else {
+                    rows.back().first[e] ^= true;
+                }
+            }
+        }
+    }
+
+    // Perform Gaussian elimination on the table.
+    size_t num_solved = 0;
+    for (size_t k = 0; k < num_measurements; k++) {
+        size_t pivot = SIZE_MAX;
+        // Try to find a DETECTOR pivot.
+        for (size_t r = num_solved; r < rows.size() && pivot == SIZE_MAX; r++) {
+            if (rows[r].first[k] && !rows[r].second) {
+                pivot = r;
+            }
+        }
+        // Fall back to a flow invariant pivot.
+        for (size_t r = num_solved; r < rows.size() && pivot == SIZE_MAX; r++) {
+            if (rows[r].first[k]) {
+                pivot = r;
+            }
+        }
+        if (pivot == SIZE_MAX) {
+            continue;
+        }
+
+        for (size_t r = 0; r < rows.size(); r++) {
+            if (rows[r].first[k] && r != pivot) {
+                rows[r].first ^= rows[pivot].first;
+            }
+        }
+        if (pivot != num_solved) {
+            std::swap(rows[pivot], rows[num_solved]);
+        }
+        num_solved++;
+    }
+
+
+    // Any rows from invariants that the detector rows failed to clear are assumed to be the missing detectors.
+    Circuit result;
+    for (auto &r : rows) {
+        if (r.second && r.first.not_zero()) {
+            // Attempt to reduce the weight of the results by at least not overlapping with existing detectors.
+            for (const auto &det : original_detector_rows_for_cleanup) {
+                if (r.first.is_subset_of_or_equal_to(det)) {
+                    r.first ^= det;
+                }
+            }
+
+            // Convert set bits into a DETECTOR instruction.
+            r.first.for_each_set_bit([&](size_t bit_position) {
+                result.target_buf.append_tail(GateTarget::rec((int32_t)bit_position - (int32_t)num_measurements));
+            });
+            result.operations.push_back(CircuitInstruction{
+                GateType::DETECTOR,
+                {},
+                result.target_buf.commit_tail(),
+                "",
+            });
+        }
+    }
+
+    return result;
+}
+
+Circuit stim::missing_detectors(const Circuit& circuit, bool unknown_input) {
+    if (unknown_input) {
+        return missing_detectors_impl(circuit);
+    } else {
+        Circuit with_resets;
+        uint32_t num_qubits = (uint32_t)circuit.count_qubits();
+        for (uint32_t k = 0; k < num_qubits; k++) {
+            with_resets.target_buf.append_tail(GateTarget::qubit(k));
+        }
+        with_resets.operations.push_back(CircuitInstruction{
+            GateType::R,
+            {},
+            with_resets.target_buf.commit_tail(),
+            "",
+        });
+        with_resets += circuit;
+        return missing_detectors_impl(with_resets);
+    }
+}

--- a/src/stim/util_top/missing_detectors.h
+++ b/src/stim/util_top/missing_detectors.h
@@ -14,18 +14,15 @@
  * limitations under the License.
  */
 
-#ifndef _STIM_UTIL_TOP_COUNT_DETERMINED_MEASUREMENTS_H
-#define _STIM_UTIL_TOP_COUNT_DETERMINED_MEASUREMENTS_H
+#ifndef _STIM_UTIL_TOP_MISSING_DETECTORS_H
+#define _STIM_UTIL_TOP_MISSING_DETECTORS_H
 
 #include "stim/circuit/circuit.h"
 
 namespace stim {
 
-template <size_t W>
-uint64_t count_determined_measurements(const Circuit &circuit, bool unknown_input = false);
+Circuit missing_detectors(const Circuit &circuit, bool unknown_input);
 
 }  // namespace stim
-
-#include "stim/util_top/count_determined_measurements.inl"
 
 #endif

--- a/src/stim/util_top/missing_detectors.test.cc
+++ b/src/stim/util_top/missing_detectors.test.cc
@@ -1,0 +1,366 @@
+#include "stim/util_top/missing_detectors.h"
+
+#include <stim/simulators/error_analyzer.h>
+#include <stim/util_bot/test_util.test.h>
+
+#include "gtest/gtest.h"
+
+#include "stim/circuit/circuit.h"
+#include "stim/util_top/has_flow.h"
+
+using namespace stim;
+
+TEST(missing_detectors, circuit) {
+    ASSERT_EQ(missing_detectors(Circuit(R"CIRCUIT(
+    )CIRCUIT"), false), Circuit(R"CIRCUIT(
+    )CIRCUIT"));
+
+    ASSERT_EQ(missing_detectors(Circuit(R"CIRCUIT(
+        R 0
+        M 0
+        DETECTOR rec[-1]
+    )CIRCUIT"), false), Circuit(R"CIRCUIT(
+    )CIRCUIT"));
+
+    ASSERT_EQ(missing_detectors(Circuit(R"CIRCUIT(
+        R 0
+        M 0
+        DETECTOR rec[-1]
+        DETECTOR rec[-1]
+    )CIRCUIT"), false), Circuit(R"CIRCUIT(
+    )CIRCUIT"));
+
+    ASSERT_EQ(missing_detectors(Circuit(R"CIRCUIT(
+        R 0
+        M 0
+    )CIRCUIT"), false), Circuit(R"CIRCUIT(
+        DETECTOR rec[-1]
+    )CIRCUIT"));
+
+    ASSERT_EQ(missing_detectors(Circuit(R"CIRCUIT(
+        M 0
+    )CIRCUIT"), false), Circuit(R"CIRCUIT(
+        DETECTOR rec[-1]
+    )CIRCUIT"));
+
+    ASSERT_EQ(missing_detectors(Circuit(R"CIRCUIT(
+        M 0
+    )CIRCUIT"), true), Circuit(R"CIRCUIT(
+    )CIRCUIT"));
+
+    ASSERT_EQ(missing_detectors(Circuit(R"CIRCUIT(
+        R 0 1
+        M 0 1
+        DETECTOR rec[-1]
+    )CIRCUIT"), false), Circuit(R"CIRCUIT(
+        DETECTOR rec[-2]
+    )CIRCUIT"));
+
+    ASSERT_EQ(missing_detectors(Circuit(R"CIRCUIT(
+        MPP Z0*Z1 X0*X1
+        TICK
+        MPP Z0*Z1 X0*X1
+        DETECTOR rec[-1] rec[-3]
+        DETECTOR rec[-2] rec[-4]
+    )CIRCUIT"), false), Circuit(R"CIRCUIT(
+        DETECTOR rec[-4]
+    )CIRCUIT"));
+
+    ASSERT_EQ(missing_detectors(Circuit(R"CIRCUIT(
+        MPP Z0*Z1 X0*X1
+        TICK
+        MPP Z0*Z1 X0*X1
+        DETECTOR rec[-1] rec[-3]
+        DETECTOR rec[-2] rec[-4]
+        DETECTOR rec[-1] rec[-3] rec[-2] rec[-4]
+    )CIRCUIT"), false), Circuit(R"CIRCUIT(
+        DETECTOR rec[-3] rec[-2] rec[-1]
+    )CIRCUIT"));
+
+    ASSERT_EQ(missing_detectors(Circuit(R"CIRCUIT(
+        MPP Z0*Z1 X0*X1
+        TICK
+        MPP Z0*Z1 X0*X1
+        DETECTOR rec[-1] rec[-3]
+        DETECTOR rec[-2] rec[-4]
+    )CIRCUIT"), true), Circuit(R"CIRCUIT(
+    )CIRCUIT"));
+
+    ASSERT_EQ(missing_detectors(Circuit(R"CIRCUIT(
+        MPP Z0*Z1 X0*X1
+        TICK
+        MPP Z0*Z1 X0*X1
+        OBSERVABLE_INCLUDE(0) rec[-1]
+        DETECTOR rec[-2] rec[-4]
+        OBSERVABLE_INCLUDE(0) rec[-3]
+    )CIRCUIT"), true), Circuit(R"CIRCUIT(
+    )CIRCUIT"));
+
+    ASSERT_EQ(missing_detectors(Circuit(R"CIRCUIT(
+        OBSERVABLE_INCLUDE(0) Z0 Z1
+        MPP Z0*Z1 X0*X1
+        TICK
+        MPP Z0*Z1 X0*X1
+        OBSERVABLE_INCLUDE(0) Z0 Z1
+        OBSERVABLE_INCLUDE(0) rec[-1]
+        DETECTOR rec[-2] rec[-4]
+        OBSERVABLE_INCLUDE(0) rec[-3]
+    )CIRCUIT"), true), Circuit(R"CIRCUIT(
+        DETECTOR rec[-3] rec[-1]
+    )CIRCUIT"));
+}
+
+TEST(missing_detectors, big_case_honeycomb_code) {
+    Circuit c = Circuit(R"CIRCUIT(
+        R 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53
+        TICK
+        MYY 8 9 17 18 26 27 35 36 44 45 51 52 5 6 14 15 23 24 32 33 41 42 0 1 7 16 25 34 43 50 11 12 20 21 29 30 38 39 47 48 3 4 13 22 31 40 2 10 19 28 37 46 49 53
+        TICK
+        MX 0 1 2 3 4 8 51 50 52 41 47 53
+        MXX 48 49 9 10 18 19 27 28 36 37 45 46 11 20 29 38 6 7 15 16 24 25 33 34 42 43 12 13 21 22 30 31 39 40 5 14 23 32 17 26 35 44
+        DETECTOR rec[-32] rec[-33] rec[-49]
+        DETECTOR rec[-29] rec[-30] rec[-40]
+        DETECTOR rec[-25] rec[-27] rec[-55]
+        DETECTOR rec[-21] rec[-22] rec[-23] rec[-34] rec[-41]
+        DETECTOR rec[-20] rec[-28] rec[-31] rec[-37] rec[-60]
+        DETECTOR rec[-9] rec[-24] rec[-26] rec[-46] rec[-50]
+        DETECTOR rec[-7] rec[-8] rec[-15] rec[-39] rec[-44] rec[-45]
+        DETECTOR rec[-5] rec[-6] rec[-14] rec[-38] rec[-42] rec[-43]
+        DETECTOR rec[-4] rec[-12] rec[-13] rec[-48] rec[-53] rec[-54]
+        DETECTOR rec[-3] rec[-10] rec[-11] rec[-47] rec[-51] rec[-52]
+        DETECTOR rec[-2] rec[-18] rec[-19] rec[-36] rec[-58] rec[-59]
+        DETECTOR rec[-1] rec[-16] rec[-17] rec[-35] rec[-56] rec[-57]
+        TICK
+        M 0 5 14 23 32 41 13 22 31 40 49 53
+        MZZ 19 20 28 29 37 38 46 47 10 11 21 30 4 12 2 3 39 48 16 17 25 26 34 35 43 44 50 51 7 8 15 24 1 6 33 42 9 18 27 36 45 52
+        TICK
+        MYY 8 9 17 18 26 27 35 36 44 45 51 52 5 6 14 15 23 24 32 33 41 42 0 1 7 16 25 34 43 50 11 12 20 21 29 30 38 39 47 48 3 4 13 22 31 40 2 10 19 28 37 46 49 53
+        DETECTOR rec[-15] rec[-26] rec[-27] rec[-30] rec[-34] rec[-39] rec[-108] rec[-119] rec[-120]
+        DETECTOR rec[-14] rec[-24] rec[-25] rec[-29] rec[-37] rec[-38] rec[-107] rec[-117] rec[-118]
+        DETECTOR rec[-13] rec[-22] rec[-23] rec[-28] rec[-35] rec[-36] rec[-106] rec[-115] rec[-116]
+        DETECTOR rec[-4] rec[-7] rec[-12] rec[-41] rec[-42] rec[-44] rec[-97] rec[-100] rec[-105]
+        DETECTOR rec[-3] rec[-10] rec[-11] rec[-43] rec[-47] rec[-48] rec[-96] rec[-103] rec[-104]
+        DETECTOR rec[-2] rec[-8] rec[-9] rec[-40] rec[-45] rec[-46] rec[-95] rec[-101] rec[-102]
+        TICK
+        M 0 5 14 23 32 41 13 22 31 40 49 53
+        MZZ 19 20 28 29 37 38 46 47 10 11 21 30 4 12 2 3 39 48 16 17 25 26 34 35 43 44 50 51 7 8 15 24 1 6 33 42 9 18 27 36 45 52
+        DETECTOR rec[-26] rec[-27] rec[-86] rec[-87]
+        DETECTOR rec[-24] rec[-25] rec[-84] rec[-85]
+        DETECTOR rec[-22] rec[-23] rec[-82] rec[-83]
+        DETECTOR rec[-16] rec[-20] rec[-21] rec[-76] rec[-80] rec[-81]
+        DETECTOR rec[-14] rec[-15] rec[-17] rec[-74] rec[-75] rec[-77]
+        DETECTOR rec[-13] rec[-18] rec[-19] rec[-73] rec[-78] rec[-79]
+        DETECTOR rec[-6] rec[-30] rec[-31] rec[-66] rec[-90] rec[-91]
+        DETECTOR rec[-5] rec[-32] rec[-33] rec[-65] rec[-92] rec[-93]
+        DETECTOR rec[-4] rec[-28] rec[-29] rec[-64] rec[-88] rec[-89]
+        DETECTOR rec[-3] rec[-7] rec[-12] rec[-63] rec[-67] rec[-72]
+        DETECTOR rec[-2] rec[-10] rec[-11] rec[-62] rec[-70] rec[-71]
+        DETECTOR rec[-1] rec[-8] rec[-9] rec[-61] rec[-68] rec[-69]
+        TICK
+        MX 0 1 2 3 4 8 51 50 52 41 47 53
+        MXX 48 49 9 10 18 19 27 28 36 37 45 46 11 20 29 38 6 7 15 16 24 25 33 34 42 43 12 13 21 22 30 31 39 40 5 14 23 32 17 26 35 44
+        DETECTOR rec[-30] rec[-31] rec[-47] rec[-107] rec[-156] rec[-157]
+        DETECTOR rec[-26] rec[-27] rec[-41] rec[-101] rec[-152] rec[-153]
+        DETECTOR rec[-16] rec[-23] rec[-25] rec[-34] rec[-51] rec[-94] rec[-111] rec[-142] rec[-149] rec[-151]
+        DETECTOR rec[-15] rec[-19] rec[-20] rec[-36] rec[-50] rec[-54] rec[-96] rec[-110] rec[-114] rec[-141] rec[-145] rec[-146]
+        DETECTOR rec[-14] rec[-17] rec[-18] rec[-35] rec[-52] rec[-53] rec[-95] rec[-112] rec[-113] rec[-140] rec[-143] rec[-144]
+        DETECTOR rec[-13] rec[-28] rec[-32] rec[-38] rec[-40] rec[-98] rec[-100] rec[-139] rec[-154] rec[-158]
+        DETECTOR rec[-2] rec[-11] rec[-12] rec[-39] rec[-44] rec[-45] rec[-99] rec[-104] rec[-105] rec[-128] rec[-137] rec[-138]
+        DETECTOR rec[-1] rec[-9] rec[-10] rec[-37] rec[-42] rec[-43] rec[-97] rec[-102] rec[-103] rec[-127] rec[-135] rec[-136]
+        TICK
+        MYY 8 9 17 18 26 27 35 36 44 45 51 52 5 6 14 15 23 24 32 33 41 42 0 1 7 16 25 34 43 50 11 12 20 21 29 30 38 39 47 48 3 4 13 22 31 40 2 10 19 28 37 46 49 53
+        DETECTOR rec[-15] rec[-20] rec[-21] rec[-31] rec[-39] rec[-40] rec[-157] rec[-165] rec[-166] rec[-201] rec[-206] rec[-207]
+        DETECTOR rec[-14] rec[-18] rec[-19] rec[-30] rec[-37] rec[-38] rec[-156] rec[-163] rec[-164] rec[-200] rec[-204] rec[-205]
+        DETECTOR rec[-6] rec[-11] rec[-12] rec[-34] rec[-35] rec[-42] rec[-160] rec[-161] rec[-168] rec[-192] rec[-197] rec[-198]
+        DETECTOR rec[-5] rec[-9] rec[-10] rec[-32] rec[-33] rec[-41] rec[-158] rec[-159] rec[-167] rec[-191] rec[-195] rec[-196]
+        DETECTOR rec[-3] rec[-25] rec[-26] rec[-29] rec[-45] rec[-46] rec[-155] rec[-171] rec[-172] rec[-189] rec[-211] rec[-212]
+        DETECTOR rec[-2] rec[-23] rec[-24] rec[-28] rec[-43] rec[-44] rec[-154] rec[-169] rec[-170] rec[-188] rec[-209] rec[-210]
+        TICK
+        MX 0 1 2 3 4 8 51 50 52 41 47 53
+        MXX 48 49 9 10 18 19 27 28 36 37 45 46 11 20 29 38 6 7 15 16 24 25 33 34 42 43 12 13 21 22 30 31 39 40 5 14 23 32 17 26 35 44
+        DETECTOR rec[-32] rec[-33] rec[-92] rec[-93]
+        DETECTOR rec[-29] rec[-30] rec[-89] rec[-90]
+        DETECTOR rec[-25] rec[-27] rec[-85] rec[-87]
+        DETECTOR rec[-21] rec[-22] rec[-23] rec[-81] rec[-82] rec[-83]
+        DETECTOR rec[-20] rec[-28] rec[-31] rec[-80] rec[-88] rec[-91]
+        DETECTOR rec[-9] rec[-24] rec[-26] rec[-69] rec[-84] rec[-86]
+        DETECTOR rec[-7] rec[-8] rec[-15] rec[-67] rec[-68] rec[-75]
+        DETECTOR rec[-5] rec[-6] rec[-14] rec[-65] rec[-66] rec[-74]
+        DETECTOR rec[-4] rec[-12] rec[-13] rec[-64] rec[-72] rec[-73]
+        DETECTOR rec[-3] rec[-10] rec[-11] rec[-63] rec[-70] rec[-71]
+        DETECTOR rec[-2] rec[-18] rec[-19] rec[-62] rec[-78] rec[-79]
+        DETECTOR rec[-1] rec[-16] rec[-17] rec[-61] rec[-76] rec[-77]
+        TICK
+        M 0 5 14 23 32 41 13 22 31 40 49 53
+        MZZ 19 20 28 29 37 38 46 47 10 11 21 30 4 12 2 3 39 48 16 17 25 26 34 35 43 44 50 51 7 8 15 24 1 6 33 42 9 18 27 36 45 52
+        DETECTOR rec[-31] rec[-32] rec[-37] rec[-97] rec[-157] rec[-158]
+        DETECTOR rec[-29] rec[-30] rec[-36] rec[-96] rec[-155] rec[-156]
+        DETECTOR rec[-16] rec[-25] rec[-26] rec[-39] rec[-40] rec[-99] rec[-100] rec[-142] rec[-151] rec[-152]
+        DETECTOR rec[-13] rec[-23] rec[-24] rec[-38] rec[-54] rec[-98] rec[-114] rec[-139] rec[-149] rec[-150]
+        DETECTOR rec[-6] rec[-11] rec[-12] rec[-35] rec[-44] rec[-45] rec[-95] rec[-104] rec[-105] rec[-132] rec[-137] rec[-138]
+        DETECTOR rec[-4] rec[-9] rec[-10] rec[-34] rec[-42] rec[-43] rec[-94] rec[-102] rec[-103] rec[-130] rec[-135] rec[-136]
+        DETECTOR rec[-3] rec[-17] rec[-21] rec[-48] rec[-52] rec[-53] rec[-108] rec[-112] rec[-113] rec[-129] rec[-143] rec[-147]
+        DETECTOR rec[-2] rec[-19] rec[-20] rec[-47] rec[-50] rec[-51] rec[-107] rec[-110] rec[-111] rec[-128] rec[-145] rec[-146]
+        TICK
+        MYY 8 9 17 18 26 27 35 36 44 45 51 52 5 6 14 15 23 24 32 33 41 42 0 1 7 16 25 34 43 50 11 12 20 21 29 30 38 39 47 48 3 4 13 22 31 40 2 10 19 28 37 46 49 53
+        DETECTOR rec[-15] rec[-26] rec[-27] rec[-30] rec[-34] rec[-39] rec[-156] rec[-160] rec[-165] rec[-201] rec[-212] rec[-213]
+        DETECTOR rec[-14] rec[-24] rec[-25] rec[-29] rec[-37] rec[-38] rec[-155] rec[-163] rec[-164] rec[-200] rec[-210] rec[-211]
+        DETECTOR rec[-13] rec[-22] rec[-23] rec[-28] rec[-35] rec[-36] rec[-154] rec[-161] rec[-162] rec[-199] rec[-208] rec[-209]
+        DETECTOR rec[-4] rec[-7] rec[-12] rec[-41] rec[-42] rec[-44] rec[-167] rec[-168] rec[-170] rec[-190] rec[-193] rec[-198]
+        DETECTOR rec[-3] rec[-10] rec[-11] rec[-43] rec[-47] rec[-48] rec[-169] rec[-173] rec[-174] rec[-189] rec[-196] rec[-197]
+        DETECTOR rec[-2] rec[-8] rec[-9] rec[-40] rec[-45] rec[-46] rec[-166] rec[-171] rec[-172] rec[-188] rec[-194] rec[-195]
+        TICK
+        M 0 5 14 23 32 41 13 22 31 40 49 53
+        MZZ 19 20 28 29 37 38 46 47 10 11 21 30 4 12 2 3 39 48 16 17 25 26 34 35 43 44 50 51 7 8 15 24 1 6 33 42 9 18 27 36 45 52
+        DETECTOR rec[-26] rec[-27] rec[-86] rec[-87]
+        DETECTOR rec[-24] rec[-25] rec[-84] rec[-85]
+        DETECTOR rec[-22] rec[-23] rec[-82] rec[-83]
+        DETECTOR rec[-16] rec[-20] rec[-21] rec[-76] rec[-80] rec[-81]
+        # OOPS DETECTOR rec[-14] rec[-15] rec[-17] rec[-74] rec[-75] rec[-77]
+        DETECTOR rec[-13] rec[-18] rec[-19] rec[-73] rec[-78] rec[-79]
+        DETECTOR rec[-6] rec[-30] rec[-31] rec[-66] rec[-90] rec[-91]
+        DETECTOR rec[-5] rec[-32] rec[-33] rec[-65] rec[-92] rec[-93]
+        DETECTOR rec[-4] rec[-28] rec[-29] rec[-64] rec[-88] rec[-89]
+        DETECTOR rec[-3] rec[-7] rec[-12] rec[-63] rec[-67] rec[-72]
+        DETECTOR rec[-2] rec[-10] rec[-11] rec[-62] rec[-70] rec[-71]
+        DETECTOR rec[-1] rec[-8] rec[-9] rec[-61] rec[-68] rec[-69]
+        TICK
+        MX 0 1 2 3 4 8 51 50 52 41 47 53
+        MXX 48 49 9 10 18 19 27 28 36 37 45 46 11 20 29 38 6 7 15 16 24 25 33 34 42 43 12 13 21 22 30 31 39 40 5 14 23 32 17 26 35 44
+        DETECTOR rec[-30] rec[-31] rec[-47] rec[-107] rec[-156] rec[-157]
+        DETECTOR rec[-26] rec[-27] rec[-41] rec[-101] rec[-152] rec[-153]
+        DETECTOR rec[-16] rec[-23] rec[-25] rec[-34] rec[-51] rec[-94] rec[-111] rec[-142] rec[-149] rec[-151]
+        DETECTOR rec[-15] rec[-19] rec[-20] rec[-36] rec[-50] rec[-54] rec[-96] rec[-110] rec[-114] rec[-141] rec[-145] rec[-146]
+        DETECTOR rec[-14] rec[-17] rec[-18] rec[-35] rec[-52] rec[-53] rec[-95] rec[-112] rec[-113] rec[-140] rec[-143] rec[-144]
+        DETECTOR rec[-13] rec[-28] rec[-32] rec[-38] rec[-40] rec[-98] rec[-100] rec[-139] rec[-154] rec[-158]
+        DETECTOR rec[-2] rec[-11] rec[-12] rec[-39] rec[-44] rec[-45] rec[-99] rec[-104] rec[-105] rec[-128] rec[-137] rec[-138]
+        DETECTOR rec[-1] rec[-9] rec[-10] rec[-37] rec[-42] rec[-43] rec[-97] rec[-102] rec[-103] rec[-127] rec[-135] rec[-136]
+        TICK
+        MYY 8 9 17 18 26 27 35 36 44 45 51 52 5 6 14 15 23 24 32 33 41 42 0 1 7 16 25 34 43 50 11 12 20 21 29 30 38 39 47 48 3 4 13 22 31 40 2 10 19 28 37 46 49 53
+        DETECTOR rec[-15] rec[-20] rec[-21] rec[-31] rec[-39] rec[-40] rec[-157] rec[-165] rec[-166] rec[-201] rec[-206] rec[-207]
+        DETECTOR rec[-14] rec[-18] rec[-19] rec[-30] rec[-37] rec[-38] rec[-156] rec[-163] rec[-164] rec[-200] rec[-204] rec[-205]
+        DETECTOR rec[-6] rec[-11] rec[-12] rec[-34] rec[-35] rec[-42] rec[-160] rec[-161] rec[-168] rec[-192] rec[-197] rec[-198]
+        DETECTOR rec[-5] rec[-9] rec[-10] rec[-32] rec[-33] rec[-41] rec[-158] rec[-159] rec[-167] rec[-191] rec[-195] rec[-196]
+        DETECTOR rec[-3] rec[-25] rec[-26] rec[-29] rec[-45] rec[-46] rec[-155] rec[-171] rec[-172] rec[-189] rec[-211] rec[-212]
+        DETECTOR rec[-2] rec[-23] rec[-24] rec[-28] rec[-43] rec[-44] rec[-154] rec[-169] rec[-170] rec[-188] rec[-209] rec[-210]
+        TICK
+        MX 0 1 2 3 4 8 51 50 52 41 47 53
+        MXX 48 49 9 10 18 19 27 28 36 37 45 46 11 20 29 38 6 7 15 16 24 25 33 34 42 43 12 13 21 22 30 31 39 40 5 14 23 32 17 26 35 44
+        DETECTOR rec[-32] rec[-33] rec[-92] rec[-93]
+        DETECTOR rec[-29] rec[-30] rec[-89] rec[-90]
+        DETECTOR rec[-25] rec[-27] rec[-85] rec[-87]
+        DETECTOR rec[-21] rec[-22] rec[-23] rec[-81] rec[-82] rec[-83]
+        DETECTOR rec[-20] rec[-28] rec[-31] rec[-80] rec[-88] rec[-91]
+        DETECTOR rec[-9] rec[-24] rec[-26] rec[-69] rec[-84] rec[-86]
+        DETECTOR rec[-7] rec[-8] rec[-15] rec[-67] rec[-68] rec[-75]
+        DETECTOR rec[-5] rec[-6] rec[-14] rec[-65] rec[-66] rec[-74]
+        DETECTOR rec[-4] rec[-12] rec[-13] rec[-64] rec[-72] rec[-73]
+        DETECTOR rec[-3] rec[-10] rec[-11] rec[-63] rec[-70] rec[-71]
+        DETECTOR rec[-2] rec[-18] rec[-19] rec[-62] rec[-78] rec[-79]
+        DETECTOR rec[-1] rec[-16] rec[-17] rec[-61] rec[-76] rec[-77]
+        TICK
+        M 0 5 14 23 32 41 13 22 31 40 49 53
+        MZZ 19 20 28 29 37 38 46 47 10 11 21 30 4 12 2 3 39 48 16 17 25 26 34 35 43 44 50 51 7 8 15 24 1 6 33 42 9 18 27 36 45 52
+        DETECTOR rec[-31] rec[-32] rec[-37] rec[-97] rec[-157] rec[-158]
+        DETECTOR rec[-29] rec[-30] rec[-36] rec[-96] rec[-155] rec[-156]
+        DETECTOR rec[-16] rec[-25] rec[-26] rec[-39] rec[-40] rec[-99] rec[-100] rec[-142] rec[-151] rec[-152]
+        DETECTOR rec[-13] rec[-23] rec[-24] rec[-38] rec[-54] rec[-98] rec[-114] rec[-139] rec[-149] rec[-150]
+        DETECTOR rec[-6] rec[-11] rec[-12] rec[-35] rec[-44] rec[-45] rec[-95] rec[-104] rec[-105] rec[-132] rec[-137] rec[-138]
+        DETECTOR rec[-4] rec[-9] rec[-10] rec[-34] rec[-42] rec[-43] rec[-94] rec[-102] rec[-103] rec[-130] rec[-135] rec[-136]
+        DETECTOR rec[-3] rec[-17] rec[-21] rec[-48] rec[-52] rec[-53] rec[-108] rec[-112] rec[-113] rec[-129] rec[-143] rec[-147]
+        DETECTOR rec[-2] rec[-19] rec[-20] rec[-47] rec[-50] rec[-51] rec[-107] rec[-110] rec[-111] rec[-128] rec[-145] rec[-146]
+        TICK
+        MYY 8 9 17 18 26 27 35 36 44 45 51 52 5 6 14 15 23 24 32 33 41 42 0 1 7 16 25 34 43 50 11 12 20 21 29 30 38 39 47 48 3 4 13 22 31 40 2 10 19 28 37 46 49 53
+        DETECTOR rec[-15] rec[-26] rec[-27] rec[-30] rec[-34] rec[-39] rec[-156] rec[-160] rec[-165] rec[-201] rec[-212] rec[-213]
+        DETECTOR rec[-14] rec[-24] rec[-25] rec[-29] rec[-37] rec[-38] rec[-155] rec[-163] rec[-164] rec[-200] rec[-210] rec[-211]
+        DETECTOR rec[-13] rec[-22] rec[-23] rec[-28] rec[-35] rec[-36] rec[-154] rec[-161] rec[-162] rec[-199] rec[-208] rec[-209]
+        DETECTOR rec[-4] rec[-7] rec[-12] rec[-41] rec[-42] rec[-44] rec[-167] rec[-168] rec[-170] rec[-190] rec[-193] rec[-198]
+        DETECTOR rec[-3] rec[-10] rec[-11] rec[-43] rec[-47] rec[-48] rec[-169] rec[-173] rec[-174] rec[-189] rec[-196] rec[-197]
+        DETECTOR rec[-2] rec[-8] rec[-9] rec[-40] rec[-45] rec[-46] rec[-166] rec[-171] rec[-172] rec[-188] rec[-194] rec[-195]
+        TICK
+        M 0 5 14 23 32 41 13 22 31 40 49 53
+        MZZ 19 20 28 29 37 38 46 47 10 11 21 30 4 12 2 3 39 48 16 17 25 26 34 35 43 44 50 51 7 8 15 24 1 6 33 42 9 18 27 36 45 52
+        DETECTOR rec[-26] rec[-27] rec[-86] rec[-87]
+        DETECTOR rec[-24] rec[-25] rec[-84] rec[-85]
+        DETECTOR rec[-22] rec[-23] rec[-82] rec[-83]
+        DETECTOR rec[-16] rec[-20] rec[-21] rec[-76] rec[-80] rec[-81]
+        DETECTOR rec[-14] rec[-15] rec[-17] rec[-74] rec[-75] rec[-77]
+        DETECTOR rec[-13] rec[-18] rec[-19] rec[-73] rec[-78] rec[-79]
+        DETECTOR rec[-6] rec[-30] rec[-31] rec[-66] rec[-90] rec[-91]
+        DETECTOR rec[-5] rec[-32] rec[-33] rec[-65] rec[-92] rec[-93]
+        DETECTOR rec[-4] rec[-28] rec[-29] rec[-64] rec[-88] rec[-89]
+        DETECTOR rec[-3] rec[-7] rec[-12] rec[-63] rec[-67] rec[-72]
+        DETECTOR rec[-2] rec[-10] rec[-11] rec[-62] rec[-70] rec[-71]
+        DETECTOR rec[-1] rec[-8] rec[-9] rec[-61] rec[-68] rec[-69]
+        TICK
+        MX 0 1 2 3 4 8 51 50 52 41 47 53
+        MXX 9 10 18 19 27 28 36 37 45 46 11 20 29 38 6 7 15 16 24 25 33 34 42 43 12 13 21 22 30 31 39 40 5 14 23 32 17 26 35 44 48 49
+        DETECTOR rec[-30] rec[-31] rec[-47] rec[-107] rec[-156] rec[-157]
+        DETECTOR rec[-26] rec[-27] rec[-41] rec[-101] rec[-152] rec[-153]
+        DETECTOR rec[-17] rec[-23] rec[-25] rec[-34] rec[-51] rec[-94] rec[-111] rec[-142] rec[-149] rec[-151]
+        DETECTOR rec[-16] rec[-20] rec[-21] rec[-36] rec[-50] rec[-54] rec[-96] rec[-110] rec[-114] rec[-141] rec[-145] rec[-146]
+        DETECTOR rec[-15] rec[-18] rec[-19] rec[-35] rec[-52] rec[-53] rec[-95] rec[-112] rec[-113] rec[-140] rec[-143] rec[-144]
+        DETECTOR rec[-14] rec[-28] rec[-32] rec[-38] rec[-40] rec[-98] rec[-100] rec[-139] rec[-154] rec[-158]
+        DETECTOR rec[-3] rec[-12] rec[-13] rec[-39] rec[-44] rec[-45] rec[-99] rec[-104] rec[-105] rec[-128] rec[-137] rec[-138]
+        DETECTOR rec[-2] rec[-10] rec[-11] rec[-37] rec[-42] rec[-43] rec[-97] rec[-102] rec[-103] rec[-127] rec[-135] rec[-136]
+        TICK
+        MYY 8 9 17 18 26 27 35 36 44 45 51 52 5 6 14 15 23 24 32 33 41 42 0 1 7 16 25 34 43 50 11 12 20 21 29 30 38 39 47 48 3 4 13 22 31 40 2 10 19 28 37 46 49 53
+        DETECTOR rec[-15] rec[-20] rec[-21] rec[-32] rec[-40] rec[-41] rec[-157] rec[-165] rec[-166] rec[-201] rec[-206] rec[-207]
+        DETECTOR rec[-14] rec[-18] rec[-19] rec[-31] rec[-38] rec[-39] rec[-156] rec[-163] rec[-164] rec[-200] rec[-204] rec[-205]
+        DETECTOR rec[-6] rec[-11] rec[-12] rec[-35] rec[-36] rec[-43] rec[-160] rec[-161] rec[-168] rec[-192] rec[-197] rec[-198]
+        DETECTOR rec[-5] rec[-9] rec[-10] rec[-33] rec[-34] rec[-42] rec[-158] rec[-159] rec[-167] rec[-191] rec[-195] rec[-196]
+        DETECTOR rec[-3] rec[-25] rec[-26] rec[-30] rec[-46] rec[-47] rec[-155] rec[-171] rec[-172] rec[-189] rec[-211] rec[-212]
+        DETECTOR rec[-2] rec[-23] rec[-24] rec[-29] rec[-44] rec[-45] rec[-154] rec[-169] rec[-170] rec[-188] rec[-209] rec[-210]
+        TICK
+        M 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53
+        DETECTOR rec[-53] rec[-54] rec[-70] rec[-113] rec[-114]
+        DETECTOR rec[-50] rec[-51] rec[-61] rec[-110] rec[-111]
+        DETECTOR rec[-44] rec[-45] rec[-46] rec[-52] rec[-58] rec[-81] rec[-102] rec[-109] rec[-112]
+        DETECTOR rec[-42] rec[-43] rec[-44] rec[-50] rec[-51] rec[-52] rec[-58] rec[-61] rec[-66] rec[-128] rec[-129] rec[-131] rec[-151] rec[-154] rec[-159]
+        DETECTOR rec[-38] rec[-39] rec[-40] rec[-47] rec[-48] rec[-49] rec[-69] rec[-74] rec[-75] rec[-86] rec[-94] rec[-95]
+        DETECTOR rec[-36] rec[-37] rec[-38] rec[-45] rec[-46] rec[-47] rec[-69] rec[-80] rec[-81] rec[-117] rec[-121] rec[-126] rec[-162] rec[-173] rec[-174]
+        DETECTOR rec[-32] rec[-33] rec[-34] rec[-41] rec[-42] rec[-43] rec[-60] rec[-65] rec[-66] rec[-89] rec[-90] rec[-97]
+        DETECTOR rec[-26] rec[-27] rec[-28] rec[-35] rec[-36] rec[-37] rec[-57] rec[-79] rec[-80] rec[-84] rec[-100] rec[-101]
+        DETECTOR rec[-24] rec[-25] rec[-26] rec[-33] rec[-34] rec[-35] rec[-57] rec[-64] rec[-65] rec[-130] rec[-134] rec[-135] rec[-150] rec[-157] rec[-158]
+        DETECTOR rec[-20] rec[-21] rec[-22] rec[-29] rec[-30] rec[-31] rec[-68] rec[-72] rec[-73] rec[-85] rec[-92] rec[-93]
+        DETECTOR rec[-18] rec[-19] rec[-20] rec[-27] rec[-28] rec[-29] rec[-68] rec[-78] rec[-79] rec[-116] rec[-124] rec[-125] rec[-161] rec[-171] rec[-172]
+        DETECTOR rec[-14] rec[-15] rec[-16] rec[-23] rec[-24] rec[-25] rec[-59] rec[-63] rec[-64] rec[-87] rec[-88] rec[-96]
+        DETECTOR rec[-8] rec[-9] rec[-10] rec[-17] rec[-18] rec[-19] rec[-56] rec[-77] rec[-78] rec[-83] rec[-98] rec[-99]
+        DETECTOR rec[-6] rec[-7] rec[-8] rec[-15] rec[-16] rec[-17] rec[-56] rec[-62] rec[-63] rec[-127] rec[-132] rec[-133] rec[-149] rec[-155] rec[-156]
+        DETECTOR rec[-4] rec[-11] rec[-12] rec[-13] rec[-67] rec[-71] rec[-91] rec[-105] rec[-107]
+        DETECTOR rec[-2] rec[-3] rec[-76] rec[-106] rec[-108]
+        DETECTOR rec[-2] rec[-3] rec[-4] rec[-9] rec[-10] rec[-11] rec[-67] rec[-76] rec[-77] rec[-115] rec[-122] rec[-123] rec[-160] rec[-169] rec[-170]
+        DETECTOR rec[-1] rec[-5] rec[-6] rec[-7] rec[-55] rec[-62] rec[-82] rec[-103] rec[-104]
+        OBSERVABLE_INCLUDE(0) rec[-2] rec[-3] rec[-9] rec[-10] rec[-18] rec[-19] rec[-27] rec[-28] rec[-36] rec[-37] rec[-45] rec[-46] rec[-76] rec[-77] rec[-78] rec[-79] rec[-80] rec[-81] rec[-83] rec[-84] rec[-108] rec[-109] rec[-115] rec[-116] rec[-117] rec[-175] rec[-176] rec[-177] rec[-208] rec[-209] rec[-234] rec[-235] rec[-268] rec[-269] rec[-294] rec[-295] rec[-301] rec[-302] rec[-303] rec[-361] rec[-362] rec[-363] rec[-394] rec[-395] rec[-420] rec[-421] rec[-454] rec[-455] rec[-480] rec[-481] rec[-487] rec[-488] rec[-489] rec[-547] rec[-548] rec[-549] rec[-580] rec[-581] rec[-606] rec[-607] rec[-634] rec[-635] rec[-636] rec[-637] rec[-638] rec[-639]
+    )CIRCUIT");
+    Circuit suffix = missing_detectors(c, true);
+    ASSERT_EQ(suffix, Circuit(R"CIRCUIT(
+        DETECTOR rec[-377] rec[-375] rec[-374] rec[-317] rec[-315] rec[-314]
+    )CIRCUIT"));
+}
+
+TEST(missing_detectors, toric_code_global_stabilizer_product) {
+    Circuit c = Circuit(R"CIRCUIT(
+        R 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
+        TICK
+        MPP X0*X4*X5*X1 X2*X6*X7*X3 X10*X14*X15*X11 X8*X12*X13*X9
+        TICK
+        MPP X5*X9*X10*X6 X1*X13*X14*X2 X0*X12*X15*X3 X4*X8*X11*X7
+        TICK
+        MPP Z4*Z8*Z9*Z5 Z6*Z10*Z11*Z7 Z2*Z14*Z15*Z3 Z0*Z12*Z13*Z1
+        TICK
+        MPP Z1*Z5*Z6*Z2 Z9*Z13*Z14*Z10 Z8*Z12*Z15*Z11 Z0*Z4*Z7*Z3
+        DETECTOR rec[-1]
+        DETECTOR rec[-2]
+        DETECTOR rec[-3]
+        DETECTOR rec[-4]
+        DETECTOR rec[-5]
+        DETECTOR rec[-6]
+        DETECTOR rec[-7]
+        DETECTOR rec[-8]
+    )CIRCUIT");
+    Circuit suffix = missing_detectors(c, true);
+    ASSERT_EQ(suffix, Circuit(R"CIRCUIT(
+        DETECTOR rec[-16] rec[-15] rec[-14] rec[-13] rec[-12] rec[-11] rec[-10] rec[-9]
+    )CIRCUIT"));
+}


### PR DESCRIPTION
- Add `stim.Circuit.missing_detectors`
- Add `unknown_input=False` argument to `stim.Circuit.count_determined_measurements`
- Add `stim.FlipSimulator.append_measurement_flips`

Fixes https://github.com/quantumlib/Stim/issues/973

Fixes https://github.com/quantumlib/Stim/issues/981

Fixes https://github.com/quantumlib/Stim/issues/987