### PR TITLE
Add reference for "Logical gates on Floquet codes via folds and twists"

### DIFF
--- a/doc/circuit_data_references.md
+++ b/doc/circuit_data_references.md
@@ -45,3 +45,4 @@
 - [arXiv:2503.18657](https://arxiv.org/abs/2503.18657) → [GitHub repo for "Efficient Magic State Cultivation on RP^2"](https://github.com/Zihan-Chen-PhMA/Cultiv_T_RP2/) (circuits are in the circuit_garage/ directory)
 - [arXiv:2507.08069](https://arxiv.org/abs/2507.08069) → [Stim circuits and simulation results for "A dynamic circuit for the honeycomb Floquet code"](https://zenodo.org/records/15854678)
 - [arXiv:2507.19430](https://arxiv.org/abs/2507.19430) → [Stim circuits and parity check matrices for "Directional Codes: a new family of quantum LDPC codes on hexagonal- and square-grid connectivity hardware" manuscript](https://zenodo.org/records/16422162)
+- [arXiv:2512.17999](https://arxiv.org/abs/2512.17999) → [Stim circuits for "Logical gates on Floquet codes via folds and twists"](https://zenodo.org/records/17966122)


### PR DESCRIPTION
Adding a link to [arXiv:2512.17999](https://arxiv.org/abs/2512.17999) with corresponding [Zenodo respository](https://zenodo.org/records/17966122).