### PR TITLE
ci: add manylinux aarch64 wheel builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,13 @@ jobs:
           {os: ubuntu-24.04, dist: cp312-manylinux_x86_64},
           {os: ubuntu-24.04, dist: cp313-manylinux_x86_64},
           {os: ubuntu-24.04, dist: cp314-manylinux_x86_64},
+          {os: ubuntu-24.04, dist: cp38-manylinux_aarch64, linuxarch: aarch64},
+          {os: ubuntu-24.04, dist: cp39-manylinux_aarch64, linuxarch: aarch64},
+          {os: ubuntu-24.04, dist: cp310-manylinux_aarch64, linuxarch: aarch64},
+          {os: ubuntu-24.04, dist: cp311-manylinux_aarch64, linuxarch: aarch64},
+          {os: ubuntu-24.04, dist: cp312-manylinux_aarch64, linuxarch: aarch64},
+          {os: ubuntu-24.04, dist: cp313-manylinux_aarch64, linuxarch: aarch64},
+          {os: ubuntu-24.04, dist: cp314-manylinux_aarch64, linuxarch: aarch64},
 
           # cp38-manylinux_i686 disabled because pandas isn't prebuilt and takes 20 minutes to build.
           # {os: ubuntu-latest, dist: cp38-manylinux_i686},
@@ -144,12 +151,17 @@ jobs:
         ]
     env:
       CIBW_BUILD: "${{ matrix.os_dist.dist }}"
+      CIBW_ARCHS_LINUX: "${{ matrix.os_dist.linuxarch || 'auto' }}"
       CIBW_ARCHS_MACOS: "${{ matrix.os_dist.macosarch }}"
       CIBW_TEST_REQUIRES: cirq-core pytest
       CIBW_TEST_COMMAND: pytest {project}/src {project}/glue/cirq && stim help
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3
+      - if: runner.os == 'Linux' && matrix.os_dist.linuxarch == 'aarch64'
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        with:
+          platforms: arm64
       - run: python dev/overwrite_dev_versions_with_date.py
       - run: python -m pip install pybind11~=2.11.1 cibuildwheel~=3.3.1 setuptools wheel
       - run: python -m cibuildwheel --print-build-identifiers

--- a/doc/developer_documentation.md
+++ b/doc/developer_documentation.md
@@ -518,8 +518,9 @@ cibuildwheels can also be invoked locally, assuming you have Docker installed, u
 
 ```bash
 CIBW_BUILD=cp39-manylinux_x86_64 cibuildwheel --platform linux
+CIBW_BUILD=cp39-manylinux_aarch64 CIBW_ARCHS_LINUX=aarch64 cibuildwheel --platform linux
 # output goes into wheelhouse/
-````
+```
 
 When these wheels are finished building, they are automatically uploaded to
 pypi as a dev version of stim.


### PR DESCRIPTION
This PR adds Linux ARM (manylinux aarch64) wheel builds to the cibuildwheel matrix and wires Linux arch/QEMU setup for those jobs.

Summary:
- add cp38-cp314 manylinux_aarch64 entries
- set CIBW_ARCHS_LINUX from matrix metadata
- enable docker/setup-qemu-action for aarch64 jobs
- update developer docs with local aarch64 cibuildwheel example

Validation performed locally:
- cibuildwheel identifier checks for all new aarch64 targets
- full cibuildwheel build+test pass for cp311-manylinux_aarch64