### PR TITLE
Fix `explain_detector_error_model_errors` mixing up Y/Z of `PAULI_CHANNEL_2`

### DIFF
--- a/src/stim/simulators/error_matcher.cc
+++ b/src/stim/simulators/error_matcher.cc
@@ -222,8 +222,10 @@ void ErrorMatcher::err_pauli_channel_2(const CircuitInstruction &op) {
                 }
                 bool x0 = p0 & 1;
                 bool z0 = p0 & 2;
+                x0 ^= z0;
                 bool x1 = p1 & 1;
                 bool z1 = p1 & 2;
+                x1 ^= z1;
                 uint32_t m0 = x0 * TARGET_PAULI_X_BIT + z0 * TARGET_PAULI_Z_BIT;
                 uint32_t m1 = x1 * TARGET_PAULI_X_BIT + z1 * TARGET_PAULI_Z_BIT;
                 pair[0].data = t[k].data | m0;

--- a/src/stim/simulators/error_matcher.test.cc
+++ b/src/stim/simulators/error_matcher.test.cc
@@ -609,3 +609,310 @@ ExplainedError {
 }
 )RESULT");
 }
+
+TEST(ErrorMatcher, PAULI_CHANNEL_2) {
+    std::vector<ExplainedError> actual;
+
+    actual = ErrorMatcher::explain_errors_from_circuit(
+        Circuit(R"CIRCUIT(
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            PAULI_CHANNEL_2(0.1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) 0 1
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            DETECTOR rec[-1] rec[-5]
+            DETECTOR rec[-2] rec[-6]
+            DETECTOR rec[-3] rec[-7]
+            DETECTOR rec[-4] rec[-8]
+        )CIRCUIT"),
+        nullptr,
+        false);
+    ASSERT_EQ(actual.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations[0].flipped_pauli_product, (std::vector<GateTargetWithCoords>{GateTargetWithCoords{GateTarget::x(1)}}));
+
+    actual = ErrorMatcher::explain_errors_from_circuit(
+        Circuit(R"CIRCUIT(
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            PAULI_CHANNEL_2(0, 0.1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) 0 1
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            DETECTOR rec[-1] rec[-5]
+            DETECTOR rec[-2] rec[-6]
+            DETECTOR rec[-3] rec[-7]
+            DETECTOR rec[-4] rec[-8]
+        )CIRCUIT"),
+        nullptr,
+        false);
+    ASSERT_EQ(actual.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations[0].flipped_pauli_product, (std::vector<GateTargetWithCoords>{GateTargetWithCoords{GateTarget::y(1)}}));
+
+    actual = ErrorMatcher::explain_errors_from_circuit(
+        Circuit(R"CIRCUIT(
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            PAULI_CHANNEL_2(0, 0, 0.1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) 0 1
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            DETECTOR rec[-1] rec[-5]
+            DETECTOR rec[-2] rec[-6]
+            DETECTOR rec[-3] rec[-7]
+            DETECTOR rec[-4] rec[-8]
+        )CIRCUIT"),
+        nullptr,
+        false);
+    ASSERT_EQ(actual.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations[0].flipped_pauli_product, (std::vector<GateTargetWithCoords>{GateTargetWithCoords{GateTarget::z(1)}}));
+
+    actual = ErrorMatcher::explain_errors_from_circuit(
+        Circuit(R"CIRCUIT(
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            PAULI_CHANNEL_2(0, 0, 0, 0.1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) 0 1
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            DETECTOR rec[-1] rec[-5]
+            DETECTOR rec[-2] rec[-6]
+            DETECTOR rec[-3] rec[-7]
+            DETECTOR rec[-4] rec[-8]
+        )CIRCUIT"),
+        nullptr,
+        false);
+    ASSERT_EQ(actual.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations[0].flipped_pauli_product, (std::vector<GateTargetWithCoords>{
+        GateTargetWithCoords{GateTarget::x(0)},
+    }));
+
+    actual = ErrorMatcher::explain_errors_from_circuit(
+        Circuit(R"CIRCUIT(
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            PAULI_CHANNEL_2(0, 0, 0, 0, 0.1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) 0 1
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            DETECTOR rec[-1] rec[-5]
+            DETECTOR rec[-2] rec[-6]
+            DETECTOR rec[-3] rec[-7]
+            DETECTOR rec[-4] rec[-8]
+        )CIRCUIT"),
+        nullptr,
+        false);
+    ASSERT_EQ(actual.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations[0].flipped_pauli_product, (std::vector<GateTargetWithCoords>{
+        GateTargetWithCoords{GateTarget::x(0)},
+        GateTargetWithCoords{GateTarget::x(1)},
+    }));
+
+    actual = ErrorMatcher::explain_errors_from_circuit(
+        Circuit(R"CIRCUIT(
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            PAULI_CHANNEL_2(0, 0, 0, 0, 0, 0.1, 0, 0, 0, 0, 0, 0, 0, 0, 0) 0 1
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            DETECTOR rec[-1] rec[-5]
+            DETECTOR rec[-2] rec[-6]
+            DETECTOR rec[-3] rec[-7]
+            DETECTOR rec[-4] rec[-8]
+        )CIRCUIT"),
+        nullptr,
+        false);
+    ASSERT_EQ(actual.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations[0].flipped_pauli_product, (std::vector<GateTargetWithCoords>{
+        GateTargetWithCoords{GateTarget::x(0)},
+        GateTargetWithCoords{GateTarget::y(1)},
+    }));
+
+    actual = ErrorMatcher::explain_errors_from_circuit(
+        Circuit(R"CIRCUIT(
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            PAULI_CHANNEL_2(0, 0, 0, 0, 0, 0, 0.1, 0, 0, 0, 0, 0, 0, 0, 0) 0 1
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            DETECTOR rec[-1] rec[-5]
+            DETECTOR rec[-2] rec[-6]
+            DETECTOR rec[-3] rec[-7]
+            DETECTOR rec[-4] rec[-8]
+        )CIRCUIT"),
+        nullptr,
+        false);
+    ASSERT_EQ(actual.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations[0].flipped_pauli_product, (std::vector<GateTargetWithCoords>{
+        GateTargetWithCoords{GateTarget::x(0)},
+        GateTargetWithCoords{GateTarget::z(1)},
+    }));
+
+    actual = ErrorMatcher::explain_errors_from_circuit(
+        Circuit(R"CIRCUIT(
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            PAULI_CHANNEL_2(0, 0, 0, 0, 0, 0, 0, 0.1, 0, 0, 0, 0, 0, 0, 0) 0 1
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            DETECTOR rec[-1] rec[-5]
+            DETECTOR rec[-2] rec[-6]
+            DETECTOR rec[-3] rec[-7]
+            DETECTOR rec[-4] rec[-8]
+        )CIRCUIT"),
+        nullptr,
+        false);
+    ASSERT_EQ(actual.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations[0].flipped_pauli_product, (std::vector<GateTargetWithCoords>{
+        GateTargetWithCoords{GateTarget::y(0)},
+    }));
+
+    actual = ErrorMatcher::explain_errors_from_circuit(
+        Circuit(R"CIRCUIT(
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            PAULI_CHANNEL_2(0, 0, 0, 0, 0, 0, 0, 0, 0.1, 0, 0, 0, 0, 0, 0) 0 1
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            DETECTOR rec[-1] rec[-5]
+            DETECTOR rec[-2] rec[-6]
+            DETECTOR rec[-3] rec[-7]
+            DETECTOR rec[-4] rec[-8]
+        )CIRCUIT"),
+        nullptr,
+        false);
+    ASSERT_EQ(actual.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations[0].flipped_pauli_product, (std::vector<GateTargetWithCoords>{
+        GateTargetWithCoords{GateTarget::y(0)},
+        GateTargetWithCoords{GateTarget::x(1)},
+    }));
+
+    actual = ErrorMatcher::explain_errors_from_circuit(
+        Circuit(R"CIRCUIT(
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            PAULI_CHANNEL_2(0, 0, 0, 0, 0, 0, 0, 0, 0, 0.1, 0, 0, 0, 0, 0) 0 1
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            DETECTOR rec[-1] rec[-5]
+            DETECTOR rec[-2] rec[-6]
+            DETECTOR rec[-3] rec[-7]
+            DETECTOR rec[-4] rec[-8]
+        )CIRCUIT"),
+        nullptr,
+        false);
+    ASSERT_EQ(actual.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations[0].flipped_pauli_product, (std::vector<GateTargetWithCoords>{
+        GateTargetWithCoords{GateTarget::y(0)},
+        GateTargetWithCoords{GateTarget::y(1)},
+    }));
+
+    actual = ErrorMatcher::explain_errors_from_circuit(
+        Circuit(R"CIRCUIT(
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            PAULI_CHANNEL_2(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.1, 0, 0, 0, 0) 0 1
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            DETECTOR rec[-1] rec[-5]
+            DETECTOR rec[-2] rec[-6]
+            DETECTOR rec[-3] rec[-7]
+            DETECTOR rec[-4] rec[-8]
+        )CIRCUIT"),
+        nullptr,
+        false);
+    ASSERT_EQ(actual.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations[0].flipped_pauli_product, (std::vector<GateTargetWithCoords>{
+        GateTargetWithCoords{GateTarget::y(0)},
+        GateTargetWithCoords{GateTarget::z(1)},
+    }));
+
+    actual = ErrorMatcher::explain_errors_from_circuit(
+        Circuit(R"CIRCUIT(
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            PAULI_CHANNEL_2(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.1, 0, 0, 0) 0 1
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            DETECTOR rec[-1] rec[-5]
+            DETECTOR rec[-2] rec[-6]
+            DETECTOR rec[-3] rec[-7]
+            DETECTOR rec[-4] rec[-8]
+        )CIRCUIT"),
+        nullptr,
+        false);
+    ASSERT_EQ(actual.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations[0].flipped_pauli_product, (std::vector<GateTargetWithCoords>{
+        GateTargetWithCoords{GateTarget::z(0)},
+    }));
+
+    actual = ErrorMatcher::explain_errors_from_circuit(
+        Circuit(R"CIRCUIT(
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            PAULI_CHANNEL_2(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.1, 0, 0) 0 1
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            DETECTOR rec[-1] rec[-5]
+            DETECTOR rec[-2] rec[-6]
+            DETECTOR rec[-3] rec[-7]
+            DETECTOR rec[-4] rec[-8]
+        )CIRCUIT"),
+        nullptr,
+        false);
+    ASSERT_EQ(actual.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations[0].flipped_pauli_product, (std::vector<GateTargetWithCoords>{
+        GateTargetWithCoords{GateTarget::z(0)},
+        GateTargetWithCoords{GateTarget::x(1)},
+    }));
+
+    actual = ErrorMatcher::explain_errors_from_circuit(
+        Circuit(R"CIRCUIT(
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            PAULI_CHANNEL_2(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.1, 0) 0 1
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            DETECTOR rec[-1] rec[-5]
+            DETECTOR rec[-2] rec[-6]
+            DETECTOR rec[-3] rec[-7]
+            DETECTOR rec[-4] rec[-8]
+        )CIRCUIT"),
+        nullptr,
+        false);
+    ASSERT_EQ(actual.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations[0].flipped_pauli_product, (std::vector<GateTargetWithCoords>{
+        GateTargetWithCoords{GateTarget::z(0)},
+        GateTargetWithCoords{GateTarget::y(1)},
+    }));
+
+    actual = ErrorMatcher::explain_errors_from_circuit(
+        Circuit(R"CIRCUIT(
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            PAULI_CHANNEL_2(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.1) 0 1
+            MXX 0 2 1 3
+            MZZ 0 2 1 3
+            DETECTOR rec[-1] rec[-5]
+            DETECTOR rec[-2] rec[-6]
+            DETECTOR rec[-3] rec[-7]
+            DETECTOR rec[-4] rec[-8]
+        )CIRCUIT"),
+        nullptr,
+        false);
+    ASSERT_EQ(actual.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations.size(), 1);
+    ASSERT_EQ(actual[0].circuit_error_locations[0].flipped_pauli_product, (std::vector<GateTargetWithCoords>{
+        GateTargetWithCoords{GateTarget::z(0)},
+        GateTargetWithCoords{GateTarget::z(1)},
+    }));
+}


### PR DESCRIPTION
- Fix a missed XY-to-XZ encoding correction
- Add a brute force unit test that verifies all 15 cases

Fixes https://github.com/quantumlib/Stim/issues/1005