### PR TITLE
Remove extra over-mixing checks

### DIFF
--- a/src/stim/simulators/error_analyzer.cc
+++ b/src/stim/simulators/error_analyzer.cc
@@ -816,9 +816,6 @@ void ErrorAnalyzer::undo_DEPOLARIZE1(const CircuitInstruction &inst) {
     if (!accumulate_errors) {
         return;
     }
-    if (inst.args[0] > 0.75) {
-        throw std::invalid_argument("Can't analyze over-mixing DEPOLARIZE1 errors (probability > 3/4).");
-    }
     double p = depolarize1_probability_to_independent_per_channel_probability(inst.args[0]);
     for (auto q : inst.targets) {
         add_error_combinations<2>(
@@ -835,9 +832,6 @@ void ErrorAnalyzer::undo_DEPOLARIZE1(const CircuitInstruction &inst) {
 void ErrorAnalyzer::undo_DEPOLARIZE2(const CircuitInstruction &inst) {
     if (!accumulate_errors) {
         return;
-    }
-    if (inst.args[0] > 15.0 / 16.0) {
-        throw std::invalid_argument("Can't analyze over-mixing DEPOLARIZE2 errors (probability > 15/16).");
     }
     double p = depolarize2_probability_to_independent_per_channel_probability(inst.args[0]);
     for (size_t i = 0; i < inst.targets.size(); i += 2) {

--- a/src/stim/util_bot/error_decomp.test.cc
+++ b/src/stim/util_bot/error_decomp.test.cc
@@ -158,3 +158,29 @@ TEST(conversions, independent_vs_disjoint_xyz_errors_round_trip_fuzz) {
         ASSERT_NEAR(z, z3, 1e-6) << "x=" << x << ",y=" << y << ",z=" << z;
     }
 }
+
+TEST(conversions, depolarize1_probability_to_independent_per_channel_probability_throws_invalid_argument_if_p_greater_than_0_75) {
+    const double invalid_p = 0.76;
+    const std::string expected_error_message = "depolarize1_probability_to_independent_per_channel_probability with p>0.75; p=" + std::to_string(invalid_p);
+    EXPECT_THROW({
+        try {
+            depolarize1_probability_to_independent_per_channel_probability(invalid_p);
+        } catch (const std::invalid_argument& e) {
+            EXPECT_EQ(expected_error_message, e.what());
+            throw;
+        }
+    }, std::invalid_argument);
+}
+
+TEST(conversions, depolarize2_probability_to_independent_per_channel_probability_throws_invalid_argument_if_p_greater_than_0_9375) {
+    const double invalid_p = 0.9475;
+    const std::string expected_error_message = "depolarize2_probability_to_independent_per_channel_probability with p>15.0/16.0; p=" + std::to_string(invalid_p);
+    EXPECT_THROW({
+        try {
+            depolarize2_probability_to_independent_per_channel_probability(invalid_p);
+        } catch (const std::invalid_argument& e) {
+            EXPECT_EQ(expected_error_message, e.what());
+            throw;
+        }
+    }, std::invalid_argument);
+}


### PR DESCRIPTION
When processing DEP1 instructions in the ErrorAnalyzer, p > 0.75 is checked in:

a) undo_DEPOLARIZE1 and
b) depolarize1_probability_to_independent_per_channel_probability

Likewise, p > 0.9375 is checked in:

c) undo_DEPOLARIZE2 and
d) depolarize2_probability_to_independent_per_channel_probability

I removed checks (a) and (c). I also added tests for checks (b) and (d).

Let me know if this was intentional.

Signed-off-by: Abbas Bracken Ziad <abbas.ziad25@imperial.ac.uk>