### PR TITLE
Remove runtime type checks from sinter.AnonTaskStats

### DIFF
--- a/glue/sample/src/sinter/_data/_anon_task_stats.py
+++ b/glue/sample/src/sinter/_data/_anon_task_stats.py
@@ -1,10 +1,6 @@
 import collections
 import dataclasses
-from typing import Counter, Union, TYPE_CHECKING
-import numpy as np
-
-if TYPE_CHECKING:
-    from sinter._data._task_stats import TaskStats
+from typing import Counter
 
 
 @dataclasses.dataclass(frozen=True)
@@ -35,16 +31,10 @@ class AnonTaskStats:
     custom_counts: Counter[str] = dataclasses.field(default_factory=collections.Counter)
 
     def __post_init__(self):
-        assert isinstance(self.errors, (int, np.integer))
-        assert isinstance(self.shots, (int, np.integer))
-        assert isinstance(self.discards, (int, np.integer))
-        assert isinstance(self.seconds, (int, float, np.integer, np.floating))
-        assert isinstance(self.custom_counts, collections.Counter)
         assert self.errors >= 0
         assert self.discards >= 0
         assert self.seconds >= 0
         assert self.shots >= self.errors + self.discards
-        assert all(isinstance(k, str) and isinstance(v, (int, np.integer)) for k, v in self.custom_counts.items())
 
     def __repr__(self) -> str:
         terms = []
@@ -80,10 +70,10 @@ class AnonTaskStats:
         """
         if isinstance(other, AnonTaskStats):
             return AnonTaskStats(
-                shots=self.shots + other.shots,
-                errors=self.errors + other.errors,
-                discards=self.discards + other.discards,
-                seconds=self.seconds + other.seconds,
+                shots=int(self.shots + other.shots),
+                errors=int(self.errors + other.errors),
+                discards=int(self.discards + other.discards),
+                seconds=float(self.seconds + other.seconds),
                 custom_counts=self.custom_counts + other.custom_counts,
             )
 

--- a/glue/sample/src/sinter/_decoding/_stim_then_decode_sampler.py
+++ b/glue/sample/src/sinter/_decoding/_stim_then_decode_sampler.py
@@ -81,7 +81,7 @@ def classify_discards_and_errors(
             out_count_observable_error_combos[err_key] += 1
 
     num_errors = np.count_nonzero(fail_mask)
-    return num_discards, num_errors
+    return int(num_discards), int(num_errors)
 
 
 class DiskDecoder(CompiledDecoder):


### PR DESCRIPTION
This was causing problems in a variety of places, and ultimately just isn't very pythonic.

Obsoletes https://github.com/quantumlib/Stim/pull/1039

Fixes https://github.com/quantumlib/Stim/issues/1000