### PR TITLE
MR/MRX/MRY terminate operators with markers in Crumble or else produce an error (magenta mark)

### DIFF
--- a/glue/crumble/circuit/layer.js
+++ b/glue/crumble/circuit/layer.js
@@ -2,6 +2,15 @@ import {Operation} from "./operation.js"
 import {GATE_MAP} from "../gates/gateset.js";
 import {groupBy} from "../base/seq.js";
 
+/**
+ * @type {!Map<!string, !string>}
+ */
+const DEMOLITION_MEASURE_BASIS = new Map([
+    ['MR', 'Z'],
+    ['MRX', 'X'],
+    ['MRY', 'Y'],
+]);
+
 class Layer {
     constructor() {
         this.id_ops = /** @type {!Map<!int, !Operation>} */ new Map();
@@ -220,6 +229,16 @@ class Layer {
         let after = new Map();
         let handled = new Set();
 
+        // Record qubits involved in demolition measurements (measure + reset)
+        let demolitionResetQubits = new Set();
+        for (let op of this.id_ops.values()) {
+            if (DEMOLITION_MEASURE_BASIS.has(op.gate.name)) {
+                for (let q of op.id_targets) {
+                    demolitionResetQubits.add(q);
+                }
+            }
+        }
+
         for (let k of before.keys()) {
             let v = before.get(k);
             let op = this.id_ops.get(k);
@@ -237,19 +256,33 @@ class Layer {
                     }
                     b += r;
                 }
-                let a = op.pauliFrameAfter(b);
-                let hasErr = a.startsWith('ERR:');
-                for (let qi = 0; qi < op.id_targets.length; qi++) {
-                    let q = op.id_targets[qi];
-                    if (hasErr) {
-                        after.set(q, 'ERR:' + a[4 + qi]);
-                    } else {
-                        after.set(q, a[qi]);
+                let demolitionBasis = DEMOLITION_MEASURE_BASIS.get(op.gate.name);
+                if (demolitionBasis !== undefined) {
+                    // Only measure now. Defer reset until after markers are handled
+                    let q = op.id_targets[0];
+                    let c = b[0];
+                    after.set(q, (c === 'I' || c === demolitionBasis) ? c : 'ERR:' + c);
+                } else {
+                    let a = op.pauliFrameAfter(b);
+                    let hasErr = a.startsWith('ERR:');
+                    for (let qi = 0; qi < op.id_targets.length; qi++) {
+                        let q = op.id_targets[qi];
+                        if (hasErr) {
+                            after.set(q, 'ERR:' + a[4 + qi]);
+                        } else {
+                            after.set(q, a[qi]);
+                        }
                     }
                 }
             } else {
                 after.set(k, v);
             }
+        }
+
+        // Snapshot operators before reset to distinguish incoming from outgoing markers later
+        let demolitionIncoming = new Map();
+        for (let q of demolitionResetQubits) {
+            demolitionIncoming.set(q, after.get(q));
         }
 
         for (let op of this.markers) {
@@ -293,6 +326,18 @@ class Layer {
                 }
                 after.set(key, pauli);
             }
+        }
+
+        // Apply deferred resets
+        for (let q of demolitionResetQubits) {
+            let incoming = demolitionIncoming.get(q);
+            if (incoming === undefined || incoming === 'I') {
+                // Nothing at reset: a marker here denotes an outgoing operator
+                continue;
+            }
+            // Operator at reset: clean if a marker captured it (now I), else lost (ERR)
+            let post = after.get(q);
+            after.set(q, (post === undefined || post === 'I') ? 'I' : 'ERR:I');
         }
 
         return after;

--- a/glue/crumble/circuit/propagated_pauli_frames.test.js
+++ b/glue/crumble/circuit/propagated_pauli_frames.test.js
@@ -125,3 +125,154 @@ test("propagated_pauli_frames.fromMeasurements", () => {
         )],
     ])));
 });
+
+test("propagated_pauli_frames.fromCircuit_demolitionMeasurementMarkers", () => {
+    // Operator processing for demolition measurements (MR/MRX/MRY)
+
+    // Uncaptured: the Z reaches the MR's reset and is reported as lost at that layer.
+    let propagated = PropagatedPauliFrames.fromCircuit(Circuit.fromStimCircuit(`
+        R 0
+        MARKZ(0) 0
+        TICK
+        MR 0
+        TICK
+        M 0
+    `), 0);
+    assertThat(propagated).isEqualTo(new PropagatedPauliFrames(new Map([
+        [0.5, new PropagatedPauliFrameLayer(
+            new Map([[0, 'Z']]),
+            new Set(),
+            [],
+        )],
+        [1, new PropagatedPauliFrameLayer(
+            new Map(),
+            new Set([0]),
+            [],
+        )],
+    ])));
+
+    // Captured: a co-located MARKZ (measured basis) captures the incoming Z, so it ends cleanly.
+    propagated = PropagatedPauliFrames.fromCircuit(Circuit.fromStimCircuit(`
+        R 0
+        MARKZ(0) 0
+        TICK
+        MR 0
+        MARKZ(0) 0
+        TICK
+        M 0
+    `), 0);
+    assertThat(propagated).isEqualTo(new PropagatedPauliFrames(new Map([
+        [0.5, new PropagatedPauliFrameLayer(
+            new Map([[0, 'Z']]),
+            new Set(),
+            [],
+        )],
+    ])));
+
+    // Outgoing: with nothing flowing in, a MARKZ at the MR introduces a Z on the reset's output,
+    // which propagates forward (here it passes through the following M).
+    propagated = PropagatedPauliFrames.fromCircuit(Circuit.fromStimCircuit(`
+        MR 0
+        MARKZ(0) 0
+        TICK
+        M 0
+    `), 0);
+    assertThat(propagated).isEqualTo(new PropagatedPauliFrames(new Map([
+        [0.5, new PropagatedPauliFrameLayer(
+            new Map([[0, 'Z']]),
+            new Set(),
+            [],
+        )],
+        [1.5, new PropagatedPauliFrameLayer(
+            new Map([[0, 'Z']]),
+            new Set(),
+            [],
+        )],
+    ])));
+
+    // The measured basis is per gate: MRX captures an X.
+    propagated = PropagatedPauliFrames.fromCircuit(Circuit.fromStimCircuit(`
+        RX 0
+        MARKX(0) 0
+        TICK
+        MRX 0
+        MARKX(0) 0
+        TICK
+        MX 0
+    `), 0);
+    assertThat(propagated).isEqualTo(new PropagatedPauliFrames(new Map([
+        [0.5, new PropagatedPauliFrameLayer(
+            new Map([[0, 'X']]),
+            new Set(),
+            [],
+        )],
+    ])));
+
+    // MRY reports an uncaptured Y.
+    propagated = PropagatedPauliFrames.fromCircuit(Circuit.fromStimCircuit(`
+        RY 0
+        MARKY(0) 0
+        TICK
+        MRY 0
+        TICK
+        MY 0
+    `), 0);
+    assertThat(propagated).isEqualTo(new PropagatedPauliFrames(new Map([
+        [0.5, new PropagatedPauliFrameLayer(
+            new Map([[0, 'Y']]),
+            new Set(),
+            [],
+        )],
+        [1, new PropagatedPauliFrameLayer(
+            new Map(),
+            new Set([0]),
+            [],
+        )],
+    ])));
+
+    // A marker in the wrong basis does not capture the incoming operator: it is still reported.
+    propagated = PropagatedPauliFrames.fromCircuit(Circuit.fromStimCircuit(`
+        R 0
+        MARKZ(0) 0
+        TICK
+        MR 0
+        MARKX(0) 0
+        TICK
+        M 0
+    `), 0);
+    assertThat(propagated).isEqualTo(new PropagatedPauliFrames(new Map([
+        [0.5, new PropagatedPauliFrameLayer(
+            new Map([[0, 'Z']]),
+            new Set(),
+            [],
+        )],
+        [1, new PropagatedPauliFrameLayer(
+            new Map(),
+            new Set([0]),
+            [],
+        )],
+    ])));
+
+    // An operator that anticommutes with the measured basis (X into an MR) cannot be captured and
+    // is reported at the measurement.
+    propagated = PropagatedPauliFrames.fromCircuit(Circuit.fromStimCircuit(`
+        RX 0
+        MARKX(0) 0
+        TICK
+        MR 0
+        TICK
+        M 0
+    `), 0);
+    assertThat(propagated).isEqualTo(new PropagatedPauliFrames(new Map([
+        [0.5, new PropagatedPauliFrameLayer(
+            new Map([[0, 'X']]),
+            new Set(),
+            [],
+        )],
+        [1, new PropagatedPauliFrameLayer(
+            new Map(),
+            new Set([0]),
+            [],
+        )],
+    ])));
+});


### PR DESCRIPTION
Disclaimer: The changes in this PR were written in part by Claude Code; my non-existent JS skills would have produced much lower-quality code. But I reviewed everything and this PR text is written by me. If this can't be merged for legal reasons, perhaps it can serve as a basis for a future patch.

The [documentation](https://github.com/quantumlib/Stim/blob/main/doc/gates.md#MR) states that the circuit `M 0; R 0` should be equivalent to `MR 0`, but in Crumble there is a divergence of the two. An incoming Z operator passes through `M` and causes an error at `R` if not captured by a `MARKZ` (first row in upper figure). For `MR` the behavior deviates: the operator simply passes through (third row in upper figure).

Trying to capture the operator with a `MARKZ` will just create a new operator (second row in upper figure).

The fix is to first handle potential inbound operators upon measurement and then creating an error (magenta mark) at the reset if applicable.

Upstream:
<img width="325" height="304" alt="Screenshot 2026-07-08 at 14 38 23" src="https://github.com/user-attachments/assets/f2b0b380-4ed7-4695-8486-c712a7250eb2" />

This PR (the behavior I'd expect):
<img width="308" height="283" alt="Screenshot 2026-07-08 at 14 36 04" src="https://github.com/user-attachments/assets/383c6ef5-bd83-4985-a9d4-c17d80aafce5" />

