### PR TITLE
Build aarch64 (arm64) Linux wheels in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,12 @@ jobs:
           {os: ubuntu-24.04, dist: cp313-manylinux_x86_64},
           {os: ubuntu-24.04, dist: cp314-manylinux_x86_64},
 
+          {os: ubuntu-24.04-arm, dist: cp310-manylinux_aarch64},
+          {os: ubuntu-24.04-arm, dist: cp311-manylinux_aarch64},
+          {os: ubuntu-24.04-arm, dist: cp312-manylinux_aarch64},
+          {os: ubuntu-24.04-arm, dist: cp313-manylinux_aarch64},
+          {os: ubuntu-24.04-arm, dist: cp314-manylinux_aarch64},
+
           # manylinux_i686 disabled because scipy isn't prebuilt and fails to build.
           #
           # The actual error seen in github actions:


### PR DESCRIPTION
## Summary

This repo does not currently build wheels for aarch64 (arm64) Linux. This PR adds `manylinux_aarch64` wheel builds to the CI matrix, so users on ARM64 Linux (e.g. AWS Graviton, Ampere servers, Raspberry Pi) can install stim via a prebuilt wheel instead of building from source.

## Changes

- `.github/workflows/ci.yml`: added 5 new `build_dist` matrix entries (`cp310`-`cp314`, `dist: cpXXX-manylinux_aarch64`) using GitHub's native `ubuntu-24.04-arm` runners. This mirrors the existing x86_64 manylinux entries and requires no QEMU/binfmt emulation setup since the runner is natively arm64.

No changes were needed in `setup.py`: it already skips the x86-only SSE2 extension module when built on non-x86 architectures (see `_get_extensions()`), falling back to the base extension set, so the aarch64 build produces a working wheel without any arch-specific code changes.

## Testing

- Validated the updated workflow YAML parses correctly.
- Full build verification will happen via this PR's CI run (a native aarch64 Docker build/test cannot be run locally in this environment).