### PR TITLE
Add missing include for GCC 16

### DIFF
--- a/src/stim/dem/dem_instruction.h
+++ b/src/stim/dem/dem_instruction.h
@@ -1,6 +1,7 @@
 #ifndef _STIM_DEM_DEM_INSTRUCTION_H
 #define _STIM_DEM_DEM_INSTRUCTION_H
 
+#include <cstdint>
 #include <memory>
 #include <set>
 #include <string>


### PR DESCRIPTION
Building Stim fails for me on Fedora 44 with GCC 16.

This PR fixes that by adding a missing include.