### PR TITLE
Add inter-append coalescing to `stimflow.ChunkBuilder`

### DIFF
--- a/glue/stimflow/doc/api.md
+++ b/glue/stimflow/doc/api.md
@@ -31,6 +31,7 @@
     - [`stimflow.ChunkBuilder.add_discarded_flow_input`](#stimflow.ChunkBuilder.add_discarded_flow_input)
     - [`stimflow.ChunkBuilder.add_discarded_flow_output`](#stimflow.ChunkBuilder.add_discarded_flow_output)
     - [`stimflow.ChunkBuilder.add_flow`](#stimflow.ChunkBuilder.add_flow)
+    - [`stimflow.ChunkBuilder.add_obs_name_index`](#stimflow.ChunkBuilder.add_obs_name_index)
     - [`stimflow.ChunkBuilder.append`](#stimflow.ChunkBuilder.append)
     - [`stimflow.ChunkBuilder.append_feedback`](#stimflow.ChunkBuilder.append_feedback)
     - [`stimflow.ChunkBuilder.finish_chunk`](#stimflow.ChunkBuilder.finish_chunk)
@@ -391,10 +392,65 @@ def find_distance(
     self,
     *,
     max_search_weight: int,
-    noise: float | NoiseModel = 0.001,
+    noise: float | NoiseModel | None = 0.001,
     noiseless_qubits: Iterable[float | int | complex] = (),
     skip_adding_noise: bool = False,
 ) -> int:
+    """Searches for logical errors and returns the length of the shortest one found.
+
+    Args:
+        max_search_weight: Determines how the search is truncated. The search process
+            will ignore errors, or combinations of errors, that produce more detection
+            events than this value. Set to `2` to search for graphlike errors.
+        noise: Determines the noise model to use. If set to a float, then uniform
+            depolarizing noise is used (with the float used as the noise parameter).
+            Defaults to 1e-3 uniform depolarizing noise. If set to None, no noise
+            is added to the circuit (e.g. you may use this if the circuit already
+            contains noise instructions). Can be also be set to an `sf.NoiseModel`.
+        noiseless_qubits: Qubits to not add any noise to when applying the noise
+            model.
+        skip_adding_noise: Defaults to False. When set to True, skips applying the
+            specified noise model to the qubits. This is just a "nicer to read"
+            version of setting `noise=None`.
+
+    Examples:
+        >>> import stimflow as sf
+        >>> import stim
+
+        >>> # Check that a distance 3 rep code protects the Z logical.
+        >>> obs_z = sf.PauliMap({"Z": [0]}, obs_name="LZ")
+        >>> chunk = sf.Chunk(
+        ...     circuit=stim.Circuit('''
+        ...         QUBIT_COORDS(0, 0) 0
+        ...         QUBIT_COORDS(1, 0) 1
+        ...         QUBIT_COORDS(2, 0) 2
+        ...         QUBIT_COORDS(3, 0) 3
+        ...         QUBIT_COORDS(4, 0) 4
+        ...         R 1 3
+        ...         CX 0 1 2 3
+        ...         CX 4 3 2 1
+        ...         M 1 3
+        ...     '''),
+        ...     flows=[
+        ...         sf.Flow(start=sf.PauliMap({"Z": [0, 2]}), measurement_indices=[0]),
+        ...         sf.Flow(end=sf.PauliMap({"Z": [0, 2]}), measurement_indices=[0]),
+        ...         sf.Flow(start=sf.PauliMap({"Z": [2, 4]}), measurement_indices=[1]),
+        ...         sf.Flow(end=sf.PauliMap({"Z": [2, 4]}), measurement_indices=[1]),
+        ...         sf.Flow(start=obs_z, end=obs_z),
+        ...     ],
+        ... )
+        >>> chunk.find_distance(max_search_weight=2)
+        3
+
+        >>> # ...but the X logical isn't protected.
+        >>> obs_x = sf.PauliMap({"X": [0, 2, 4]}, obs_name="LX")
+        >>> chunk = chunk.with_edits(flows=[
+        ...     *chunk.flows,
+        ...     sf.Flow(start=obs_x, end=obs_x),
+        ... ])
+        >>> chunk.find_distance(max_search_weight=2)
+        1
+    """
 ```
 
 <a name="stimflow.Chunk.find_logical_error"></a>
@@ -406,7 +462,7 @@ def find_logical_error(
     self,
     *,
     max_search_weight: int,
-    noise: float | NoiseModel = 0.001,
+    noise: float | NoiseModel | None = 0.001,
     noiseless_qubits: Iterable[float | int | complex] = (),
     skip_adding_noise: bool = False,
 ) -> list[stim.ExplainedError]:
@@ -498,8 +554,67 @@ def time_reversed(
 # (in class stimflow.Chunk)
 def to_closed_circuit(
     self,
+    *,
+    skip_verification: bool = False,
 ) -> stim.Circuit:
-    """Compiles the chunk into a circuit by conjugating with mpp init/end chunks.
+    """Compiles the chunk into a circuit with magical flow initialization / termination.
+
+    Observable flows will be terminated with `OBSERVABLE_INCLUDE` instructions targeting
+    Pauli terms. This allows anticommuting observables to be simultaneously tested when
+    simulating the circuit. Non-observable flows are terminated by `MPP` instructions.
+
+    Args:
+        skip_verification: Defaults to False. When set to False, the method will
+            fail with an error if the chunk is malformed (e.g. declares flows that
+            its circuit doesn't have). When set to True, these errors will be
+            ignored.
+
+    Examples:
+        >>> import stimflow as sf
+        >>> import stim
+        >>> obs_x = sf.PauliMap({"X": [0, 2]}, obs_name="LX")
+        >>> obs_z = sf.PauliMap({"Z": [0]}, obs_name="LZ")
+        >>> chunk = sf.Chunk(
+        ...     circuit=stim.Circuit('''
+        ...         QUBIT_COORDS(0, 0) 0
+        ...         QUBIT_COORDS(1, 0) 1
+        ...         QUBIT_COORDS(2, 0) 2
+        ...         R 1
+        ...         CX 0 1
+        ...         CX 2 1
+        ...         M 1
+        ...     '''),
+        ...     flows=[
+        ...         sf.Flow(start=sf.PauliMap({"Z": [0, 2]}), measurement_indices=[0]),
+        ...         sf.Flow(end=sf.PauliMap({"Z": [0, 2]}), measurement_indices=[0]),
+        ...         sf.Flow(start=obs_x, end=obs_x),
+        ...         sf.Flow(start=obs_z, end=obs_z),
+        ...     ],
+        ... )
+        >>> chunk.to_closed_circuit()
+        stim.Circuit('''
+            QUBIT_COORDS(0, 0) 0
+            QUBIT_COORDS(1, 0) 1
+            QUBIT_COORDS(2, 0) 2
+            OBSERVABLE_INCLUDE(0) X0 X2
+            TICK
+            OBSERVABLE_INCLUDE(1) Z0
+            TICK
+            MPP Z0*Z2
+            TICK
+            R 1
+            CX 0 1 2 1
+            M 1
+            DETECTOR(1, 0, 0) rec[-2] rec[-1]
+            SHIFT_COORDS(0, 0, 1)
+            TICK
+            MPP Z0*Z2
+            DETECTOR(1, 0, 0) rec[-2] rec[-1]
+            TICK
+            OBSERVABLE_INCLUDE(0) X0 X2
+            TICK
+            OBSERVABLE_INCLUDE(1) Z0
+        ''')
     """
 ```
 
@@ -700,50 +815,77 @@ class ChunkBuilder:
         >>> obs = sf.PauliMap({data_qubits[0]: "Z"}).with_obs_name("LZ")
         >>> builder.add_flow(start=obs, end=obs)
         >>> chunk = builder.finish_chunk()
-
         >>> chunk.verify()
-        >>> print(chunk.to_closed_circuit())
-        QUBIT_COORDS(0, 0) 0
-        QUBIT_COORDS(0.5, 0) 1
-        QUBIT_COORDS(1, 0) 2
-        QUBIT_COORDS(1.5, 0) 3
-        QUBIT_COORDS(2, 0) 4
-        QUBIT_COORDS(2.5, 0) 5
-        QUBIT_COORDS(3, 0) 6
-        QUBIT_COORDS(3.5, 0) 7
-        QUBIT_COORDS(4, 0) 8
-        QUBIT_COORDS(4.5, 0) 9
-        QUBIT_COORDS(5, 0) 10
-        OBSERVABLE_INCLUDE(0) Z0
-        TICK
-        MPP Z0*Z2 Z4*Z6 Z8*Z10
-        TICK
-        MPP Z2*Z4 Z6*Z8
-        TICK
-        R 9 7 5 3 1
-        TICK
-        CX 8 9 6 7 4 5 2 3 0 1
-        TICK
-        CX 8 7 6 5 4 3 2 1 10 9
-        TICK
-        M 9 7 5 3 1
-        DETECTOR(4.5, 0, 0) rec[-8] rec[-5]
-        DETECTOR(3.5, 0, 0) rec[-6] rec[-4]
-        DETECTOR(2.5, 0, 0) rec[-9] rec[-3]
-        DETECTOR(1.5, 0, 0) rec[-7] rec[-2]
-        DETECTOR(0.5, 0, 0) rec[-10] rec[-1]
-        SHIFT_COORDS(0, 0, 1)
-        TICK
-        MPP Z0*Z2 Z4*Z6 Z8*Z10
-        TICK
-        MPP Z2*Z4 Z6*Z8
-        DETECTOR(0.5, 0, 0) rec[-6] rec[-5]
-        DETECTOR(2.5, 0, 0) rec[-8] rec[-4]
-        DETECTOR(4.5, 0, 0) rec[-10] rec[-3]
-        DETECTOR(1.5, 0, 0) rec[-7] rec[-2]
-        DETECTOR(3.5, 0, 0) rec[-9] rec[-1]
-        TICK
-        OBSERVABLE_INCLUDE(0) Z0
+        >>> chunk
+        stimflow.Chunk(
+            q2i={4.5: 0, 3.5: 1, 2.5: 2, 1.5: 3, 0.5: 4, 4.0: 5, 3.0: 6, 2.0: 7, 1.0: 8, 0.0: 9, 5.0: 10},
+            circuit=stim.Circuit('''
+                R 0 1 2 3 4
+                TICK
+                CX 5 0 6 1 7 2 8 3 9 4
+                TICK
+                CX 5 1 6 2 7 3 8 4 10 0
+                TICK
+                M 0 1 2 3 4
+            '''),
+            flows=[
+                stimflow.Flow(
+                    start=stimflow.PauliMap.from_zs([(4+0j), (5+0j)]),
+                    measurement_indices=(0,),
+                    center=(4.5+0j),
+                ),
+                stimflow.Flow(
+                    end=stimflow.PauliMap.from_zs([(4+0j), (5+0j)]),
+                    measurement_indices=(0,),
+                    center=(4.5+0j),
+                ),
+                stimflow.Flow(
+                    start=stimflow.PauliMap.from_zs([(3+0j), (4+0j)]),
+                    measurement_indices=(1,),
+                    center=(3.5+0j),
+                ),
+                stimflow.Flow(
+                    end=stimflow.PauliMap.from_zs([(3+0j), (4+0j)]),
+                    measurement_indices=(1,),
+                    center=(3.5+0j),
+                ),
+                stimflow.Flow(
+                    start=stimflow.PauliMap.from_zs([(2+0j), (3+0j)]),
+                    measurement_indices=(2,),
+                    center=(2.5+0j),
+                ),
+                stimflow.Flow(
+                    end=stimflow.PauliMap.from_zs([(2+0j), (3+0j)]),
+                    measurement_indices=(2,),
+                    center=(2.5+0j),
+                ),
+                stimflow.Flow(
+                    start=stimflow.PauliMap.from_zs([(1+0j), (2+0j)]),
+                    measurement_indices=(3,),
+                    center=(1.5+0j),
+                ),
+                stimflow.Flow(
+                    end=stimflow.PauliMap.from_zs([(1+0j), (2+0j)]),
+                    measurement_indices=(3,),
+                    center=(1.5+0j),
+                ),
+                stimflow.Flow(
+                    start=stimflow.PauliMap.from_zs([0j, (1+0j)]),
+                    measurement_indices=(4,),
+                    center=(0.5+0j),
+                ),
+                stimflow.Flow(
+                    end=stimflow.PauliMap.from_zs([0j, (1+0j)]),
+                    measurement_indices=(4,),
+                    center=(0.5+0j),
+                ),
+                stimflow.Flow(
+                    start=stimflow.PauliMap({0j: 'Z'}, obs_name='LZ'),
+                    end=stimflow.PauliMap({0j: 'Z'}, obs_name='LZ'),
+                    center=0j,
+                ),
+            ],
+        )
     """
 ```
 
@@ -1028,6 +1170,43 @@ def add_flow(
     """
 ```
 
+<a name="stimflow.ChunkBuilder.add_obs_name_index"></a>
+```python
+# stimflow.ChunkBuilder.add_obs_name_index
+
+# (in class stimflow.ChunkBuilder)
+def add_obs_name_index(
+    self,
+    obs_name: str,
+    obs_index: int,
+) -> None:
+    """Associates an explicit stim observable index with a stimflow observable name.
+
+    Note that the name-to-index association typically happens automatically. For example,
+    `builder.append("OBSERVABLE_INCLUDE", some_named_obs)` will automatically pick an unused
+    index to use if `some_named_obs`'s name is not already indexed.
+
+    Args:
+        obs_name: The name of the observable to use when referring it in stimflow.
+        obs_index: The index to use when referring to the observable in a stim circuit.
+
+    Examples:
+        >>> import stimflow as sf
+        >>> builder = sf.ChunkBuilder()
+        >>> obs = sf.PauliMap({0: "Z"}, obs_name="LX")
+        >>> builder.add_obs_name_index(obs.obs_name, 5)
+        >>> builder.append("OBSERVABLE_INCLUDE", obs)
+        >>> builder.finish_chunk()
+        stimflow.Chunk(
+            q2i={0j: 0},
+            o2i={'LX': 5},
+            circuit=stim.Circuit('''
+                OBSERVABLE_INCLUDE(5) Z0
+            '''),
+        )
+    """
+```
+
 <a name="stimflow.ChunkBuilder.append"></a>
 ```python
 # stimflow.ChunkBuilder.append
@@ -1055,7 +1234,7 @@ def append(
         b = builder.q2i[5]
         c = builder.q2i[0]
         d = builder.q2i[1j]
-        builder.circuit.append('CZ', [a, b, c, d])
+        builder._circuit.append('CZ', [a, b, c, d])
 
     you would say
 
@@ -1111,6 +1290,135 @@ def append(
             - 'skip': When a qubit position outside `allowed_qubits` is encountered,
                 ignore it. Note that, for two-qubit and multi-qubit operations, this
                 will ignore the pair or group of targets containing the skipped position.
+
+    Examples:
+        >>> import stim
+        >>> import stimflow as sf
+
+        >>> # Build a repetition code idling chunk.
+        >>> d = 5
+        >>> data_qubits = range(d)
+        >>> measure_qubits = [q + 0.5 for q in data_qubits[::-1]]
+        >>> builder = sf.ChunkBuilder()
+        >>> builder.append("R", measure_qubits)
+        >>> builder.append("TICK")
+        >>> builder.append("CX", [(m-0.5, m) for m in measure_qubits])
+        >>> builder.append("TICK")
+        >>> builder.append("CX", [(m+0.5, m) for m in measure_qubits])
+        >>> builder.append("TICK")
+        >>> builder.append("M", measure_qubits)
+        >>> for m in measure_qubits:
+        ...     stabilizer = sf.PauliMap.from_zs([m-0.5, m+0.5])
+        ...     builder.add_flow(start=stabilizer, measurements=[m])
+        ...     builder.add_flow(end=stabilizer, measurements=[m])
+        >>> obs = sf.PauliMap({data_qubits[0]: "Z"}).with_obs_name("LZ")
+        >>> builder.add_flow(start=obs, end=obs)
+        >>> chunk = builder.finish_chunk()
+        >>> chunk.verify()
+        >>> chunk
+        stimflow.Chunk(
+            q2i={4.5: 0, 3.5: 1, 2.5: 2, 1.5: 3, 0.5: 4, 4.0: 5, 3.0: 6, 2.0: 7, 1.0: 8, 0.0: 9, 5.0: 10},
+            circuit=stim.Circuit('''
+                R 0 1 2 3 4
+                TICK
+                CX 5 0 6 1 7 2 8 3 9 4
+                TICK
+                CX 5 1 6 2 7 3 8 4 10 0
+                TICK
+                M 0 1 2 3 4
+            '''),
+            flows=[
+                stimflow.Flow(
+                    start=stimflow.PauliMap.from_zs([(4+0j), (5+0j)]),
+                    measurement_indices=(0,),
+                    center=(4.5+0j),
+                ),
+                stimflow.Flow(
+                    end=stimflow.PauliMap.from_zs([(4+0j), (5+0j)]),
+                    measurement_indices=(0,),
+                    center=(4.5+0j),
+                ),
+                stimflow.Flow(
+                    start=stimflow.PauliMap.from_zs([(3+0j), (4+0j)]),
+                    measurement_indices=(1,),
+                    center=(3.5+0j),
+                ),
+                stimflow.Flow(
+                    end=stimflow.PauliMap.from_zs([(3+0j), (4+0j)]),
+                    measurement_indices=(1,),
+                    center=(3.5+0j),
+                ),
+                stimflow.Flow(
+                    start=stimflow.PauliMap.from_zs([(2+0j), (3+0j)]),
+                    measurement_indices=(2,),
+                    center=(2.5+0j),
+                ),
+                stimflow.Flow(
+                    end=stimflow.PauliMap.from_zs([(2+0j), (3+0j)]),
+                    measurement_indices=(2,),
+                    center=(2.5+0j),
+                ),
+                stimflow.Flow(
+                    start=stimflow.PauliMap.from_zs([(1+0j), (2+0j)]),
+                    measurement_indices=(3,),
+                    center=(1.5+0j),
+                ),
+                stimflow.Flow(
+                    end=stimflow.PauliMap.from_zs([(1+0j), (2+0j)]),
+                    measurement_indices=(3,),
+                    center=(1.5+0j),
+                ),
+                stimflow.Flow(
+                    start=stimflow.PauliMap.from_zs([0j, (1+0j)]),
+                    measurement_indices=(4,),
+                    center=(0.5+0j),
+                ),
+                stimflow.Flow(
+                    end=stimflow.PauliMap.from_zs([0j, (1+0j)]),
+                    measurement_indices=(4,),
+                    center=(0.5+0j),
+                ),
+                stimflow.Flow(
+                    start=stimflow.PauliMap({0j: 'Z'}, obs_name='LZ'),
+                    end=stimflow.PauliMap({0j: 'Z'}, obs_name='LZ'),
+                    center=0j,
+                ),
+            ],
+        )
+
+        >>> # Fancy OBSERVABLE_INCLUDE stuff.
+        >>> builder = sf.ChunkBuilder()
+        >>> obs = sf.PauliMap({"Z": [0, 1, 2]}, obs_name="LZ")
+        >>> builder.append("RX", [0, 1, 2])
+        >>> builder.append("OBSERVABLE_INCLUDE", obs)
+        >>> builder.add_flow(end=sf.PauliMap({"X": [0, 1]}))
+        >>> builder.add_flow(end=sf.PauliMap({"X": [1, 2]}))
+        >>> builder.add_flow(end=obs)
+        >>> chunk = builder.finish_chunk()
+        >>> chunk.verify()
+        >>> chunk
+        stimflow.Chunk(
+            q2i={0: 0, 1: 1, 2: 2},
+            o2i={'LZ': 0},
+            circuit=stim.Circuit('''
+                RX 0 1 2
+                OBSERVABLE_INCLUDE(0) Z0 Z1 Z2
+            '''),
+            flows=[
+                stimflow.Flow(
+                    end=stimflow.PauliMap.from_xs([0j, (1+0j)]),
+                    center=(0.5+0j),
+                ),
+                stimflow.Flow(
+                    end=stimflow.PauliMap.from_xs([(1+0j), (2+0j)]),
+                    center=(1.5+0j),
+                ),
+                stimflow.Flow(
+                    end=stimflow.PauliMap.from_zs([0j, (1+0j), (2+0j)], obs_name='LZ'),
+                    center=(1+0j),
+                ),
+            ],
+        )
     """
 ```
 
@@ -1897,6 +2205,31 @@ class ChunkLoop:
 
     For duck typing purposes, many methods supported by Chunk are supported by
     ChunkLoop.
+
+    Examples:
+        >>> import stim
+        >>> import stimflow as sf
+        >>> zz = sf.PauliMap({0: 'Z', 1 + 1j: 'Z'})
+        >>> lz = sf.PauliMap({0: 'Z'}, obs_name='L_ZI')
+        >>> lx = sf.PauliMap({0: 'X', 1 + 1j: 'X'}, obs_name='L_XX')
+        >>> idle_chunk = sf.Chunk(
+        ...     stim.Circuit('''
+        ...         QUBIT_COORDS(0, 0) 0
+        ...         QUBIT_COORDS(0, 1) 1
+        ...         QUBIT_COORDS(1, 1) 2
+        ...         R 1
+        ...         CX 0 1 2 1
+        ...         M 1
+        ...     '''),
+        ...     flows=[
+        ...         sf.Flow(start=zz, measurement_indices=[0]),
+        ...         sf.Flow(end=zz, measurement_indices=[0]),
+        ...         sf.Flow(start=lz, end=lz),
+        ...         sf.Flow(start=lx, end=lx),
+        ...     ]
+        ... )
+        >>> idle_ten_times = sf.ChunkLoop([idle_chunk], repetitions=10)
+        >>> idle_ten_times.verify()
     """
 ```
 
@@ -3141,16 +3474,66 @@ def __init__(
     after: dict[str, float | tuple[float, ...]] | None = None,
     flip_result: float = 0,
 ):
-    """
+    """Initializes a NoiseRule.
 
     Args:
-        after: A dictionary mapping noise rule names to their probability argument.
-            For example, {"DEPOLARIZE2": 0.01, "X_ERROR": 0.02} will add two qubit
-            depolarization with parameter 0.01 and also add 2% bit flip noise. These
-            noise channels occur after all other operations in the moment and are applied
-            to the same targets as the relevant operation.
+        before: A name-to-argument mapping of noise instructions to add before some
+            instruction that is being made noisy. For example,
+                after={"DEPOLARIZE2": 0.01, "X_ERROR": 0.02}
+            will add two qubit depolarization with parameter 0.01 and also add 2%
+            bit flip noise. These noise channels occur before all other operations
+            in the moment and are applied to the same targets as the relevant operation.
+        after: A name-to-argument mapping of noise instructions to add after some
+            instruction that is being made noisy. For example,
+                after={"DEPOLARIZE2": 0.01, "X_ERROR": 0.02}
+            will add two qubit depolarization with parameter 0.01 and also add 2%
+            bit flip noise. These noise channels occur after all other operations
+            in the moment and are applied to the same targets as the relevant operation.
         flip_result: The probability that a measurement result should be reported incorrectly.
             Only valid when applied to operations that produce measurement results.
+
+    Examples:
+        >>> import stim
+        >>> import stimflow as sf
+        >>> noise = sf.NoiseModel(gate_rules={
+        ...     'R': sf.NoiseRule(after={"X_ERROR": 5e-3}),
+        ...     'M': sf.NoiseRule(flip_result=1e-3),
+        ...     'CZ': sf.NoiseRule(after={"Z_ERROR": 3e-3, "DEPOLARIZE2": 1e-3}),
+        ...     'H': sf.NoiseRule(before={"PAULI_CHANNEL_1": (1e-3, 1e-2, 1e-3)}),
+        ... })
+        >>> noise.noisy_circuit(stim.Circuit('''
+        ...     R 1
+        ...     TICK
+        ...     H 1
+        ...     TICK
+        ...     CZ 0 1
+        ...     TICK
+        ...     CZ 2 1
+        ...     TICK
+        ...     H 1
+        ...     TICK
+        ...     M 1
+        ... '''))
+        stim.Circuit('''
+            R 1
+            X_ERROR(0.005) 1
+            TICK
+            PAULI_CHANNEL_1(0.001, 0.01, 0.001) 1
+            H 1
+            TICK
+            CZ 0 1
+            DEPOLARIZE2(0.001) 0 1
+            Z_ERROR(0.003) 0 1
+            TICK
+            CZ 2 1
+            DEPOLARIZE2(0.001) 2 1
+            Z_ERROR(0.003) 2 1
+            TICK
+            PAULI_CHANNEL_1(0.001, 0.01, 0.001) 1
+            H 1
+            TICK
+            M(0.001) 1
+        ''')
     """
 ```
 

--- a/glue/stimflow/src/stimflow/_chunk/_chunk.py
+++ b/glue/stimflow/src/stimflow/_chunk/_chunk.py
@@ -138,6 +138,17 @@ class Chunk:
             for flow in flows:
                 if flow.obs_name is not None and flow.obs_name not in o2i:
                     o2i[flow.obs_name] = len(o2i)
+        else:
+            for k, v in o2i.items():
+                if isinstance(k, PauliMap):
+                    obs_name_repr = 'some_observable_name' if k.obs_name is None else repr(k.obs_name)
+                    raise ValueError(
+                        f"Used an observable, instead of its name, as a key for o2i.\n"
+                        f"Did you mean\n"
+                        f"    o2i={{..., {obs_name_repr}: {v!r}, ...}}\n"
+                        f"instead of\n"
+                        f"    o2i={{..., {k!r}: {v!r}, ...}}\n"
+                        f"?")
 
         self.q2i: dict[complex, int] = q2i
         self.o2i: dict[Any, int] = o2i
@@ -321,6 +332,8 @@ class Chunk:
     def __repr__(self) -> str:
         lines = ["stimflow.Chunk("]
         lines.append(f"    q2i={self.q2i!r},")
+        if self.o2i:
+            lines.append(f"    o2i={self.o2i!r},")
         lines.append(f"    circuit={self.circuit!r},".replace("\n", "\n    "))
         if self.flows:
             lines.append(f"    flows=[")

--- a/glue/stimflow/src/stimflow/_chunk/_chunk.py
+++ b/glue/stimflow/src/stimflow/_chunk/_chunk.py
@@ -538,10 +538,65 @@ class Chunk:
         self,
         *,
         max_search_weight: int,
-        noise: float | NoiseModel = 1e-3,
+        noise: float | NoiseModel | None = 1e-3,
         noiseless_qubits: Iterable[float | int | complex] = (),
         skip_adding_noise: bool = False,
     ) -> int:
+        """Searches for logical errors and returns the length of the shortest one found.
+
+        Args:
+            max_search_weight: Determines how the search is truncated. The search process
+                will ignore errors, or combinations of errors, that produce more detection
+                events than this value. Set to `2` to search for graphlike errors.
+            noise: Determines the noise model to use. If set to a float, then uniform
+                depolarizing noise is used (with the float used as the noise parameter).
+                Defaults to 1e-3 uniform depolarizing noise. If set to None, no noise
+                is added to the circuit (e.g. you may use this if the circuit already
+                contains noise instructions). Can be also be set to an `sf.NoiseModel`.
+            noiseless_qubits: Qubits to not add any noise to when applying the noise
+                model.
+            skip_adding_noise: Defaults to False. When set to True, skips applying the
+                specified noise model to the qubits. This is just a "nicer to read"
+                version of setting `noise=None`.
+
+        Examples:
+            >>> import stimflow as sf
+            >>> import stim
+
+            >>> # Check that a distance 3 rep code protects the Z logical.
+            >>> obs_z = sf.PauliMap({"Z": [0]}, obs_name="LZ")
+            >>> chunk = sf.Chunk(
+            ...     circuit=stim.Circuit('''
+            ...         QUBIT_COORDS(0, 0) 0
+            ...         QUBIT_COORDS(1, 0) 1
+            ...         QUBIT_COORDS(2, 0) 2
+            ...         QUBIT_COORDS(3, 0) 3
+            ...         QUBIT_COORDS(4, 0) 4
+            ...         R 1 3
+            ...         CX 0 1 2 3
+            ...         CX 4 3 2 1
+            ...         M 1 3
+            ...     '''),
+            ...     flows=[
+            ...         sf.Flow(start=sf.PauliMap({"Z": [0, 2]}), measurement_indices=[0]),
+            ...         sf.Flow(end=sf.PauliMap({"Z": [0, 2]}), measurement_indices=[0]),
+            ...         sf.Flow(start=sf.PauliMap({"Z": [2, 4]}), measurement_indices=[1]),
+            ...         sf.Flow(end=sf.PauliMap({"Z": [2, 4]}), measurement_indices=[1]),
+            ...         sf.Flow(start=obs_z, end=obs_z),
+            ...     ],
+            ... )
+            >>> chunk.find_distance(max_search_weight=2)
+            3
+
+            >>> # ...but the X logical isn't protected.
+            >>> obs_x = sf.PauliMap({"X": [0, 2, 4]}, obs_name="LX")
+            >>> chunk = chunk.with_edits(flows=[
+            ...     *chunk.flows,
+            ...     sf.Flow(start=obs_x, end=obs_x),
+            ... ])
+            >>> chunk.find_distance(max_search_weight=2)
+            1
+        """
         err = self.find_logical_error(
             max_search_weight=max_search_weight,
             noise=noise,
@@ -550,11 +605,69 @@ class Chunk:
         )
         return len(err)
 
-    def to_closed_circuit(self) -> stim.Circuit:
-        """Compiles the chunk into a circuit by conjugating with mpp init/end chunks."""
+    def to_closed_circuit(self, *, skip_verification: bool = False) -> stim.Circuit:
+        """Compiles the chunk into a circuit with magical flow initialization / termination.
+
+        Observable flows will be terminated with `OBSERVABLE_INCLUDE` instructions targeting
+        Pauli terms. This allows anticommuting observables to be simultaneously tested when
+        simulating the circuit. Non-observable flows are terminated by `MPP` instructions.
+
+        Args:
+            skip_verification: Defaults to False. When set to False, the method will
+                fail with an error if the chunk is malformed (e.g. declares flows that
+                its circuit doesn't have). When set to True, these errors will be
+                ignored.
+
+        Examples:
+            >>> import stimflow as sf
+            >>> import stim
+            >>> obs_x = sf.PauliMap({"X": [0, 2]}, obs_name="LX")
+            >>> obs_z = sf.PauliMap({"Z": [0]}, obs_name="LZ")
+            >>> chunk = sf.Chunk(
+            ...     circuit=stim.Circuit('''
+            ...         QUBIT_COORDS(0, 0) 0
+            ...         QUBIT_COORDS(1, 0) 1
+            ...         QUBIT_COORDS(2, 0) 2
+            ...         R 1
+            ...         CX 0 1
+            ...         CX 2 1
+            ...         M 1
+            ...     '''),
+            ...     flows=[
+            ...         sf.Flow(start=sf.PauliMap({"Z": [0, 2]}), measurement_indices=[0]),
+            ...         sf.Flow(end=sf.PauliMap({"Z": [0, 2]}), measurement_indices=[0]),
+            ...         sf.Flow(start=obs_x, end=obs_x),
+            ...         sf.Flow(start=obs_z, end=obs_z),
+            ...     ],
+            ... )
+            >>> chunk.to_closed_circuit()
+            stim.Circuit('''
+                QUBIT_COORDS(0, 0) 0
+                QUBIT_COORDS(1, 0) 1
+                QUBIT_COORDS(2, 0) 2
+                OBSERVABLE_INCLUDE(0) X0 X2
+                TICK
+                OBSERVABLE_INCLUDE(1) Z0
+                TICK
+                MPP Z0*Z2
+                TICK
+                R 1
+                CX 0 1 2 1
+                M 1
+                DETECTOR(1, 0, 0) rec[-2] rec[-1]
+                SHIFT_COORDS(0, 0, 1)
+                TICK
+                MPP Z0*Z2
+                DETECTOR(1, 0, 0) rec[-2] rec[-1]
+                TICK
+                OBSERVABLE_INCLUDE(0) X0 X2
+                TICK
+                OBSERVABLE_INCLUDE(1) Z0
+            ''')
+        """
         from stimflow._chunk._chunk_compiler import ChunkCompiler
 
-        compiler = ChunkCompiler()
+        compiler = ChunkCompiler(skip_verification_before_append=True)
         compiler.append_magic_init_chunk(self.start_interface())
         compiler.append(self)
         compiler.append_magic_end_chunk(self.end_interface())
@@ -617,7 +730,7 @@ class Chunk:
         self,
         *,
         max_search_weight: int,
-        noise: float | NoiseModel = 1e-3,
+        noise: float | NoiseModel | None = 1e-3,
         noiseless_qubits: Iterable[float | int | complex] = (),
         skip_adding_noise: bool = False,
     ) -> list[stim.ExplainedError]:
@@ -625,9 +738,10 @@ class Chunk:
         if not skip_adding_noise:
             if isinstance(noise, float):
                 noise = NoiseModel.uniform_depolarizing(1e-3, allow_multiple_uses_of_a_qubit_in_one_tick=True)
-            circuit = noise.noisy_circuit_skipping_mpp_boundaries(
-                circuit, immune_qubit_coords=noiseless_qubits
-            )
+            if noise is not None:
+                circuit = noise.noisy_circuit_skipping_mpp_boundaries(
+                    circuit, immune_qubit_coords=noiseless_qubits
+                )
         if max_search_weight == 2:
             return circuit.shortest_graphlike_error(canonicalize_circuit_errors=True)
         return circuit.search_for_undetectable_logical_errors(

--- a/glue/stimflow/src/stimflow/_chunk/_chunk_builder.py
+++ b/glue/stimflow/src/stimflow/_chunk/_chunk_builder.py
@@ -58,50 +58,77 @@ class ChunkBuilder:
         >>> obs = sf.PauliMap({data_qubits[0]: "Z"}).with_obs_name("LZ")
         >>> builder.add_flow(start=obs, end=obs)
         >>> chunk = builder.finish_chunk()
-
         >>> chunk.verify()
-        >>> print(chunk.to_closed_circuit())
-        QUBIT_COORDS(0, 0) 0
-        QUBIT_COORDS(0.5, 0) 1
-        QUBIT_COORDS(1, 0) 2
-        QUBIT_COORDS(1.5, 0) 3
-        QUBIT_COORDS(2, 0) 4
-        QUBIT_COORDS(2.5, 0) 5
-        QUBIT_COORDS(3, 0) 6
-        QUBIT_COORDS(3.5, 0) 7
-        QUBIT_COORDS(4, 0) 8
-        QUBIT_COORDS(4.5, 0) 9
-        QUBIT_COORDS(5, 0) 10
-        OBSERVABLE_INCLUDE(0) Z0
-        TICK
-        MPP Z0*Z2 Z4*Z6 Z8*Z10
-        TICK
-        MPP Z2*Z4 Z6*Z8
-        TICK
-        R 9 7 5 3 1
-        TICK
-        CX 8 9 6 7 4 5 2 3 0 1
-        TICK
-        CX 8 7 6 5 4 3 2 1 10 9
-        TICK
-        M 9 7 5 3 1
-        DETECTOR(4.5, 0, 0) rec[-8] rec[-5]
-        DETECTOR(3.5, 0, 0) rec[-6] rec[-4]
-        DETECTOR(2.5, 0, 0) rec[-9] rec[-3]
-        DETECTOR(1.5, 0, 0) rec[-7] rec[-2]
-        DETECTOR(0.5, 0, 0) rec[-10] rec[-1]
-        SHIFT_COORDS(0, 0, 1)
-        TICK
-        MPP Z0*Z2 Z4*Z6 Z8*Z10
-        TICK
-        MPP Z2*Z4 Z6*Z8
-        DETECTOR(0.5, 0, 0) rec[-6] rec[-5]
-        DETECTOR(2.5, 0, 0) rec[-8] rec[-4]
-        DETECTOR(4.5, 0, 0) rec[-10] rec[-3]
-        DETECTOR(1.5, 0, 0) rec[-7] rec[-2]
-        DETECTOR(3.5, 0, 0) rec[-9] rec[-1]
-        TICK
-        OBSERVABLE_INCLUDE(0) Z0
+        >>> chunk
+        stimflow.Chunk(
+            q2i={4.5: 0, 3.5: 1, 2.5: 2, 1.5: 3, 0.5: 4, 4.0: 5, 3.0: 6, 2.0: 7, 1.0: 8, 0.0: 9, 5.0: 10},
+            circuit=stim.Circuit('''
+                R 0 1 2 3 4
+                TICK
+                CX 5 0 6 1 7 2 8 3 9 4
+                TICK
+                CX 5 1 6 2 7 3 8 4 10 0
+                TICK
+                M 0 1 2 3 4
+            '''),
+            flows=[
+                stimflow.Flow(
+                    start=stimflow.PauliMap.from_zs([(4+0j), (5+0j)]),
+                    measurement_indices=(0,),
+                    center=(4.5+0j),
+                ),
+                stimflow.Flow(
+                    end=stimflow.PauliMap.from_zs([(4+0j), (5+0j)]),
+                    measurement_indices=(0,),
+                    center=(4.5+0j),
+                ),
+                stimflow.Flow(
+                    start=stimflow.PauliMap.from_zs([(3+0j), (4+0j)]),
+                    measurement_indices=(1,),
+                    center=(3.5+0j),
+                ),
+                stimflow.Flow(
+                    end=stimflow.PauliMap.from_zs([(3+0j), (4+0j)]),
+                    measurement_indices=(1,),
+                    center=(3.5+0j),
+                ),
+                stimflow.Flow(
+                    start=stimflow.PauliMap.from_zs([(2+0j), (3+0j)]),
+                    measurement_indices=(2,),
+                    center=(2.5+0j),
+                ),
+                stimflow.Flow(
+                    end=stimflow.PauliMap.from_zs([(2+0j), (3+0j)]),
+                    measurement_indices=(2,),
+                    center=(2.5+0j),
+                ),
+                stimflow.Flow(
+                    start=stimflow.PauliMap.from_zs([(1+0j), (2+0j)]),
+                    measurement_indices=(3,),
+                    center=(1.5+0j),
+                ),
+                stimflow.Flow(
+                    end=stimflow.PauliMap.from_zs([(1+0j), (2+0j)]),
+                    measurement_indices=(3,),
+                    center=(1.5+0j),
+                ),
+                stimflow.Flow(
+                    start=stimflow.PauliMap.from_zs([0j, (1+0j)]),
+                    measurement_indices=(4,),
+                    center=(0.5+0j),
+                ),
+                stimflow.Flow(
+                    end=stimflow.PauliMap.from_zs([0j, (1+0j)]),
+                    measurement_indices=(4,),
+                    center=(0.5+0j),
+                ),
+                stimflow.Flow(
+                    start=stimflow.PauliMap({0j: 'Z'}, obs_name='LZ'),
+                    end=stimflow.PauliMap({0j: 'Z'}, obs_name='LZ'),
+                    center=0j,
+                ),
+            ],
+        )
     """
 
     def __init__(
@@ -759,6 +786,135 @@ class ChunkBuilder:
                 - 'skip': When a qubit position outside `allowed_qubits` is encountered,
                     ignore it. Note that, for two-qubit and multi-qubit operations, this
                     will ignore the pair or group of targets containing the skipped position.
+
+        Examples:
+            >>> import stim
+            >>> import stimflow as sf
+
+            >>> # Build a repetition code idling chunk.
+            >>> d = 5
+            >>> data_qubits = range(d)
+            >>> measure_qubits = [q + 0.5 for q in data_qubits[::-1]]
+            >>> builder = sf.ChunkBuilder()
+            >>> builder.append("R", measure_qubits)
+            >>> builder.append("TICK")
+            >>> builder.append("CX", [(m-0.5, m) for m in measure_qubits])
+            >>> builder.append("TICK")
+            >>> builder.append("CX", [(m+0.5, m) for m in measure_qubits])
+            >>> builder.append("TICK")
+            >>> builder.append("M", measure_qubits)
+            >>> for m in measure_qubits:
+            ...     stabilizer = sf.PauliMap.from_zs([m-0.5, m+0.5])
+            ...     builder.add_flow(start=stabilizer, measurements=[m])
+            ...     builder.add_flow(end=stabilizer, measurements=[m])
+            >>> obs = sf.PauliMap({data_qubits[0]: "Z"}).with_obs_name("LZ")
+            >>> builder.add_flow(start=obs, end=obs)
+            >>> chunk = builder.finish_chunk()
+            >>> chunk.verify()
+            >>> chunk
+            stimflow.Chunk(
+                q2i={4.5: 0, 3.5: 1, 2.5: 2, 1.5: 3, 0.5: 4, 4.0: 5, 3.0: 6, 2.0: 7, 1.0: 8, 0.0: 9, 5.0: 10},
+                circuit=stim.Circuit('''
+                    R 0 1 2 3 4
+                    TICK
+                    CX 5 0 6 1 7 2 8 3 9 4
+                    TICK
+                    CX 5 1 6 2 7 3 8 4 10 0
+                    TICK
+                    M 0 1 2 3 4
+                '''),
+                flows=[
+                    stimflow.Flow(
+                        start=stimflow.PauliMap.from_zs([(4+0j), (5+0j)]),
+                        measurement_indices=(0,),
+                        center=(4.5+0j),
+                    ),
+                    stimflow.Flow(
+                        end=stimflow.PauliMap.from_zs([(4+0j), (5+0j)]),
+                        measurement_indices=(0,),
+                        center=(4.5+0j),
+                    ),
+                    stimflow.Flow(
+                        start=stimflow.PauliMap.from_zs([(3+0j), (4+0j)]),
+                        measurement_indices=(1,),
+                        center=(3.5+0j),
+                    ),
+                    stimflow.Flow(
+                        end=stimflow.PauliMap.from_zs([(3+0j), (4+0j)]),
+                        measurement_indices=(1,),
+                        center=(3.5+0j),
+                    ),
+                    stimflow.Flow(
+                        start=stimflow.PauliMap.from_zs([(2+0j), (3+0j)]),
+                        measurement_indices=(2,),
+                        center=(2.5+0j),
+                    ),
+                    stimflow.Flow(
+                        end=stimflow.PauliMap.from_zs([(2+0j), (3+0j)]),
+                        measurement_indices=(2,),
+                        center=(2.5+0j),
+                    ),
+                    stimflow.Flow(
+                        start=stimflow.PauliMap.from_zs([(1+0j), (2+0j)]),
+                        measurement_indices=(3,),
+                        center=(1.5+0j),
+                    ),
+                    stimflow.Flow(
+                        end=stimflow.PauliMap.from_zs([(1+0j), (2+0j)]),
+                        measurement_indices=(3,),
+                        center=(1.5+0j),
+                    ),
+                    stimflow.Flow(
+                        start=stimflow.PauliMap.from_zs([0j, (1+0j)]),
+                        measurement_indices=(4,),
+                        center=(0.5+0j),
+                    ),
+                    stimflow.Flow(
+                        end=stimflow.PauliMap.from_zs([0j, (1+0j)]),
+                        measurement_indices=(4,),
+                        center=(0.5+0j),
+                    ),
+                    stimflow.Flow(
+                        start=stimflow.PauliMap({0j: 'Z'}, obs_name='LZ'),
+                        end=stimflow.PauliMap({0j: 'Z'}, obs_name='LZ'),
+                        center=0j,
+                    ),
+                ],
+            )
+
+            >>> # Fancy OBSERVABLE_INCLUDE stuff.
+            >>> builder = sf.ChunkBuilder()
+            >>> obs = sf.PauliMap({"Z": [0, 1, 2]}, obs_name="LZ")
+            >>> builder.append("RX", [0, 1, 2])
+            >>> builder.append("OBSERVABLE_INCLUDE", obs)
+            >>> builder.add_flow(end=sf.PauliMap({"X": [0, 1]}))
+            >>> builder.add_flow(end=sf.PauliMap({"X": [1, 2]}))
+            >>> builder.add_flow(end=obs)
+            >>> chunk = builder.finish_chunk()
+            >>> chunk.verify()
+            >>> chunk
+            stimflow.Chunk(
+                q2i={0: 0, 1: 1, 2: 2},
+                o2i={'LZ': 0},
+                circuit=stim.Circuit('''
+                    RX 0 1 2
+                    OBSERVABLE_INCLUDE(0) Z0 Z1 Z2
+                '''),
+                flows=[
+                    stimflow.Flow(
+                        end=stimflow.PauliMap.from_xs([0j, (1+0j)]),
+                        center=(0.5+0j),
+                    ),
+                    stimflow.Flow(
+                        end=stimflow.PauliMap.from_xs([(1+0j), (2+0j)]),
+                        center=(1.5+0j),
+                    ),
+                    stimflow.Flow(
+                        end=stimflow.PauliMap.from_zs([0j, (1+0j), (2+0j)], obs_name='LZ'),
+                        center=(1+0j),
+                    ),
+                ],
+            )
         """
         __tracebackhide__ = True
         data = stim.gate_data(gate)
@@ -800,16 +956,16 @@ class ChunkBuilder:
             if isinstance(targets, PauliMap):
                 if arg is None and targets.obs_name is None:
                     raise ValueError(
-                        "Received a stimflow.PauliMap target for an OBSERVABLE_INCLUDE instruction, but can't figure out its name.\n"
-                        "(The name is used in order to give consistent index to OBSERVABLE_INCLUDE instructions.)\n"
-                        "(The mapping is stored in the field `stimflow.ChunkBuilder.o2i`.)\n"
+                        "Can't figure out the index to use for an OBSERVABLE_INCLUDE instruction.\n"
                         "\n"
                         "You can do either of the following to fix the error:\n"
-                        "   (a) Pass in a PauliMap with a name (see `stimflow.PauliMap.with_obs_name(name)`)\n"
-                        "   (b) Do a manual override by adding `arg=index` to the `stimflow.ChunkBuilder.append` call\n"
+                        "    (a) Automatic indexing (recommended).\n"
+                        "        Name the given observable, e.g. via `stimflow.PauliMap.with_obs_name`.\n"
+                        "        A consistent index will automatically be associated with the name.\n"
+                        "    (b) Manual indexing.\n"
+                        "        Add an `arg=index` to the `stimflow.ChunkBuilder.append` call.\n"
                         "\n"
-                        "Note that, if you do both (a) and (b), the builder will remember the "
-                        "name-to-index association."
+                        "Note that, if you do both (a) and (b), the builder will remember the name-to-index association.\n"
                     )
                 elif arg is not None and targets.obs_name is not None:
                     if not isinstance(arg, (int, float)) or arg != int(arg):
@@ -822,8 +978,11 @@ class ChunkBuilder:
                             f"Specified {arg=} and {targets=} but {self.o2i[targets.obs_name]=} is "
                             f"inconsistent with {arg=}."
                         )
-                elif arg is None:
+                elif arg is None and targets.obs_name is not None:
                     arg = self._ensure_obs_index_of(targets.obs_name)
+                elif arg is not None and targets.obs_name is None:
+                    # Manual indexing with no associated name.
+                    pass
 
                 self._ensure_indices(
                     targets.keys(),

--- a/glue/stimflow/src/stimflow/_chunk/_chunk_builder.py
+++ b/glue/stimflow/src/stimflow/_chunk/_chunk_builder.py
@@ -985,29 +985,6 @@ class ChunkBuilder:
                     self._rec(measure_key_func(t), [self._num_measurements])
                 self._num_measurements += 1
 
-    def _2q_targets_to_qubit_index_pairs_with_original_index(
-        self,
-        *,
-        data: stim.GateData,
-    ) -> list[tuple[int, int, int]]:
-        index_swapped = data.name in _SWAP_CONJUGATED_MAP
-        index_sorted = data.is_symmetric_gate
-
-        targets = tuple(tuple(cast(Any, pair)) for pair in targets)
-        current_index_pairs: list[tuple[int, int, int]] = []
-        for k in range(len(targets)):
-            a, b = targets[k]
-            if a in self._buffered_seen or b in self._buffered_seen:
-                self._buffered_targets_2q.extend(sorted(current_index_pairs))
-                self._buffered_seen.clear()
-            ai = self.q2i.get(a)
-            bi = self.q2i.get(b)
-            if ai is not None and bi is not None:
-                if index_swapped or (index_sorted and ai > bi):
-                    ai, bi = bi, ai
-                current_index_pairs.append((ai, bi, k))
-        return sorted(current_index_pairs)
-
     def _append_2q(
         self,
         *,

--- a/glue/stimflow/src/stimflow/_chunk/_chunk_builder.py
+++ b/glue/stimflow/src/stimflow/_chunk/_chunk_builder.py
@@ -12,7 +12,22 @@ from stimflow._core._flow import Flow
 from stimflow._core._pauli_map import PauliMap
 from stimflow._core._tile import Tile
 
-_SWAP_CONJUGATED_MAP = {"XCZ": "CX", "YCZ": "CY", "YCX": "XCY", "SWAPCX": "CXSWAP"}
+_SWAP_CONJUGATED_MAP: dict[str, str] = {"XCZ": "CX", "YCZ": "CY", "YCX": "XCY", "SWAPCX": "CXSWAP"}
+_SELF_COMMUTING_2Q_GATES: frozenset[str] = frozenset([
+    "CZ",
+    "XCX",
+    "YCY",
+    "SQRT_XX",
+    "SQRT_ZZ",
+    "SQRT_YY",
+    "II",
+    "II_ERROR",
+    "DEPOLARIZE2",
+    "PAULI_CHANNEL_2",
+    "MXX",
+    "MZZ",
+    "MYY",
+])
 
 
 class ChunkBuilder:
@@ -108,7 +123,7 @@ class ChunkBuilder:
         self.allowed_qubits: set[complex] | None = None if allowed_qubits is None else set(allowed_qubits)
         self._num_measurements: int = 0
         self._recorded_measurements: dict[Any, list[int]] = {}
-        self.circuit: stim.Circuit = stim.Circuit()
+        self._circuit: stim.Circuit = stim.Circuit()
         self.q2i: dict[complex, int] = {}
         self.o2i: dict[Any, int] = {}
         self._flows: list[Flow] = []
@@ -117,6 +132,10 @@ class ChunkBuilder:
         self._flows_with_auto_end: list[Flow] = []
         self._discarded_output_flows: list[PauliMap] = []
         self._discarded_input_flows: list[PauliMap] = []
+        self._buffered_targets_1q: list[int] = []
+        self._buffered_targets_2q: list[tuple[int, int]] = []
+        self._buffered_gate: str | None = None
+        self._buffered_tag: str = ""
 
         # Index allowed qubits.
         if allowed_qubits is not None:
@@ -538,6 +557,8 @@ class ChunkBuilder:
     ) -> Chunk:
         """Finishes producing the circuit."""
 
+        self._flush_buffered_gate()
+
         from stimflow._chunk._flow_util import _solve_auto_flow_starts
         from stimflow._chunk._flow_util import _solve_auto_flow_ends
         from stimflow._chunk._flow_util import _solve_auto_flow_ms
@@ -548,25 +569,25 @@ class ChunkBuilder:
 
         solved_starts = _solve_auto_flow_starts(
             flows=self._flows_with_auto_start,
-            circuit=self.circuit,
+            circuit=self._circuit,
             q2i=self.q2i,
             failure_out=start_fails,
         )
         solved_ends = _solve_auto_flow_ends(
             flows=self._flows_with_auto_end,
-            circuit=self.circuit,
+            circuit=self._circuit,
             q2i=self.q2i,
             failure_out=end_fails,
         )
         solved_ms = _solve_auto_flow_ms(
             flows=self._flows_with_auto_ms,
-            circuit=self.circuit,
+            circuit=self._circuit,
             q2i=self.q2i,
             o2i=self.o2i,
             failure_out=measure_fails,
         )
 
-        out_circuit = self.circuit.copy()
+        out_circuit = self._circuit.copy()
         if start_fails or end_fails or measure_fails:
             lines = []
             if start_fails:
@@ -630,6 +651,31 @@ class ChunkBuilder:
             wants_to_merge_with_prev=wants_to_merge_with_prev,
         )
 
+    def _flush_buffered_gate(self):
+        if self._buffered_gate is None:
+            return
+
+        data = stim.gate_data(self._buffered_gate)
+        if data.is_single_qubit_gate:
+            indices = sorted(self._buffered_targets_1q)
+        elif data.is_two_qubit_gate:
+            indices = []
+            _canonicalize_2q_indices(
+                targets=self._buffered_targets_2q,
+                out_indices=indices,
+                is_symmetric_gate=data.is_symmetric_gate,
+                out_original_order=None,
+            )
+        else:
+            raise NotImplementedError(f'{data=}')
+
+        self._circuit.append(self._buffered_gate, indices, tag=self._buffered_tag)
+        self._buffered_gate = None
+        self._buffered_tag = ""
+        self._buffered_targets_2q.clear()
+        self._buffered_targets_1q.clear()
+
+
     def append(
         self,
         gate: str,
@@ -657,7 +703,7 @@ class ChunkBuilder:
             b = builder.q2i[5]
             c = builder.q2i[0]
             d = builder.q2i[1j]
-            builder.circuit.append('CZ', [a, b, c, d])
+            builder._circuit.append('CZ', [a, b, c, d])
 
         you would say
 
@@ -717,22 +763,41 @@ class ChunkBuilder:
         __tracebackhide__ = True
         data = stim.gate_data(gate)
 
-        if data.name == "TICK":
+        if self._buffered_gate != _SWAP_CONJUGATED_MAP.get(data.name, data.name) or self._buffered_tag != tag or arg is not None:
+            self._flush_buffered_gate()
+
+        if data.is_two_qubit_gate:
+            self._append_2q(
+                gate=gate,
+                data=data,
+                targets=cast(Any, targets),
+                arg=arg,
+                measure_key_func=cast(Any, measure_key_func),
+                tag=tag,
+                unknown_qubit_append_mode=unknown_qubit_append_mode,
+            )
+        elif data.name == "TICK":
             if arg is not None:
                 raise ValueError(f"TICK takes no arguments but got {arg=}.")
             if targets:
                 raise ValueError(f"TICK takes no targets but got {targets=}.")
-            self.circuit.append("TICK", tag=tag)
+            self._circuit.append("TICK", tag=tag)
 
         elif data.name == "SHIFT_COORDS":
             if arg is None:
                 raise ValueError(f"SHIFT_COORDS expects {arg=} to not be None.")
             if targets:
                 raise ValueError(f"SHIFT_COORDS takes no targets but got {targets=}.")
-            self.circuit.append("SHIFT_COORDS", [], arg, tag=tag)
+            self._circuit.append("SHIFT_COORDS", [], arg, tag=tag)
 
-        elif data.name == "DETECTOR" or data.name == "OBSERVABLE_INCLUDE":
-            if isinstance(targets, PauliMap) and data.name == "OBSERVABLE_INCLUDE":
+        elif data.name == "DETECTOR":
+            t0 = self._num_measurements
+            times = self.lookup_measurement_indices(targets)
+            rec_targets = [stim.target_rec(t - t0) for t in sorted(times)]
+            self._circuit.append(data.name, rec_targets, arg, tag=tag)
+
+        elif data.name == "OBSERVABLE_INCLUDE":
+            if isinstance(targets, PauliMap):
                 if arg is None and targets.obs_name is None:
                     raise ValueError(
                         "Received a stimflow.PauliMap target for an OBSERVABLE_INCLUDE instruction, but can't figure out its name.\n"
@@ -768,7 +833,7 @@ class ChunkBuilder:
                     unknown_qubit_append_mode=unknown_qubit_append_mode,
                 )
                 ps = targets.to_stim_pauli_string(self.q2i)
-                self.circuit.append(
+                self._circuit.append(
                     data.name,
                     [stim.target_pauli(q, ps[q]) for q in ps.pauli_indices()],
                     arg,
@@ -778,7 +843,7 @@ class ChunkBuilder:
                 t0 = self._num_measurements
                 times = self.lookup_measurement_indices(targets)
                 rec_targets = [stim.target_rec(t - t0) for t in sorted(times)]
-                self.circuit.append(data.name, rec_targets, arg, tag=tag)
+                self._circuit.append(data.name, rec_targets, arg, tag=tag)
 
         elif data.name == "MPP":
             self._append_mpp(
@@ -811,18 +876,7 @@ class ChunkBuilder:
                     for q in qs:
                         i = self.q2i[q]
                         stim_targets.append(stim.target_pauli(i, targets[0][q]))
-                    self.circuit.append("CORRELATED_ERROR", stim_targets, arg, tag=tag)
-
-        elif data.is_two_qubit_gate:
-            self._append_2q(
-                gate=gate,
-                data=data,
-                targets=cast(Any, targets),
-                arg=arg,
-                measure_key_func=cast(Any, measure_key_func),
-                tag=tag,
-                unknown_qubit_append_mode=unknown_qubit_append_mode,
-            )
+                    self._circuit.append("CORRELATED_ERROR", stim_targets, arg, tag=tag)
 
         elif data.is_single_qubit_gate:
             self._append_1q(
@@ -881,7 +935,7 @@ class ChunkBuilder:
                     stim_targets.append(stim.target_combiner())
                 stim_targets.pop()
 
-        self.circuit.append(gate, stim_targets, arg, tag=tag)
+        self._circuit.append(gate, stim_targets, arg, tag=tag)
 
         for target in targets:
             if measure_key_func is not None:
@@ -917,13 +971,42 @@ class ChunkBuilder:
         if not indices:
             return
 
-        self.circuit.append(gate, [e[0] for e in indices], arg, tag=tag)
+        if arg is None and not data.produces_measurements:
+            self._buffered_gate = data.name
+            self._buffered_tag = tag
+            self._buffered_targets_1q.extend([e[0] for e in indices])
+            return
+
+        self._circuit.append(gate, [e[0] for e in indices], arg, tag=tag)
         if data.produces_measurements:
             for _, k in indices:
                 t = targets[k]
                 if measure_key_func is not None:
                     self._rec(measure_key_func(t), [self._num_measurements])
                 self._num_measurements += 1
+
+    def _2q_targets_to_qubit_index_pairs_with_original_index(
+        self,
+        *,
+        data: stim.GateData,
+    ) -> list[tuple[int, int, int]]:
+        index_swapped = data.name in _SWAP_CONJUGATED_MAP
+        index_sorted = data.is_symmetric_gate
+
+        targets = tuple(tuple(cast(Any, pair)) for pair in targets)
+        current_index_pairs: list[tuple[int, int, int]] = []
+        for k in range(len(targets)):
+            a, b = targets[k]
+            if a in self._buffered_seen or b in self._buffered_seen:
+                self._buffered_targets_2q.extend(sorted(current_index_pairs))
+                self._buffered_seen.clear()
+            ai = self.q2i.get(a)
+            bi = self.q2i.get(b)
+            if ai is not None and bi is not None:
+                if index_swapped or (index_sorted and ai > bi):
+                    ai, bi = bi, ai
+                current_index_pairs.append((ai, bi, k))
+        return sorted(current_index_pairs)
 
     def _append_2q(
         self,
@@ -955,30 +1038,44 @@ class ChunkBuilder:
 
         # Canonicalize gate and target pairs.
         targets = [tuple(cast(Any, pair)) for pair in targets]
-        index_pairs: list[tuple[int, int, int]] = []
+        unsorted_index_pairs: list[tuple[int, int]] = []
         index_swapped = data.name in _SWAP_CONJUGATED_MAP
-        index_sorted = data.is_symmetric_gate
-        for k in range(len(targets)):
-            a, b = targets[k]
+        kept_targets = []
+        for a, b in targets:
             ai = self.q2i.get(a)
             bi = self.q2i.get(b)
+            if index_swapped:
+                ai, bi = bi, ai
             if ai is not None and bi is not None:
-                if index_swapped or (index_sorted and ai > bi):
-                    ai, bi = bi, ai
-                index_pairs.append((ai, bi, k))
-        index_pairs = sorted(index_pairs)
-        if not index_pairs:
+                unsorted_index_pairs.append((ai, bi))
+                kept_targets.append((a, b))
+        if not unsorted_index_pairs:
             return
 
         if index_swapped:
             gate = _SWAP_CONJUGATED_MAP[data.name]
+            data = stim.gate_data(gate)
 
-        self.circuit.append(gate, [i for pair in index_pairs for i in pair[:2]], arg, tag=tag)
+        if arg is None and not data.produces_measurements:
+            self._buffered_gate = data.name
+            self._buffered_tag = tag
+            self._buffered_targets_2q.extend(unsorted_index_pairs)
+            return
 
-        # Record both qubit orderings.
+        indices = []
+        original_order = []
+        _canonicalize_2q_indices(
+            targets=unsorted_index_pairs,
+            is_symmetric_gate=data.is_symmetric_gate,
+            out_indices=indices,
+            out_original_order=original_order,
+        )
+        self._circuit.append(gate, indices, arg, tag=tag)
+
+        # Record a measurement key for both qubit orderings.
         if data.produces_measurements:
-            for _, _, k in index_pairs:
-                a, b = targets[k]
+            for k in original_order:
+                a, b = kept_targets[k]
                 if measure_key_func is not None:
                     k1 = measure_key_func((a, b))
                     k2 = measure_key_func((b, a))
@@ -1016,4 +1113,35 @@ class ChunkBuilder:
         rec_targets = [stim.target_rec(t - t0) for t in sorted(times)]
         for rec in rec_targets:
             for i in indices:
-                self.circuit.append(gate, [rec, i])
+                self._circuit.append(gate, [rec, i])
+
+
+def _canonicalize_2q_indices(
+    *,
+    targets: Iterable[tuple[int, int]],
+    is_symmetric_gate: bool,
+    out_indices: list[int],
+    out_original_order: list[int] | None,
+):
+    seen_qubits = set()
+    buffered_targets: list[tuple[int, int, int]] = []
+
+    def _flush_buffer():
+        for a, b, k in sorted(buffered_targets):
+            out_indices.append(a)
+            out_indices.append(b)
+            if out_original_order is not None:
+                out_original_order.append(k)
+        buffered_targets.clear()
+        seen_qubits.clear()
+
+    for k, (a, b) in enumerate(targets):
+        if is_symmetric_gate and a > b:
+            a, b = b, a
+        if a in seen_qubits or b in seen_qubits:
+            _flush_buffer()
+        seen_qubits.add(a)
+        seen_qubits.add(b)
+        buffered_targets.append((a, b, k))
+
+    _flush_buffer()

--- a/glue/stimflow/src/stimflow/_chunk/_chunk_builder.py
+++ b/glue/stimflow/src/stimflow/_chunk/_chunk_builder.py
@@ -302,6 +302,46 @@ class ChunkBuilder:
             )
         return xor_sorted(result)
 
+    def add_obs_name_index(self, obs_name: str, obs_index: int) -> None:
+        """Associates an explicit stim observable index with a stimflow observable name.
+
+        Note that the name-to-index association typically happens automatically. For example,
+        `builder.append("OBSERVABLE_INCLUDE", some_named_obs)` will automatically pick an unused
+        index to use if `some_named_obs`'s name is not already indexed.
+
+        Args:
+            obs_name: The name of the observable to use when referring it in stimflow.
+            obs_index: The index to use when referring to the observable in a stim circuit.
+
+        Examples:
+            >>> import stimflow as sf
+            >>> builder = sf.ChunkBuilder()
+            >>> obs = sf.PauliMap({0: "Z"}, obs_name="LX")
+            >>> builder.add_obs_name_index(obs.obs_name, 5)
+            >>> builder.append("OBSERVABLE_INCLUDE", obs)
+            >>> builder.finish_chunk()
+            stimflow.Chunk(
+                q2i={0j: 0},
+                o2i={'LX': 5},
+                circuit=stim.Circuit('''
+                    OBSERVABLE_INCLUDE(5) Z0
+                '''),
+            )
+        """
+        if isinstance(obs_name, PauliMap):
+            raise ValueError("Passed a `stimflow.PauliMap`, instead of its `obs_name`, into `stimflow.ChunkBuilder.add_obs_name_index`.\n"
+                             f"    Got {obs_name=!r}")
+        if obs_name is None:
+            raise ValueError(f"Expected an observable name but got {obs_name=!r}.")
+        old_arg = self.o2i.setdefault(obs_name, obs_index)
+        if old_arg != obs_index:
+            raise ValueError(
+                f"Called add_obs_name_index({obs_name=}, {obs_index=}) but {obs_name=} "
+                f"was already mapped to a different index ({old_arg}).\n"
+                f"For example, this can happen if you call `builder.append('OBSERVABLE_INCLUDE', ...)` before "
+                f"calling `builder.add_obs_name_index` due to the append method picking an automatic index."
+            )
+
     def add_discarded_flow_input(self, flow: PauliMap | Tile) -> None:
         """Annotates that an input stabilizer won't be used.
 
@@ -975,8 +1015,10 @@ class ChunkBuilder:
                         self.o2i[targets.obs_name] = int(arg)
                     elif old_arg != arg:
                         raise ValueError(
-                            f"Specified {arg=} and {targets=} but {self.o2i[targets.obs_name]=} is "
-                            f"inconsistent with {arg=}."
+                            f"Got {targets=} and {arg=}, but that arg is inconsistent with the previously "
+                            f"specified index of {self.o2i[targets.obs_name]} for the observable.\n"
+                            f"    To use the existing index, drop the `arg` argument.\n"
+                            f"    To force the index, drop the observable's name (e.g. `obs.with_obs_name(None)`)."
                         )
                 elif arg is None and targets.obs_name is not None:
                     arg = self._ensure_obs_index_of(targets.obs_name)

--- a/glue/stimflow/src/stimflow/_chunk/_chunk_builder_test.py
+++ b/glue/stimflow/src/stimflow/_chunk/_chunk_builder_test.py
@@ -1,6 +1,7 @@
 import numpy as np
 import stim
 
+import pytest
 import stimflow
 
 
@@ -408,3 +409,28 @@ def test_auto_obs():
             center=1,
         ),
     )
+
+
+def test_obs_indexing():
+    builder = stimflow.ChunkBuilder()
+    with pytest.raises(ValueError, match="index"):
+        builder.append("OBSERVABLE_INCLUDE", stimflow.PauliMap({"Z": [0]}))
+    assert builder.o2i.get('LL') is None
+    builder.append("OBSERVABLE_INCLUDE", stimflow.PauliMap({"Z": [0]}, obs_name='LL'))
+    assert builder.o2i.get('LL') == 0
+    builder.add_obs_name_index('LL', 0)
+    with pytest.raises(ValueError, match="different index"):
+        builder.add_obs_name_index('LL', 1)
+    assert builder.finish_chunk().circuit == stim.Circuit("""
+        OBSERVABLE_INCLUDE(0) Z0
+    """)
+
+    builder = stimflow.ChunkBuilder()
+    builder.add_obs_name_index('LL', 3)
+    assert builder.o2i.get('LL') == 3
+    with pytest.raises(ValueError, match="inconsistent"):
+        builder.append("OBSERVABLE_INCLUDE", stimflow.PauliMap({"Z": [0]}, obs_name='LL'), arg=2)
+    builder.append("OBSERVABLE_INCLUDE", stimflow.PauliMap({"Z": [0]}, obs_name='LL'))
+    assert builder.finish_chunk().circuit == stim.Circuit("""
+        OBSERVABLE_INCLUDE(3) Z0
+    """)

--- a/glue/stimflow/src/stimflow/_chunk/_chunk_builder_test.py
+++ b/glue/stimflow/src/stimflow/_chunk/_chunk_builder_test.py
@@ -7,7 +7,7 @@ import stimflow
 def test_builder_init():
     builder = stimflow.ChunkBuilder([0, 1j, 3 + 2j])
     assert builder.q2i == {0: 0, 1j: 1, 3 + 2j: 2}
-    assert builder.circuit == stim.Circuit(
+    assert builder.finish_chunk().circuit == stim.Circuit(
         """
         """
     )
@@ -17,7 +17,7 @@ def test_append_tick():
     builder = stimflow.ChunkBuilder([0])
     builder.append("TICK")
     builder.append("TICK")
-    assert builder.circuit == stim.Circuit(
+    assert builder.finish_chunk().circuit == stim.Circuit(
         """
         TICK
         TICK
@@ -28,7 +28,7 @@ def test_append_tick():
 def test_append_shift_coords():
     builder = stimflow.ChunkBuilder([0])
     builder.append("SHIFT_COORDS", arg=[0, 0, 1])
-    assert builder.circuit == stim.Circuit(
+    assert builder.finish_chunk().circuit == stim.Circuit(
         """
         SHIFT_COORDS(0, 0, 1)
         """
@@ -62,7 +62,7 @@ def test_append_measurements_canonical_order():
     assert builder.lookup_measurement_indices([(2, 5)]) == [3]
     assert builder.lookup_measurement_indices([(3, 4)]) == [4]
 
-    assert builder.circuit == stim.Circuit(
+    assert builder.finish_chunk().circuit == stim.Circuit(
         """
         MX 2 3 5
         MZZ 2 5 3 4
@@ -79,7 +79,7 @@ def test_append_mpp():
     assert builder.lookup_measurement_indices([xxx]) == [0]
     assert builder.lookup_measurement_indices([z_z]) == [1]
 
-    assert builder.circuit == stim.Circuit(
+    assert builder.finish_chunk().circuit == stim.Circuit(
         """
         MPP X0*X1*X2 Z0*Z2
         """
@@ -93,7 +93,7 @@ def test_append_observable_include():
     builder.append("M", [2 + 3j, 5 + 7j, 11 + 13j], measure_key_func=lambda e: (e, "X"))
     builder.append("OBSERVABLE_INCLUDE", [(5 + 7j, "X")], arg=2)
 
-    assert builder.circuit == stim.Circuit(
+    assert builder.finish_chunk().circuit == stim.Circuit(
         """
         R 1
         M 0 1 2
@@ -109,7 +109,7 @@ def test_append_detector():
     builder.append("M", [2 + 3j, 5 + 7j, 11 + 13j], measure_key_func=lambda e: (e, "X"))
     builder.append("DETECTOR", [(5 + 7j, "X")], arg=[2, 3, 5])
 
-    assert builder.circuit == stim.Circuit(
+    assert builder.finish_chunk().circuit == stim.Circuit(
         """
         R 1
         M 0 1 2
@@ -168,7 +168,7 @@ def test_make_surface_code_first_round():
     for z in stimflow.sorted_complex(mzs):
         builder.append("DETECTOR", [z], arg=[z.real, z.imag, 0])
 
-    assert builder.circuit == stim.Circuit(
+    assert builder.finish_chunk().circuit == stim.Circuit(
         """
         RX 0 7 9 16
         R 1 2 3 4 5 6 8 10 11 12 13 14 15
@@ -194,7 +194,7 @@ def test_make_surface_code_first_round():
 def test_skip_unknown_1qm():
     builder = stimflow.ChunkBuilder(allowed_qubits=[0, 1, 2, 3])
     builder.append("M", [2, -1, 1, 25, 3], unknown_qubit_append_mode="skip")
-    assert builder.circuit == stim.Circuit(
+    assert builder.finish_chunk().circuit == stim.Circuit(
         """
         M 1 2 3
     """
@@ -208,13 +208,82 @@ def test_skip_unknown_2qm():
     builder = stimflow.ChunkBuilder(allowed_qubits=[0, 1, 2, 3])
     builder.append("MZZ", [(2, 3), (-1, 5), (0, 1)], unknown_qubit_append_mode="skip")
     assert builder.q2i == {0: 0, 1: 1, 2: 2, 3: 3}
-    assert builder.circuit == stim.Circuit(
+    assert builder.finish_chunk().circuit == stim.Circuit(
         """
         MZZ 0 1 2 3
-    """
+        """
     )
     assert builder.lookup_measurement_indices([(0, 1)]) == builder.lookup_measurement_indices([(1, 0)]) == [0]
     assert builder.lookup_measurement_indices([(2, 3)]) == builder.lookup_measurement_indices([(3, 2)]) == [1]
+
+
+def test_single_qubit_gate_coalescing_across_multiple_calls():
+    builder = stimflow.ChunkBuilder(allowed_qubits=range(10))
+    builder.append("H", [4, 5])
+    builder.append("H_XZ", [1, 0])
+    builder.append("H", [11], unknown_qubit_append_mode='skip')
+    builder.append("H", [12], unknown_qubit_append_mode='include')
+    chunk = builder.finish_chunk()
+    assert chunk.q2i[12] == 10
+    assert chunk.circuit == stim.Circuit(
+        """
+        H 0 1 4 5 10
+        """
+    )
+
+
+def test_two_qubit_gate_coalescing_across_multiple_calls():
+    builder = stimflow.ChunkBuilder(allowed_qubits=range(10))
+    builder.append("CX", [(4, 5), (6, 7)])
+    builder.append("ZCX", [(1, 0)])
+    builder.append("XCZ", [(2, 3)])
+    builder.append("CX", [(0, 4)])
+    builder.append("CX", [(3, 12)], unknown_qubit_append_mode='skip')
+    builder.append("CX", [(2, 13)], unknown_qubit_append_mode='include')
+    chunk = builder.finish_chunk()
+    assert chunk.q2i[13] == 10
+    assert chunk.circuit == stim.Circuit(
+        """
+        CX 1 0 3 2 4 5 6 7 0 4 2 10
+        """
+    )
+
+    builder = stimflow.ChunkBuilder(allowed_qubits=range(10))
+    builder.append("CX", [(4, 5)])
+    builder.append("CX", [(1, 0)])
+    builder.append("CZ", [(2, 3)])
+    builder.append("CX", [(6, 7)])
+    assert builder.finish_chunk().circuit == stim.Circuit(
+        """
+        CX 1 0 4 5
+        CZ 2 3
+        CX 6 7
+        """
+    )
+
+    builder = stimflow.ChunkBuilder(allowed_qubits=range(10))
+    builder.append("CX", [(4, 5)])
+    builder.append("CX", [(1, 0)])
+    builder.append("TICK")
+    builder.append("CX", [(6, 7)])
+    assert builder.finish_chunk().circuit == stim.Circuit(
+        """
+        CX 1 0 4 5
+        TICK
+        CX 6 7
+        """
+    )
+
+    builder = stimflow.ChunkBuilder(allowed_qubits=range(10))
+    builder.append("CZ", [(4, 5)])
+    builder.append("CZ", [(1, 0)])
+    builder.append("CZ", [(2, 3)])
+    builder.append("CZ", [(0, 4)])
+    assert builder.finish_chunk().circuit == stim.Circuit(
+        """
+        CZ 0 1 2 3 4 5 0 4
+        """
+    )
 
 
 def test_partial_observable_include_memory_experiment():

--- a/glue/stimflow/src/stimflow/_chunk/_chunk_loop.py
+++ b/glue/stimflow/src/stimflow/_chunk/_chunk_loop.py
@@ -27,6 +27,31 @@ class ChunkLoop:
 
     For duck typing purposes, many methods supported by Chunk are supported by
     ChunkLoop.
+
+    Examples:
+        >>> import stim
+        >>> import stimflow as sf
+        >>> zz = sf.PauliMap({0: 'Z', 1 + 1j: 'Z'})
+        >>> lz = sf.PauliMap({0: 'Z'}, obs_name='L_ZI')
+        >>> lx = sf.PauliMap({0: 'X', 1 + 1j: 'X'}, obs_name='L_XX')
+        >>> idle_chunk = sf.Chunk(
+        ...     stim.Circuit('''
+        ...         QUBIT_COORDS(0, 0) 0
+        ...         QUBIT_COORDS(0, 1) 1
+        ...         QUBIT_COORDS(1, 1) 2
+        ...         R 1
+        ...         CX 0 1 2 1
+        ...         M 1
+        ...     '''),
+        ...     flows=[
+        ...         sf.Flow(start=zz, measurement_indices=[0]),
+        ...         sf.Flow(end=zz, measurement_indices=[0]),
+        ...         sf.Flow(start=lz, end=lz),
+        ...         sf.Flow(start=lx, end=lx),
+        ...     ]
+        ... )
+        >>> idle_ten_times = sf.ChunkLoop([idle_chunk], repetitions=10)
+        >>> idle_ten_times.verify()
     """
 
     def __init__(self, chunks: Iterable[Chunk | ChunkLoop], repetitions: int):

--- a/glue/stimflow/src/stimflow/_core/_noise.py
+++ b/glue/stimflow/src/stimflow/_core/_noise.py
@@ -33,16 +33,66 @@ class NoiseRule:
         after: dict[str, float | tuple[float, ...]] | None = None,
         flip_result: float = 0,
     ):
-        """
+        """Initializes a NoiseRule.
 
         Args:
-            after: A dictionary mapping noise rule names to their probability argument.
-                For example, {"DEPOLARIZE2": 0.01, "X_ERROR": 0.02} will add two qubit
-                depolarization with parameter 0.01 and also add 2% bit flip noise. These
-                noise channels occur after all other operations in the moment and are applied
-                to the same targets as the relevant operation.
+            before: A name-to-argument mapping of noise instructions to add before some
+                instruction that is being made noisy. For example,
+                    after={"DEPOLARIZE2": 0.01, "X_ERROR": 0.02}
+                will add two qubit depolarization with parameter 0.01 and also add 2%
+                bit flip noise. These noise channels occur before all other operations
+                in the moment and are applied to the same targets as the relevant operation.
+            after: A name-to-argument mapping of noise instructions to add after some
+                instruction that is being made noisy. For example,
+                    after={"DEPOLARIZE2": 0.01, "X_ERROR": 0.02}
+                will add two qubit depolarization with parameter 0.01 and also add 2%
+                bit flip noise. These noise channels occur after all other operations
+                in the moment and are applied to the same targets as the relevant operation.
             flip_result: The probability that a measurement result should be reported incorrectly.
                 Only valid when applied to operations that produce measurement results.
+
+        Examples:
+            >>> import stim
+            >>> import stimflow as sf
+            >>> noise = sf.NoiseModel(gate_rules={
+            ...     'R': sf.NoiseRule(after={"X_ERROR": 5e-3}),
+            ...     'M': sf.NoiseRule(flip_result=1e-3),
+            ...     'CZ': sf.NoiseRule(after={"Z_ERROR": 3e-3, "DEPOLARIZE2": 1e-3}),
+            ...     'H': sf.NoiseRule(before={"PAULI_CHANNEL_1": (1e-3, 1e-2, 1e-3)}),
+            ... })
+            >>> noise.noisy_circuit(stim.Circuit('''
+            ...     R 1
+            ...     TICK
+            ...     H 1
+            ...     TICK
+            ...     CZ 0 1
+            ...     TICK
+            ...     CZ 2 1
+            ...     TICK
+            ...     H 1
+            ...     TICK
+            ...     M 1
+            ... '''))
+            stim.Circuit('''
+                R 1
+                X_ERROR(0.005) 1
+                TICK
+                PAULI_CHANNEL_1(0.001, 0.01, 0.001) 1
+                H 1
+                TICK
+                CZ 0 1
+                DEPOLARIZE2(0.001) 0 1
+                Z_ERROR(0.003) 0 1
+                TICK
+                CZ 2 1
+                DEPOLARIZE2(0.001) 2 1
+                Z_ERROR(0.003) 2 1
+                TICK
+                PAULI_CHANNEL_1(0.001, 0.01, 0.001) 1
+                H 1
+                TICK
+                M(0.001) 1
+            ''')
         """
         if after is None:
             after = {}

--- a/glue/stimflow/src/stimflow/_layers/_transpile_test.py
+++ b/glue/stimflow/src/stimflow/_layers/_transpile_test.py
@@ -544,7 +544,7 @@ def test_tagged_layers_not_affected():
     builder.append("H", [0 + 0j])
     builder.append("tick")
     builder.append("H", [0 + 0j], tag="tag")
-    actual = stimflow.transpile_to_z_basis_interaction_circuit(builder.circuit)
+    actual = stimflow.transpile_to_z_basis_interaction_circuit(builder.finish_chunk().circuit)
     assert builder.q2i == {0: 0}
     expected = stim.Circuit(
         """
@@ -566,7 +566,7 @@ def test_tagged_layers_not_affected_2q():
     builder.append("CNOT", [(0 + 0j, 1 + 0j)], tag="test")
     builder.append("tick")
     builder.append("M", [0 + 0j, 1 + 0j])
-    actual = stimflow.transpile_to_z_basis_interaction_circuit(builder.circuit)
+    actual = stimflow.transpile_to_z_basis_interaction_circuit(builder.finish_chunk().circuit)
     assert builder.q2i == {0: 0, 1: 1}
     expected = stim.Circuit(
         """
@@ -593,7 +593,7 @@ def test_tagged_layers_simultaneous_ops():
     builder.append("X", [2])
     builder.append("tick")
     builder.append("M", [0 + 0j, 1 + 0j])
-    actual = stimflow.transpile_to_z_basis_interaction_circuit(builder.circuit)
+    actual = stimflow.transpile_to_z_basis_interaction_circuit(builder.finish_chunk().circuit)
     assert builder.q2i == {0: 0, 1: 1, 2: 2}
     expected = stim.Circuit(
         """
@@ -619,7 +619,7 @@ def test_tagged_layers_with_measurements():
     builder.append("CNOT", [(0 + 0j, 1 + 0j)], tag="test")
     builder.append("tick")
     builder.append("M", [0 + 0j, 1 + 0j], tag="test again")
-    actual = stimflow.transpile_to_z_basis_interaction_circuit(builder.circuit)
+    actual = stimflow.transpile_to_z_basis_interaction_circuit(builder.finish_chunk().circuit)
     assert builder.q2i == {0: 0, 1: 1}
     expected = stim.Circuit(
         """

--- a/glue/stimflow/src/stimflow/_viz/_viz_html.py
+++ b/glue/stimflow/src/stimflow/_viz/_viz_html.py
@@ -61,7 +61,7 @@ def html_viewer(
         )
 
     elif isinstance(obj, Chunk):
-        circuit = obj.to_closed_circuit()
+        circuit = obj.to_closed_circuit(skip_verification=True)
         if background is None:
             start = obj.start_patch()
             end = obj.end_patch()


### PR DESCRIPTION
- Calling `builder.append("CX", A); builder.append("CX", B)` now ultimately produces the same output as `builder.append("CX", A + B)`
    - This fixes some usage annoyances I was noticing where I was manually coalescing calls in order to avoid ordering issues when making refactors later
- Allow `noise=None` in `stimflow.Chunk.find_distance`
- Add `stimflow.Builder.add_obs_name_index`
- Improve error messages and error checking related to the mapping between stimflow observable names and stim observable indices
- Add more docstrings and examples

Fixes https://github.com/quantumlib/Stim/issues/1091 (by adding better error messages to guide the user towards success)
